### PR TITLE
Use platform default shortcut key in menus

### DIFF
--- a/core/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/core/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -118,6 +118,8 @@ public class BasicFrame extends JFrame {
 
 	private static final Translator trans = Application.getTranslator();
 
+	private static final int SHORTCUT_KEY = Toolkit.getDefaultToolkit().getMenuShortcutKeyMask();
+	
 	public static final int COMPONENT_TAB = 0;
 	public static final int SIMULATION_TAB = 1;
 
@@ -272,13 +274,13 @@ public class BasicFrame extends JFrame {
 
 		// Remove JTree key events that interfere with menu accelerators
 		InputMap im = SwingUtilities.getUIInputMap(tree, JComponent.WHEN_FOCUSED);
-		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_X, ActionEvent.CTRL_MASK), null);
-		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_C, ActionEvent.CTRL_MASK), null);
-		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_V, ActionEvent.CTRL_MASK), null);
-		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_A, ActionEvent.CTRL_MASK), null);
-		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_S, ActionEvent.CTRL_MASK), null);
-		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_O, ActionEvent.CTRL_MASK), null);
-		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_N, ActionEvent.CTRL_MASK), null);
+		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_X, SHORTCUT_KEY), null);
+		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_C, SHORTCUT_KEY), null);
+		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_V, SHORTCUT_KEY), null);
+		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_A, SHORTCUT_KEY), null);
+		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_S, SHORTCUT_KEY), null);
+		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_O, SHORTCUT_KEY), null);
+		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_N, SHORTCUT_KEY), null);
 
 
 
@@ -398,7 +400,7 @@ public class BasicFrame extends JFrame {
 
 		//// New
 		item = new JMenuItem(trans.get("main.menu.file.new"), KeyEvent.VK_N);
-		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, ActionEvent.CTRL_MASK));
+		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, SHORTCUT_KEY));
 		item.setMnemonic(KeyEvent.VK_N);
 		//// Create a new rocket design
 		item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.file.new.desc"));
@@ -415,7 +417,7 @@ public class BasicFrame extends JFrame {
 
 		//// Open...
 		item = new JMenuItem(trans.get("main.menu.file.open"), KeyEvent.VK_O);
-		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, ActionEvent.CTRL_MASK));
+		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, SHORTCUT_KEY));
 		//// Open a rocket design
 		item.getAccessibleContext().setAccessibleDescription(trans.get("BasicFrame.item.Openrocketdesign"));
 		item.setIcon(Icons.FILE_OPEN);
@@ -440,7 +442,7 @@ public class BasicFrame extends JFrame {
 		//// Open an example rocket design
 		item.getAccessibleContext().setAccessibleDescription(trans.get("BasicFrame.item.Openexamplerocketdesign"));
 		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O,
-				ActionEvent.CTRL_MASK | ActionEvent.SHIFT_MASK));
+				SHORTCUT_KEY | ActionEvent.SHIFT_MASK));
 		item.setIcon(Icons.FILE_OPEN_EXAMPLE);
 		item.addActionListener(new ActionListener() {
 			@Override
@@ -461,7 +463,7 @@ public class BasicFrame extends JFrame {
 
 		//// Save
 		item = new JMenuItem(trans.get("main.menu.file.save"), KeyEvent.VK_S);
-		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, ActionEvent.CTRL_MASK));
+		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, SHORTCUT_KEY));
 		//// Save the current rocket design
 		item.getAccessibleContext().setAccessibleDescription(trans.get("BasicFrame.item.SavecurRocketdesign"));
 		item.setIcon(Icons.FILE_SAVE);
@@ -477,7 +479,7 @@ public class BasicFrame extends JFrame {
 		//// Save as...
 		item = new JMenuItem(trans.get("main.menu.file.saveAs"), KeyEvent.VK_A);
 		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S,
-				ActionEvent.CTRL_MASK | ActionEvent.SHIFT_MASK));
+				SHORTCUT_KEY | ActionEvent.SHIFT_MASK));
 		//// Save the current rocket design to a new file
 		item.getAccessibleContext().setAccessibleDescription(trans.get("BasicFrame.item.SavecurRocketdesnewfile"));
 		item.setIcon(Icons.FILE_SAVE_AS);
@@ -492,7 +494,7 @@ public class BasicFrame extends JFrame {
 
 		//// Print...
 		item = new JMenuItem(trans.get("main.menu.file.print"), KeyEvent.VK_P);
-		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, ActionEvent.CTRL_MASK));
+		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, SHORTCUT_KEY));
 		//// Print parts list and fin template
 		item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.file.print.desc"));
 		item.setIcon(Icons.FILE_PRINT);
@@ -510,7 +512,7 @@ public class BasicFrame extends JFrame {
 
 		//// Close
 		item = new JMenuItem(trans.get("main.menu.file.close"), KeyEvent.VK_C);
-		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_W, ActionEvent.CTRL_MASK));
+		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_W, SHORTCUT_KEY));
 		//// Close the current rocket design
 		item.getAccessibleContext().setAccessibleDescription(trans.get("BasicFrame.item.Closedesign"));
 		item.setIcon(Icons.FILE_CLOSE);
@@ -527,7 +529,7 @@ public class BasicFrame extends JFrame {
 
 		//// Quit
 		item = new JMenuItem(trans.get("main.menu.file.quit"), KeyEvent.VK_Q);
-		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Q, ActionEvent.CTRL_MASK));
+		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Q, SHORTCUT_KEY));
 		//// Quit the program
 		item.getAccessibleContext().setAccessibleDescription(trans.get("BasicFrame.item.Quitprogram"));
 		item.setIcon(Icons.FILE_QUIT);
@@ -552,7 +554,7 @@ public class BasicFrame extends JFrame {
 
 		Action action = UndoRedoAction.newUndoAction(document);
 		item = new JMenuItem(action);
-		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Z, ActionEvent.CTRL_MASK));
+		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Z, SHORTCUT_KEY));
 		item.setMnemonic(KeyEvent.VK_U);
 		//// Undo the previous operation
 		item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.edit.undo.desc"));
@@ -561,7 +563,7 @@ public class BasicFrame extends JFrame {
 
 		action = UndoRedoAction.newRedoAction(document);
 		item = new JMenuItem(action);
-		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Y, ActionEvent.CTRL_MASK));
+		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Y, SHORTCUT_KEY));
 		item.setMnemonic(KeyEvent.VK_R);
 		//// Redo the previously undone operation
 		item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.edit.redo.desc"));

--- a/core/src/net/sf/openrocket/gui/main/RocketActions.java
+++ b/core/src/net/sf/openrocket/gui/main/RocketActions.java
@@ -1,6 +1,7 @@
 package net.sf.openrocket.gui.main;
 
 
+import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.util.ArrayList;
@@ -39,11 +40,11 @@ import net.sf.openrocket.util.Pair;
 public class RocketActions {
 
 	public static final KeyStroke CUT_KEY_STROKE = KeyStroke.getKeyStroke(KeyEvent.VK_X,
-			ActionEvent.CTRL_MASK);
+			Toolkit.getDefaultToolkit().getMenuShortcutKeyMask());
 	public static final KeyStroke COPY_KEY_STROKE = KeyStroke.getKeyStroke(KeyEvent.VK_C,
-			ActionEvent.CTRL_MASK);
+			Toolkit.getDefaultToolkit().getMenuShortcutKeyMask());
 	public static final KeyStroke PASTE_KEY_STROKE = KeyStroke.getKeyStroke(KeyEvent.VK_V,
-			ActionEvent.CTRL_MASK);
+			Toolkit.getDefaultToolkit().getMenuShortcutKeyMask());
 	
 	private final OpenRocketDocument document;
 	private final Rocket rocket;


### PR DESCRIPTION
Use the ToolKit function to get the default shortcut key for the platform, use this for the accelerators on the menus. OSX should have Command-Z for undo, not Control-Z. Windows retains Control-Z shortcut. Linux untested, but should stay Control according to the default.
(This covers more than undo: the basic frame actions and cut/copy/paste) 
