### PR TITLE
Prevent reordering columns in flight configuration tables to prevent casting exceptions.

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
@@ -18,8 +18,6 @@ import net.sf.openrocket.formatting.RocketDescriptor;
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.rocketcomponent.FlightConfigurableComponent;
-import net.sf.openrocket.rocketcomponent.MotorConfiguration;
-import net.sf.openrocket.rocketcomponent.MotorMount;
 import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.Pair;
@@ -87,7 +85,7 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 				ListSelectionModel model = (ListSelectionModel) e.getSource();
 				for( int row = firstrow; row <= lastrow; row ++) {
 					if ( model.isSelectedIndex(row) ) {
-						String id = (String) table.getValueAt(row, 0);
+						String id = (String) table.getValueAt(row, table.convertColumnIndexToView(0));
 						rocket.getDefaultConfiguration().setFlightConfigurationID(id);
 						return;
 					}
@@ -106,8 +104,8 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 
 	protected T getSelectedComponent() {
 
-		int col = table.getSelectedColumn();
-		int row = table.getSelectedRow();
+		int col = table.convertColumnIndexToModel(table.getSelectedColumn());
+		int row = table.convertRowIndexToModel(table.getSelectedRow());
 		if ( row < 0 || col < 0 ) {
 			return null;
 		}
@@ -120,8 +118,8 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 	}
 
 	protected String getSelectedConfigurationId() {
-		int col = table.getSelectedColumn();
-		int row = table.getSelectedRow();
+		int col = table.convertColumnIndexToModel(table.getSelectedColumn());
+		int row = table.convertRowIndexToModel(table.getSelectedRow());
 		if ( row < 0 || col < 0 ) {
 			return null;
 		}
@@ -141,6 +139,7 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 			Component c = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
 			JLabel label = (JLabel) c;
 
+			column = table.convertColumnIndexToModel(column);
 			switch (column) {
 			case 0: {
 				label.setText(descriptor.format(rocket, (String) value));

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
@@ -134,6 +134,7 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 
 		};
 		JTable configurationTable = new JTable(configurationTableModel);
+		configurationTable.getTableHeader().setReorderingAllowed(false);
 		configurationTable.setCellSelectionEnabled(true);
 		configurationTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 		configurationTable.setDefaultRenderer(Object.class, new MotorTableCellRenderer());
@@ -263,6 +264,8 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 
 		@Override
 		public Component getTableCellRendererComponent(JTable table,Object value, boolean isSelected, boolean hasFocus, int row,int column) {
+			column = table.convertColumnIndexToModel(column);
+			row = table.convertRowIndexToModel(row);
 			switch (column) {
 			case 0: {
 				JLabel label = new JLabel(descriptor.format(rocket, (String) value));

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
@@ -1,8 +1,5 @@
 package net.sf.openrocket.gui.main.flightconfigpanel;
 
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -15,20 +12,16 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
-import javax.swing.table.DefaultTableCellRenderer;
 
 import net.sf.openrocket.formatting.RocketDescriptor;
 import net.sf.openrocket.gui.dialogs.flightconfiguration.DeploymentSelectionDialog;
-import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.rocketcomponent.DeploymentConfiguration;
 import net.sf.openrocket.rocketcomponent.DeploymentConfiguration.DeployEvent;
-import net.sf.openrocket.rocketcomponent.MotorMount;
 import net.sf.openrocket.rocketcomponent.RecoveryDevice;
 import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
-import net.sf.openrocket.util.Pair;
 
 public class RecoveryConfigurationPanel extends FlightConfigurablePanel<RecoveryDevice> {
 
@@ -74,6 +67,7 @@ public class RecoveryConfigurationPanel extends FlightConfigurablePanel<Recovery
 		//// Recovery selection 
 		recoveryTableModel = new FlightConfigurableTableModel<RecoveryDevice>(RecoveryDevice.class, rocket);
 		JTable recoveryTable = new JTable(recoveryTableModel);
+		recoveryTable.getTableHeader().setReorderingAllowed(false);
 		recoveryTable.setCellSelectionEnabled(true);
 		recoveryTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 		recoveryTable.addMouseListener(new MouseAdapter() {

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
@@ -1,8 +1,5 @@
 package net.sf.openrocket.gui.main.flightconfigpanel;
 
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseAdapter;
@@ -15,20 +12,15 @@ import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
-import javax.swing.table.DefaultTableCellRenderer;
 
 import net.sf.openrocket.formatting.RocketDescriptor;
 import net.sf.openrocket.gui.dialogs.flightconfiguration.SeparationSelectionDialog;
-import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.l10n.Translator;
-import net.sf.openrocket.rocketcomponent.MotorMount;
-import net.sf.openrocket.rocketcomponent.RecoveryDevice;
 import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.rocketcomponent.Stage;
 import net.sf.openrocket.rocketcomponent.StageSeparationConfiguration;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
-import net.sf.openrocket.util.Pair;
 
 public class SeparationConfigurationPanel extends FlightConfigurablePanel<Stage> {
 	
@@ -81,6 +73,7 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<Stage>
 
 		};
 		JTable separationTable = new JTable(separationTableModel);
+		separationTable.getTableHeader().setReorderingAllowed(false);
 		separationTable.setCellSelectionEnabled(true);
 		separationTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 		separationTable.addMouseListener(new MouseAdapter() {


### PR DESCRIPTION
Tighten up FlightConfigurablePanel to allow for column or row reordering.  However, just in case, the motor, recovery, and separation panels explicitly disallow column reordering.
