### PR TITLE
Added support for Travis-CI hosted continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: java
+jdk:
+  - oraclejdk7
+script: "ant clean build serialize-motors serialize-presets jar"

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,302 @@
+<project name="OpenRocket" basedir="./core">
+
+	<property file="resources/build.properties" />
+	
+	<property name="src.dir"    	value="${basedir}/src"/>		<!-- Source directory -->
+	<property name="src-test.dir"	value="${basedir}/test"/>		<!-- Test directory -->
+	<property name="build.dir"   	value="${basedir}/build"/>		<!-- Build directory -->
+	<property name="build-test.dir" value="${basedir}/build/test"/>		<!-- Build directory -->
+	<property name="lib.dir"     	value="${basedir}/lib"/>		<!-- Library source directory -->
+	<property name="libtest.dir"	value="${basedir}/lib-test"/>		<!-- Library test source directory -->
+	<property name="libextra.dir"	value="${basedir}/lib-extra"/>		<!-- Library extra source directory -->
+	<property name="tmp.dir"	value="${basedir}/tmp"/>		<!-- Temporary directory -->
+	<property name="resources.dir"	value="${basedir}/resources"/>		<!-- Resources directory -->
+	<property name="resources-src.dir"	value="${basedir}/resources-src"/>	<!-- Resources directory -->
+	
+	<!-- Distribution directory, from which stuff is jar'ed -->
+	<property name="dist.dir"    	value="${build.dir}/dist"/> 
+	<property name="dist-test.dir"	value="${build.dir}/dist-test"/>
+	
+	<property name="classes.dir" value="${dist.dir}"/>	<!-- Directory for classes -->
+	<property name="jar.dir"     value="${build.dir}/jar"/>	<!-- Directory for built jar's -->
+
+	<property name="pkgname"     value="${ant.project.name}-${build.version}"/>
+	
+	<property name="jar.file"    value="${jar.dir}/${ant.project.name}.jar"/>
+	<property name="dist.bin"    value="${jar.dir}/${pkgname}.jar"/>
+	<property name="dist.src"    value="${jar.dir}/${pkgname}-src.zip"/>
+	
+	<!-- The main class of the application -->
+	<property name="main-class"  value="net.sf.openrocket.startup.Startup"/>
+
+	<property name="expanded-libs" value="${lib.dir}/miglayout15-swing.jar"/>
+	
+	<!-- Classpath definitions -->
+	<path id="classpath">
+		<fileset dir="${lib.dir}" includes="**/*.jar"/>
+	</path>
+	
+	<path id="test-classpath">
+		<path refid="classpath"/>
+		<pathelement location="${resources.dir}"/>
+		<pathelement location="${build-test.dir}"/>
+		<pathelement location="${classes.dir}"/>
+		<pathelement location="${src-test.dir}"/>
+		<fileset dir="${libtest.dir}/" includes="*.jar"/>
+	</path>
+
+	<path id="run-classpath">
+		<path refid="classpath"/>
+		<pathelement location="${resources.dir}"/>
+		<pathelement location="${classes.dir}"/>
+	</path>
+
+	<!-- Add Ant-contrib tasks so we can use for loop -->
+	<taskdef resource="net/sf/antcontrib/antlib.xml">
+		<classpath>
+			<pathelement location="${libextra.dir}/ant-contrib-1.0b3.jar"/>
+		</classpath>
+	</taskdef>
+
+	
+	<!-- CLEAN -->
+	<target name="clean" description="Removes all build artifacts">
+		<delete dir="${build.dir}"/>
+		<delete dir="${tmp.dir}/"/>
+	</target>
+		
+	
+	<!-- BUILD -->
+	<target name="build">
+		<mkdir dir="${classes.dir}"/>
+		<echo level="info">Compiling main classes</echo>
+		<javac debug="true" srcdir="${src.dir}" destdir="${classes.dir}" classpathref="classpath" includeantruntime="false"/>
+	</target>
+	
+	<!-- Executible Eclipse-Jar-In-Jar style JAR -->
+	<target name="jar" depends="build,serialize-presets,serialize-motors" description="Create the OpenRocket executable JAR">
+		<mkdir dir="${jar.dir}" />
+		<jar destfile="${jar.file}" basedir="${dist.dir}">
+			<manifest>
+				<attribute name="Main-Class" value="${main-class}" />
+				<attribute name="SplashScreen-Image" value="pix/splashscreen.png" />
+				<attribute name="Classpath-Jars" value="${lib.dir}/gluegen-rt.jar ${lib.dir}/jogl.all.jar" />
+			</manifest>
+
+			<!-- Include, in the root of the JAR, the resources needed by OR -->
+			<fileset dir="${src.dir}/" includes="META-INF/" />
+			<fileset dir="${resources.dir}/" />
+			
+			
+			<!-- Libraries to extract into base JAR -->
+			<zipfileset src="${lib.dir}/miglayout15-swing.jar" />
+			<zipfileset src="${lib.dir}/guice-3.0.jar" />
+			<zipfileset src="${lib.dir}/aopalliance.jar"/>
+			<zipfileset src="${lib.dir}/guice-3.0.jar"/>
+			<zipfileset src="${lib.dir}/guice-multibindings-3.0.jar"/>
+			<zipfileset src="${lib.dir}/iText-5.0.2.jar"/>
+			<zipfileset src="${lib.dir}/javax.inject.jar"/>
+			<zipfileset src="${lib.dir}/jcommon-1.0.16.jar"/>
+			<zipfileset src="${lib.dir}/jfreechart-1.0.13.jar"/>
+			<zipfileset src="${lib.dir}/miglayout15-swing.jar"/>
+			<zipfileset src="${lib.dir}/opencsv-2.3.jar"/>
+			<zipfileset src="${lib.dir}/OrangeExtensions-1.2.jar"/>
+			
+			
+			<!-- JOGL libraries need to be jar-in-jar -->
+			<zipfileset dir="${lib.dir}/jogl" prefix="lib">
+				<include name="*.jar"/>
+			</zipfileset>
+			
+			<!-- Include metafiles about OR -->
+			<fileset dir="${basedir}" includes="LICENSE.TXT README.TXT ChangeLog ReleaseNotes fileformat.txt" />
+		</jar>
+	</target>
+	
+	<target name="serialize-presets" depends="build" description="Preprocess the orc preset files into serialized form">
+	    <java classname="net.sf.openrocket.startup.SerializePresets"
+	          fork="true"
+			  classpathref="run-classpath"
+			  failonerror="true">
+	    </java>
+	</target>
+	<target name="serialize-motors" depends="build" description="Preprocess the motor files into serialized form">
+	    <java classname="net.sf.openrocket.startup.SerializeMotors"
+	          fork="true"
+			  classpathref="run-classpath"
+			  failonerror="true">
+	    	<arg value="${resources-src.dir}/datafiles/thrustcurves/"/>
+	    	<arg value="${resources.dir}/datafiles/thrustcurves/thrustcurves.ser"/>
+	    </java>
+	</target>
+
+	<!-- CONVERT vendor csv to ORC files -->
+	<macrodef name="build-orc-file">
+		<attribute name="dir"/>
+		<attribute name="vendor"/>
+		<sequential>
+			<echo>Generating ORC file for vendor @{vendor}</echo>
+			<java classname="net.sf.openrocket.preset.loader.RocksimComponentFileTranslator"
+				fork="true"
+				classpathref="run-classpath"
+				failonerror="true">
+				<arg value="@{dir}"/>
+				<arg value="${resources-src.dir}/datafiles/presets/@{vendor}.orc"/>
+			</java>
+		</sequential>
+	</macrodef>
+
+	<target name="generate-orc-files"
+		description="Generate ORC file from vendor csv"
+		depends="build">
+
+		<for param="vendor-dir">
+			<dirset dir="${resources-src.dir}/datafiles/rocksim_components"
+				includes="*"/>
+			<sequential>
+				<propertyregex property="vendor"
+					override="true"
+					input="@{vendor-dir}"
+					select="\1"
+					regexp=".*[/\\]([^/\\]*)$"/>
+				<build-orc-file dir="@{vendor-dir}" vendor="${vendor}"/>
+			</sequential>
+		</for>
+	</target>
+	
+	<!-- DIST-SRC -->
+	<target name="dist-src">
+		<echo>			
+		Building source distribution
+		</echo>
+		<mkdir dir="${build.dir}/${pkgname}"/>
+		<mkdir dir="${jar.dir}"/>
+		<copy todir="${build.dir}/${pkgname}">
+			<fileset dir="${basedir}" includes="*" excludes="*.log">
+				<type type="file"/>
+			</fileset>
+			<fileset dir="${basedir}" includes="${resources.dir}/ ${lib.dir}/ ${lib-test.dir}/ ${src.dir}/ ${test.dir}/ ${resources-src.dir}/datafiles/"/>
+		</copy>
+		<zip destfile="${dist.src}" basedir="${build.dir}" includes="${pkgname}/"/>
+		<delete dir="${build.dir}/${pkgname}"/>
+	</target>
+	
+	
+	<!-- DIST-SRC-TEST -->
+	<target name="dist-src-test" depends="dist-src">
+		<echo>
+		Testing source distribution
+		</echo>
+		<delete dir="${dist-test.dir}"/>
+		<mkdir dir="${dist-test.dir}"/>
+		<unzip dest="${dist-test.dir}" src="${dist.src}"/>
+		<ant dir="${dist-test.dir}/${pkgname}" antfile="build.xml" target="jar"/>
+		<ant dir="${dist-test.dir}/${pkgname}" antfile="build.xml" target="unittest"/>
+		<delete dir="${dist-test.dir}"/>
+		<echo>
+		Source distribution test successful
+		</echo>
+	</target>	
+	
+	
+	<!-- DIST-BIN -->
+	<target name="dist-bin" depends="check,clean,unittest,jar">
+		<move file="${jar.file}" tofile="${dist.bin}"/>
+	</target>
+
+	
+	<!-- DIST -->
+	<target name="dist" depends="dist-bin,dist-src,dist-src-test">
+		<echo>Distribution ${build.version} (${build.source}) built into directory ${jar.dir}</echo>
+	</target>
+	
+	
+	<!-- CHECK -->
+	<target name="check" depends="checktodo,checkascii"/>
+	
+	<!-- CHECK TODOs -->
+	<target name="todo" depends="checktodo"/>
+	<target name="checktodo">
+		<tempfile property="todo.file" prefix="checktodo-"/>
+		<echo>Checking project for FIXMEs.</echo>
+		<concat destfile="${todo.file}">
+			<fileset dir="${src.dir}">
+			    <include name="**/*.java"/>
+			</fileset>
+			<fileset dir="${src-test.dir}">
+			    <include name="**/*.java"/>
+			</fileset>
+			<filterchain>
+				<linecontainsregexp>
+					<regexp pattern="(FIXME|TODO:.*CRITICAL)"/>
+				</linecontainsregexp>
+			</filterchain>
+		</concat>
+		<loadfile srcfile="${todo.file}" property="criticaltodos"/>
+		<delete file="${todo.file}"/>
+		<fail if="criticaltodos">CRITICAL TODOs exist in project:
+${criticaltodos}</fail>
+		<echo>No critical TODOs in project.</echo>
+	</target>
+	
+	
+	<!-- CHECK ASCII -->
+	<target name="ascii" depends="checkascii"/>
+	<target name="checkascii">
+		<tempfile property="ascii.file" prefix="checkascii-"/>
+		<echo>Checking project for non-ASCII characters.</echo>
+		<concat destfile="${ascii.file}">
+			<fileset dir="${src.dir}">
+			    <include name="**/*.java"/>
+			</fileset>
+			<fileset dir="${src-test.dir}">
+			    <include name="**/*.java"/>
+			</fileset>
+			<filterchain>
+				<linecontainsregexp>
+					<regexp pattern="\P{ASCII}"/>
+				</linecontainsregexp>
+			</filterchain>
+		</concat>
+		<loadfile srcfile="${ascii.file}" property="nonascii"/>
+		<delete file="${ascii.file}"/>
+		<fail if="nonascii">Non-ASCII characters exist in project:
+${nonascii}</fail>
+		<echo>No non-ASCII characters in project.</echo>
+	</target>
+	
+	
+	<!--  Unit tests  -->
+	<target name="unittest" description="Execute unit tests" depends="build">
+		<echo>Building unit tests</echo>
+		<mkdir dir="${build-test.dir}"/>
+		<javac debug="true" srcdir="${src-test.dir}" destdir="${build-test.dir}" classpathref="test-classpath"/>
+		
+		<echo>Running unit tests</echo>
+		<mkdir dir="${tmp.dir}/rawtestoutput"/>
+		<junit fork="yes" forkmode="once" printsummary="false" failureproperty="junit.failure">
+			<classpath>
+				<path refid="test-classpath"/>
+				<path location="${basedir}"/>
+			</classpath>
+			<batchtest todir="${tmp.dir}/rawtestoutput">
+				<fileset dir="${build-test.dir}">
+					<include name="**/Test*.class" />
+					<include name="**/*Test.class" />
+					<exclude name="**/*$*.class" />
+					<exclude name="Test.class" />
+				</fileset>
+				<formatter type="xml"/>
+			</batchtest>
+		</junit>
+		<junitreport todir="${tmp.dir}">
+			<fileset dir="${tmp.dir}/rawtestoutput"/>
+			<report todir="${tmp.dir}/test-reports"/>
+		</junitreport>
+		<fail if="junit.failure" message="Unit test(s) failed.  See report in ${basedir}/${tmp.dir}/test-reports/index.html"/>
+		<echo>
+	Unit tests passed successfully.
+		</echo>
+ 	</target>
+    
+</project>

--- a/core/src/net/sf/openrocket/utils/MotorCompare.java
+++ b/core/src/net/sf/openrocket/utils/MotorCompare.java
@@ -76,7 +76,7 @@ public class MotorCompare {
 				System.out.print("(ERR:" + e.getMessage() + ")");
 			}
 			if (m != null) {
-				motors.addAll((List<? extends ThrustCurveMotor>) m);
+				motors.addAll((List) m);
 				for (int i = 0; i < m.size(); i++)
 					files.add(file);
 			}


### PR DESCRIPTION
Travis-CI offers a hosted CI service with github integration, and it's free for open source projects.  I have my branch running on Travis-CI already, here's the build history:  https://travis-ci.org/soupwizard/openrocket/builds

This changelist includes several things to support travis-ci:
- Travis-ci wants the build.xml in repo root dir, copied and added it there.  
- Updated build.xml to point to core/ subdirectory (since the build.xml is in openrocket root) and fixed places in build.xml that had hardcoded path references to use relative references.
- Added .travis.yml config file, it will do "ant clean build serialize-motors serialize-presets jar"
- Travis-ci only has java 1.7, not 1.6.  A change to fix a build warning in MotorCompare.java that I did a couple of days ago now causes a build error with 1.7; changing it back so that it only causes a warning again.

After this is merged, you can integrate travis-ci to github by following these instructions:  http://about.travis-ci.org/docs/user/getting-started/
