### PR TITLE
OpenRocketDocument leaks after closing BasicFrame

### DIFF
--- a/core/src/net/sf/openrocket/gui/main/MRUDesignFileAction.java
+++ b/core/src/net/sf/openrocket/gui/main/MRUDesignFileAction.java
@@ -19,8 +19,9 @@ public final class MRUDesignFileAction extends JMenu {
     /**
      * The window to which an open design file action will be parented to (typically an instance of BasicFrame).
      */
-    private Window parent;
+    private final Window parent;
 
+    private final PropertyChangeListener myListener;
     /**
      * Constructor.
      *
@@ -32,17 +33,23 @@ public final class MRUDesignFileAction extends JMenu {
         super(s);
 
         parent = theParent;
-        MRUDesignFile opts = MRUDesignFile.getInstance();
-        opts.addPropertyChangeListener(new PropertyChangeListener() {
+        myListener = new PropertyChangeListener() {
             public void propertyChange(PropertyChangeEvent evt) {
                 if (!evt.getPropertyName().equals(MRUDesignFile.MRU_FILE_LIST_PROPERTY)) {
                     return;
                 }
                 updateMenu();
             }
-        });
+        };
 
+        MRUDesignFile opts = MRUDesignFile.getInstance();
+        opts.addPropertyChangeListener(myListener);
         updateMenu();
+    }
+    
+    public void deregister() {
+        MRUDesignFile opts = MRUDesignFile.getInstance();
+        opts.removePropertyChangeListener(myListener);
     }
 
     /**

--- a/core/src/net/sf/openrocket/gui/main/RocketActions.java
+++ b/core/src/net/sf/openrocket/gui/main/RocketActions.java
@@ -102,7 +102,11 @@ public class RocketActions {
 		});
 	}
 
+	public void dispose() {
+		OpenRocketClipboard.removeClipboardListener(this.pasteAction);
+	}
 	/**
+	 * 
 	 * Update the state of all of the actions.
 	 */
 	private void updateActions() {


### PR DESCRIPTION
Even after the BasicFrame for a rocket was closed, there were still some dangling references to it in various parts of the system.  Since the basic frame holds on to the OpenRocketDocument, this is a significant resource leak.
