### PR TITLE
The motors in the motor selector are not sorted by default.

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -1401,6 +1401,7 @@ TCurveMotorCol.DESIGNATION = Designation
 TCurveMotorCol.TYPE = Type
 TCurveMotorCol.DIAMETER = Diameter
 TCurveMotorCol.LENGTH = Length
+TCurveMotorCol.TOTAL_IMPULSE = Total Impulse
 
 TCurveMotor.ttip.diameter = Diameter:
 TCurveMotor.ttip.length = Length:

--- a/core/src/net/sf/openrocket/database/motor/ThrustCurveMotorSet.java
+++ b/core/src/net/sf/openrocket/database/motor/ThrustCurveMotorSet.java
@@ -41,6 +41,7 @@ public class ThrustCurveMotorSet implements Comparable<ThrustCurveMotorSet> {
 	private String simplifiedDesignation = null;
 	private double diameter = -1;
 	private double length = -1;
+	private long totalImpulse = 0;
 	private Motor.Type type = Motor.Type.UNKNOWN;
 	
 	
@@ -54,6 +55,7 @@ public class ThrustCurveMotorSet implements Comparable<ThrustCurveMotorSet> {
 			simplifiedDesignation = simplifyDesignation(designation);
 			diameter = motor.getDiameter();
 			length = motor.getLength();
+			totalImpulse = Math.round((motor.getTotalImpulseEstimate()));
 		}
 		
 		// Verify that the motor can be added
@@ -218,7 +220,13 @@ public class ThrustCurveMotorSet implements Comparable<ThrustCurveMotorSet> {
 		return type;
 	}
 	
-	
+	/**
+	 * Return the estimated total impulse for this motor type.
+	 * @return estimated total impulse
+	 */
+	public long getTotalImpuse() {
+		return totalImpulse;
+	}
 	
 	
 	@Override

--- a/core/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorColumns.java
+++ b/core/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorColumns.java
@@ -42,6 +42,22 @@ enum ThrustCurveMotorColumns {
 			return new DesignationComparator();
 		}
 	},
+	//// TotalImpulse
+	TOTAL_IMPULSE("TCurveMotorCol.TOTAL_IMPULSE") {
+		@Override
+		public Object getValue(ThrustCurveMotorSet m) {
+			return m.getTotalImpuse();
+		}
+		
+		@Override
+		public Comparator<?> getComparator() {
+			return new Comparator<Long>() {
+				public int compare(Long o1, Long o2) {
+					return o1.compareTo(o2);
+				}
+			};
+		}
+	},
 	//// Type
 	TYPE("TCurveMotorCol.TYPE") {
 		@Override
@@ -79,7 +95,7 @@ enum ThrustCurveMotorColumns {
 		}
 	};
 	
-
+	
 	private final String title;
 	private final int width;
 	private static final Translator trans = Application.getTranslator();

--- a/core/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorSelectionPanel.java
+++ b/core/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorSelectionPanel.java
@@ -12,6 +12,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -34,6 +35,8 @@ import javax.swing.JTextField;
 import javax.swing.ListCellRenderer;
 import javax.swing.ListSelectionModel;
 import javax.swing.RowFilter;
+import javax.swing.RowSorter;
+import javax.swing.SortOrder;
 import javax.swing.SwingUtilities;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
@@ -262,6 +265,15 @@ public class ThrustCurveMotorSelectionPanel extends JPanel implements MotorSelec
 			table.getColumnModel().getColumn(i).setPreferredWidth(column.getWidth());
 		}
 		table.setRowSorter(sorter);
+		// force initial sort order to by diameter, total impulse, manufacturer
+		{
+			RowSorter.SortKey[] sortKeys = {
+					new RowSorter.SortKey(ThrustCurveMotorColumns.DIAMETER.ordinal(), SortOrder.ASCENDING),
+					new RowSorter.SortKey(ThrustCurveMotorColumns.TOTAL_IMPULSE.ordinal(), SortOrder.ASCENDING),
+					new RowSorter.SortKey(ThrustCurveMotorColumns.MANUFACTURER.ordinal(), SortOrder.ASCENDING)
+			};
+			sorter.setSortKeys(Arrays.asList(sortKeys));
+		}
 		
 		// Set selection and double-click listeners
 		table.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
@@ -557,7 +569,6 @@ public class ThrustCurveMotorSelectionPanel extends JPanel implements MotorSelec
 		setDelays(false);
 		
 	}
-	
 	
 	@Override
 	public Motor getSelectedMotor() {


### PR DESCRIPTION
Added total impulse column to motor selector dialog.  When the dialog is first displayed, sort the data in a reasonable way.
