### PR TITLE
Catch UnsupportedOperationExceptions from getDesktop.

### DIFF
--- a/core/src/net/sf/openrocket/gui/util/EditDecalHelper.java
+++ b/core/src/net/sf/openrocket/gui/util/EditDecalHelper.java
@@ -164,7 +164,7 @@ public class EditDecalHelper {
 		if (useSystemEditor) {
 			try {
 				Desktop.getDesktop().edit(tmpFile);
-			} catch (IOException ioex) {
+			} catch (Exception ioex) {
 				throw new EditDecalHelperException(trans.get("EditDecalHelper.launchSystemEditorException"), trans.get("EditDecalHelper.editPreferencesHelp"), ioex);
 			}
 		} else {


### PR DESCRIPTION
Fix for Issue 118.  Catch the unsupportedOperationException and display message.
