### PR TITLE
Fix Classpath-Jars value in build.xml

### DIFF
--- a/core/build.xml
+++ b/core/build.xml
@@ -80,7 +80,7 @@
 			<manifest>
 				<attribute name="Main-Class" value="${main-class}" />
 				<attribute name="SplashScreen-Image" value="pix/splashscreen.png" />
-				<attribute name="Classpath-Jars" value="${lib.dir}/gluegen-rt.jar ${lib.dir}/jogl.all.jar" />
+				<attribute name="Classpath-Jars" value="lib/gluegen-rt.jar lib/jogl.all.jar" />
 			</manifest>
 
 			<!-- Include, in the root of the JAR, the resources needed by OR -->


### PR DESCRIPTION
The Classpath-Jars variable in the executable jar manifest needs to get a relative path inside the jar, "lib/whatever.jar" but has been getting a filesystem directory.
