### PR TITLE
Added a dialog box warning when users try to run a simulation with no simulations selected.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-Source code for the U of L USLI team's version of OpenRocket, used for flight simulation.


### PR DESCRIPTION
Note that the change of import line numbers and deletion of an extra line are accidental - shouldn't need to change those.
