### PR TITLE
Remove "Attempted firing event..." log statement

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import net.sf.openrocket.l10n.Translator;
-import net.sf.openrocket.logging.LogHelper;
 import net.sf.openrocket.preset.ComponentPreset;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.ArrayList;
@@ -24,7 +23,6 @@ import net.sf.openrocket.util.UniqueID;
 
 
 public abstract class RocketComponent implements ChangeSource, Cloneable, Iterable<RocketComponent> {
-	private static final LogHelper log = Application.getLogger();
 	private static final Translator trans = Application.getTranslator();
 	
 	/*
@@ -1527,7 +1525,6 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 		checkState();
 		if (parent == null) {
 			/* Ignore if root invalid. */
-			log.debug("Attempted firing event " + e + " with root " + this.getComponentName() + ", ignoring event");
 			return;
 		}
 		getRoot().fireComponentChangeEvent(e);


### PR DESCRIPTION
This statement adds a lot of time to the startup process. It also adds about a minute to the preset & motor serialization (20 seconds to 1 minute 30 seconds on my desktop!).
