### PR TITLE
Fix SLF "{}" substitution in Debug log & Error reports

### DIFF
--- a/swing/src/net/sf/openrocket/logging/LogbackBufferLoggerAdaptor.java
+++ b/swing/src/net/sf/openrocket/logging/LogbackBufferLoggerAdaptor.java
@@ -64,6 +64,6 @@ public class LogbackBufferLoggerAdaptor extends AppenderBase<ILoggingEvent> {
 		if (e.getThrowableProxy() != null) {
 			t = ((ThrowableProxy) e.getThrowableProxy()).getThrowable();
 		}
-		return new LogLine(l, new TraceException(), e.getMessage(), t);
+		return new LogLine(l, new TraceException(), e.getFormattedMessage(), t);
 	}
 }

--- a/swing/src/net/sf/openrocket/startup/SwingStartup.java
+++ b/swing/src/net/sf/openrocket/startup/SwingStartup.java
@@ -58,7 +58,7 @@ public class SwingStartup {
 		
 		// Initialize logging first so we can use it
 		initializeLogging();
-		log.info("Starting up OpenRocket version " + BuildProperties.getVersion());
+		log.info("Starting up OpenRocket version {}", BuildProperties.getVersion());
 		
 		// Check that we're not running headless
 		log.info("Checking for graphics head");


### PR DESCRIPTION
SLF allows you to say

``` java
log.info("Starting up OpenRocket version {}", BuildProperties.getVersion());
```

Instead of

``` java
log.info("Starting up OpenRocket version " + BuildProperties.getVersion());
```

But the adapter from Logback's ILoggingEvents to the OpenRocket LogLine is taking the un-substituted message like so:
### Bad:

![image](https://f.cloud.github.com/assets/1305026/2058963/52dca1ca-8b8f-11e3-8935-93639e93ec85.png)

this change fixes it:
### Good:

![image](https://f.cloud.github.com/assets/1305026/2058966/88f96964-8b8f-11e3-906a-b4b186f23ee7.png)

This changeset also pointlessly changes the first log message output to use the SLF substitution. The only reason not to use it everywhere is the pain of changing it.
