### PR TITLE
Remove non-ascii chars from java files

### DIFF
--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/sky/builtin/Meadow.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/sky/builtin/Meadow.java
@@ -2,6 +2,7 @@ package net.sf.openrocket.gui.figure3d.photo.sky.builtin;
 
 import net.sf.openrocket.gui.figure3d.photo.sky.Sky.Credit;
 import net.sf.openrocket.gui.figure3d.photo.sky.SkyBox;
+import net.sf.openrocket.util.Chars;
 
 public class Meadow extends SkyBox implements Credit {
 	public static final Meadow instance = new Meadow();
@@ -12,7 +13,7 @@ public class Meadow extends SkyBox implements Credit {
 	
 	@Override
 	public String getCredit() {
-		return "© Emil Persson, aka Humus.\nCC-BY 3.0 Attribution License.";
+		return Chars.COPY + " Emil Persson, aka Humus.\nCC-BY 3.0 Attribution License.";
 	}
 	
 	@Override

--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/sky/builtin/Miramar.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/sky/builtin/Miramar.java
@@ -2,6 +2,7 @@ package net.sf.openrocket.gui.figure3d.photo.sky.builtin;
 
 import net.sf.openrocket.gui.figure3d.photo.sky.Sky.Credit;
 import net.sf.openrocket.gui.figure3d.photo.sky.SkyBox;
+import net.sf.openrocket.util.Chars;
 
 public class Miramar extends SkyBox implements Credit {
 	public static final Miramar instance = new Miramar();
@@ -12,7 +13,7 @@ public class Miramar extends SkyBox implements Credit {
 	
 	@Override
 	public String getCredit() {
-		return "© Jockum Skoglund aka hipshot.\nCC-BY 3.0 Attribution License.";
+		return Chars.COPY + " Jockum Skoglund aka hipshot.\nCC-BY 3.0 Attribution License.";
 	}
 	
 	@Override

--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/sky/builtin/Storm.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/sky/builtin/Storm.java
@@ -2,6 +2,7 @@ package net.sf.openrocket.gui.figure3d.photo.sky.builtin;
 
 import net.sf.openrocket.gui.figure3d.photo.sky.Sky.Credit;
 import net.sf.openrocket.gui.figure3d.photo.sky.SkyBoxCross;
+import net.sf.openrocket.util.Chars;
 
 public class Storm extends SkyBoxCross implements Credit {
 	public static final Storm instance = new Storm();
@@ -12,7 +13,7 @@ public class Storm extends SkyBoxCross implements Credit {
 	
 	@Override
 	public String getCredit() {
-		return "© Jockum Skoglund aka hipshot.\nCC-BY 3.0 Attribution License.";
+		return Chars.COPY + " Jockum Skoglund aka hipshot.\nCC-BY 3.0 Attribution License.";
 	}
 	
 	@Override


### PR DESCRIPTION
The photo booth files contained non-ascii and non-utf8 chars in Java files, which failed to compile on my machine.  Because of that I've kept all Java files strictly in ascii, and used Unicode escapes where other chars are needed.  (The "ant ascii" task checks for this as well.)
