### PR TITLE
Fixes and improves 3d rendering of transitions

### DIFF
--- a/core/src/net/sf/openrocket/gui/figure3d/geometry/ComponentRenderer.java
+++ b/core/src/net/sf/openrocket/gui/figure3d/geometry/ComponentRenderer.java
@@ -128,7 +128,7 @@ public class ComponentRenderer {
 			if (which == Surface.INSIDE) {
 				gl.glFrontFace(GL.GL_CCW);
 			}
-			TransitionRenderer.drawTransition(gl, t, LOD, t.getType() == Shape.CONICAL ? 4 : LOD / 2);
+			TransitionRenderer.drawTransition(gl, t, LOD, t.getType() == Shape.CONICAL ? 4 : LOD / 2, which == Surface.INSIDE ? -t.getThickness() : 0);
 			if (which == Surface.INSIDE) {
 				gl.glFrontFace(GL.GL_CW);
 			}

--- a/core/src/net/sf/openrocket/gui/figure3d/geometry/TransitionRenderer.java
+++ b/core/src/net/sf/openrocket/gui/figure3d/geometry/TransitionRenderer.java
@@ -126,7 +126,7 @@ final class TransitionRenderer {
 	}
 	
 	static final void drawTransition(final GL2 gl, final Transition tr,
-			final int slices, final int stacks) {
+			final int slices, final int stacks, final double offsetRadius) {
 		
 		double da, r, dzBase;
 		double x, y, z, nz, lnz = 0;
@@ -145,8 +145,8 @@ final class TransitionRenderer {
 			double dz = t < 0.025 ? dzBase / 8.0 : dzBase;
 			double zNext = Math.min(z + dz, tr.getLength());
 			
-			r = tr.getRadius(z);
-			double rNext = tr.getRadius(zNext);
+			r = Math.max(0, tr.getRadius(z) + offsetRadius);
+			double rNext = Math.max(0, tr.getRadius(zNext) + offsetRadius);
 			
 			
 			// Z component of normal vectors


### PR DESCRIPTION
Does not render shoulders when their length is zero.
Renders the main part of a transition with thickness.
