### PR TITLE
Fix github issue #84 "The CP & CG markers appear in the 2d rear view."

### DIFF
--- a/core/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/core/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -297,6 +297,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 					go3D();
 				} else {
 					figure.setType(v.type);
+					updateExtras(); // when switching from side view to back view, need to clear CP & CG markers
 					go2D();
 				}
 			}


### PR DESCRIPTION
The CP & CG markers were not being removed when switching from Side to Back view.  Code to do that (and add them back when switching to Side view) is in updateExtras(), so I just added a call to that when changing to a 2D view.
