### PR TITLE
Bugfix:  If configured wrong, booster stage recovery device would not deploy.

### DIFF
--- a/swing/src/net/sf/openrocket/gui/adaptors/EnumModel.java
+++ b/swing/src/net/sf/openrocket/gui/adaptors/EnumModel.java
@@ -1,9 +1,13 @@
 package net.sf.openrocket.gui.adaptors;
 
+import java.util.ArrayList;
 import java.util.EventObject;
 
 import javax.swing.AbstractListModel;
 import javax.swing.ComboBoxModel;
+import javax.swing.MutableComboBoxModel;
+
+import org.jfree.util.Log;
 
 import net.sf.openrocket.util.ChangeSource;
 import net.sf.openrocket.util.Reflection;
@@ -11,7 +15,7 @@ import net.sf.openrocket.util.StateChangeListener;
 
 
 public class EnumModel<T extends Enum<T>> extends AbstractListModel 
-		implements ComboBoxModel, StateChangeListener {
+		implements ComboBoxModel, MutableComboBoxModel, StateChangeListener {
 
 	private final ChangeSource source;
 	private final String valueName;
@@ -19,6 +23,8 @@ public class EnumModel<T extends Enum<T>> extends AbstractListModel
 	
 	private final Enum<T>[] values;
 	private Enum<T> currentValue = null;
+	
+	ArrayList<Enum<T>> displayedValues = new ArrayList<Enum<T>>();
 	
 	private final Reflection.Method getMethod;
 	private final Reflection.Method setMethod;
@@ -60,6 +66,9 @@ public class EnumModel<T extends Enum<T>> extends AbstractListModel
 		else 
 			this.values = enumClass.getEnumConstants();
 		
+		for (Enum<T> e : this.values){
+			this.displayedValues.add( e );
+		}
 		this.nullText = nullText;
 		
 		stateChanged(null);  // Update current value
@@ -99,19 +108,19 @@ public class EnumModel<T extends Enum<T>> extends AbstractListModel
 
 	@Override
 	public Object getElementAt(int index) {
+		if( ( index < 0 ) || ( index >= this.displayedValues.size())){
+			return nullText; // bad parameter
+		}
+
 		if (values[index] == null)
 			return nullText;
-		return values[index];
+		return displayedValues.get( index);
 	}
 
 	@Override
 	public int getSize() {
-		return values.length;
+		return displayedValues.size();
 	}
-
-
-
-
 
 	@SuppressWarnings("unchecked")
 	@Override
@@ -128,6 +137,33 @@ public class EnumModel<T extends Enum<T>> extends AbstractListModel
 	@Override
 	public String toString() {
 		return "EnumModel["+source.getClass().getCanonicalName()+":"+valueName+"]";
+	}
+
+	@Override
+	public void addElement(Object item) {
+		// Not actually allowed.  The model starts out with all the enums, and only allows hiding some.
+	}
+
+	@Override
+	public void removeElement(Object obj) {
+		if( null == obj ){
+			return;
+		}
+		this.displayedValues.remove( obj );
+	}
+
+	@Override
+	public void insertElementAt(Object item, int index) {
+		// Not actually allowed.  The model starts out with all the enums, and only allows hiding some.
+	}
+
+	@Override
+	public void removeElementAt(int index) {
+		if( ( index < 0 ) || ( index >= this.displayedValues.size())){
+			return; // bad parameter
+		}
+
+		this.displayedValues.remove( index );
 	}
 
 }

--- a/swing/src/net/sf/openrocket/gui/configdialog/ParachuteConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/ParachuteConfig.java
@@ -4,6 +4,7 @@ package net.sf.openrocket.gui.configdialog;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
+import javax.swing.ComboBoxModel;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
@@ -25,6 +26,7 @@ import net.sf.openrocket.gui.components.UnitSelector;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.material.Material;
 import net.sf.openrocket.rocketcomponent.DeploymentConfiguration;
+import net.sf.openrocket.rocketcomponent.DeploymentConfiguration.DeployEvent;
 import net.sf.openrocket.rocketcomponent.Parachute;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.startup.Application;
@@ -85,7 +87,7 @@ public class ParachuteConfig extends RecoveryDeviceConfig {
 		//// Material:
 		panel.add(new JLabel(trans.get("ParachuteCfg.lbl.Material")));
 		
-		JComboBox combo = new JComboBox(new MaterialModel(panel, component,
+		JComboBox<?> combo = new JComboBox(new MaterialModel(panel, component,
 				Material.Type.SURFACE));
 		combo.setToolTipText(trans.get("ParachuteCfg.combo.MaterialModel"));
 		panel.add(combo, "spanx 3, growx, wrap 30lp");
@@ -193,7 +195,13 @@ public class ParachuteConfig extends RecoveryDeviceConfig {
 		panel.add(new JLabel(trans.get("ParachuteCfg.lbl.Deploysat") + " " + CommonStrings.dagger), "");
 		
 		DeploymentConfiguration deploymentConfig = parachute.getDeploymentConfiguration().getDefault();
-		combo = new JComboBox(new EnumModel<DeploymentConfiguration.DeployEvent>(deploymentConfig, "DeployEvent"));
+		// this issues a warning because EnumModel ipmlements ComboBoxModel without a parameter...
+		ComboBoxModel<DeploymentConfiguration.DeployEvent> deployOptionsModel = new EnumModel<DeploymentConfiguration.DeployEvent>(deploymentConfig, "DeployEvent");
+		combo = new JComboBox<DeploymentConfiguration.DeployEvent>( deployOptionsModel );
+		if( (component.getStageNumber() + 1 ) == d.getRocket().getStageCount() ){
+			//	This is the bottom stage:  Restrict deployment options.
+			combo.removeItem( DeployEvent.LOWER_STAGE_SEPARATION );
+		}
 		panel.add(combo, "spanx 3, growx, wrap");
 		
 		// ... and delay

--- a/swing/src/net/sf/openrocket/gui/configdialog/RecoveryDeviceConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RecoveryDeviceConfig.java
@@ -13,6 +13,8 @@ import net.sf.openrocket.rocketcomponent.RocketComponent;
 
 public abstract class RecoveryDeviceConfig extends RocketComponentConfig {
 	
+	private static final long serialVersionUID = 7263235700953855062L;
+	
 	protected final List<JComponent> altitudeComponents = new ArrayList<JComponent>();
 	
 	public RecoveryDeviceConfig(OpenRocketDocument d, RocketComponent component) {

--- a/swing/src/net/sf/openrocket/gui/configdialog/StreamerConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/StreamerConfig.java
@@ -4,6 +4,7 @@ package net.sf.openrocket.gui.configdialog;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
+import javax.swing.ComboBoxModel;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
@@ -26,6 +27,7 @@ import net.sf.openrocket.material.Material;
 import net.sf.openrocket.rocketcomponent.DeploymentConfiguration;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.rocketcomponent.Streamer;
+import net.sf.openrocket.rocketcomponent.DeploymentConfiguration.DeployEvent;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
 
@@ -196,6 +198,10 @@ public class StreamerConfig extends RecoveryDeviceConfig {
 		
 		DeploymentConfiguration deploymentConfig = streamer.getDeploymentConfiguration().getDefault();
 		combo = new JComboBox(new EnumModel<DeploymentConfiguration.DeployEvent>(deploymentConfig, "DeployEvent"));
+		if( (component.getStageNumber() + 1 ) == d.getRocket().getStageCount() ){
+			//	This is the bottom stage.  restrict deployment options.
+			combo.removeItem( DeployEvent.LOWER_STAGE_SEPARATION );
+		}
 		panel.add(combo, "spanx 3, growx, wrap");
 		
 		// ... and delay

--- a/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/DeploymentSelectionDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/DeploymentSelectionDialog.java
@@ -76,7 +76,11 @@ public class DeploymentSelectionDialog extends JDialog {
 		//// Deploys at:
 		panel.add(new JLabel(trans.get("ParachuteCfg.lbl.Deploysat")), "");
 		
-		final JComboBox event = new JComboBox(new EnumModel<DeployEvent>(newConfiguration, "DeployEvent"));
+		final JComboBox<?> event = new JComboBox(new EnumModel<DeployEvent>(newConfiguration, "DeployEvent"));
+		if( (component.getStageNumber() + 1 ) == rocket.getStageCount() ){
+			//	This is the bottom stage:  Restrict deployment options.
+			event.removeItem( DeployEvent.LOWER_STAGE_SEPARATION );
+		}
 		panel.add(event, "spanx 3, growx, wrap");
 		
 		// ... and delay


### PR DESCRIPTION
… deploy. This patch prevents the UI from showing those options.

====
Problem:
    A RecoveryDevice sometimes fails to deploy if set to “Lower Stage Separation”.  (see attached file:  simply run the simulation, plot results, and note that the booster stage craters because the parachute did not deploy.)  Shout out to joe.b.bowen@gmail.com for reporting the bug.

Cause: 
    The "Lower Stage Separation" is interpreted in code as time after the previous stage separates.  Obviously, this doesn't make much sense for the lowermost stage, but OR allows the user to select this-- making it seem like a bug.

Solution A: 
Prevent user selection of error states. These UI modications are in this pull request.
