### PR TITLE
Update registered language code in L10nPropertyReport

### DIFF
--- a/core/src/net/sf/openrocket/utils/L10nPropertyReport.java
+++ b/core/src/net/sf/openrocket/utils/L10nPropertyReport.java
@@ -10,7 +10,7 @@ import java.util.Properties;
 
 public class L10nPropertyReport {
 	
-	private static String[] supportedLocales = new String[] { "en", "de", "es", "fr", "it", "ru", "cs", "pl", "ja", "pt", "uk_UA" };
+	private static String[] supportedLocales = new String[] { "en", "de", "es", "fr", "it", "ru", "cs", "pl", "ja", "pt", "tr", "zh_CN", "uk_UA" };
 	
 	public static void main(String[] args) throws Exception {
 		


### PR DESCRIPTION
Update registered language code in L10nPropertyReport.java
Register "tr", "zh_CN".

Existing property files (13):

messages.properties
messages_cs.properties
messages_de.properties
messages_es.properties
messages_fr.properties
messages_it.properties
messages_ja.properties
messages_pl.properties
messages_pt.properties
messages_ru.properties
messages_tr.properties
messages_uk_UA.properties
messages_zh_CN.properties
