### PR TITLE
Fixed unittest failure, cleaned up unit test output

### DIFF
--- a/core/build.xml
+++ b/core/build.xml
@@ -326,6 +326,7 @@ ${nonascii}</fail>
 				<!-- <formatter type="xml"/> -->
                 <formatter type="plain" usefile="false" />
 			</batchtest>
+            <jvmarg value="-Dlogback.configurationFile=config/logback-stdout-level-error.xml"/>
 		</junit>
 		<fail if="junit.failure" message="Unit test(s) failed.  See output above for failures."/>
 		<echo>

--- a/core/config/logback-stdout-level-error.xml
+++ b/core/config/logback-stdout-level-error.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="ERROR">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/core/src/net/sf/openrocket/util/TestRockets.java
+++ b/core/src/net/sf/openrocket/util/TestRockets.java
@@ -320,7 +320,7 @@ public class TestRockets {
 		finset.setFinCount(4);
 		
 		finset.setCantAngle(0 * Math.PI / 180);
-		System.err.println("Fin cant angle: " + (finset.getCantAngle() * 180 / Math.PI));
+		//System.err.println("Fin cant angle: " + (finset.getCantAngle() * 180 / Math.PI));
 		
 		mcomp = new MassComponent(0.2, 0.03, 0.045 + 0.060);
 		mcomp.setRelativePosition(Position.TOP);
@@ -539,7 +539,7 @@ public class TestRockets {
 		
 		
 		finset.setCantAngle(0 * Math.PI / 180);
-		System.err.println("Fin cant angle: " + (finset.getCantAngle() * 180 / Math.PI));
+		//System.err.println("Fin cant angle: " + (finset.getCantAngle() * 180 / Math.PI));
 		
 		
 		// Stage construction

--- a/core/test/net/sf/openrocket/communication/UpdateInfoTest.java
+++ b/core/test/net/sf/openrocket/communication/UpdateInfoTest.java
@@ -25,7 +25,7 @@ public class UpdateInfoTest extends BaseTestCase {
 	
 	/** How much long does the test allow it to take */
 	private static final int ALLOWANCE = 2000;
-
+	
 	
 	private HttpURLConnectionMock setup() {
 		HttpURLConnectionMock connection = new HttpURLConnectionMock();
@@ -41,7 +41,7 @@ public class UpdateInfoTest extends BaseTestCase {
 		assertEquals(Communicator.UPDATE_INFO_URL + "?version=" + BuildProperties.getVersion(),
 				connection.getTrueUrl());
 		assertTrue(connection.getConnectTimeout() > 0);
-		assertEquals(BuildProperties.getVersion() + "+" + BuildProperties.getBuildSource(), 
+		assertEquals(BuildProperties.getVersion() + "+" + BuildProperties.getBuildSource(),
 				connection.getRequestProperty("X-OpenRocket-Version"));
 		assertNotNull(connection.getRequestProperty("X-OpenRocket-Country"));
 		assertNotNull(connection.getRequestProperty("X-OpenRocket-ID"));
@@ -52,19 +52,19 @@ public class UpdateInfoTest extends BaseTestCase {
 		assertFalse(connection.getUseCaches());
 	}
 	
-
+	
 	@Test
 	public void testUpdateAvailable() throws IOException {
 		HttpURLConnectionMock connection = setup();
 		connection.setResponseCode(Communicator.UPDATE_INFO_UPDATE_AVAILABLE);
 		
 		String content =
-			"Version: 6.6.6pre A \n" +
-			"Extra:  information\n" +
-			"100:hundred\n" +
-			"50:  m\u00e4 \n\n" +
-			"1:     one\n" +
-			"-2: none";
+				"Version: 6.6.6pre A \n" +
+						"Extra:  information\n" +
+						"100:hundred\n" +
+						"50:  m\u00e4 \n\n" +
+						"1:     one\n" +
+						"-2: none";
 		connection.setContent(content);
 		
 		UpdateInfoRetriever retriever = new UpdateInfoRetriever();
@@ -75,40 +75,40 @@ public class UpdateInfoTest extends BaseTestCase {
 		
 		waitfor(retriever);
 		assertFalse(connection.hasFailed());
-
+		
 		UpdateInfo info = retriever.getUpdateInfo();
 		assertNotNull(info);
-
+		
 		check(connection);
-
+		
 		assertEquals("6.6.6pre A", info.getLatestVersion());
-
+		
 		List<ComparablePair<Integer, String>> updates = info.getUpdates();
 		assertEquals(3, updates.size());
 		Collections.sort(updates);
-		assertEquals(1, (int)updates.get(0).getU());
+		assertEquals(1, (int) updates.get(0).getU());
 		assertEquals("one", updates.get(0).getV());
-		assertEquals(50, (int)updates.get(1).getU());
+		assertEquals(50, (int) updates.get(1).getU());
 		assertEquals("m\u00e4", updates.get(1).getV());
-		assertEquals(100, (int)updates.get(2).getU());
+		assertEquals(100, (int) updates.get(2).getU());
 		assertEquals("hundred", updates.get(2).getV());
 	}
 	
 	
 	
-
+	
 	@Test
 	public void testUpdateNotAvailable() throws IOException {
 		HttpURLConnectionMock connection = setup();
 		connection.setResponseCode(Communicator.UPDATE_INFO_NO_UPDATE_CODE);
 		
 		String content =
-			"Version: 6.6.6pre A \n" +
-			"Extra:  information\n" +
-			"100:hundred\n" +
-			"50:  m\u00e4 \n\n" +
-			"1:     one\n" +
-			"-2: none";
+				"Version: 6.6.6pre A \n" +
+						"Extra:  information\n" +
+						"100:hundred\n" +
+						"50:  m\u00e4 \n\n" +
+						"1:     one\n" +
+						"-2: none";
 		connection.setContent(content);
 		
 		UpdateInfoRetriever retriever = new UpdateInfoRetriever();
@@ -119,12 +119,12 @@ public class UpdateInfoTest extends BaseTestCase {
 		
 		waitfor(retriever);
 		assertFalse(connection.hasFailed());
-
+		
 		UpdateInfo info = retriever.getUpdateInfo();
 		assertNotNull(info);
-
+		
 		check(connection);
-
+		
 		assertEquals(BuildProperties.getVersion(), info.getLatestVersion());
 		assertEquals(0, info.getUpdates().size());
 	}
@@ -136,7 +136,7 @@ public class UpdateInfoTest extends BaseTestCase {
 		HttpURLConnectionMock connection = setup();
 		connection.setResponseCode(404);
 		connection.setContent("Version: 1.2.3");
-
+		
 		UpdateInfoRetriever retriever = new UpdateInfoRetriever();
 		retriever.start();
 		assertNull(retriever.getUpdateInfo());
@@ -144,12 +144,12 @@ public class UpdateInfoTest extends BaseTestCase {
 		assertFalse(connection.hasFailed());
 		assertNull(retriever.getUpdateInfo());
 		check(connection);
-
+		
 		
 		connection = setup();
 		connection.setResponseCode(Communicator.UPDATE_INFO_UPDATE_AVAILABLE);
 		connection.setContentType("text/xml");
-
+		
 		retriever = new UpdateInfoRetriever();
 		retriever.start();
 		assertNull(retriever.getUpdateInfo());
@@ -157,17 +157,17 @@ public class UpdateInfoTest extends BaseTestCase {
 		assertFalse(connection.hasFailed());
 		assertNull(retriever.getUpdateInfo());
 		check(connection);
-
-
-
+		
+		
+		
 		connection = setup();
 		connection.setResponseCode(Communicator.UPDATE_INFO_UPDATE_AVAILABLE);
 		String content =
-			"100:hundred\n" +
-			"50:  m\u00e4 \n\n" +
-			"1:     one\n";
+				"100:hundred\n" +
+						"50:  m\u00e4 \n\n" +
+						"1:     one\n";
 		connection.setContent(content);
-
+		
 		retriever = new UpdateInfoRetriever();
 		retriever.start();
 		assertNull(retriever.getUpdateInfo());
@@ -175,12 +175,12 @@ public class UpdateInfoTest extends BaseTestCase {
 		assertFalse(connection.hasFailed());
 		assertNull(retriever.getUpdateInfo());
 		check(connection);
-
-
+		
+		
 		connection = setup();
 		connection.setResponseCode(Communicator.UPDATE_INFO_UPDATE_AVAILABLE);
 		connection.setContent(new byte[0]);
-
+		
 		retriever = new UpdateInfoRetriever();
 		retriever.start();
 		assertNull(retriever.getUpdateInfo());
@@ -195,15 +195,15 @@ public class UpdateInfoTest extends BaseTestCase {
 	public void testRandomInputData() {
 		
 		Random rnd = new Random();
-		for (int i=0; i<10; i++) {
+		for (int i = 0; i < 10; i++) {
 			int size = (int) ((1 + 0.3 * rnd.nextGaussian()) * Math.pow(i, 6));
 			byte[] buf = new byte[size];
 			rnd.nextBytes(buf);
-
+			
 			HttpURLConnectionMock connection = setup();
 			connection.setResponseCode(Communicator.UPDATE_INFO_UPDATE_AVAILABLE);
 			connection.setContent(buf);
-
+			
 			UpdateInfoRetriever retriever = new UpdateInfoRetriever();
 			retriever.start();
 			assertNull(retriever.getUpdateInfo());
@@ -215,22 +215,23 @@ public class UpdateInfoTest extends BaseTestCase {
 		
 	}
 	
-
+	
 	
 	private void waitfor(UpdateInfoRetriever retriever) {
 		long t = System.currentTimeMillis();
 		
 		while (retriever.isRunning()) {
-			if (System.currentTimeMillis() >= t+ALLOWANCE) {
+			if (System.currentTimeMillis() >= t + ALLOWANCE) {
 				fail("retriever took too long to respond");
 			}
-
+			
 			try {
 				Thread.sleep(10);
-			} catch (InterruptedException e) { }
+			} catch (InterruptedException e) {
+			}
 		}
 		
-		System.out.println("Waiting took " + (System.currentTimeMillis()-t) + " ms");
+		//System.out.println("Waiting took " + (System.currentTimeMillis()-t) + " ms");
 	}
-
+	
 }

--- a/core/test/net/sf/openrocket/file/iterator/TestDirectoryIterator.java
+++ b/core/test/net/sf/openrocket/file/iterator/TestDirectoryIterator.java
@@ -18,7 +18,9 @@ public class TestDirectoryIterator {
 		}, true);
 		
 		while (iterator.hasNext()) {
-			System.out.println("" + iterator.next());
+			// TODO need checks here to ensure correct things were done
+			//System.out.println("" + iterator.next());
+			iterator.next();
 		}
 		
 	}

--- a/core/test/net/sf/openrocket/file/rocksim/export/RocksimDocumentDTOTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/export/RocksimDocumentDTOTest.java
@@ -41,23 +41,24 @@ public class RocksimDocumentDTOTest extends RocksimTestBase {
 		RocksimDocumentDTO message = new RocksimDocumentDTO();
 		message.setDesign(design);
 		
-		
 		StringWriter stringWriter = new StringWriter();
 		marshaller.marshal(message, stringWriter);
 		
 		String response = stringWriter.toString();
 		
-		System.err.println(response);
+		// TODO need checks here to validation that correct things were done
+		//System.err.println(response);
 	}
 	
 	@Test
 	public void testRoundTrip() throws Exception {
+		// TODO need checks here to validate that correct things were done
 		OpenRocketDocument ord = RocksimLoaderTest.loadRocksimRocket3(new RocksimLoader());
 		
 		Assert.assertNotNull(ord);
 		String result = new RocksimSaver().marshalToRocksim(ord);
 		
-		//        System.err.println(result);
+		//  System.err.println(result);
 		
 		File output = new File("rt.rkt");
 		FileWriter fw = new FileWriter(output);

--- a/core/test/net/sf/openrocket/logging/LogLevelTest.java
+++ b/core/test/net/sf/openrocket/logging/LogLevelTest.java
@@ -1,22 +1,64 @@
 package net.sf.openrocket.logging;
 
-import static net.sf.openrocket.logging.LogLevel.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
 public class LogLevelTest {
-
+	
 	@Test
-	public void testLevels() {
-		assertTrue(DEBUG.atLeast(DEBUG));
-		assertFalse(DEBUG.atLeast(INFO));
-		assertTrue(ERROR.atLeast(WARN));
+	public void testLogLevelSeverityCompares() {
 		
-		assertTrue(ERROR.moreThan(WARN));
-		assertFalse(ERROR.moreThan(ERROR));
+		// tests comparing level to itself
+		assertTrue(LogLevel.DEBUG.atLeast(LogLevel.DEBUG));
+		assertFalse(LogLevel.DEBUG.moreThan(LogLevel.DEBUG));
 		
-		assertEquals(5, LENGTH);
+		// tests comparing high severity to lower severity (positive tests)
+		assertTrue(LogLevel.ERROR.atLeast(LogLevel.WARN));
+		assertTrue(LogLevel.ERROR.moreThan(LogLevel.WARN));
+		assertTrue(LogLevel.STDERR.atLeast(LogLevel.VBOSE));
+		assertTrue(LogLevel.STDERR.moreThan(LogLevel.VBOSE));
+		
+		// tests comparing lower severity to higher severity (negative tests)
+		assertFalse(LogLevel.WARN.atLeast(LogLevel.ERROR));
+		assertFalse(LogLevel.WARN.moreThan(LogLevel.ERROR));
+		assertFalse(LogLevel.VBOSE.atLeast(LogLevel.STDERR));
+		assertFalse(LogLevel.VBOSE.moreThan(LogLevel.STDERR));
+		
+	}
+	
+	@Test
+	public void testLogLevelFromString() {
+		
+		LogLevel logLevelReturned;
+		
+		// null value should return default
+		logLevelReturned = LogLevel.fromString(null, LogLevel.INFO);
+		assertTrue(logLevelReturned == LogLevel.INFO);
+		
+		// invalid value should return default
+		logLevelReturned = LogLevel.fromString("not a valid log level", LogLevel.INFO);
+		assertTrue(logLevelReturned == LogLevel.INFO);
+		
+		// lowercase value should be uppercased and return correct same value
+		logLevelReturned = LogLevel.fromString("debug", LogLevel.INFO);
+		assertTrue(logLevelReturned == LogLevel.DEBUG);
+		
+		// leading and trailing whitespace in value should be trimmed and return correct same value
+		logLevelReturned = LogLevel.fromString("  DEBUG  ", LogLevel.INFO);
+		assertTrue(logLevelReturned == LogLevel.DEBUG);
+		
+		// value of all should return lowest level (most verbose) of logging
+		logLevelReturned = LogLevel.fromString("all", LogLevel.INFO);
+		assertTrue(logLevelReturned == LogLevel.LOWEST);
+		
+	}
+	
+	@Test
+	public void testMaxLengthOfAnyLogLevelName() {
+		assertEquals("Max length of at least one log level name is different than expected.", 6, LogLevel.LENGTH);
 	}
 	
 }

--- a/core/test/net/sf/openrocket/rocketcomponent/ComponentCompareTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/ComponentCompareTest.java
@@ -14,15 +14,15 @@ import net.sf.openrocket.util.BaseTestCase.BaseTestCase;
 import org.junit.Test;
 
 public class ComponentCompareTest extends BaseTestCase {
-
+	
 	@Test
 	public void testComponentEquality() {
 		
-		System.out.println("TEST CLASSPATH: " + System.getProperty("java.class.path"));
+		//System.out.println("TEST CLASSPATH: " + System.getProperty("java.class.path"));
 		
 		Rocket r1 = net.sf.openrocket.util.TestRockets.makeBigBlue();
 		Rocket r2 = net.sf.openrocket.util.TestRockets.makeBigBlue();
-
+		
 		Iterator<RocketComponent> i1 = r1.iterator(true);
 		Iterator<RocketComponent> i2 = r2.iterator(true);
 		while (i1.hasNext()) {
@@ -35,7 +35,7 @@ public class ComponentCompareTest extends BaseTestCase {
 			ComponentCompare.assertSimilarity(c1, c2);
 		}
 		assertFalse(i2.hasNext());
-
+		
 		
 		ComponentCompare.assertDeepEquality(r1, r2);
 		ComponentCompare.assertDeepSimilarity(r1, r2, false);
@@ -59,7 +59,7 @@ public class ComponentCompareTest extends BaseTestCase {
 			
 			if (c1 instanceof FinSet) {
 				finsetfound = true;
-				FinSet f1 = (FinSet)c1;
+				FinSet f1 = (FinSet) c1;
 				f1.setTabHeight(0.001);
 				
 				try {
@@ -77,16 +77,16 @@ public class ComponentCompareTest extends BaseTestCase {
 	@Test
 	public void testComponentSimilarity() throws IllegalFinPointException {
 		FinSet trap = new TrapezoidFinSet(
-				5,   // fins
+				5, // fins
 				5.0, // root
 				3.0, // tip
 				0.0, // sweep
 				2.0); // height
 		FinSet free = new FreeformFinSet(new Coordinate[] {
-				new Coordinate(0,0),
-				new Coordinate(0,2),
-				new Coordinate(3,2),
-				new Coordinate(5,0)
+				new Coordinate(0, 0),
+				new Coordinate(0, 2),
+				new Coordinate(3, 2),
+				new Coordinate(5, 0)
 		});
 		free.setFinCount(5);
 		
@@ -116,7 +116,7 @@ public class ComponentCompareTest extends BaseTestCase {
 		t2.addChild(trap);
 		
 		ComponentCompare.assertDeepSimilarity(t1, t2, false);
-
+		
 		try {
 			ComponentCompare.assertDeepEquality(t1, t2);
 			fail();
@@ -125,7 +125,7 @@ public class ComponentCompareTest extends BaseTestCase {
 		}
 		
 		t1.addChild(new TrapezoidFinSet());
-
+		
 		try {
 			ComponentCompare.assertDeepSimilarity(t1, t2, true);
 			fail();

--- a/core/test/net/sf/openrocket/rocketcomponent/SymmetricComponentVolumeTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/SymmetricComponentVolumeTest.java
@@ -24,14 +24,14 @@ public class SymmetricComponentVolumeTest extends BaseTestCase {
 		
 		Coordinate cg = nc.getCG();
 		
-		System.out.println(nc.getComponentVolume() + "\t" + nc.getMass());
-		System.out.println(cg);
+		//System.out.println(nc.getComponentVolume() + "\t" + nc.getMass());
+		//System.out.println(cg);
 		
 		double volume = Math.PI / 3.0;
 		
 		double mass = density * volume;
 		
-		System.out.println(volume);
+		//System.out.println(volume);
 		
 		assertEquals(volume, nc.getComponentVolume(), epsilonPercent * volume);
 		assertEquals(mass, nc.getMass(), epsilonPercent * mass);
@@ -58,15 +58,15 @@ public class SymmetricComponentVolumeTest extends BaseTestCase {
 		
 		Coordinate cg = nc.getCG();
 		
-		System.out.println(nc.getComponentVolume() + "\t" + nc.getMass());
-		System.out.println(cg);
+		//System.out.println(nc.getComponentVolume() + "\t" + nc.getMass());
+		//System.out.println(cg);
 		
 		double volume = Math.PI / 3.0;
 		volume += Math.PI;
 		
 		double mass = density * volume;
 		
-		System.out.println(volume + "\t" + mass);
+		//System.out.println(volume + "\t" + mass);
 		
 		assertEquals(volume, nc.getComponentVolume(), epsilonPercent * volume);
 		assertEquals(mass, nc.getMass(), epsilonPercent * mass);
@@ -90,8 +90,8 @@ public class SymmetricComponentVolumeTest extends BaseTestCase {
 		
 		Coordinate cg = nc.getCG();
 		
-		System.out.println(nc.getComponentVolume() + "\t" + nc.getMass());
-		System.out.println(cg);
+		//System.out.println(nc.getComponentVolume() + "\t" + nc.getMass());
+		//System.out.println(cg);
 		
 		double volume = Math.PI / 3.0; // outer volume
 		
@@ -105,7 +105,7 @@ public class SymmetricComponentVolumeTest extends BaseTestCase {
 		
 		double mass = density * volume;
 		
-		System.out.println(volume);
+		//System.out.println(volume);
 		
 		assertEquals(volume, nc.getComponentVolume(), epsilonPercent * volume);
 		assertEquals(mass, nc.getMass(), epsilonPercent * mass);
@@ -132,8 +132,8 @@ public class SymmetricComponentVolumeTest extends BaseTestCase {
 		
 		Coordinate cg = nc.getCG();
 		
-		System.out.println(nc.getComponentVolume() + "\t" + nc.getMass());
-		System.out.println(cg);
+		//System.out.println(nc.getComponentVolume() + "\t" + nc.getMass());
+		//System.out.println(cg);
 		
 		double volume = Math.PI / 3.0; // outer volume
 		
@@ -150,7 +150,7 @@ public class SymmetricComponentVolumeTest extends BaseTestCase {
 		
 		double mass = density * volume;
 		
-		System.out.println(volume);
+		//System.out.println(volume);
 		
 		assertEquals(volume, nc.getComponentVolume(), epsilonPercent * volume);
 		assertEquals(mass, nc.getMass(), epsilonPercent * mass);
@@ -175,14 +175,14 @@ public class SymmetricComponentVolumeTest extends BaseTestCase {
 		
 		Coordinate cg = nc.getCG();
 		
-		System.out.println(nc.getComponentVolume() + "\t" + nc.getMass());
-		System.out.println(cg);
+		//System.out.println(nc.getComponentVolume() + "\t" + nc.getMass());
+		//System.out.println(cg);
 		
 		double volume = Math.PI / 3.0 * (2.0 * 2.0 + 2.0 * 1.0 + 1.0 * 1.0) * 4.0;
 		
 		double mass = density * volume;
 		
-		System.out.println(volume);
+		//System.out.println(volume);
 		
 		assertEquals(volume, nc.getComponentVolume(), epsilonPercent * volume);
 		assertEquals(mass, nc.getMass(), epsilonPercent * mass);
@@ -213,8 +213,8 @@ public class SymmetricComponentVolumeTest extends BaseTestCase {
 		
 		Coordinate cg = nc.getCG();
 		
-		System.out.println(nc.getComponentVolume() + "\t" + nc.getMass());
-		System.out.println(cg);
+		//System.out.println(nc.getComponentVolume() + "\t" + nc.getMass());
+		//System.out.println(cg);
 		
 		double volume = Math.PI / 3.0 * (2.0 * 2.0 + 2.0 * 1.0 + 1.0 * 1.0) * 4.0;
 		// plus aft shoulder:
@@ -224,7 +224,7 @@ public class SymmetricComponentVolumeTest extends BaseTestCase {
 		
 		double mass = density * volume;
 		
-		System.out.println(volume);
+		//System.out.println(volume);
 		
 		assertEquals(volume, nc.getComponentVolume(), epsilonPercent * volume);
 		assertEquals(mass, nc.getMass(), epsilonPercent * mass);
@@ -249,8 +249,8 @@ public class SymmetricComponentVolumeTest extends BaseTestCase {
 		
 		Coordinate cg = nc.getCG();
 		
-		System.out.println(nc.getComponentVolume() + "\t" + nc.getMass());
-		System.out.println(cg);
+		//System.out.println(nc.getComponentVolume() + "\t" + nc.getMass());
+		//System.out.println(cg);
 		
 		// Volume of filled transition = 
 		double filledVolume = Math.PI / 3.0 * (1.0 * 1.0 + 1.0 * 0.5 + 0.5 * 0.5) * 1.0;
@@ -271,7 +271,7 @@ public class SymmetricComponentVolumeTest extends BaseTestCase {
 		
 		double mass = density * volume;
 		
-		System.out.println(volume);
+		//System.out.println(volume);
 		
 		assertEquals(volume, nc.getComponentVolume(), epsilonPercent * volume);
 		assertEquals(mass, nc.getMass(), epsilonPercent * mass);
@@ -302,8 +302,8 @@ public class SymmetricComponentVolumeTest extends BaseTestCase {
 		
 		Coordinate cg = nc.getCG();
 		
-		System.out.println(nc.getComponentVolume() + "\t" + nc.getMass());
-		System.out.println(cg);
+		//System.out.println(nc.getComponentVolume() + "\t" + nc.getMass());
+		//System.out.println(cg);
 		
 		// Volume of filled transition = 
 		double filledVolume = Math.PI / 3.0 * (1.0 * 1.0 + 1.0 * 0.5 + 0.5 * 0.5) * 1.0;
@@ -329,7 +329,7 @@ public class SymmetricComponentVolumeTest extends BaseTestCase {
 		
 		double mass = density * volume;
 		
-		System.out.println(volume);
+		//System.out.println(volume);
 		
 		assertEquals(volume, nc.getComponentVolume(), epsilonPercent * volume);
 		assertEquals(mass, nc.getMass(), epsilonPercent * mass);
@@ -354,8 +354,8 @@ public class SymmetricComponentVolumeTest extends BaseTestCase {
 		
 		Coordinate cg = nc.getCG();
 		
-		System.out.println(nc.getComponentVolume() + "\t" + nc.getMass());
-		System.out.println(cg);
+		//System.out.println(nc.getComponentVolume() + "\t" + nc.getMass());
+		//System.out.println(cg);
 		
 		// Volume of filled transition = 
 		double filledVolume = Math.PI / 3.0 * (1.0 * 1.0 + 1.0 * 0.5 + 0.5 * 0.5) * 1.0;
@@ -377,7 +377,7 @@ public class SymmetricComponentVolumeTest extends BaseTestCase {
 		
 		double mass = density * volume;
 		
-		System.out.println(volume);
+		//System.out.println(volume);
 		
 		assertEquals(volume, nc.getComponentVolume(), epsilonPercent * volume);
 		assertEquals(mass, nc.getMass(), epsilonPercent * mass);
@@ -409,8 +409,8 @@ public class SymmetricComponentVolumeTest extends BaseTestCase {
 		
 		Coordinate cg = nc.getCG();
 		
-		System.out.println(nc.getComponentVolume() + "\t" + nc.getMass());
-		System.out.println(cg);
+		//System.out.println(nc.getComponentVolume() + "\t" + nc.getMass());
+		//System.out.println(cg);
 		
 		// Volume of filled transition = 
 		double filledVolume = Math.PI / 3.0 * (1.0 * 1.0 + 1.0 * 0.5 + 0.5 * 0.5) * 1.0;
@@ -438,7 +438,7 @@ public class SymmetricComponentVolumeTest extends BaseTestCase {
 		
 		double mass = density * volume;
 		
-		System.out.println(volume);
+		//System.out.println(volume);
 		
 		assertEquals(volume, nc.getComponentVolume(), epsilonPercent * volume);
 		assertEquals(mass, nc.getMass(), epsilonPercent * mass);

--- a/core/test/net/sf/openrocket/simulation/customexpression/TestExpressions.java
+++ b/core/test/net/sf/openrocket/simulation/customexpression/TestExpressions.java
@@ -17,7 +17,7 @@ public class TestExpressions extends BaseTestCase {
 		//CustomExpression exp = new CustomExpression(doc, "Kinetic energy", "Ek", "J", ".5*m*Vt^2");
 		
 		CustomExpression exp = new CustomExpression(doc, "Average mass", "Mavg", "kg", "mean(m[0:t])");
-		System.out.println(exp.getExpressionString());
+		//System.out.println(exp.getExpressionString());
 		
 	}
 }

--- a/core/test/net/sf/openrocket/util/Base64Test.java
+++ b/core/test/net/sf/openrocket/util/Base64Test.java
@@ -1,17 +1,17 @@
 package net.sf.openrocket.util;
 
+import static org.junit.Assert.fail;
+
 import java.util.Arrays;
 import java.util.Random;
-
-import static org.junit.Assert.*;
 
 import org.junit.Test;
 
 public class Base64Test {
-
+	
 	@Test
 	public void oldMainTest() throws Exception {
-
+		
 		// TODO - this test case should probably be less random and more targeted to
 		// special cases such as:
 		// null input
@@ -19,24 +19,23 @@ public class Base64Test {
 		// decoding bad string
 		
 		Random rnd = new Random();
-
-		for (int round=0; round < 1000; round++) {
+		
+		for (int round = 0; round < 1000; round++) {
 			int n = rnd.nextInt(1000);
 			n = 100000;
-
+			
 			byte[] array = new byte[n];
 			rnd.nextBytes(array);
-
+			
 			String encoded = Base64.encode(array);
-
+			
 			byte[] decoded = null;
 			decoded = Base64.decode(encoded);
-
+			
 			if (!Arrays.equals(array, decoded)) {
-				fail("Data differs!  n="+n);
+				fail("Data differs!  n=" + n);
 			}
-			System.out.println("n="+n+" ok!");
-
+			
 		}
 	}
 }

--- a/core/test/net/sf/openrocket/util/GeodeticComputationStrategyTest.java
+++ b/core/test/net/sf/openrocket/util/GeodeticComputationStrategyTest.java
@@ -1,6 +1,7 @@
 package net.sf.openrocket.util;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
@@ -25,11 +26,11 @@ public class GeodeticComputationStrategyTest {
 		WorldCoordinate wc = new WorldCoordinate(lat1, lon1, 0.0);
 		wc = GeodeticComputationStrategy.SPHERICAL.addCoordinate(wc, coord);
 		
-		System.out.println(wc.getLatitudeDeg());
-		System.out.println(lat2);
+		//System.out.println(wc.getLatitudeDeg());
+		//System.out.println(lat2);
 		
-		System.out.println(wc.getLongitudeDeg());
-		System.out.println(lon2);
+		//System.out.println(wc.getLongitudeDeg());
+		//System.out.println(lon2);
 		
 		assertEquals(lat2, wc.getLatitudeDeg(), 0.001);
 		assertEquals(lon2, wc.getLongitudeDeg(), 0.001);
@@ -43,46 +44,46 @@ public class GeodeticComputationStrategyTest {
 		double min = 1 / 60.0;
 		double sec = 1 / 3600.0;
 		
-
+		
 		// Test zero movement
-		System.out.println("\nTesting zero movement");
+		//System.out.println("\nTesting zero movement");
 		testAddCoordinate(50.0, 20.0, 0, 123, 50.0, 20.0, false);
 		
-
+		
 		/*
 		 * These example values have been computed using the calculator at
 		 * http://www.movable-type.co.uk/scripts/latlong.html
 		 */
-
+		
 		// Long distance NE over England, crosses Greenwich meridian
 		// 50 03N  005 42W  to  58 38N  003 04E  is  1109km at 027 16'07"
-		System.out.println("\nTesting 1109km NE over England");
+		//System.out.println("\nTesting 1109km NE over England");
 		testAddCoordinate(50 + 3 * min, -5 - 42 * min, 1109000, 27 + 16 * min + 7 * sec, 58 + 38 * min, 3 + 4 * min, false);
 		
 		// SW over Brazil
 		// -10N  -60E  to  -11N  -61E  is  155.9km at 224 25'34"
-		System.out.println("\nTesting 155km SW over Brazil");
+		//System.out.println("\nTesting 155km SW over Brazil");
 		testAddCoordinate(-10, -60, 155900, 224 + 25 * min + 34 * sec, -11, -61, true);
 		
 		// NW over the 180 meridian
 		// 63N  -179E  to  63 01N  179E  is  100.9km at 271 56'34"
-		System.out.println("\nTesting 100km NW over 180 meridian");
+		//System.out.println("\nTesting 100km NW over 180 meridian");
 		testAddCoordinate(63, -179, 100900, 271 + 56 * min + 34 * sec, 63 + 1 * min, 179, true);
 		
 		// NE near the north pole
 		// 89 50N  0E  to 89 45N  175E  is 46.29 km at 003 00'01"
-		System.out.println("\nTesting 46km NE near north pole");
+		//System.out.println("\nTesting 46km NE near north pole");
 		testAddCoordinate(89 + 50 * min, 0, 46290, 3 + 0 * min + 1 * sec, 89 + 45 * min, 175, false);
 		
 		// S directly over south pole
 		// -89 50N  12E  to  -89 45N  192E  is  46.33km at 180 00'00"
-		System.out.println("\nTesting 46km directly over south pole ");
+		//System.out.println("\nTesting 46km directly over south pole ");
 		testAddCoordinate(-89 - 50 * min, 12, 46330, 180, -89 - 45 * min, -168, false);
 		
 	}
 	
 	private void testAddCoordinate(double initialLatitude, double initialLongitude, double distance, double bearing,
-				double finalLatitude, double finalLongitude, boolean testFlat) {
+			double finalLatitude, double finalLongitude, boolean testFlat) {
 		
 		double tolerance;
 		
@@ -97,16 +98,16 @@ public class GeodeticComputationStrategyTest {
 		
 		// Test SPHERICAL
 		tolerance = 0.0015 * distance / 111325;
-		System.out.println("\nSpherical tolerance: " + tolerance);
+		//System.out.println("\nSpherical tolerance: " + tolerance);
 		WorldCoordinate result = GeodeticComputationStrategy.SPHERICAL.addCoordinate(wc, coord);
 		
-		System.out.println("Difference Lat: " + Math.abs(finalLatitude - result.getLatitudeDeg()));
-		System.out.println("Difference Lon: " + Math.abs(finalLongitude - result.getLongitudeDeg()));
+		//System.out.println("Difference Lat: " + Math.abs(finalLatitude - result.getLatitudeDeg()));
+		//System.out.println("Difference Lon: " + Math.abs(finalLongitude - result.getLongitudeDeg()));
 		assertEquals(finalLatitude, result.getLatitudeDeg(), tolerance);
 		assertEquals(finalLongitude, result.getLongitudeDeg(), tolerance);
 		assertEquals(1000.0, result.getAltitude(), 0.0);
 		
-
+		
 		// Test WGS84
 		/*
 		 * Note: Since the example values are computed using a spherical earth approximation,
@@ -115,24 +116,24 @@ public class GeodeticComputationStrategyTest {
 		 * the greatest.
 		 */
 		tolerance = 0.04 * distance / 111325;
-		System.out.println("\nWGS84 tolerance: " + tolerance);
+		//System.out.println("\nWGS84 tolerance: " + tolerance);
 		result = GeodeticComputationStrategy.WGS84.addCoordinate(wc, coord);
 		
-		System.out.println("Difference Lat: " + Math.abs(finalLatitude - result.getLatitudeDeg()));
-		System.out.println("Difference Lon: " + Math.abs(finalLongitude - result.getLongitudeDeg()));
+		//System.out.println("Difference Lat: " + Math.abs(finalLatitude - result.getLatitudeDeg()));
+		//System.out.println("Difference Lon: " + Math.abs(finalLongitude - result.getLongitudeDeg()));
 		assertEquals(finalLatitude, result.getLatitudeDeg(), tolerance);
 		assertEquals(finalLongitude, result.getLongitudeDeg(), tolerance);
 		assertEquals(1000.0, result.getAltitude(), 0.0);
 		
-
+		
 		// Test FLAT
 		if (testFlat) {
 			tolerance = 0.02 * distance / 111325;
-			System.out.println("\nFlat tolerance: " + tolerance);
+			//System.out.println("\nFlat tolerance: " + tolerance);
 			result = GeodeticComputationStrategy.FLAT.addCoordinate(wc, coord);
 			
-			System.out.println("Difference Lat: " + Math.abs(finalLatitude - result.getLatitudeDeg()));
-			System.out.println("Difference Lon: " + Math.abs(finalLongitude - result.getLongitudeDeg()));
+			//System.out.println("Difference Lat: " + Math.abs(finalLatitude - result.getLatitudeDeg()));
+			//System.out.println("Difference Lon: " + Math.abs(finalLongitude - result.getLongitudeDeg()));
 			assertEquals(finalLatitude, result.getLatitudeDeg(), tolerance);
 			assertEquals(finalLongitude, result.getLongitudeDeg(), tolerance);
 			assertEquals(1000.0, result.getAltitude(), 0.0);
@@ -142,7 +143,7 @@ public class GeodeticComputationStrategyTest {
 	}
 	
 	
-
+	
 	@Test
 	public void testSpericalGetCoriolisAcceleration() {
 		
@@ -150,7 +151,7 @@ public class GeodeticComputationStrategyTest {
 		Coordinate velocity = new Coordinate(-1000, 0, 0);
 		WorldCoordinate wc = new WorldCoordinate(45, 0, 0);
 		double north_accel = GeodeticComputationStrategy.SPHERICAL.getCoriolisAcceleration(wc, velocity).y;
-		System.out.println("North accel " + north_accel);
+		//System.out.println("North accel " + north_accel);
 		assertTrue(north_accel < 0.0);
 		
 	}

--- a/core/test/net/sf/openrocket/util/QuaternionTest.java
+++ b/core/test/net/sf/openrocket/util/QuaternionTest.java
@@ -1,48 +1,49 @@
 package net.sf.openrocket.util;
 
-import org.junit.Test;
 import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 
 
 public class QuaternionTest {
-
+	
 	@Test
 	public void oldMainTest() {
-
+		
 		// This is normalized already
 		Quaternion q = new Quaternion(0.237188, 0.570190, -0.514542, 0.594872);
-		assertEquals( 1.0, q.norm(), 0.01);
-
-		q.normalize();
-		assertEquals( 0.237188, q.getW(), 0.00001);
-		assertEquals( 0.570190, q.getX(), 0.00001);
-		assertEquals( -0.514542, q.getY(), 0.00001);
-		assertEquals( 0.594872, q.getZ(), 0.00001);
-		assertEquals( 1.0, q.norm(), 0.01);
-
-		Coordinate c = new Coordinate(148578428.914, 8126778.954, -607.741);
-
-		Coordinate r = q.rotate(c);
-
-		System.out.println("Rotated: " + q.rotate(c));
-
-		assertEquals( -42312599.537, r.x, 0.001);
-		assertEquals( -48162747.551, r.y, 0.001);
-		assertEquals( 134281904.197, r.z, 0.001);
-
-		c = new Coordinate(0,1,0);
-		Coordinate rot = new Coordinate(Math.PI/4,0,0);
-
-		System.out.println("Before: "+c);
-		c = Quaternion.rotation(rot).invRotate(c);
-		System.out.println("After: "+c);
+		assertEquals(1.0, q.norm(), 0.01);
 		
-		assertEquals( 0.0, c.x, 0.001);
-		assertEquals( 0.707, c.y, 0.001);
-		assertEquals( -0.707, c.z, 0.001);
-
-
+		q.normalize();
+		assertEquals(0.237188, q.getW(), 0.00001);
+		assertEquals(0.570190, q.getX(), 0.00001);
+		assertEquals(-0.514542, q.getY(), 0.00001);
+		assertEquals(0.594872, q.getZ(), 0.00001);
+		assertEquals(1.0, q.norm(), 0.01);
+		
+		Coordinate c = new Coordinate(148578428.914, 8126778.954, -607.741);
+		
+		Coordinate r = q.rotate(c);
+		
+		//System.out.println("Rotated: " + q.rotate(c));
+		
+		assertEquals(-42312599.537, r.x, 0.001);
+		assertEquals(-48162747.551, r.y, 0.001);
+		assertEquals(134281904.197, r.z, 0.001);
+		
+		c = new Coordinate(0, 1, 0);
+		Coordinate rot = new Coordinate(Math.PI / 4, 0, 0);
+		
+		//System.out.println("Before: "+c);
+		c = Quaternion.rotation(rot).invRotate(c);
+		//System.out.println("After: "+c);
+		
+		assertEquals(0.0, c.x, 0.001);
+		assertEquals(0.707, c.y, 0.001);
+		assertEquals(-0.707, c.z, 0.001);
+		
+		
 	}
-
-
+	
+	
 }


### PR DESCRIPTION
- Fixed unittest failure in LogLevelTest (and improved tests)
- Added config dir with logback config file that set logging to stdout and level to Error.
- Modified unittest target used by travis-ci to use new logback config file to reduce clutter in unittest output.  
- Commented out superfluous System.println's from various unit tests to also reduce clutter.

Also, eclipse reformated some of the lines to match code style.
