### PR TITLE
Possible fix to infinite loop in printing code.

### DIFF
--- a/core/src/net/sf/openrocket/gui/print/visitor/PageFitPrintStrategy.java
+++ b/core/src/net/sf/openrocket/gui/print/visitor/PageFitPrintStrategy.java
@@ -90,7 +90,9 @@ public class PageFitPrintStrategy {
 
         Collections.sort(componentToPrint);
 
-    	while (componentToPrint.size() > 0) {
+        boolean somethingPrinted = true;
+    	while (componentToPrint.size() > 0 && somethingPrinted) {
+    		somethingPrinted = false;
     		int pageY = marginY;
     		Boolean anyAddedToRow;
 
@@ -113,6 +115,7 @@ public class PageFitPrintStrategy {
 		        			pageY = rowY + dim.height + marginY;
                         }
 		        		entry.remove();
+		        		somethingPrinted = true;
 		        		component.print(g2);
 		        		anyAddedToRow = true;
 		        	}
@@ -121,7 +124,21 @@ public class PageFitPrintStrategy {
     		} while (anyAddedToRow);
 
         	g2.dispose();
-        	document.newPage();
+        	if ( somethingPrinted ) {
+        		document.newPage();
+        	}
+    	}
+    	
+    	// Now print the big things.
+    	if ( componentToPrint.size() > 0 ) {
+        	ListIterator<PrintableComponent> entry = componentToPrint.listIterator();
+        	while( entry.hasNext() ) {
+	        	PrintableComponent component = entry.next();
+        		Graphics2D g2 = cb.createGraphics(pageSize.width, pageSize.height);
+        		component.print(g2);
+        		g2.dispose();
+        		document.newPage();
+        	}
     	}
     }
 


### PR DESCRIPTION
There is a an infinite loop in the print layout code.  It is exploited when one tries to print large fins which are about the size of a page.  The fin layout strategy tests if the fin will fit on a page without including any margins.  If it fits it sends the fin to the page fit layout strategy.  However, in the page fit layout strategy, it only prints things which fit with margins of .3inch.  If the fin is bigger than this (in either dimension), the while loop ends up in an infinite loop.
