### PR TITLE
fixed ~180 build warnings

### DIFF
--- a/core/src-extra/altimeter/Alt15K.java
+++ b/core/src-extra/altimeter/Alt15K.java
@@ -43,7 +43,7 @@ public class Alt15K {
 	public static String[] getNames() {
 		ArrayList<String> list = new ArrayList<String>();;
 		
-		Enumeration pids = CommPortIdentifier.getPortIdentifiers();
+		Enumeration<?> pids = CommPortIdentifier.getPortIdentifiers();
 
 		while (pids.hasMoreElements()) {
 		    CommPortIdentifier pid = (CommPortIdentifier) pids.nextElement();
@@ -59,7 +59,7 @@ public class Alt15K {
 	public Alt15K(String name) throws IOException {
 		CommPortIdentifier pID = null;
 		
-		Enumeration portIdentifiers = CommPortIdentifier.getPortIdentifiers();
+		Enumeration<?> portIdentifiers = CommPortIdentifier.getPortIdentifiers();
 		while (portIdentifiers.hasMoreElements()) {
 		    CommPortIdentifier pid = (CommPortIdentifier) portIdentifiers.nextElement();
 		    

--- a/core/src-extra/altimeter/RotationLogger.java
+++ b/core/src-extra/altimeter/RotationLogger.java
@@ -37,7 +37,7 @@ public class RotationLogger {
 	public static String[] getNames() {
 		ArrayList<String> list = new ArrayList<String>();;
 		
-		Enumeration pids = CommPortIdentifier.getPortIdentifiers();
+		Enumeration<?> pids = CommPortIdentifier.getPortIdentifiers();
 
 		while (pids.hasMoreElements()) {
 		    CommPortIdentifier pid = (CommPortIdentifier) pids.nextElement();
@@ -53,23 +53,23 @@ public class RotationLogger {
 	
 
 	public RotationLogger(String name) throws IOException {
-		CommPortIdentifier portID = null;
+		CommPortIdentifier myPortID  = null;
 		
-		Enumeration portIdentifiers = CommPortIdentifier.getPortIdentifiers();
+		Enumeration<?> portIdentifiers = CommPortIdentifier.getPortIdentifiers();
 		while (portIdentifiers.hasMoreElements()) {
 		    CommPortIdentifier pid = (CommPortIdentifier) portIdentifiers.nextElement();
 		    
 		    if(pid.getPortType() == CommPortIdentifier.PORT_SERIAL &&
 		       pid.getName().equals(name)) {
-		        portID = pid;
+		        myPortID  = pid;
 		        break;
 		    }
 		}
 		
-		if (portID==null) {
+		if (myPortID == null) {
 			throw new IOException("Port '"+name+"' not found.");
 		}
-		this.portID = portID;
+		this.portID = myPortID ;
 	}
 	
 	

--- a/core/src-extra/altimeter/SerialDownload.java
+++ b/core/src-extra/altimeter/SerialDownload.java
@@ -32,7 +32,7 @@ public class SerialDownload {
 	public static String[] getNames() {
 		ArrayList<String> list = new ArrayList<String>();;
 		
-		Enumeration pids = CommPortIdentifier.getPortIdentifiers();
+		Enumeration<?> pids = CommPortIdentifier.getPortIdentifiers();
 
 		while (pids.hasMoreElements()) {
 		    CommPortIdentifier pid = (CommPortIdentifier) pids.nextElement();
@@ -48,23 +48,23 @@ public class SerialDownload {
 	
 
 	public SerialDownload(String name) throws IOException {
-		CommPortIdentifier portID = null;
+		CommPortIdentifier myPortID  = null;
 		
-		Enumeration portIdentifiers = CommPortIdentifier.getPortIdentifiers();
+		Enumeration<?> portIdentifiers = CommPortIdentifier.getPortIdentifiers();
 		while (portIdentifiers.hasMoreElements()) {
 		    CommPortIdentifier pid = (CommPortIdentifier) portIdentifiers.nextElement();
 		    
 		    if(pid.getPortType() == CommPortIdentifier.PORT_SERIAL &&
 		       pid.getName().equals(name)) {
-		        portID = pid;
+		        myPortID  = pid;
 		        break;
 		    }
 		}
 		
-		if (portID==null) {
+		if (myPortID == null) {
 			throw new IOException("Port '"+name+"' not found.");
 		}
-		this.portID = portID;
+		this.portID = myPortID ;
 	}
 	
 	

--- a/core/src/de/congrace/exp4j/AbstractExpression.java
+++ b/core/src/de/congrace/exp4j/AbstractExpression.java
@@ -17,8 +17,6 @@
 package de.congrace.exp4j;
 
 import java.text.NumberFormat;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Abstract base class for mathematical expressions

--- a/core/src/de/congrace/exp4j/CustomFunction.java
+++ b/core/src/de/congrace/exp4j/CustomFunction.java
@@ -3,7 +3,6 @@ package de.congrace.exp4j;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Stack;
 
 import de.congrace.exp4j.FunctionToken.Function;

--- a/core/src/de/congrace/exp4j/ExpressionBuilder.java
+++ b/core/src/de/congrace/exp4j/ExpressionBuilder.java
@@ -128,8 +128,8 @@ public class ExpressionBuilder {
 	 *            a map of variable names to variable values
 	 * @return the {@link ExpressionBuilder} instance
 	 */
-	public ExpressionBuilder withVariables(VariableSet variables) {
-		this.variables = variables;
+	public ExpressionBuilder withVariables(VariableSet myVariables) {
+		this.variables = myVariables;
 		return this;
 	}
 }

--- a/core/src/de/congrace/exp4j/NumberToken.java
+++ b/core/src/de/congrace/exp4j/NumberToken.java
@@ -16,7 +16,6 @@
  */
 package de.congrace.exp4j;
 
-import java.util.Map;
 import java.util.Stack;
 
 /**

--- a/core/src/net/sf/openrocket/document/OpenRocketDocument.java
+++ b/core/src/net/sf/openrocket/document/OpenRocketDocument.java
@@ -2,7 +2,6 @@ package net.sf.openrocket.document;
 
 import java.io.File;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -19,7 +18,6 @@ import net.sf.openrocket.rocketcomponent.Configuration;
 import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.simulation.FlightDataType;
 import net.sf.openrocket.simulation.customexpression.CustomExpression;
-import net.sf.openrocket.simulation.exception.SimulationListenerException;
 import net.sf.openrocket.simulation.listeners.SimulationListener;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.ArrayList;

--- a/core/src/net/sf/openrocket/document/Simulation.java
+++ b/core/src/net/sf/openrocket/document/Simulation.java
@@ -74,6 +74,7 @@ public class Simulation implements ChangeSource, Cloneable {
 	private final Class<? extends SimulationEngine> simulationEngineClass = BasicEventSimulationEngine.class;
 	private Class<? extends SimulationStepper> simulationStepperClass = RK4SimulationStepper.class;
 	private Class<? extends AerodynamicCalculator> aerodynamicCalculatorClass = BarrowmanCalculator.class;
+	@SuppressWarnings("unused")
 	private Class<? extends MassCalculator> massCalculatorClass = BasicMassCalculator.class;
 
 	/** Listeners for this object */

--- a/core/src/net/sf/openrocket/file/openrocket/importt/OpenRocketLoader.java
+++ b/core/src/net/sf/openrocket/file/openrocket/importt/OpenRocketLoader.java
@@ -744,6 +744,7 @@ class DatatypeHandler extends AbstractElementHandler {
 }
 
 class CustomExpressionHandler extends AbstractElementHandler {
+	@SuppressWarnings("unused")
 	private final DocumentLoadingContext context;
 	private final OpenRocketContentHandler contentHandler;
 	public CustomExpression currentExpression;

--- a/core/src/net/sf/openrocket/file/rocksim/export/BasePartDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/BasePartDTO.java
@@ -107,11 +107,11 @@ public abstract class BasePartDTO {
 
             setDensity(comp.getMaterial().getDensity() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_BULK_DENSITY);
             setDensityType(RocksimDensityType.toCode(comp.getMaterial().getType()));
-            String material = comp.getMaterial().getName();
-            if (material.startsWith(BaseHandler.ROCKSIM_MATERIAL_PREFIX)) {
-                material = material.substring(BaseHandler.ROCKSIM_MATERIAL_PREFIX.length());
+            String compMaterial = comp.getMaterial().getName();
+            if (compMaterial.startsWith(BaseHandler.ROCKSIM_MATERIAL_PREFIX)) {
+                compMaterial = compMaterial.substring(BaseHandler.ROCKSIM_MATERIAL_PREFIX.length());
             }
-            setMaterial(material);
+            setMaterial(compMaterial);
 
             setFinishCode(RocksimFinishCode.toCode(comp.getFinish()));
         }
@@ -121,11 +121,11 @@ public abstract class BasePartDTO {
             setLocationMode(RocksimLocationMode.toCode(comp.getRelativePosition()));
             setDensity(comp.getMaterial().getDensity() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_BULK_DENSITY);
             setDensityType(RocksimDensityType.toCode(comp.getMaterial().getType()));
-            String material = comp.getMaterial().getName();
-            if (material.startsWith(BaseHandler.ROCKSIM_MATERIAL_PREFIX)) {
-                material = material.substring(BaseHandler.ROCKSIM_MATERIAL_PREFIX.length());
+            String compMaterial = comp.getMaterial().getName();
+            if (compMaterial.startsWith(BaseHandler.ROCKSIM_MATERIAL_PREFIX)) {
+                compMaterial = compMaterial.substring(BaseHandler.ROCKSIM_MATERIAL_PREFIX.length());
             }
-            setMaterial(material);
+            setMaterial(compMaterial);
         }
         else if (ec instanceof RecoveryDevice) {
             RecoveryDevice comp = (RecoveryDevice) ec;
@@ -133,11 +133,11 @@ public abstract class BasePartDTO {
             setLocationMode(RocksimLocationMode.toCode(comp.getRelativePosition()));
             setDensity(comp.getMaterial().getDensity() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_SURFACE_DENSITY);
             setDensityType(RocksimDensityType.toCode(comp.getMaterial().getType()));
-            String material = comp.getMaterial().getName();
-            if (material.startsWith(BaseHandler.ROCKSIM_MATERIAL_PREFIX)) {
-                material = material.substring(BaseHandler.ROCKSIM_MATERIAL_PREFIX.length());
+            String compMaterial = comp.getMaterial().getName();
+            if (compMaterial.startsWith(BaseHandler.ROCKSIM_MATERIAL_PREFIX)) {
+                compMaterial = compMaterial.substring(BaseHandler.ROCKSIM_MATERIAL_PREFIX.length());
             }
-            setMaterial(material);
+            setMaterial(compMaterial);
         }
 
         if (ec instanceof RingComponent) {

--- a/core/src/net/sf/openrocket/file/rocksim/importt/BaseHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/BaseHandler.java
@@ -276,7 +276,7 @@ public abstract class BaseHandler<C extends RocketComponent> extends AbstractEle
 	 *
 	 * @return the Method instance, or null
 	 */
-	private static Method getMethod(RocketComponent component, String name, Class[] args) {
+	private static Method getMethod(RocketComponent component, String name, Class<?>[] args) {
 		Method method = null;
 		try {
 			method = component.getClass().getMethod(name, args);

--- a/core/src/net/sf/openrocket/file/rocksim/importt/FinSetHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/FinSetHandler.java
@@ -69,7 +69,8 @@ class FinSetHandler extends AbstractElementHandler {
     /**
      * The length of the mid-chord (aka height).
      */
-    private double midChordLen = 0.0d;
+    @SuppressWarnings("unused")
+	private double midChordLen = 0.0d;
     /**
      * The distance of the leading edge from root to top.
      */
@@ -322,16 +323,16 @@ class FinSetHandler extends AbstractElementHandler {
     /**
      * Convert a Rocksim string that represents fin plan points into an array of OpenRocket coordinates.
      *
-     * @param pointList a comma and pipe delimited string of X,Y coordinates from Rocksim.  This is of the format:
+     * @param myPointList a comma and pipe delimited string of X,Y coordinates from Rocksim.  This is of the format:
      *                  <pre>x0,y0|x1,y1|x2,y2|... </pre>
      * @param warnings  the warning set to convey incompatibilities to the user
      *
      * @return an array of OpenRocket Coordinates
      */
-    private Coordinate[] toCoordinates (String pointList, WarningSet warnings) {
+    private Coordinate[] toCoordinates (String myPointList, WarningSet warnings) {
         List<Coordinate> result = new ArrayList<Coordinate>();
-        if (pointList != null && pointList.length() > 0) {
-            String[] points = pointList.split("\\Q|\\E");
+        if (myPointList != null && myPointList.length() > 0) {
+            String[] points = myPointList.split("\\Q|\\E");
             for (String point : points) {
                 String[] aPoint = point.split(",");
                 try {

--- a/core/src/net/sf/openrocket/file/rocksim/importt/ParachuteHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/ParachuteHandler.java
@@ -87,7 +87,8 @@ class ParachuteHandler extends RecoveryDeviceHandler<Parachute> {
             }
             if (RocksimCommonConstants.SPILL_HOLE_DIA.equals(element)) {
                 //Not supported in OpenRocket
-                double spillHoleRadius = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS;
+                @SuppressWarnings("unused")
+				double spillHoleRadius = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS;
                 warnings.add("Parachute spill holes are not supported. Ignoring.");
             }
             if (RocksimCommonConstants.SHROUD_LINE_MASS_PER_MM.equals(element)) {

--- a/core/src/net/sf/openrocket/gui/adaptors/DoubleModel.java
+++ b/core/src/net/sf/openrocket/gui/adaptors/DoubleModel.java
@@ -263,19 +263,19 @@ public class DoubleModel implements StateChangeListener, ChangeSource, Invalidat
 		
 		private void updateExponentialParameters() {
 			double pos = this.linearPosition;
-			double minValue = this.min.getValue();
-			double midValue = this.mid.getValue();
-			double maxValue = this.max.getValue();
+			double myMinValue = this.min.getValue();
+			double myMidValue = this.mid.getValue();
+			double myMaxValue = this.max.getValue();
 			/*
 			 * quad2..0 are calculated such that
 			 *   f(pos)  = mid      - continuity
 			 *   f(1)    = max      - end point
 			 *   f'(pos) = linear1  - continuity of derivative
 			 */
-			double delta = (midValue - minValue) / pos;
-			quad2 = (maxValue - midValue - delta + delta * pos) / pow2(pos - 1);
-			quad1 = (delta + 2 * (midValue - maxValue) * pos - delta * pos * pos) / pow2(pos - 1);
-			quad0 = (midValue - (2 * midValue + delta) * pos + (maxValue + delta) * pos * pos) / pow2(pos - 1);
+			double delta = (myMidValue - myMinValue) / pos;
+			quad2 = (myMaxValue - myMidValue - delta + delta * pos) / pow2(pos - 1);
+			quad1 = (delta + 2 * (myMidValue - myMaxValue) * pos - delta * pos * pos) / pow2(pos - 1);
+			quad0 = (myMidValue - (2 * myMidValue + delta) * pos + (myMaxValue + delta) * pos * pos) / pow2(pos - 1);
 		}
 		
 		private double pow2(double x) {

--- a/core/src/net/sf/openrocket/gui/adaptors/MaterialModel.java
+++ b/core/src/net/sf/openrocket/gui/adaptors/MaterialModel.java
@@ -142,7 +142,9 @@ public class MaterialModel extends AbstractListModel implements
 		return database.size() + 1;
 	}
 
-
+	public Material.Type getType() {
+		return type;
+	}
 
 	////////  Change listeners
 

--- a/core/src/net/sf/openrocket/gui/components/ColorChooser.java
+++ b/core/src/net/sf/openrocket/gui/components/ColorChooser.java
@@ -74,7 +74,7 @@ public class ColorChooser extends JPanel {
                 Runnable showDialog = new Runnable() {
                     @Override
                     public void run () {
-                        dialog.show();
+                        dialog.setVisible(true);
                     }
                 };
                 SwingUtilities.invokeLater(showDialog);
@@ -88,9 +88,9 @@ public class ColorChooser extends JPanel {
         model.addChangeListener(new ChangeListener() {
             @Override
             public void stateChanged (ChangeEvent evt) {
-                ColorSelectionModel model = (ColorSelectionModel) evt.getSource();
+                ColorSelectionModel myModel = (ColorSelectionModel) evt.getSource();
                 // Get the new color value 
-                curColor = model.getSelectedColor();
+                curColor = myModel.getSelectedColor();
                 field.setBackground(curColor);
             }
         });

--- a/core/src/net/sf/openrocket/gui/components/SimulationExportPanel.java
+++ b/core/src/net/sf/openrocket/gui/components/SimulationExportPanel.java
@@ -287,18 +287,18 @@ public class SimulationExportPanel extends JPanel {
 		}
 		
 		@Override
-		public Component getTableCellRendererComponent(JTable table, Object value,
+		public Component getTableCellRendererComponent(JTable myTable, Object value,
 				boolean isSelected, boolean hasFocus, int row, int column) {
 			
-			Component component = renderer.getTableCellRendererComponent(table,
+			Component component = renderer.getTableCellRendererComponent(myTable,
 					value, isSelected, hasFocus, row, column);
 			
 			if (selected[row]) {
-				component.setBackground(table.getSelectionBackground());
-				component.setForeground(table.getSelectionForeground());
+				component.setBackground(myTable.getSelectionBackground());
+				component.setForeground(myTable.getSelectionForeground());
 			} else {
-				component.setBackground(table.getBackground());
-				component.setForeground(table.getForeground());
+				component.setBackground(myTable.getBackground());
+				component.setForeground(myTable.getForeground());
 			}
 			
 			return component;

--- a/core/src/net/sf/openrocket/gui/components/compass/CompassSelectionButton.java
+++ b/core/src/net/sf/openrocket/gui/components/compass/CompassSelectionButton.java
@@ -41,7 +41,9 @@ public class CompassSelectionButton extends FlatButton implements Resettable {
 	private static int minWidth = -1;
 	
 
+	@SuppressWarnings("hiding")
 	private final DoubleModel model;
+	
 	private final ChangeListener listener;
 	
 	private JPopupMenu popup;

--- a/core/src/net/sf/openrocket/gui/configdialog/BodyTubeConfig.java
+++ b/core/src/net/sf/openrocket/gui/configdialog/BodyTubeConfig.java
@@ -2,18 +2,15 @@ package net.sf.openrocket.gui.configdialog;
 
 
 import javax.swing.JCheckBox;
-import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
 
 import net.miginfocom.swing.MigLayout;
-import net.sf.openrocket.database.ComponentPresetDatabase;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.gui.SpinnerEditor;
 import net.sf.openrocket.gui.adaptors.BooleanModel;
 import net.sf.openrocket.gui.adaptors.DoubleModel;
-import net.sf.openrocket.gui.adaptors.PresetModel;
 import net.sf.openrocket.gui.components.BasicSlider;
 import net.sf.openrocket.gui.components.UnitSelector;
 import net.sf.openrocket.l10n.Translator;

--- a/core/src/net/sf/openrocket/gui/configdialog/NoseConeConfig.java
+++ b/core/src/net/sf/openrocket/gui/configdialog/NoseConeConfig.java
@@ -12,12 +12,10 @@ import javax.swing.JSlider;
 import javax.swing.JSpinner;
 
 import net.miginfocom.swing.MigLayout;
-import net.sf.openrocket.database.ComponentPresetDatabase;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.gui.SpinnerEditor;
 import net.sf.openrocket.gui.adaptors.BooleanModel;
 import net.sf.openrocket.gui.adaptors.DoubleModel;
-import net.sf.openrocket.gui.adaptors.PresetModel;
 import net.sf.openrocket.gui.components.BasicSlider;
 import net.sf.openrocket.gui.components.DescriptionArea;
 import net.sf.openrocket.gui.components.UnitSelector;

--- a/core/src/net/sf/openrocket/gui/configdialog/ShockCordConfig.java
+++ b/core/src/net/sf/openrocket/gui/configdialog/ShockCordConfig.java
@@ -28,9 +28,7 @@ public class ShockCordConfig extends RocketComponentConfig {
 		JPanel panel = new JPanel(new MigLayout("gap rel unrel", "[][65lp::][30lp::]", ""));
 		JLabel label;
 		DoubleModel m;
-		JSpinner spin;
-		String tip;
-		
+		JSpinner spin;	
 
 		//////  Left side
 		

--- a/core/src/net/sf/openrocket/gui/customexpression/CustomExpressionDialog.java
+++ b/core/src/net/sf/openrocket/gui/customexpression/CustomExpressionDialog.java
@@ -2,22 +2,18 @@ package net.sf.openrocket.gui.customexpression;
 
 import java.awt.Window;
 
-import javax.swing.BorderFactory;
 import javax.swing.JDialog;
 import javax.swing.JPanel;
 
 import net.sf.openrocket.document.OpenRocketDocument;
-import net.sf.openrocket.document.Simulation;
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.l10n.Translator;
-import net.sf.openrocket.logging.LogHelper;
-import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.startup.Application;
 
 public class CustomExpressionDialog extends JDialog {
 	private static final Translator trans = Application.getTranslator();
-	private static final LogHelper log = Application.getLogger();
 	
+	@SuppressWarnings("unused")
 	private final Window parentWindow;
 	private final OpenRocketDocument doc;
 	
@@ -27,7 +23,7 @@ public class CustomExpressionDialog extends JDialog {
 		this.doc = doc;
 		this.parentWindow = parent;
 		
-		JPanel panel = new CustomExpressionPanel(doc, this);
+		JPanel panel = new CustomExpressionPanel(this.doc, this);
 		this.add( panel );
 		
 		GUIUtil.setDisposableDialogOptions(this, null);

--- a/core/src/net/sf/openrocket/gui/customexpression/CustomExpressionPanel.java
+++ b/core/src/net/sf/openrocket/gui/customexpression/CustomExpressionPanel.java
@@ -16,7 +16,6 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
-import javax.swing.border.Border;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
 import net.miginfocom.swing.MigLayout;

--- a/core/src/net/sf/openrocket/gui/customexpression/ExpressionBuilderDialog.java
+++ b/core/src/net/sf/openrocket/gui/customexpression/ExpressionBuilderDialog.java
@@ -10,21 +10,17 @@ import java.awt.event.KeyListener;
 
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
-import javax.swing.JCheckBox;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
-import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 
 import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.document.OpenRocketDocument;
-import net.sf.openrocket.document.Simulation;
 import net.sf.openrocket.gui.util.Icons;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.logging.LogHelper;
-import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.simulation.customexpression.CustomExpression;
 import net.sf.openrocket.startup.Application;
 
@@ -45,7 +41,9 @@ public class ExpressionBuilderDialog extends JDialog {
 	private CustomExpression expression;
 	private CustomExpression previousExpressionCopy;
 	
+	@SuppressWarnings("unused")
 	private final Window parentWindow;
+	@SuppressWarnings("unused")
 	private final OpenRocketDocument doc;
 	
 	// Define these check indicators to show if fields are OK
@@ -160,8 +158,8 @@ public class ExpressionBuilderDialog extends JDialog {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				log.debug("Opening insert variable window");
-				Window parentWindow = SwingUtilities.getWindowAncestor(ExpressionBuilderDialog.this);
-				new VariableSelector(parentWindow, ExpressionBuilderDialog.this, doc).setVisible(true);
+				Window myParentWindow = SwingUtilities.getWindowAncestor(ExpressionBuilderDialog.this);
+				new VariableSelector(myParentWindow, ExpressionBuilderDialog.this, doc).setVisible(true);
 			}
 		});
 		
@@ -171,8 +169,8 @@ public class ExpressionBuilderDialog extends JDialog {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				log.debug("Opening insert operator window");
-				Window parentWindow = SwingUtilities.getWindowAncestor(ExpressionBuilderDialog.this);
-				new OperatorSelector(parentWindow, ExpressionBuilderDialog.this).setVisible(true);
+				Window myParentWindow = SwingUtilities.getWindowAncestor(ExpressionBuilderDialog.this);
+				new OperatorSelector(myParentWindow, ExpressionBuilderDialog.this).setVisible(true);
 			}
 		});
 		

--- a/core/src/net/sf/openrocket/gui/customexpression/OperatorSelector.java
+++ b/core/src/net/sf/openrocket/gui/customexpression/OperatorSelector.java
@@ -33,6 +33,7 @@ public class OperatorSelector extends JDialog {
 	private static final Translator trans = Application.getTranslator();
 	private static final LogHelper log = Application.getLogger();
 
+	@SuppressWarnings("unused")
 	private final Window parentWindow;
 	
 	private final JTable table;

--- a/core/src/net/sf/openrocket/gui/customexpression/VariableSelector.java
+++ b/core/src/net/sf/openrocket/gui/customexpression/VariableSelector.java
@@ -4,7 +4,6 @@ import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 
@@ -20,14 +19,10 @@ import javax.swing.JTable;
 import javax.swing.KeyStroke;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
-import javax.swing.table.JTableHeader;
-
 import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.document.OpenRocketDocument;
-import net.sf.openrocket.document.Simulation;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.logging.LogHelper;
-import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.startup.Application;
 
 /**

--- a/core/src/net/sf/openrocket/gui/customexpression/VariableTableModel.java
+++ b/core/src/net/sf/openrocket/gui/customexpression/VariableTableModel.java
@@ -3,22 +3,11 @@
  */
 package net.sf.openrocket.gui.customexpression;
 
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
-import java.util.Vector;
-
-import javax.swing.JTable;
 import javax.swing.table.AbstractTableModel;
-import javax.swing.table.TableColumn;
-import javax.swing.table.TableColumnModel;
-
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.l10n.Translator;
-import net.sf.openrocket.simulation.customexpression.CustomExpression;
 import net.sf.openrocket.simulation.FlightDataType;
 import net.sf.openrocket.startup.Application;
 

--- a/core/src/net/sf/openrocket/gui/dialogs/BugReportDialog.java
+++ b/core/src/net/sf/openrocket/gui/dialogs/BugReportDialog.java
@@ -315,6 +315,7 @@ public class BugReportDialog extends JDialog {
 	 * @param text	the bug report text.
 	 * @return		whether opening the client succeeded.
 	 */
+	@SuppressWarnings("unused")
 	private boolean openEmail(String text) {
 		String version;
 		

--- a/core/src/net/sf/openrocket/gui/dialogs/CustomMaterialDialog.java
+++ b/core/src/net/sf/openrocket/gui/dialogs/CustomMaterialDialog.java
@@ -12,7 +12,6 @@ import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
-import javax.swing.JSpinner.DefaultEditor;
 import javax.swing.JTextField;
 
 import net.miginfocom.swing.MigLayout;

--- a/core/src/net/sf/openrocket/gui/dialogs/preferences/MaterialEditPanel.java
+++ b/core/src/net/sf/openrocket/gui/dialogs/preferences/MaterialEditPanel.java
@@ -364,9 +364,9 @@ public class MaterialEditPanel extends JPanel {
 		 * @see javax.swing.table.DefaultTableCellRenderer#getTableCellRendererComponent(javax.swing.JTable, java.lang.Object, boolean, boolean, int, int)
 		 */
 		@Override
-		public Component getTableCellRendererComponent(JTable table, Object value,
+		public Component getTableCellRendererComponent(JTable myTable, Object value,
 				boolean isSelected, boolean hasFocus, int row, int column) {
-			Component c = super.getTableCellRendererComponent(table, value, isSelected,
+			Component c = super.getTableCellRendererComponent(myTable, value, isSelected,
 					hasFocus, row, column);
 			if (c instanceof JLabel) {
 				JLabel label = (JLabel) c;
@@ -374,12 +374,12 @@ public class MaterialEditPanel extends JPanel {
 				
 				if (isSelected) {
 					if (m.isUserDefined())
-						label.setForeground(table.getSelectionForeground());
+						label.setForeground(myTable.getSelectionForeground());
 					else
 						label.setForeground(Color.GRAY);
 				} else {
 					if (m.isUserDefined())
-						label.setForeground(table.getForeground());
+						label.setForeground(myTable.getForeground());
 					else
 						label.setForeground(Color.GRAY);
 				}

--- a/core/src/net/sf/openrocket/gui/dialogs/preferences/PreferencesDialog.java
+++ b/core/src/net/sf/openrocket/gui/dialogs/preferences/PreferencesDialog.java
@@ -618,7 +618,7 @@ public class PreferencesDialog extends JDialog {
 
 
 		// Progress dialog
-		final JDialog dialog = new JDialog(this, ModalityType.APPLICATION_MODAL);
+		final JDialog dialog1 = new JDialog(this, ModalityType.APPLICATION_MODAL);
 		JPanel panel = new JPanel(new MigLayout());
 
 		//// Checking for updates...
@@ -633,13 +633,13 @@ public class PreferencesDialog extends JDialog {
 		cancel.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				dialog.dispose();
+				dialog1.dispose();
 			}
 		});
 		panel.add(cancel, "right");
-		dialog.add(panel);
+		dialog1.add(panel);
 
-		GUIUtil.setDisposableDialogOptions(dialog, cancel);
+		GUIUtil.setDisposableDialogOptions(dialog1, cancel);
 
 
 		// Timer to monitor progress
@@ -651,7 +651,7 @@ public class PreferencesDialog extends JDialog {
 			public void actionPerformed(ActionEvent e) {
 				if (!retriever.isRunning() || startTime + 10000 < System.currentTimeMillis()) {
 					timer.stop();
-					dialog.dispose();
+					dialog1.dispose();
 				}
 			}
 		};
@@ -660,7 +660,7 @@ public class PreferencesDialog extends JDialog {
 
 
 		// Wait for action
-		dialog.setVisible(true);
+		dialog1.setVisible(true);
 
 
 		// Check result

--- a/core/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetTable.java
+++ b/core/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetTable.java
@@ -168,8 +168,8 @@ public class ComponentPresetTable extends JTable {
 		sorter.setRowFilter( filter );
 	}
 
-	public void updateData( List<ComponentPreset> presets ) {
-		this.presets = presets;
+	public void updateData( List<ComponentPreset> myPresets ) {
+		this.presets = myPresets;
 		this.favorites = Application.getPreferences().getComponentFavorites(presetType);
 		this.tableModel.fireTableDataChanged();
 	}

--- a/core/src/net/sf/openrocket/gui/figureelements/RocketInfo.java
+++ b/core/src/net/sf/openrocket/gui/figureelements/RocketInfo.java
@@ -69,15 +69,15 @@ public class RocketInfo implements FigureElement {
 	
 	
 	@Override
-	public void paint(Graphics2D g2, double scale) {
+	public void paint(Graphics2D myG2, double scale) {
 		throw new UnsupportedOperationException("paint() must be called with coordinates");
 	}
 
 	@Override
-	public void paint(Graphics2D g2, double scale, Rectangle visible) {
-		this.g2 = g2;
+	public void paint(Graphics2D myG2, double scale, Rectangle visible) {
+		this.g2 = myG2;
 		this.line = FONT.getLineMetrics("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
-				g2.getFontRenderContext()).getHeight();
+				myG2.getFontRenderContext()).getHeight();
 		
 		x1 = visible.x + MARGIN;
 		x2 = visible.x + visible.width - MARGIN;

--- a/core/src/net/sf/openrocket/gui/help/tours/SlideShowComponent.java
+++ b/core/src/net/sf/openrocket/gui/help/tours/SlideShowComponent.java
@@ -19,6 +19,7 @@ import net.sf.openrocket.gui.components.ImageDisplayComponent;
  */
 public class SlideShowComponent extends JSplitPane {
 	
+	@SuppressWarnings("hiding")
 	private final int WIDTH = 600;
 	private final int HEIGHT_IMAGE = 400;
 	private final int HEIGHT_TEXT = 100;

--- a/core/src/net/sf/openrocket/gui/main/ComponentAddButtons.java
+++ b/core/src/net/sf/openrocket/gui/main/ComponentAddButtons.java
@@ -190,9 +190,9 @@ public class ComponentAddButtons extends JPanel implements Scrollable {
 				
 				@Override
 				public void stateChanged(ChangeEvent e) {
-					Dimension d = ComponentAddButtons.this.viewport.getExtentSize();
-					if (d.width != oldWidth) {
-						oldWidth = d.width;
+					Dimension d1 = ComponentAddButtons.this.viewport.getExtentSize();
+					if (d1.width != oldWidth) {
+						oldWidth = d1.width;
 						flowButtons();
 					}
 				}

--- a/core/src/net/sf/openrocket/gui/main/SimulationEditDialog.java
+++ b/core/src/net/sf/openrocket/gui/main/SimulationEditDialog.java
@@ -855,6 +855,7 @@ public class SimulationEditDialog extends JDialog {
 	}
 	
 	
+	@SuppressWarnings("unused")
 	private void performPlot(PlotConfiguration config) {
 		
 		// Fill the auto-selections

--- a/core/src/net/sf/openrocket/gui/main/SimulationRunDialog.java
+++ b/core/src/net/sf/openrocket/gui/main/SimulationRunDialog.java
@@ -98,6 +98,7 @@ public class SimulationRunDialog extends JDialog {
 	 * will result in an exception being thrown!
 	 */
 	private final Simulation[] simulations;
+	@SuppressWarnings("unused")
 	private final OpenRocketDocument document;
 	private final String[] simulationNames;
 	private final SimulationWorker[] simulationWorkers;

--- a/core/src/net/sf/openrocket/gui/plot/PlotConfiguration.java
+++ b/core/src/net/sf/openrocket/gui/plot/PlotConfiguration.java
@@ -588,6 +588,7 @@ public class PlotConfiguration implements Cloneable {
 	
 	
 
+	@SuppressWarnings("unused")
 	private double roundScaleUp(double scale) {
 		double mul = 1;
 		while (scale >= 10) {
@@ -614,6 +615,7 @@ public class PlotConfiguration implements Cloneable {
 	}
 	
 	
+	@SuppressWarnings("unused")
 	private double roundScaleDown(double scale) {
 		double mul = 1;
 		while (scale >= 10) {

--- a/core/src/net/sf/openrocket/gui/plot/SimulationPlotPanel.java
+++ b/core/src/net/sf/openrocket/gui/plot/SimulationPlotPanel.java
@@ -399,9 +399,9 @@ public class SimulationPlotPanel extends JPanel {
 				public void itemStateChanged(ItemEvent e) {
 					if (modifying > 0)
 						return;
-					FlightDataType type = (FlightDataType) typeSelector.getSelectedItem();
-					configuration.setPlotDataType(index, type);
-					unitSelector.setUnitGroup(type.getUnitGroup());
+					FlightDataType selectedType = (FlightDataType) typeSelector.getSelectedItem();
+					configuration.setPlotDataType(index, selectedType);
+					unitSelector.setUnitGroup(selectedType.getUnitGroup());
 					unitSelector.setSelectedUnit(configuration.getUnit(index));
 					setToCustom();
 				}
@@ -418,8 +418,8 @@ public class SimulationPlotPanel extends JPanel {
 				public void itemStateChanged(ItemEvent e) {
 					if (modifying > 0)
 						return;
-					Unit unit = unitSelector.getSelectedUnit();
-					configuration.setPlotDataUnit(index, unit);
+					Unit selectedUnit = unitSelector.getSelectedUnit();
+					configuration.setPlotDataUnit(index, selectedUnit);
 				}
 			});
 			this.add(unitSelector, "width 40lp, gapright para");

--- a/core/src/net/sf/openrocket/gui/preset/ButtonColumn.java
+++ b/core/src/net/sf/openrocket/gui/preset/ButtonColumn.java
@@ -114,7 +114,7 @@ public class ButtonColumn extends AbstractCellEditor
 
 	@Override
 	public Component getTableCellEditorComponent(
-		JTable table, Object value, boolean isSelected, int row, int column)
+		JTable myTable, Object value, boolean isSelected, int row, int column)
 	{
 		if (value == null)
 		{
@@ -147,16 +147,16 @@ public class ButtonColumn extends AbstractCellEditor
 //
 	@Override
 	public Component getTableCellRendererComponent(
-		JTable table, Object value, boolean isSelected, boolean hasFocus, int row, int column)
+		JTable myTable, Object value, boolean isSelected, boolean hasFocus, int row, int column)
 	{
 		if (isSelected)
 		{
-			renderButton.setForeground(table.getSelectionForeground());
-	 		renderButton.setBackground(table.getSelectionBackground());
+			renderButton.setForeground(myTable.getSelectionForeground());
+	 		renderButton.setBackground(myTable.getSelectionBackground());
 		}
 		else
 		{
-			renderButton.setForeground(table.getForeground());
+			renderButton.setForeground(myTable.getForeground());
 			renderButton.setBackground(UIManager.getColor("Button.background"));
 		}
 

--- a/core/src/net/sf/openrocket/gui/preset/ComponentPresetEditor.java
+++ b/core/src/net/sf/openrocket/gui/preset/ComponentPresetEditor.java
@@ -230,22 +230,22 @@ public class ComponentPresetEditor extends JPanel implements PresetResultListene
     @Override
     public void notifyResult(final ComponentPreset preset) {
         if (preset != null) {
-            DataTableModel model = (DataTableModel) table.getModel();
+            DataTableModel myModel = (DataTableModel) table.getModel();
             //Is this a new preset?
             String description = preset.has(ComponentPreset.DESCRIPTION) ? preset.get(ComponentPreset.DESCRIPTION) :
                     preset.getPartNo();
             if (!editContext.isEditingSelected() || table.getSelectedRow() == -1) {
-                model.addRow(new Object[]{preset.getManufacturer().getDisplayName(), preset.getType().name(),
+                myModel.addRow(new Object[]{preset.getManufacturer().getDisplayName(), preset.getType().name(),
                         preset.getPartNo(), description, Icons.EDIT_DELETE}, preset);
             }
             else {
                 //This is a modified preset; update all of the columns and the stored associated instance.
                 int row = table.getSelectedRow();
-                model.setValueAt(preset.getManufacturer().getDisplayName(), row, 0);
-                model.setValueAt(preset.getType().name(), row, 1);
-                model.setValueAt(preset.getPartNo(), row, 2);
-                model.setValueAt(description, row, 3);
-                model.associated.set(row, preset);
+                myModel.setValueAt(preset.getManufacturer().getDisplayName(), row, 0);
+                myModel.setValueAt(preset.getType().name(), row, 1);
+                myModel.setValueAt(preset.getPartNo(), row, 2);
+                myModel.setValueAt(description, row, 3);
+                myModel.associated.set(row, preset);
             }
         }
         editContext.setEditingSelected(false);

--- a/core/src/net/sf/openrocket/gui/preset/DeselectableComboBox.java
+++ b/core/src/net/sf/openrocket/gui/preset/DeselectableComboBox.java
@@ -16,7 +16,7 @@ public class DeselectableComboBox extends JComboBox {
         super.setRenderer(new DeselectedtemsRenderer());
     }
 
-    private Set disabled_items = new HashSet();
+    private Set<Integer> disabled_items = new HashSet<Integer>();
 
     public void addItem(Object anObject, boolean disabled) {
         super.addItem(anObject);
@@ -28,7 +28,7 @@ public class DeselectableComboBox extends JComboBox {
     @Override
     public void removeAllItems() {
         super.removeAllItems();
-        disabled_items = new HashSet();
+        disabled_items = new HashSet<Integer>();
     }
 
     @Override

--- a/core/src/net/sf/openrocket/gui/preset/MaterialModel.java
+++ b/core/src/net/sf/openrocket/gui/preset/MaterialModel.java
@@ -6,7 +6,6 @@ import net.sf.openrocket.database.Databases;
 import net.sf.openrocket.gui.dialogs.CustomMaterialDialog;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.material.Material;
-import net.sf.openrocket.preset.loader.MaterialHolder;
 import net.sf.openrocket.startup.Application;
 
 import javax.swing.DefaultComboBoxModel;

--- a/core/src/net/sf/openrocket/gui/preset/PresetEditorDialog.java
+++ b/core/src/net/sf/openrocket/gui/preset/PresetEditorDialog.java
@@ -1208,11 +1208,11 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 	 *
 	 * @param preset the preset to edit
 	 */
-	private void fillEditor(ComponentPreset preset, MaterialHolder holder) {
+	private void fillEditor(ComponentPreset preset, MaterialHolder matHolder) {
 		ComponentPreset.Type t = preset.getType();
 		
 		mfgTextField.setText(preset.get(ComponentPreset.MANUFACTURER).getDisplayName());
-		setMaterial(materialChooser, preset, holder, Material.Type.BULK, ComponentPreset.MATERIAL);
+		setMaterial(materialChooser, preset, matHolder, Material.Type.BULK, ComponentPreset.MATERIAL);
 		switch (t) {
 		case BODY_TUBE:
 			typeCombo.setSelectedItem(trans.get(BODY_TUBE_KEY));
@@ -1444,7 +1444,7 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 			}
 			break;
 		case PARACHUTE:
-			setMaterial(materialChooser, preset, holder, Material.Type.SURFACE, ComponentPreset.MATERIAL);
+			setMaterial(materialChooser, preset, matHolder, Material.Type.SURFACE, ComponentPreset.MATERIAL);
 			typeCombo.setSelectedItem(trans.get(PARACHUTE_KEY));
 			pcDescTextField.setText(preset.get(ComponentPreset.DESCRIPTION));
 			if (preset.has(ComponentPreset.LINE_COUNT)) {
@@ -1470,13 +1470,13 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 				pcImage = new ImageIcon(byteArrayToImage(preset.get(ComponentPreset.IMAGE)));
 				pcImageBtn.setIcon(pcImage);
 			}
-			setMaterial(pcLineMaterialChooser, preset, holder, Material.Type.LINE, ComponentPreset.LINE_MATERIAL);
+			setMaterial(pcLineMaterialChooser, preset, matHolder, Material.Type.LINE, ComponentPreset.LINE_MATERIAL);
 			//                pcLineMaterialChooser.setModel(new MaterialModel(PresetEditorDialog.this, Material.Type.LINE));
 			
 			//                pcLineMaterialChooser.getModel().setSelectedItem(preset.get(ComponentPreset.LINE_MATERIAL));
 			break;
 		case STREAMER:
-			setMaterial(materialChooser, preset, holder, Material.Type.SURFACE, ComponentPreset.MATERIAL);
+			setMaterial(materialChooser, preset, matHolder, Material.Type.SURFACE, ComponentPreset.MATERIAL);
 			typeCombo.setSelectedItem(trans.get(STREAMER_KEY));
 			stDescTextField.setText(preset.get(ComponentPreset.DESCRIPTION));
 			if (preset.has(ComponentPreset.LENGTH)) {
@@ -1506,7 +1506,7 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 	}
 	
 	private void setMaterial(final JComboBox chooser, final ComponentPreset preset, final MaterialHolder holder,
-			final Material.Type theType, final TypedKey key) {
+			final Material.Type theType, final TypedKey<Material> key) {
 		if (holder == null) {
 			chooser.setModel(new MaterialModel(PresetEditorDialog.this, theType));
 		}

--- a/core/src/net/sf/openrocket/gui/print/PrintableTransition.java
+++ b/core/src/net/sf/openrocket/gui/print/PrintableTransition.java
@@ -177,13 +177,13 @@ public class PrintableTransition extends AbstractPrintable<Transition> {
 	 * @param x     the center of the circle's x coordinate
 	 * @param y     the center of the circle's y
 	 * @param line  the line to draw
-	 * @param theta the angle
+	 * @param myTheta the angle
 	 */
-	private void drawAlignmentMarks(Graphics2D g2, int x, int y, Line2D.Float line, float theta) {
+	private void drawAlignmentMarks(Graphics2D g2, int x, int y, Line2D.Float line, float myTheta) {
 		g2.translate(x, y);
-		g2.rotate(Math.toRadians(-theta));
+		g2.rotate(Math.toRadians(-myTheta));
 		g2.draw(line);
-		g2.rotate(Math.toRadians(theta));
+		g2.rotate(Math.toRadians(myTheta));
 		g2.translate(-x, -y);
 	}
 

--- a/core/src/net/sf/openrocket/gui/print/visitor/CenteringRingStrategy.java
+++ b/core/src/net/sf/openrocket/gui/print/visitor/CenteringRingStrategy.java
@@ -148,7 +148,7 @@ public class CenteringRingStrategy {
      */
     private void render(final CenteringRing component) {
         try {
-            AbstractPrintable pfs;
+            AbstractPrintable<CenteringRing> pfs;
             pfs = PrintableCenteringRing.create(component, findMotorMount(component));
 
             java.awt.Dimension size = pfs.getSize();

--- a/core/src/net/sf/openrocket/gui/print/visitor/PageFitPrintStrategy.java
+++ b/core/src/net/sf/openrocket/gui/print/visitor/PageFitPrintStrategy.java
@@ -8,10 +8,7 @@ import com.itextpdf.text.pdf.PdfContentByte;
 import com.itextpdf.text.pdf.PdfWriter;
 import net.sf.openrocket.gui.print.PrintUnit;
 import net.sf.openrocket.gui.print.PrintableComponent;
-import net.sf.openrocket.logging.LogHelper;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
-import net.sf.openrocket.startup.Application;
-
 import java.awt.Graphics2D;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -24,11 +21,6 @@ import java.util.Set;
  * @author Jason Blood <dyster2000@gmail.com>
  */
 public class PageFitPrintStrategy {
-
-    /**
-     * The logger.
-     */
-    private static final LogHelper log = Application.getLogger();
 
     /**
      * The iText document.

--- a/core/src/net/sf/openrocket/gui/print/visitor/PartsDetailVisitorStrategy.java
+++ b/core/src/net/sf/openrocket/gui/print/visitor/PartsDetailVisitorStrategy.java
@@ -42,7 +42,6 @@ import com.itextpdf.text.Chunk;
 import com.itextpdf.text.Document;
 import com.itextpdf.text.DocumentException;
 import com.itextpdf.text.Element;
-import com.itextpdf.text.Font;
 import com.itextpdf.text.Image;
 import com.itextpdf.text.Paragraph;
 import com.itextpdf.text.Phrase;

--- a/core/src/net/sf/openrocket/gui/print/visitor/TransitionStrategy.java
+++ b/core/src/net/sf/openrocket/gui/print/visitor/TransitionStrategy.java
@@ -113,7 +113,7 @@ public class TransitionStrategy {
      */
     private boolean render(final Transition component) {
         try {
-            AbstractPrintable pfs;
+            AbstractPrintable<?> pfs;
             if (component instanceof NoseCone) {
                 pfs = new PrintableNoseCone((NoseCone) component);
             }

--- a/core/src/net/sf/openrocket/gui/util/SaveCSVWorker.java
+++ b/core/src/net/sf/openrocket/gui/util/SaveCSVWorker.java
@@ -59,6 +59,7 @@ public class SaveCSVWorker extends SwingWorker<Void, Void> {
 		estimate = Math.max(estimate, 1000);
 		
 		// Create the ProgressOutputStream that provides progress estimates
+		@SuppressWarnings("resource")
 		ProgressOutputStream os = new ProgressOutputStream(
 				new BufferedOutputStream(new FileOutputStream(file)), 
 				estimate, this) {

--- a/core/src/net/sf/openrocket/gui/util/SaveFileWorker.java
+++ b/core/src/net/sf/openrocket/gui/util/SaveFileWorker.java
@@ -30,6 +30,7 @@ public class SaveFileWorker extends SwingWorker<Void, Void> {
 				document.getDefaultStorageOptions());
 		
 		// Create the ProgressOutputStream that provides progress estimates
+		@SuppressWarnings("resource")
 		ProgressOutputStream os = new ProgressOutputStream(
 				new BufferedOutputStream(new FileOutputStream(file)), 
 				estimate, this) {

--- a/core/src/net/sf/openrocket/masscalc/BasicMassCalculator.java
+++ b/core/src/net/sf/openrocket/masscalc/BasicMassCalculator.java
@@ -2,10 +2,8 @@ package net.sf.openrocket.masscalc;
 
 import static net.sf.openrocket.util.MathUtil.pow2;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 
 import net.sf.openrocket.motor.Motor;

--- a/core/src/net/sf/openrocket/plugin/JIJ.java
+++ b/core/src/net/sf/openrocket/plugin/JIJ.java
@@ -16,7 +16,7 @@ public class JIJ {
 		for (int i = 0; i < cps.length; i++) {
 			urls[i] = new File(cps[i]).toURI().toURL();
 		}
-		urls[cps.length] = new File("/home/sampo/Projects/OpenRocket/core/example.jar").toURL();
+		urls[cps.length] = new File("/home/sampo/Projects/OpenRocket/core/example.jar").toURI().toURL();
 		
 		System.out.println("Classpath: " + Arrays.toString(urls));
 		

--- a/core/src/net/sf/openrocket/plugin/Test.java
+++ b/core/src/net/sf/openrocket/plugin/Test.java
@@ -36,7 +36,7 @@ public class Test {
 		//		}
 		
 		List<File> jars = Arrays.asList(new File("/home/sampo/Projects/OpenRocket/core/example.jar"));
-		URL[] urls = { new File("/home/sampo/Projects/OpenRocket/core/example.jar").toURL() };
+		URL[] urls = { new File("/home/sampo/Projects/OpenRocket/core/example.jar").toURI().toURL() };
 		ClassLoader classLoader = new URLClassLoader(urls);
 		
 		classLoader = Test.class.getClassLoader();

--- a/core/src/net/sf/openrocket/preset/TypedKey.java
+++ b/core/src/net/sf/openrocket/preset/TypedKey.java
@@ -52,7 +52,7 @@ public class TypedKey<T> {
 			return false;
 		if (getClass() != obj.getClass())
 			return false;
-		TypedKey other = (TypedKey) obj;
+		TypedKey<?> other = (TypedKey<?>) obj;
 		if (name == null) {
 			if (other.name != null)
 				return false;

--- a/core/src/net/sf/openrocket/preset/loader/RocksimComponentFileLoader.java
+++ b/core/src/net/sf/openrocket/preset/loader/RocksimComponentFileLoader.java
@@ -93,6 +93,7 @@ public abstract class RocksimComponentFileLoader {
 	 *         component data file; the element in the list itself is an array of String, where each item in the array
 	 *         is a column (cell) in the row.  The string array is in sequential order as it appeared in the file.
 	 */
+	@SuppressWarnings("unused")
 	private void load(File file) throws FileNotFoundException {
 		load(new FileInputStream(file));
 	}

--- a/core/src/net/sf/openrocket/preset/xml/ParachuteDTO.java
+++ b/core/src/net/sf/openrocket/preset/xml/ParachuteDTO.java
@@ -6,8 +6,6 @@ import net.sf.openrocket.preset.ComponentPreset;
 import net.sf.openrocket.preset.ComponentPresetFactory;
 import net.sf.openrocket.preset.InvalidComponentPresetException;
 import net.sf.openrocket.preset.TypedPropertyMap;
-import net.sf.openrocket.preset.xml.BaseComponentDTO.AnnotatedMaterialDTO;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -1,7 +1,6 @@
 package net.sf.openrocket.rocketcomponent;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 

--- a/core/src/net/sf/openrocket/rocketcomponent/TrapezoidFinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/TrapezoidFinSet.java
@@ -131,10 +131,10 @@ public class TrapezoidFinSet extends FinSet {
 			r = MAX_SWEEP_ANGLE;
 		if (r < -MAX_SWEEP_ANGLE)
 			r = -MAX_SWEEP_ANGLE;
-		double sweep = Math.tan(r) * height;
-		if (Double.isNaN(sweep) || Double.isInfinite(sweep))
+		double mySweep = Math.tan(r) * height;
+		if (Double.isNaN(mySweep) || Double.isInfinite(mySweep))
 			return;
-		setSweep(sweep);
+		setSweep(mySweep);
 	}
 	
 	public double getHeight() {

--- a/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
+++ b/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
@@ -390,6 +390,7 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 			case IGNITION: {
 				// Ignite the motor
 				MotorMount mount = (MotorMount) event.getSource();
+				@SuppressWarnings("unused")
 				RocketComponent component = (RocketComponent) mount;
 				MotorId motorId = (MotorId) event.getData();
 				MotorInstanceConfiguration config = status.getMotorConfiguration();

--- a/core/src/net/sf/openrocket/simulation/FlightData.java
+++ b/core/src/net/sf/openrocket/simulation/FlightData.java
@@ -226,7 +226,7 @@ public class FlightData {
 		
 
 		// Launch rod velocity
-		eventloop: for (FlightEvent event : branch.getEvents()) {
+		for (FlightEvent event : branch.getEvents()) {
 			if (event.getType() == FlightEvent.Type.LAUNCHROD) {
 				double t = event.getTime();
 				List<Double> velocity = branch.get(FlightDataType.TYPE_VELOCITY_TOTAL);

--- a/core/src/net/sf/openrocket/simulation/SimulationOptions.java
+++ b/core/src/net/sf/openrocket/simulation/SimulationOptions.java
@@ -5,10 +5,8 @@ import java.util.EventListener;
 import java.util.EventObject;
 import java.util.List;
 import java.util.Random;
-import java.util.Set;
 
 import net.sf.openrocket.aerodynamics.BarrowmanCalculator;
-import net.sf.openrocket.logging.LogHelper;
 import net.sf.openrocket.masscalc.BasicMassCalculator;
 import net.sf.openrocket.models.atmosphere.AtmosphericModel;
 import net.sf.openrocket.models.atmosphere.ExtendedISAModel;
@@ -16,7 +14,6 @@ import net.sf.openrocket.models.gravity.GravityModel;
 import net.sf.openrocket.models.gravity.WGSGravityModel;
 import net.sf.openrocket.models.wind.PinkNoiseWindModel;
 import net.sf.openrocket.rocketcomponent.Rocket;
-import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.BugException;
 import net.sf.openrocket.util.ChangeSource;
 import net.sf.openrocket.util.GeodeticComputationStrategy;
@@ -33,8 +30,6 @@ import net.sf.openrocket.util.WorldCoordinate;
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
 public class SimulationOptions implements ChangeSource, Cloneable {
-	
-	private static final LogHelper log = Application.getLogger();
 	
 	public static final double MAX_LAUNCH_ROD_ANGLE = Math.PI / 3;
 	

--- a/core/src/net/sf/openrocket/simulation/customexpression/CustomExpressionSimulationListener.java
+++ b/core/src/net/sf/openrocket/simulation/customexpression/CustomExpressionSimulationListener.java
@@ -1,18 +1,14 @@
 package net.sf.openrocket.simulation.customexpression;
 
-import java.util.ArrayList;
 import java.util.List;
 
-import net.sf.openrocket.logging.LogHelper;
 import net.sf.openrocket.simulation.FlightDataBranch;
 import net.sf.openrocket.simulation.SimulationStatus;
 import net.sf.openrocket.simulation.exception.SimulationException;
 import net.sf.openrocket.simulation.listeners.AbstractSimulationListener;
-import net.sf.openrocket.startup.Application;
 
 public class CustomExpressionSimulationListener extends	AbstractSimulationListener {
 
-	private static final LogHelper log = Application.getLogger();
 	private final List<CustomExpression> expressions;
 	
 	public CustomExpressionSimulationListener(List<CustomExpression> expressions) {

--- a/core/src/net/sf/openrocket/simulation/customexpression/IndexExpression.java
+++ b/core/src/net/sf/openrocket/simulation/customexpression/IndexExpression.java
@@ -36,9 +36,9 @@ public class IndexExpression extends CustomExpression {
 		// From the given datatype, get the time and function values and make an interpolator
 
 		//Note: must get in a way that flight data system will figure out units. Otherwise there will be a type conflict when we get the new data.
-		FlightDataType type = FlightDataType.getType(null, getSymbol(), null);  
+		FlightDataType myType = FlightDataType.getType(null, getSymbol(), null);  
 				
-		List<Double> data = status.getFlightData().get(type);
+		List<Double> data = status.getFlightData().get(myType);
 		List<Double> time = status.getFlightData().get(FlightDataType.TYPE_TIME);
 		LinearInterpolator interp = new LinearInterpolator(time, data); 
 		

--- a/core/src/net/sf/openrocket/simulation/listeners/AbstractSimulationListener.java
+++ b/core/src/net/sf/openrocket/simulation/listeners/AbstractSimulationListener.java
@@ -1,7 +1,5 @@
 package net.sf.openrocket.simulation.listeners;
 
-import java.util.List;
-
 import net.sf.openrocket.aerodynamics.AerodynamicForces;
 import net.sf.openrocket.aerodynamics.FlightConditions;
 import net.sf.openrocket.models.atmosphere.AtmosphericConditions;

--- a/core/src/net/sf/openrocket/simulation/listeners/SimulationComputationListener.java
+++ b/core/src/net/sf/openrocket/simulation/listeners/SimulationComputationListener.java
@@ -1,7 +1,5 @@
 package net.sf.openrocket.simulation.listeners;
 
-import java.util.List;
-
 import net.sf.openrocket.aerodynamics.AerodynamicForces;
 import net.sf.openrocket.aerodynamics.FlightConditions;
 import net.sf.openrocket.models.atmosphere.AtmosphericConditions;

--- a/core/src/net/sf/openrocket/simulation/listeners/SimulationEventListener.java
+++ b/core/src/net/sf/openrocket/simulation/listeners/SimulationEventListener.java
@@ -1,7 +1,5 @@
 package net.sf.openrocket.simulation.listeners;
 
-import java.util.List;
-
 import net.sf.openrocket.motor.MotorId;
 import net.sf.openrocket.motor.MotorInstance;
 import net.sf.openrocket.rocketcomponent.MotorMount;

--- a/core/src/net/sf/openrocket/simulation/listeners/SimulationListener.java
+++ b/core/src/net/sf/openrocket/simulation/listeners/SimulationListener.java
@@ -1,7 +1,5 @@
 package net.sf.openrocket.simulation.listeners;
 
-import java.util.List;
-
 import net.sf.openrocket.simulation.FlightDataType;
 import net.sf.openrocket.simulation.SimulationStatus;
 import net.sf.openrocket.simulation.exception.SimulationException;

--- a/core/src/net/sf/openrocket/simulation/listeners/example/DampingMoment.java
+++ b/core/src/net/sf/openrocket/simulation/listeners/example/DampingMoment.java
@@ -7,9 +7,7 @@ import net.sf.openrocket.aerodynamics.AerodynamicCalculator;
 import net.sf.openrocket.aerodynamics.AerodynamicForces;
 import net.sf.openrocket.aerodynamics.FlightConditions;
 import net.sf.openrocket.motor.MotorId;
-import net.sf.openrocket.motor.MotorInstance;
 import net.sf.openrocket.motor.MotorInstanceConfiguration;
-import net.sf.openrocket.rocketcomponent.MotorMount;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.simulation.FlightDataBranch;
 import net.sf.openrocket.simulation.FlightDataType;
@@ -17,9 +15,7 @@ import net.sf.openrocket.simulation.SimulationStatus;
 import net.sf.openrocket.simulation.exception.SimulationException;
 import net.sf.openrocket.simulation.listeners.AbstractSimulationListener;
 import net.sf.openrocket.unit.UnitGroup;
-import net.sf.openrocket.util.ArrayList;
 import net.sf.openrocket.util.Coordinate;
-import net.sf.openrocket.util.PolyInterpolator;
 
 public class DampingMoment extends AbstractSimulationListener {
 	

--- a/core/src/net/sf/openrocket/unit/GeneralUnit.java
+++ b/core/src/net/sf/openrocket/unit/GeneralUnit.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 
 public class GeneralUnit extends Unit {
 
+	@SuppressWarnings("unused")
 	private final int significantNumbers;
 	private final int decimalRounding;
 	
@@ -57,15 +58,14 @@ public class GeneralUnit extends Unit {
 		}
 	}
 
-	
-	
-
 	// TODO: LOW: untested
 	// start, end and scale in this units
 //	@Override
 	public ArrayList<Tick> getTicks(double start, double end, double scale) {
 		ArrayList<Tick> ticks = new ArrayList<Tick>();
+		@SuppressWarnings("unused")
 		double delta;
+		@SuppressWarnings("unused")
 		int normal, major;
 
 		// TODO: LOW: more fine-grained (e.g.  0||||5||||10||||15||||20)
@@ -88,9 +88,8 @@ public class GeneralUnit extends Unit {
 			major = 100;   // TODO: LOW: More fine-grained with 5
 		}
 		
-		double v = Math.ceil(start/delta)*delta;
-		int n = (int)Math.round(v/delta);
-		
+//		double v = Math.ceil(start/delta)*delta;
+//		int n = (int)Math.round(v/delta);		
 //		while (v <= end) {
 //			if (n%major == 0)
 //				ticks.add(new Tick(v,Tick.MAJOR));

--- a/core/src/net/sf/openrocket/util/ArrayUtils.java
+++ b/core/src/net/sf/openrocket/util/ArrayUtils.java
@@ -165,6 +165,7 @@ public class ArrayUtils {
 			throw new IllegalArgumentException();
 		}
 		
+		@SuppressWarnings("unchecked")
 		T[] result = (T[]) Array.newInstance( original.getClass().getComponentType(), end-start );
 		
 		int index = 0;

--- a/core/src/net/sf/openrocket/util/Coordinate.java
+++ b/core/src/net/sf/openrocket/util/Coordinate.java
@@ -141,12 +141,12 @@ public final class Coordinate implements Cloneable, Serializable {
 				this.weight + other.weight);
 	}
 	
-	public Coordinate add(double x, double y, double z) {
-		return new Coordinate(this.x + x, this.y + y, this.z + z, this.weight);
+	public Coordinate add(double x1, double y1, double z1) {
+		return new Coordinate(this.x + x1, this.y + y1, this.z + z1, this.weight);
 	}
 	
-	public Coordinate add(double x, double y, double z, double weight) {
-		return new Coordinate(this.x + x, this.y + y, this.z + z, this.weight + weight);
+	public Coordinate add(double x1, double y1, double z1, double w1) {
+		return new Coordinate(this.x + x1, this.y + y1, this.z + z1, this.weight + w1);
 	}
 	
 	/**
@@ -164,13 +164,13 @@ public final class Coordinate implements Cloneable, Serializable {
 	 * Subtract the specified values from this Coordinate.  The weight of the result
 	 * is the same as the weight of this Coordinate.
 	 * 
-	 * @param x   	x value to subtract
-	 * @param y		y value to subtract
-	 * @param z		z value to subtract
+	 * @param x1   	x value to subtract
+	 * @param y1	y value to subtract
+	 * @param z1	z value to subtract
 	 * @return		the result.
 	 */
-	public Coordinate sub(double x, double y, double z) {
-		return new Coordinate(this.x - x, this.y - y, this.z - z, this.weight);
+	public Coordinate sub(double x1, double y1, double z1) {
+		return new Coordinate(this.x - x1, this.y - y1, this.z - z1, this.weight);
 	}
 	
 	
@@ -263,23 +263,23 @@ public final class Coordinate implements Cloneable, Serializable {
 	 * returned.
 	 */
 	public Coordinate average(Coordinate other) {
-		double x, y, z, w;
+		double x1, y1, z1, w1;
 		
 		if (other == null)
 			return this;
 		
-		w = this.weight + other.weight;
-		if (Math.abs(w) < MathUtil.pow2(MathUtil.EPSILON)) {
-			x = (this.x + other.x) / 2;
-			y = (this.y + other.y) / 2;
-			z = (this.z + other.z) / 2;
-			w = 0;
+		w1 = this.weight + other.weight;
+		if (Math.abs(w1) < MathUtil.pow2(MathUtil.EPSILON)) {
+			x1 = (this.x + other.x) / 2;
+			y1 = (this.y + other.y) / 2;
+			z1 = (this.z + other.z) / 2;
+			w1 = 0;
 		} else {
-			x = (this.x * this.weight + other.x * other.weight) / w;
-			y = (this.y * this.weight + other.y * other.weight) / w;
-			z = (this.z * this.weight + other.z * other.weight) / w;
+			x1 = (this.x * this.weight + other.x * other.weight) / w1;
+			y1 = (this.y * this.weight + other.y * other.weight) / w1;
+			z1 = (this.z * this.weight + other.z * other.weight) / w1;
 		}
-		return new Coordinate(x, y, z, w);
+		return new Coordinate(x1, y1, z1, w1);
 	}
 	
 	

--- a/core/src/net/sf/openrocket/util/Pair.java
+++ b/core/src/net/sf/openrocket/util/Pair.java
@@ -32,11 +32,12 @@ public class Pair<U,V> {
 	 * The pair is equal iff both items are equal (or null).
 	 */
 	@Override
+	@SuppressWarnings("unchecked")
 	public boolean equals(Object other) {
 		if (!(other instanceof Pair))
 			return false;
-		Object otherU = ((Pair)other).getU();
-		Object otherV = ((Pair)other).getV();
+		Object otherU = ((Pair<U,V>) other).getU();
+		Object otherV = ((Pair<U,V>) other).getV();
 		
 		if (otherU == null) {
 			if (this.u != null)

--- a/core/src/net/sf/openrocket/util/PinkNoise.java
+++ b/core/src/net/sf/openrocket/util/PinkNoise.java
@@ -92,12 +92,14 @@ public class PinkNoise {
 		return x;
 	}
 	
-	
+	// TODO: this method seems incomplete
 	public static void main(String[] arg) {
 		
+		@SuppressWarnings("unused")
 		PinkNoise source;
 		
 		source = new PinkNoise(1.0, 100);
+		@SuppressWarnings("unused")
 		double std = 0;
 		for (int i=0; i < 1000000; i++) {
 			

--- a/core/src/net/sf/openrocket/util/PolyInterpolator.java
+++ b/core/src/net/sf/openrocket/util/PolyInterpolator.java
@@ -46,37 +46,37 @@ public class PolyInterpolator {
 	 * 					constraints, the second to derivative constraints etc.
 	 */
 	public PolyInterpolator(double[] ... points) {
-		int count = 0;
+		int myCount = 0;
 		for (int i=0; i < points.length; i++) {
-			count += points[i].length;
+			myCount += points[i].length;
 		}
-		if (count == 0) {
+		if (myCount == 0) {
 			throw new IllegalArgumentException("No interpolation points defined.");
 		}
 		
-		this.count = count;
+		this.count = myCount;
 		
-		int[] mul = new int[count];
+		int[] mul = new int[myCount];
 		Arrays.fill(mul, 1);
 
-		double[][] matrix = new double[count][count];
+		double[][] matrix = new double[myCount][myCount];
 		int row = 0;
 		for (int j=0; j < points.length; j++) {
 			
 			for (int i=0; i < points[j].length; i++) {
 				double x = 1;
-				for (int col = count-1-j; col>= 0; col--) {
+				for (int col = myCount-1-j; col>= 0; col--) {
 					matrix[row][col] = x*mul[col];
 					x *= points[j][i];
 				}
 				row++;
 			}
 			
-			for (int i=0; i < count; i++) {
-				mul[i] *= (count-i-j-1);
+			for (int i=0; i < myCount; i++) {
+				mul[i] *= (myCount-i-j-1);
 			}
 		}
-		assert(row == count);
+		assert(row == myCount);
 		
 		interpolationMatrix = inverse(matrix);
 	}

--- a/core/src/net/sf/openrocket/util/QuaternionMultiply.java
+++ b/core/src/net/sf/openrocket/util/QuaternionMultiply.java
@@ -6,6 +6,7 @@ public class QuaternionMultiply {
 		public int sign = 1;
 		public String value;
 		
+		@SuppressWarnings("unused")
 		public Value multiply(Value other) {
 			Value result = new Value();
 			result.sign = this.sign * other.sign;
@@ -15,6 +16,7 @@ public class QuaternionMultiply {
 				result.value = other.value + "*" + this.value;
 			return result;
 		}
+		
 		@Override
 		public String toString() {
 			String s;
@@ -33,12 +35,9 @@ public class QuaternionMultiply {
 		}
 	}
 	
-	
-	
 	private static Value[] multiply(Value[] first, Value[] second) {
 		return null;
 	}
-	
 	
 	public static void main(String[] arg) {
 		if (arg.length % 4 != 0  || arg.length < 4) {

--- a/core/src/net/sf/openrocket/util/TestRockets.java
+++ b/core/src/net/sf/openrocket/util/TestRockets.java
@@ -40,10 +40,10 @@ public class TestRockets {
 	public TestRockets(String key) {
 		
 		if (key == null) {
-			Random rnd = new Random();
+			Random myRnd = new Random();
 			StringBuilder sb = new StringBuilder();
 			for (int i = 0; i < 6; i++) {
-				int n = rnd.nextInt(62);
+				int n = myRnd.nextInt(62);
 				if (n < 10) {
 					sb.append((char) ('0' + n));
 				} else if (n < 36) {
@@ -241,6 +241,7 @@ public class TestRockets {
 		double bodytubeLength = 0.20, bodytubeRadius = 0.01, bodytubeThickness = 0.001;
 		
 		int finCount = 3;
+		@SuppressWarnings("unused")
 		double finRootChord = 0.04, finTipChord = 0.05, finSweep = 0.01, finThickness = 0.003, finHeight = 0.03;
 		
 		
@@ -369,6 +370,7 @@ public class TestRockets {
 		BodyTube tube1, tube2, tube3;
 		TrapezoidFinSet finset;
 		TrapezoidFinSet auxfinset;
+		@SuppressWarnings("unused")
 		MassComponent mcomp;
 		
 		final double R = 0.07;

--- a/core/src/net/sf/openrocket/utils/MotorCompare.java
+++ b/core/src/net/sf/openrocket/utils/MotorCompare.java
@@ -22,10 +22,13 @@ public class MotorCompare {
 	private static final double MASS_MARGIN = 0.20;
 	
 	/** Number of time points in thrust curve to compare */
+	@SuppressWarnings("unused")
 	private static final int DIVISIONS = 100;
 	/** Maximum difference in thrust for a time point to be considered invalid */
+	@SuppressWarnings("unused")
 	private static final double THRUST_MARGIN = 0.20;
 	/** Number of invalid time points allowed */
+	@SuppressWarnings("unused")
 	private static final int ALLOWED_INVALID_POINTS = 20;
 	
 	/** Minimum number of thrust curve points allowed (incl. start and end points) */
@@ -33,18 +36,26 @@ public class MotorCompare {
 	
 	
 	public static void main(String[] args) throws IOException {
+		@SuppressWarnings("unused")
 		final double maxThrust;
+		@SuppressWarnings("unused")
 		final double maxTime;
+		@SuppressWarnings("unused")
 		int maxDelays;
+		@SuppressWarnings("unused")
 		int maxPoints;
+		@SuppressWarnings("unused")
 		int maxCommentLen;
 		
-		double min, max;
-		double diff;
+		@SuppressWarnings("unused")
+		double min, max, diff;
 		
+		@SuppressWarnings("unused")
 		int[] goodness;
 		
+		@SuppressWarnings("unused")
 		boolean bad = false;
+		@SuppressWarnings("unused")
 		List<String> cause = new ArrayList<String>();
 		
 		MotorLoader loader = new GeneralMotorLoader();
@@ -65,7 +76,7 @@ public class MotorCompare {
 				System.out.print("(ERR:" + e.getMessage() + ")");
 			}
 			if (m != null) {
-				motors.addAll((List) m);
+				motors.addAll((List<? extends ThrustCurveMotor>) m);
 				for (int i = 0; i < m.size(); i++)
 					files.add(file);
 			}
@@ -80,8 +91,8 @@ public class MotorCompare {
 
 
 	public static void compare(List<ThrustCurveMotor> motors, List<String> files) {
-		final double maxThrust;
-		final double maxTime;
+		@SuppressWarnings("unused")
+		final double maxThrust, maxTime;
 		int maxDelays;
 		int maxPoints;
 		int maxCommentLen;

--- a/core/src/net/sf/openrocket/utils/MotorCorrelation.java
+++ b/core/src/net/sf/openrocket/utils/MotorCorrelation.java
@@ -11,7 +11,6 @@ import net.sf.openrocket.file.motor.MotorLoader;
 import net.sf.openrocket.logging.LogLevel;
 import net.sf.openrocket.models.atmosphere.AtmosphericConditions;
 import net.sf.openrocket.motor.Motor;
-import net.sf.openrocket.motor.MotorDigest;
 import net.sf.openrocket.motor.MotorInstance;
 import net.sf.openrocket.motor.ThrustCurveMotor;
 import net.sf.openrocket.startup.Application;

--- a/core/src/net/sf/openrocket/utils/MotorDigester.java
+++ b/core/src/net/sf/openrocket/utils/MotorDigester.java
@@ -8,7 +8,6 @@ import java.util.List;
 import net.sf.openrocket.file.motor.GeneralMotorLoader;
 import net.sf.openrocket.file.motor.MotorLoader;
 import net.sf.openrocket.motor.Motor;
-import net.sf.openrocket.motor.MotorDigest;
 import net.sf.openrocket.motor.ThrustCurveMotor;
 
 public class MotorDigester {

--- a/core/src/net/sf/openrocket/utils/MotorPrinter.java
+++ b/core/src/net/sf/openrocket/utils/MotorPrinter.java
@@ -9,7 +9,6 @@ import java.util.List;
 import net.sf.openrocket.file.motor.GeneralMotorLoader;
 import net.sf.openrocket.file.motor.MotorLoader;
 import net.sf.openrocket.motor.Motor;
-import net.sf.openrocket.motor.MotorDigest;
 import net.sf.openrocket.motor.ThrustCurveMotor;
 
 public class MotorPrinter {

--- a/core/src/net/sf/openrocket/utils/TestFunctionOptimizerLoop.java
+++ b/core/src/net/sf/openrocket/utils/TestFunctionOptimizerLoop.java
@@ -21,12 +21,9 @@ public class TestFunctionOptimizerLoop {
 	
 	private static final double PRECISION = 0.01;
 	
-	private Point optimum;
 	private int stepCount = 0;
 	private int evaluations = 0;
 	
-	
-
 	private void go(final FunctionOptimizer optimizer, final Point optimum, final int maxSteps, ExecutorService executor) throws OptimizationException {
 		
 		Function function = new Function() {

--- a/core/test/net/sf/openrocket/communication/HttpURLConnectionMock.java
+++ b/core/test/net/sf/openrocket/communication/HttpURLConnectionMock.java
@@ -30,28 +30,36 @@ public class HttpURLConnectionMock extends HttpURLConnection {
 		}
 	}
 	
+	@SuppressWarnings("hiding")
 	private volatile boolean instanceFollowRedirects = false;
-	private volatile String requestMethod = "";
+	
+	@SuppressWarnings("hiding")
 	private volatile int responseCode;
+
+	private volatile String requestMethod = "";
 	private Map<String, String> requestProperties = new HashMap<String, String>();
 	private volatile int connectTimeout = -1;
 	private volatile String contentEncoding = "";
 	
+	@SuppressWarnings("hiding")
 	private volatile boolean doInput = false;
+	@SuppressWarnings("hiding")
 	private volatile boolean doOutput = false;
 	
 	private volatile byte[] content = null;
 	private volatile String contentType = null;
+	
+	@SuppressWarnings("hiding")
 	private volatile boolean useCaches = false;
-	
-	
+
 	private volatile InputStream inputStream = null;
 	private volatile ByteArrayOutputStream outputStream = null;
 	
 	private volatile String trueUrl = null;
 	
-	
+	@SuppressWarnings("hiding")
 	private volatile boolean connected = false;
+	
 	private volatile int connectionDelay = 0;
 	
 	private volatile boolean failed = false;
@@ -420,7 +428,7 @@ public class HttpURLConnectionMock extends HttpURLConnection {
 	
 	
 	@Override
-	public Object getContent(Class[] classes) throws IOException {
+	public Object getContent(@SuppressWarnings("rawtypes") Class[] classes) throws IOException {
 		throw new UnsupportedOperationException();
 	}
 	

--- a/core/test/net/sf/openrocket/file/rocksim/importt/RingHandlerTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/importt/RingHandlerTest.java
@@ -87,7 +87,8 @@ public class RingHandlerTest extends RocksimTestBase {
     public void testBulkhead() throws Exception {
         BodyTube tube = new BodyTube();
         RingHandler handler = new RingHandler(tube, new WarningSet());
-        CenteringRing component = (CenteringRing) getField(handler, "ring");
+        @SuppressWarnings("unused")
+		CenteringRing component = (CenteringRing) getField(handler, "ring");
         HashMap<String, String> attributes = new HashMap<String, String>();
         WarningSet warnings = new WarningSet();
 
@@ -237,7 +238,8 @@ public class RingHandlerTest extends RocksimTestBase {
 
         BodyTube tube = new BodyTube();
         RingHandler handler = new RingHandler(tube, new WarningSet());
-        CenteringRing component = (CenteringRing) getField(handler, "ring");
+        @SuppressWarnings("unused")
+		CenteringRing component = (CenteringRing) getField(handler, "ring");
     }
 
     /**

--- a/core/test/net/sf/openrocket/file/rocksim/importt/RocksimTestBase.java
+++ b/core/test/net/sf/openrocket/file/rocksim/importt/RocksimTestBase.java
@@ -41,13 +41,11 @@ public abstract class RocksimTestBase {
 	 * @exception NoSuchFieldException if a field with the specified name is
 	 * not found.
 	 */
-	public static Object getField(Object object,
-									String name)
-			throws NoSuchFieldException {
+	public static Object getField(Object object, String name) throws NoSuchFieldException {
 		if (object == null) {
 			throw new IllegalArgumentException("Invalid null object argument");
 		}
-		for (Class cls = object.getClass(); cls != null; cls = cls.getSuperclass()) {
+		for (Class<?> cls = object.getClass(); cls != null; cls = cls.getSuperclass()) {
 			try {
 				Field field = cls.getDeclaredField(name);
 				field.setAccessible(true);
@@ -73,13 +71,11 @@ public abstract class RocksimTestBase {
 	 * @exception NoSuchFieldException if a field with the specified name is
 	 * not found.
 	 */
-	public static Object getField(Class cls,
-									String name)
-			throws NoSuchFieldException {
+	public static Object getField(Class<?> cls, String name) throws NoSuchFieldException {
 		if (cls == null) {
 			throw new IllegalArgumentException("Invalid null cls argument");
 		}
-		Class base = cls;
+		Class<?> base = cls;
 		while (base != null) {
 			try {
 				Field field = base.getDeclaredField(name);

--- a/core/test/net/sf/openrocket/gui/configdialog/FinSetConfigTest.java
+++ b/core/test/net/sf/openrocket/gui/configdialog/FinSetConfigTest.java
@@ -138,7 +138,8 @@ public class FinSetConfigTest extends BaseTestCase {
         rings.add(ring1);
         rings.add(ring2);
 
-        RocketComponent parent = new BodyTube();
+        @SuppressWarnings("unused")
+		RocketComponent parent = new BodyTube();
         Double result = (Double)method.invoke(null, rings, 0.47d, 0.01, dm, ring1);
         Assert.assertEquals(0.01, result.doubleValue(), 0.0001);
     }

--- a/core/test/net/sf/openrocket/simulation/customexpression/TestExpressions.java
+++ b/core/test/net/sf/openrocket/simulation/customexpression/TestExpressions.java
@@ -2,7 +2,6 @@ package net.sf.openrocket.simulation.customexpression;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.rocketcomponent.Rocket;
 


### PR DESCRIPTION
Big commit to reduce build warnings from 232 down to 44 warnings.  By fixing the simple ones, the rest of the devs will be able to see more important warnings and fix them.

List of fixes:
- Fixed 'references to generic type needs parameterized' warnings.  There are still some left that I don't know enough about the code to fix.
- Fixed 'variable Foo is hiding variable Bar'  warnings by renaming lower scoped variables.
- Removed unused imports that were causing build warnings.
- added @suppress 'unused methods' for some methods
- added @suppress 'unused variables' for some variables; there were 1 or 2 variables that were clearly unused and unneeded, those were removed.
- added @suppress to 2  warnings about resource leaks in a file open; it was clear the files were actually closed in the same method.  There are some resource leak warnings left that should be looked at.
  - Fixed one deprecated method warning in ColorChooser.java for a java lib method by changing to use the newer replacement method.
