### PR TITLE
fixes tests giving false negative for comma decimal locale

### DIFF
--- a/core/test/net/sf/openrocket/unit/FractionalUnitTest.java
+++ b/core/test/net/sf/openrocket/unit/FractionalUnitTest.java
@@ -1,206 +1,266 @@
 package net.sf.openrocket.unit;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.text.DecimalFormat;
 
 import org.junit.Test;
 
 public class FractionalUnitTest {
-
+	
 	private final static Unit testUnit = new FractionalUnit(1, "unit", "unit", 4, 0.5);
 	private final static Unit testUnitApprox = new FractionalUnit(1, "unit", "unit", 16, 0.5, 0.02);
-
-	private final static Unit inchUnit = new FractionalUnit(0.0254, "in/64", "in", 64, 1d/16d);
+	
+	private final static Unit inchUnit = new FractionalUnit(0.0254, "in/64", "in", 64, 1d / 16d);
 	
 	@Test
 	public void testRound() {
-
+		
 		assertEquals(-1d, testUnit.round(-1.125), 0.0); // rounds to -1 since mod is even
 		assertEquals(-1d, testUnit.round(-1.0), 0.0);
 		assertEquals(-1d, testUnit.round(-.875), 0.0); // rounds to -1 since mod is even
-
+		
 		assertEquals(-0.75d, testUnit.round(-.874), 0.0);
 		assertEquals(-0.75d, testUnit.round(-.75), 0.0);
 		assertEquals(-0.75d, testUnit.round(-.626), 0.0);
-
+		
 		assertEquals(-0.5d, testUnit.round(-.625), 0.0); // rounds to -.5 since mod is even
 		assertEquals(-0.5d, testUnit.round(-.5), 0.0);
 		assertEquals(-0.5d, testUnit.round(-.375), 0.0); // rounds to -.5 since mod is even
-
+		
 		assertEquals(-0.25d, testUnit.round(-.374), 0.0);
 		assertEquals(-0.25d, testUnit.round(-.25), 0.0);
 		assertEquals(-0.25d, testUnit.round(-.126), 0.0);
-
+		
 		assertEquals(0d, testUnit.round(-.125), 0.0);
 		assertEquals(0d, testUnit.round(0), 0.0);
 		assertEquals(0d, testUnit.round(.125), 0.0);
-
+		
 		assertEquals(0.25d, testUnit.round(.126), 0.0);
 		assertEquals(0.25d, testUnit.round(.25), 0.0);
 		assertEquals(0.25d, testUnit.round(.374), 0.0);
-
+		
 		assertEquals(0.5d, testUnit.round(.375), 0.0); // rounds to .5 since mod is even
 		assertEquals(0.5d, testUnit.round(.5), 0.0);
 		assertEquals(0.5d, testUnit.round(.625), 0.0); // rounds to .5 since mod is even
-
+		
 		assertEquals(0.75d, testUnit.round(.626), 0.0);
 		assertEquals(0.75d, testUnit.round(.75), 0.0);
 		assertEquals(0.75d, testUnit.round(.874), 0.0);
-
+		
 		assertEquals(1d, testUnit.round(.875), 0.0); // rounds to 1 since mod is even
 		assertEquals(1d, testUnit.round(1.0), 0.0);
 		assertEquals(1d, testUnit.round(1.125), 0.0); // rounds to 1 since mod is even
-
+		
 	}
-
+	
 	@Test
 	public void testIncrement() {
-
-		assertEquals( -1d, testUnit.getNextValue(-1.2), 0.0);
-		assertEquals( -1d, testUnit.getNextValue(-1.4), 0.0);
-
-		assertEquals( -0.5d, testUnit.getNextValue(-0.7), 0.0);
-		assertEquals( -0.5d, testUnit.getNextValue(-0.9), 0.0);
-		assertEquals( -0.5d, testUnit.getNextValue(-1.0), 0.0);
-
-		assertEquals( 0.0d, testUnit.getNextValue(-0.05), 0.0 );
-		assertEquals( 0.0d, testUnit.getNextValue(-0.062), 0.0 );
-		assertEquals( 0.0d, testUnit.getNextValue(-0.07), 0.0 );
-		assertEquals( 0.0d, testUnit.getNextValue(-0.11), 0.0 );
-
-		assertEquals( 0.5d, testUnit.getNextValue(0), 0.0 );
-		assertEquals( 0.5d, testUnit.getNextValue(0.01), 0.0 );
-		assertEquals( 0.5d, testUnit.getNextValue(0.062), 0.0 );
-		assertEquals( 0.5d, testUnit.getNextValue(0.0625), 0.0);
-
-		assertEquals( 1d, testUnit.getNextValue(0.51), 0.0);
-		assertEquals( 1d, testUnit.getNextValue(0.7), 0.0);
+		
+		assertEquals(-1d, testUnit.getNextValue(-1.2), 0.0);
+		assertEquals(-1d, testUnit.getNextValue(-1.4), 0.0);
+		
+		assertEquals(-0.5d, testUnit.getNextValue(-0.7), 0.0);
+		assertEquals(-0.5d, testUnit.getNextValue(-0.9), 0.0);
+		assertEquals(-0.5d, testUnit.getNextValue(-1.0), 0.0);
+		
+		assertEquals(0.0d, testUnit.getNextValue(-0.05), 0.0);
+		assertEquals(0.0d, testUnit.getNextValue(-0.062), 0.0);
+		assertEquals(0.0d, testUnit.getNextValue(-0.07), 0.0);
+		assertEquals(0.0d, testUnit.getNextValue(-0.11), 0.0);
+		
+		assertEquals(0.5d, testUnit.getNextValue(0), 0.0);
+		assertEquals(0.5d, testUnit.getNextValue(0.01), 0.0);
+		assertEquals(0.5d, testUnit.getNextValue(0.062), 0.0);
+		assertEquals(0.5d, testUnit.getNextValue(0.0625), 0.0);
+		
+		assertEquals(1d, testUnit.getNextValue(0.51), 0.0);
+		assertEquals(1d, testUnit.getNextValue(0.7), 0.0);
 	}
-
+	
 	@Test
 	public void testDecrement() {
-
-		assertEquals( -1.5d, testUnit.getPreviousValue(-1.2), 0.0);
-		assertEquals( -1.5d, testUnit.getPreviousValue(-1.4), 0.0);
-		assertEquals( -1.5d, testUnit.getPreviousValue(-1.0), 0.0);
-
-		assertEquals( -1d, testUnit.getPreviousValue(-0.7), 0.0);
-		assertEquals( -1d, testUnit.getPreviousValue(-0.9), 0.0);
-
-		assertEquals( -0.5d, testUnit.getPreviousValue(-0.01), 0.0 );
-		assertEquals( -0.5d, testUnit.getPreviousValue(-0.05), 0.0 );
-		assertEquals( -0.5d, testUnit.getPreviousValue(-0.062), 0.0 );
-		assertEquals( -0.5d, testUnit.getPreviousValue(-0.07), 0.0 );
-		assertEquals( -0.5d, testUnit.getPreviousValue(0), 0.0 );
-
-		assertEquals( 0.0d, testUnit.getPreviousValue(0.49), 0.0 );
-		assertEquals( 0.0d, testUnit.getPreviousValue(0.262), 0.0 );
-		assertEquals( 0.0d, testUnit.getPreviousValue(0.51), 0.0);
-
-		assertEquals( 0.5d, testUnit.getPreviousValue(0.7), 0.0);
-
-		assertEquals( 1.0d, testUnit.getPreviousValue(1.2), 0.0);
+		
+		assertEquals(-1.5d, testUnit.getPreviousValue(-1.2), 0.0);
+		assertEquals(-1.5d, testUnit.getPreviousValue(-1.4), 0.0);
+		assertEquals(-1.5d, testUnit.getPreviousValue(-1.0), 0.0);
+		
+		assertEquals(-1d, testUnit.getPreviousValue(-0.7), 0.0);
+		assertEquals(-1d, testUnit.getPreviousValue(-0.9), 0.0);
+		
+		assertEquals(-0.5d, testUnit.getPreviousValue(-0.01), 0.0);
+		assertEquals(-0.5d, testUnit.getPreviousValue(-0.05), 0.0);
+		assertEquals(-0.5d, testUnit.getPreviousValue(-0.062), 0.0);
+		assertEquals(-0.5d, testUnit.getPreviousValue(-0.07), 0.0);
+		assertEquals(-0.5d, testUnit.getPreviousValue(0), 0.0);
+		
+		assertEquals(0.0d, testUnit.getPreviousValue(0.49), 0.0);
+		assertEquals(0.0d, testUnit.getPreviousValue(0.262), 0.0);
+		assertEquals(0.0d, testUnit.getPreviousValue(0.51), 0.0);
+		
+		assertEquals(0.5d, testUnit.getPreviousValue(0.7), 0.0);
+		
+		assertEquals(1.0d, testUnit.getPreviousValue(1.2), 0.0);
 	}
-
+	
 	@Test
 	public void testToStringDefaultPrecision() {
-
+		
+		if (isPointDecimalSeparator()) {
+			assertEquals("-1.2", testUnit.toString(-1.2));
+			assertEquals("-1.3", testUnit.toString(-1.3));
+			
+			assertEquals("-0.2", testUnit.toString(-.2));
+			assertEquals("-0.3", testUnit.toString(-.3));
+			
+			assertEquals("-0.1", testUnit.toString(-.1));
+			assertEquals("0.1", testUnit.toString(.1));
+			
+			assertEquals("0.2", testUnit.toString(.2));
+			assertEquals("0.3", testUnit.toString(.3));
+			
+			assertEquals("1.2", testUnit.toString(1.2));
+			assertEquals("1.3", testUnit.toString(1.3));
+		} else {
+			assertEquals("-1,2", testUnit.toString(-1.2));
+			assertEquals("-1,3", testUnit.toString(-1.3));
+			
+			assertEquals("-0,2", testUnit.toString(-.2));
+			assertEquals("-0,3", testUnit.toString(-.3));
+			
+			assertEquals("-0,1", testUnit.toString(-.1));
+			assertEquals("0,1", testUnit.toString(.1));
+			
+			assertEquals("0,2", testUnit.toString(.2));
+			assertEquals("0,3", testUnit.toString(.3));
+			
+			assertEquals("1,2", testUnit.toString(1.2));
+			assertEquals("1,3", testUnit.toString(1.3));
+		}
 		// default epsilon is 0.025
-		assertEquals("-1.2", testUnit.toString(-1.2)); 
+		
 		assertEquals("-1 \u00B9\u2044\u2084", testUnit.toString(-1.225));
 		assertEquals("-1 \u00B9\u2044\u2084", testUnit.toString(-1.227));
 		assertEquals("-1 \u00B9\u2044\u2084", testUnit.toString(-1.25));
 		assertEquals("-1 \u00B9\u2044\u2084", testUnit.toString(-1.25));
 		assertEquals("-1 \u00B9\u2044\u2084", testUnit.toString(-1.275));
-		assertEquals("-1.3", testUnit.toString(-1.3));
-
-		assertEquals("-0.2", testUnit.toString(-.2));
+		
 		assertEquals("-\u00B9\u2044\u2084", testUnit.toString(-.225));
 		assertEquals("-\u00B9\u2044\u2084", testUnit.toString(-.25));
 		assertEquals("-\u00B9\u2044\u2084", testUnit.toString(-.274));
 		//assertEquals("-1/4", testUnit.toString(-.275)); // this has roundoff error which pushes it over epsilon
-		assertEquals("-0.3", testUnit.toString(-.3));
-
-		assertEquals("-0.1", testUnit.toString(-.1));
+		
 		assertEquals("0", testUnit.toString(-0.024));
 		assertEquals("0", testUnit.toString(0));
 		assertEquals("0", testUnit.toString(.024));
-		assertEquals("0.1", testUnit.toString(.1));
-
-		assertEquals("0.2", testUnit.toString(.2));
+		
 		assertEquals("\u00B9\u2044\u2084", testUnit.toString(.225));
 		assertEquals("\u00B9\u2044\u2084", testUnit.toString(.25));
 		assertEquals("\u00B9\u2044\u2084", testUnit.toString(.274));
-		assertEquals("0.3", testUnit.toString(.3));
-
-		assertEquals("1.2", testUnit.toString(1.2));
+		
 		assertEquals("1 \u00B9\u2044\u2084", testUnit.toString(1.225));
 		assertEquals("1 \u00B9\u2044\u2084", testUnit.toString(1.25));
 		assertEquals("1 \u00B9\u2044\u2084", testUnit.toString(1.275));
-		assertEquals("1.3", testUnit.toString(1.3));
-
 	}
-
+	
+	
+	
 	@Test
 	public void testToStringWithPrecision() {
-
+		if (isPointDecimalSeparator()) {
+			assertEquals("-1.225", testUnitApprox.toString(-1.225));
+			assertEquals("-1.275", testUnitApprox.toString(-1.275));
+			
+			assertEquals("-0.225", testUnitApprox.toString(-.225));
+			assertEquals("-0.275", testUnitApprox.toString(-.275));
+			
+			assertEquals("-0.1", testUnitApprox.toString(-.1));
+			
+			assertEquals("-0.024", testUnitApprox.toString(-0.024));
+			assertEquals("0.024", testUnitApprox.toString(.024));
+			
+			assertEquals("0.1", testUnitApprox.toString(.1));
+			
+			assertEquals("0.275", testUnitApprox.toString(.275));
+			assertEquals("0.225", testUnitApprox.toString(.225));
+			
+			assertEquals("1.225", testUnitApprox.toString(1.225));
+			assertEquals("1.275", testUnitApprox.toString(1.275));
+		} else {
+			assertEquals("-1,225", testUnitApprox.toString(-1.225));
+			assertEquals("-1,275", testUnitApprox.toString(-1.275));
+			
+			assertEquals("-0,225", testUnitApprox.toString(-.225));
+			assertEquals("-0,275", testUnitApprox.toString(-.275));
+			
+			assertEquals("-0,1", testUnitApprox.toString(-.1));
+			
+			assertEquals("-0,024", testUnitApprox.toString(-0.024));
+			assertEquals("0,024", testUnitApprox.toString(.024));
+			
+			assertEquals("0,1", testUnitApprox.toString(.1));
+			
+			assertEquals("0,275", testUnitApprox.toString(.275));
+			assertEquals("0,225", testUnitApprox.toString(.225));
+			
+			assertEquals("1,225", testUnitApprox.toString(1.225));
+			assertEquals("1,275", testUnitApprox.toString(1.275));
+		}
 		// epsilon is .02
+		
 		assertEquals("-1 \u00B3\u2044\u2081\u2086", testUnitApprox.toString(-1.2));
-		assertEquals("-1.225", testUnitApprox.toString(-1.225));
 		assertEquals("-1 \u00B9\u2044\u2084", testUnitApprox.toString(-1.25));
-		assertEquals("-1.275", testUnitApprox.toString(-1.275));
 		assertEquals("-1 \u2075\u2044\u2081\u2086", testUnitApprox.toString(-1.3));
-
+		
 		assertEquals("-\u00B3\u2044\u2081\u2086", testUnitApprox.toString(-.2));
-		assertEquals("-0.225", testUnitApprox.toString(-.225));
 		assertEquals("-\u00B9\u2044\u2084", testUnitApprox.toString(-.25));
-		assertEquals("-0.275", testUnitApprox.toString(-.275));
 		assertEquals("-\u2075\u2044\u2081\u2086", testUnitApprox.toString(-.3));
-
-		assertEquals("-0.1", testUnitApprox.toString(-.1));
-		assertEquals("-0.024", testUnitApprox.toString(-0.024));
+		
 		assertEquals("0", testUnitApprox.toString(0));
-		assertEquals("0.024", testUnitApprox.toString(.024));
-		assertEquals("0.1", testUnitApprox.toString(.1));
-
+		
 		assertEquals("\u00B3\u2044\u2081\u2086", testUnitApprox.toString(.2));
-		assertEquals("0.225", testUnitApprox.toString(.225));
 		assertEquals("\u00B9\u2044\u2084", testUnitApprox.toString(.25));
-		assertEquals("0.275", testUnitApprox.toString(.275));
 		assertEquals("\u2075\u2044\u2081\u2086", testUnitApprox.toString(.3));
-
+		
 		assertEquals("1 \u00B3\u2044\u2081\u2086", testUnitApprox.toString(1.2));
-		assertEquals("1.225", testUnitApprox.toString(1.225));
 		assertEquals("1 \u00B9\u2044\u2084", testUnitApprox.toString(1.25));
-		assertEquals("1.275", testUnitApprox.toString(1.275));
 		assertEquals("1 \u2075\u2044\u2081\u2086", testUnitApprox.toString(1.3));
-
+	}
+	
+	private boolean isPointDecimalSeparator() {
+		return ((DecimalFormat) DecimalFormat.getInstance()).getDecimalFormatSymbols().getDecimalSeparator() == '.';
 	}
 	
 	@Test
 	public void testInchToString() {
 		
 		// Just some random test points.
-		assertEquals( "\u00B9\u2044\u2086\u2084", inchUnit.toString( 1d/64d*0.0254));
+		assertEquals("\u00B9\u2044\u2086\u2084", inchUnit.toString(1d / 64d * 0.0254));
 		
-		assertEquals( "-\u2075\u2044\u2086\u2084", inchUnit.toString( -5d/64d*0.0254));
+		assertEquals("-\u2075\u2044\u2086\u2084", inchUnit.toString(-5d / 64d * 0.0254));
 		
-		assertEquals( "4 \u00B9\u2044\u2082", inchUnit.toString( 9d/2d*0.0254));
+		assertEquals("4 \u00B9\u2044\u2082", inchUnit.toString(9d / 2d * 0.0254));
 		
-		assertEquals( "0.002", inchUnit.toString( 0.002*0.0254));
+		if (isPointDecimalSeparator()) {
+			assertEquals("0.002", inchUnit.toString(0.002 * 0.0254));
+		} else {
+			assertEquals("0,002", inchUnit.toString(0.002 * 0.0254));
+		}
 		
 		// default body tube length:
 		double length = 8d * 0.025;
 		
-		assertEquals( "7 \u2077\u2044\u2088", inchUnit.toString( length) );
+		assertEquals("7 \u2077\u2044\u2088", inchUnit.toString(length));
 		
 		// had problems with roundoff in decrement.
 		
 		double v = inchUnit.toUnit(length);
-		for ( int i = 0; i< 15; i++ ) {
-			assertTrue( v > inchUnit.getPreviousValue(v) );
+		for (int i = 0; i < 15; i++) {
+			assertTrue(v > inchUnit.getPreviousValue(v));
 			v = inchUnit.getPreviousValue(v);
 		}
 		
 	}
-
+	
 }

--- a/core/test/net/sf/openrocket/unit/UnitToStringTest.java
+++ b/core/test/net/sf/openrocket/unit/UnitToStringTest.java
@@ -2,15 +2,51 @@ package net.sf.openrocket.unit;
 
 import static org.junit.Assert.assertEquals;
 
+import java.text.DecimalFormat;
+
 import org.junit.Test;
 
 public class UnitToStringTest {
+	private boolean isPointDecimalSeparator() {
+		return ((DecimalFormat) DecimalFormat.getInstance()).getDecimalFormatSymbols().getDecimalSeparator() == '.';
+	}
 	
 	@Test
 	public void testPositiveToString() {
+		if (isPointDecimalSeparator()) {
+			testPositiveWithPoint();
+		} else {
+			testPositiveWithComma();
+		}
+		
 		// very small positive numbers ( < 0.0005) are returned as "0"
 		assertEquals("0", Unit.NOUNIT.toString(0.00040));
 		assertEquals("0", Unit.NOUNIT.toString(0.00050)); // check boundary of change in format
+		
+		// positive numbers <= 1E6
+		assertEquals("123", Unit.NOUNIT.toString(123.20));
+		assertEquals("124", Unit.NOUNIT.toString(123.50)); // round to even
+		assertEquals("124", Unit.NOUNIT.toString(123.55));
+		assertEquals("124", Unit.NOUNIT.toString(124.20));
+		assertEquals("124", Unit.NOUNIT.toString(124.50)); // round to even
+		assertEquals("125", Unit.NOUNIT.toString(124.55));
+		
+		assertEquals("1234", Unit.NOUNIT.toString(1234.2));
+		assertEquals("1234", Unit.NOUNIT.toString(1234.5)); // round to even
+		assertEquals("1235", Unit.NOUNIT.toString(1234.6));
+		assertEquals("1235", Unit.NOUNIT.toString(1235.2));
+		assertEquals("1236", Unit.NOUNIT.toString(1235.5)); // round to even
+		assertEquals("1236", Unit.NOUNIT.toString(1235.6));
+		
+		assertEquals("123457", Unit.NOUNIT.toString(123456.789));
+		
+		assertEquals("1000000", Unit.NOUNIT.toString(1000000)); // boundary check
+		
+		
+		
+	}
+	
+	private void testPositiveWithPoint() {
 		
 		// positive number < 0.095 use 3 digit decimal format
 		assertEquals("0.001", Unit.NOUNIT.toString(0.00051)); // check boundary of change in format
@@ -36,7 +72,7 @@ public class UnitToStringTest {
 		
 		assertEquals("0.095", Unit.NOUNIT.toString(0.0949)); // boundary check
 		
-		// positive numbers < 100 
+		// positive numbers < 100
 		assertEquals("0.01", Unit.NOUNIT.toString(0.0095)); // boundary check
 		
 		assertEquals("0.111", Unit.NOUNIT.toString(0.1111));
@@ -59,26 +95,6 @@ public class UnitToStringTest {
 		assertEquals("12.4", Unit.NOUNIT.toString(12.420));
 		assertEquals("12.4", Unit.NOUNIT.toString(12.450)); // round to even
 		assertEquals("12.5", Unit.NOUNIT.toString(12.455));
-		
-		// positive numbers <= 1E6
-		assertEquals("123", Unit.NOUNIT.toString(123.20));
-		assertEquals("124", Unit.NOUNIT.toString(123.50)); // round to even
-		assertEquals("124", Unit.NOUNIT.toString(123.55));
-		assertEquals("124", Unit.NOUNIT.toString(124.20));
-		assertEquals("124", Unit.NOUNIT.toString(124.50)); // round to even
-		assertEquals("125", Unit.NOUNIT.toString(124.55));
-		
-		assertEquals("1234", Unit.NOUNIT.toString(1234.2));
-		assertEquals("1234", Unit.NOUNIT.toString(1234.5)); // round to even
-		assertEquals("1235", Unit.NOUNIT.toString(1234.6));
-		assertEquals("1235", Unit.NOUNIT.toString(1235.2));
-		assertEquals("1236", Unit.NOUNIT.toString(1235.5)); // round to even
-		assertEquals("1236", Unit.NOUNIT.toString(1235.6));
-		
-		assertEquals("123457", Unit.NOUNIT.toString(123456.789));
-		
-		assertEquals("1000000", Unit.NOUNIT.toString(1000000)); // boundary check
-		
 		// positive numbers > 1E6
 		assertEquals("1.23E6", Unit.NOUNIT.toString(1234567.89));
 		assertEquals("1.23E7", Unit.NOUNIT.toString(12345678.9));
@@ -86,15 +102,152 @@ public class UnitToStringTest {
 		
 		// Inch precision
 		assertEquals("25.125", UnitGroup.UNITS_LENGTH.findApproximate("in").toString(25.125 * 25.4 / 1000));
+	}
+	
+	private void testPositiveWithComma() {
+		// positive number < 0.095 use 3 digit decimal format
+		assertEquals("0,001", Unit.NOUNIT.toString(0.00051)); // check boundary of change in format
+		assertEquals("0,001", Unit.NOUNIT.toString(0.00060));
 		
+		// rounding at third digit.
+		assertEquals("0,001", Unit.NOUNIT.toString(0.0014));
+		assertEquals("0,002", Unit.NOUNIT.toString(0.0015)); // round to even
+		assertEquals("0,002", Unit.NOUNIT.toString(0.0016));
+		assertEquals("0,002", Unit.NOUNIT.toString(0.0024));
+		assertEquals("0,002", Unit.NOUNIT.toString(0.0025)); // round to even
+		assertEquals("0,003", Unit.NOUNIT.toString(0.0026));
+		assertEquals("0,009", Unit.NOUNIT.toString(0.0094));
+		
+		assertEquals("0,01", Unit.NOUNIT.toString(0.0095)); // no trailing zeros after rounding
+		
+		assertEquals("0,011", Unit.NOUNIT.toString(0.0114));
+		assertEquals("0,012", Unit.NOUNIT.toString(0.0115)); // round to even
+		assertEquals("0,012", Unit.NOUNIT.toString(0.0119));
+		assertEquals("0,012", Unit.NOUNIT.toString(0.0124));
+		assertEquals("0,012", Unit.NOUNIT.toString(0.0125)); // round to even
+		assertEquals("0,013", Unit.NOUNIT.toString(0.0129));
+		
+		assertEquals("0,095", Unit.NOUNIT.toString(0.0949)); // boundary check
+		
+		// positive numbers < 100
+		assertEquals("0,01", Unit.NOUNIT.toString(0.0095)); // boundary check
+		
+		assertEquals("0,111", Unit.NOUNIT.toString(0.1111));
+		assertEquals("0,112", Unit.NOUNIT.toString(0.1115)); // round to even
+		assertEquals("0,112", Unit.NOUNIT.toString(0.1117));
+		assertEquals("0,112", Unit.NOUNIT.toString(0.1121));
+		assertEquals("0,112", Unit.NOUNIT.toString(0.1125)); // round to even
+		assertEquals("0,113", Unit.NOUNIT.toString(0.1127));
+		
+		assertEquals("1,11", Unit.NOUNIT.toString(1.113));
+		assertEquals("1,12", Unit.NOUNIT.toString(1.115)); // round to even
+		assertEquals("1,12", Unit.NOUNIT.toString(1.117));
+		assertEquals("1,12", Unit.NOUNIT.toString(1.123));
+		assertEquals("1,12", Unit.NOUNIT.toString(1.125)); // round to even
+		assertEquals("1,13", Unit.NOUNIT.toString(1.127));
+		
+		assertEquals("12,3", Unit.NOUNIT.toString(12.320));
+		assertEquals("12,4", Unit.NOUNIT.toString(12.350)); // round to even
+		assertEquals("12,4", Unit.NOUNIT.toString(12.355));
+		assertEquals("12,4", Unit.NOUNIT.toString(12.420));
+		assertEquals("12,4", Unit.NOUNIT.toString(12.450)); // round to even
+		assertEquals("12,5", Unit.NOUNIT.toString(12.455));
+		// positive numbers > 1E6
+		assertEquals("1,23E6", Unit.NOUNIT.toString(1234567.89));
+		assertEquals("1,23E7", Unit.NOUNIT.toString(12345678.9));
+		
+		
+		// Inch precision
+		assertEquals("25,125", UnitGroup.UNITS_LENGTH.findApproximate("in").toString(25.125 * 25.4 / 1000));
 	}
 	
 	@Test
 	public void testNegativeToString() {
+		if (isPointDecimalSeparator()) {
+			testNegativeWithPoint();
+		} else {
+			testNegativeWithComma();
+		}
+		
 		// very small negative numbers ( < 0.0005) are returned as "0"
 		assertEquals("0", Unit.NOUNIT.toString(-0.00040));
 		assertEquals("0", Unit.NOUNIT.toString(-0.00050)); // check boundary of change in format
 		
+		// negative numbers <= 1E6
+		assertEquals("-123", Unit.NOUNIT.toString(-123.20));
+		assertEquals("-124", Unit.NOUNIT.toString(-123.50)); // round to even
+		assertEquals("-124", Unit.NOUNIT.toString(-123.55));
+		assertEquals("-124", Unit.NOUNIT.toString(-124.20));
+		assertEquals("-124", Unit.NOUNIT.toString(-124.50)); // round to even
+		assertEquals("-125", Unit.NOUNIT.toString(-124.55));
+		
+		assertEquals("-1234", Unit.NOUNIT.toString(-1234.2));
+		assertEquals("-1234", Unit.NOUNIT.toString(-1234.5)); // round to even
+		assertEquals("-1235", Unit.NOUNIT.toString(-1234.6));
+		assertEquals("-1235", Unit.NOUNIT.toString(-1235.2));
+		assertEquals("-1236", Unit.NOUNIT.toString(-1235.5)); // round to even
+		assertEquals("-1236", Unit.NOUNIT.toString(-1235.6));
+		
+		assertEquals("-123457", Unit.NOUNIT.toString(-123456.789));
+		
+		assertEquals("-1000000", Unit.NOUNIT.toString(-1000000)); // boundary check
+	}
+	
+	private void testNegativeWithComma() {
+		// negative number < 0.095 use 3 digit decimal format
+		assertEquals("-0,001", Unit.NOUNIT.toString(-0.00051)); // check boundary of change in format
+		assertEquals("-0,001", Unit.NOUNIT.toString(-0.00060));
+		
+		// rounding at third digit.
+		assertEquals("-0,001", Unit.NOUNIT.toString(-0.0014));
+		assertEquals("-0,002", Unit.NOUNIT.toString(-0.0015)); // round to even
+		assertEquals("-0,002", Unit.NOUNIT.toString(-0.0016));
+		assertEquals("-0,002", Unit.NOUNIT.toString(-0.0024));
+		assertEquals("-0,002", Unit.NOUNIT.toString(-0.0025)); // round to even
+		assertEquals("-0,003", Unit.NOUNIT.toString(-0.0026));
+		assertEquals("-0,009", Unit.NOUNIT.toString(-0.0094));
+		
+		assertEquals("-0,01", Unit.NOUNIT.toString(-0.0095)); // no trailing zeros after rounding
+		
+		assertEquals("-0,011", Unit.NOUNIT.toString(-0.0114));
+		assertEquals("-0,012", Unit.NOUNIT.toString(-0.0115)); // round to even
+		assertEquals("-0,012", Unit.NOUNIT.toString(-0.0119));
+		assertEquals("-0,012", Unit.NOUNIT.toString(-0.0124));
+		assertEquals("-0,012", Unit.NOUNIT.toString(-0.0125)); // round to even
+		assertEquals("-0,013", Unit.NOUNIT.toString(-0.0129));
+		
+		assertEquals("-0,095", Unit.NOUNIT.toString(-0.0949)); // boundary check
+		
+		// negative numbers < 100 
+		assertEquals("-0,01", Unit.NOUNIT.toString(-0.0095)); // boundary check
+		
+		assertEquals("-0,111", Unit.NOUNIT.toString(-0.1111));
+		assertEquals("-0,112", Unit.NOUNIT.toString(-0.1115)); // round to even
+		assertEquals("-0,112", Unit.NOUNIT.toString(-0.1117));
+		assertEquals("-0,112", Unit.NOUNIT.toString(-0.1121));
+		assertEquals("-0,112", Unit.NOUNIT.toString(-0.1125)); // round to even
+		assertEquals("-0,113", Unit.NOUNIT.toString(-0.1127));
+		
+		assertEquals("-1,11", Unit.NOUNIT.toString(-1.113));
+		assertEquals("-1,12", Unit.NOUNIT.toString(-1.115)); // round to even
+		assertEquals("-1,12", Unit.NOUNIT.toString(-1.117));
+		assertEquals("-1,12", Unit.NOUNIT.toString(-1.123));
+		assertEquals("-1,12", Unit.NOUNIT.toString(-1.125)); // round to even
+		assertEquals("-1,13", Unit.NOUNIT.toString(-1.127));
+		
+		assertEquals("-12,3", Unit.NOUNIT.toString(-12.320));
+		assertEquals("-12,4", Unit.NOUNIT.toString(-12.350)); // round to even
+		assertEquals("-12,4", Unit.NOUNIT.toString(-12.355));
+		assertEquals("-12,4", Unit.NOUNIT.toString(-12.420));
+		assertEquals("-12,4", Unit.NOUNIT.toString(-12.450)); // round to even
+		assertEquals("-12,5", Unit.NOUNIT.toString(-12.455));
+		// negative numbers > 1E6
+		assertEquals("-1,23E6", Unit.NOUNIT.toString(-1234567.89));
+		assertEquals("-1,23E7", Unit.NOUNIT.toString(-12345678.9));
+		
+	}
+	
+	private void testNegativeWithPoint() {
 		// negative number < 0.095 use 3 digit decimal format
 		assertEquals("-0.001", Unit.NOUNIT.toString(-0.00051)); // check boundary of change in format
 		assertEquals("-0.001", Unit.NOUNIT.toString(-0.00060));
@@ -142,31 +295,9 @@ public class UnitToStringTest {
 		assertEquals("-12.4", Unit.NOUNIT.toString(-12.420));
 		assertEquals("-12.4", Unit.NOUNIT.toString(-12.450)); // round to even
 		assertEquals("-12.5", Unit.NOUNIT.toString(-12.455));
-		
-		// negative numbers <= 1E6
-		assertEquals("-123", Unit.NOUNIT.toString(-123.20));
-		assertEquals("-124", Unit.NOUNIT.toString(-123.50)); // round to even
-		assertEquals("-124", Unit.NOUNIT.toString(-123.55));
-		assertEquals("-124", Unit.NOUNIT.toString(-124.20));
-		assertEquals("-124", Unit.NOUNIT.toString(-124.50)); // round to even
-		assertEquals("-125", Unit.NOUNIT.toString(-124.55));
-		
-		assertEquals("-1234", Unit.NOUNIT.toString(-1234.2));
-		assertEquals("-1234", Unit.NOUNIT.toString(-1234.5)); // round to even
-		assertEquals("-1235", Unit.NOUNIT.toString(-1234.6));
-		assertEquals("-1235", Unit.NOUNIT.toString(-1235.2));
-		assertEquals("-1236", Unit.NOUNIT.toString(-1235.5)); // round to even
-		assertEquals("-1236", Unit.NOUNIT.toString(-1235.6));
-		
-		assertEquals("-123457", Unit.NOUNIT.toString(-123456.789));
-		
-		assertEquals("-1000000", Unit.NOUNIT.toString(-1000000)); // boundary check
-		
 		// negative numbers > 1E6
 		assertEquals("-1.23E6", Unit.NOUNIT.toString(-1234567.89));
 		assertEquals("-1.23E7", Unit.NOUNIT.toString(-12345678.9));
-		
-		
 	}
 	
 	


### PR DESCRIPTION
Changes tests for comma decimal separator locale so they won't give false negative

I'll then change this tests and ignore the rounding conflicts locally