### PR TITLE
When using 'File > Save As..' dialog, update filename directly. (Minor patch)

### DIFF
--- a/core/src/net/sf/openrocket/gui/util/SimpleFileFilter.java
+++ b/core/src/net/sf/openrocket/gui/util/SimpleFileFilter.java
@@ -30,6 +30,9 @@ public class SimpleFileFilter extends FileFilter implements java.io.FileFilter {
 		this(description, true, extensions);
 	}
 	
+	public String[] getExtensions() {
+		return extensions;
+	}
 	
 	/**
 	 * Create filter that accepts files with the provided extensions.


### PR DESCRIPTION
When using the "File > Save As..." dialog,  this patch will update the filename extension directly upon changing the FileFilter type. (Behavior that changes the extension after clicking "Accept" is preserved.)

Due to JFileChooser API limitations, I had to pull the filename-to-correct from the Rocket's document.