### PR TITLE
Fix for https://github.com/plaa/openrocket/issues/68

### DIFF
--- a/core/test/net/sf/openrocket/file/rocksim/importt/rocksimTestRocket3.rkt
+++ b/core/test/net/sf/openrocket/file/rocksim/importt/rocksimTestRocket3.rkt
@@ -472,7 +472,7 @@
 <Removed>0</Removed>
 <Station>148.7</Station>
 <Dia>414.5</Dia>
-<SpillHoleDia>0.</SpillHoleDia>
+<SpillHoleDia>1.</SpillHoleDia>
 <SideCount>15</SideCount>
 <ShroudLineCount>16</ShroudLineCount>
 <Thickness>0.05</Thickness>


### PR DESCRIPTION
Modified the test file to have nonzero spill hole so OpenRocket will generate the warning needed in the test case.
