### PR TITLE
Prevent NPE when an uninitialized table cell is rendered.

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
@@ -169,21 +169,23 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 
 			column = table.convertColumnIndexToModel(column);
 			switch (column) {
-			case 0: {
-				label.setText(descriptor.format(rocket, (String) value));
-				regular(label);
-				setSelected(label, table, isSelected, hasFocus);
-				return label;
-			}
-			default: {
-				Pair<String, T> v = (Pair<String, T>) value;
-				String id = v.getU();
-				T component = v.getV();
-				label = format(component, id, label );
-				setSelected(label, table, isSelected, hasFocus);
-				return label;
-			}
-			}
+				case 0: {
+					label.setText(descriptor.format(rocket, (String) value));
+					regular(label);
+					setSelected(label, table, isSelected, hasFocus);
+					return label;
+				}
+				default: {
+					Pair<String, T> v = (Pair<String, T>) value;
+					if(v!=null){
+						String id = v.getU();
+						T component = v.getV();
+						label = format(component, id, label );
+					}
+					setSelected(label, table, isSelected, hasFocus);
+					return label;
+				}
+			}	
 		}
 
 		private final void setSelected( JComponent c, JTable table, boolean isSelected, boolean hasFocus ) {


### PR DESCRIPTION
This simply protects against a null value from the caller.  The getTableCellRendererComponet can call with a null value if there has never been an update to the cell in the table.  Hopefully this is not a naïve fix, I could't determine if there was a bigger problem that was allowing the table cell to be uninitialized.
