### PR TITLE
[Refactor] Replaced redundant method: 'PositionValue(...)' with 'AxialOffset(...)'

### DIFF
--- a/core/src/net/sf/openrocket/file/rocksim/export/BasePartDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/BasePartDTO.java
@@ -1,5 +1,10 @@
 package net.sf.openrocket.file.rocksim.export;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
 import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
 import net.sf.openrocket.file.rocksim.RocksimDensityType;
 import net.sf.openrocket.file.rocksim.RocksimFinishCode;
@@ -11,11 +16,6 @@ import net.sf.openrocket.rocketcomponent.RecoveryDevice;
 import net.sf.openrocket.rocketcomponent.RingComponent;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.rocketcomponent.StructuralComponent;
-
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
 
 /**
  * The base class for all OpenRocket to Rocksim conversions.
@@ -88,17 +88,17 @@ public abstract class BasePartDTO {
         setUseKnownCG(ec.isCGOverridden() || ec.isMassOverridden() ? 1 : 0);
         setName(ec.getName());
 
-        setXb(ec.getPositionValue() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+        setXb(ec.getAxialOffset() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 
         //When the relative position is BOTTOM, the position location of the bottom edge of the component is +
         //to the right of the bottom of the parent, and - to the left.
         //But in Rocksim, it's + to the left and - to the right
         if (ec.getRelativePosition().equals(RocketComponent.Position.BOTTOM)) {
-            setXb((-1 * ec.getPositionValue()) * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+            setXb((-1 * ec.getAxialOffset()) * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
         }
         else if (ec.getRelativePosition().equals(RocketComponent.Position.MIDDLE)) {
             //Mapped to TOP, so adjust accordingly
-            setXb((ec.getPositionValue() + (ec.getParent().getLength() - ec.getLength()) /2)* RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+            setXb((ec.getAxialOffset() + (ec.getParent().getLength() - ec.getLength()) /2)* RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
         }
 
         if (ec instanceof ExternalComponent) {

--- a/core/src/net/sf/openrocket/file/rocksim/importt/RingHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/RingHandler.java
@@ -5,6 +5,8 @@ package net.sf.openrocket.file.rocksim.importt;
 
 import java.util.HashMap;
 
+import org.xml.sax.SAXException;
+
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.DocumentLoadingContext;
 import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
@@ -17,8 +19,6 @@ import net.sf.openrocket.rocketcomponent.EngineBlock;
 import net.sf.openrocket.rocketcomponent.RingComponent;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.rocketcomponent.TubeCoupler;
-
-import org.xml.sax.SAXException;
 
 /**
  * A SAX handler for centering rings, tube couplers, and bulkheads.
@@ -174,7 +174,7 @@ class RingHandler extends PositionDependentHandler<CenteringRing> {
 		result.setName(ring.getName());
 		setOverride(result, ring.isOverrideSubcomponentsEnabled(), ring.getOverrideMass(), ring.getOverrideCGX());
 		result.setRelativePosition(ring.getRelativePosition());
-		result.setPositionValue(ring.getPositionValue());
+		result.setAxialOffset(ring.getAxialOffset());
 		result.setMaterial(ring.getMaterial());
 		result.setThickness(result.getThickness());
 	}

--- a/core/src/net/sf/openrocket/rocketcomponent/AxialStage.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/AxialStage.java
@@ -87,13 +87,7 @@ public class AxialStage extends ComponentAssembly implements FlightConfigurableC
 		copy.separations = new FlightConfigurableParameterSet<StageSeparationConfiguration>(separations);
 		return copy;
 	}
-	
-	@Override
-	public double getPositionValue() {
-		mutex.verify();
-		
-		return this.getAxialOffset();
-	}
+
 	
 	/** 
 	 * Stages may be positioned relative to other stages. In that case, this will set the stage number 

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -257,24 +257,11 @@ public abstract class FinSet extends ExternalComponent {
 	}
 	
 	
-	
-	
-	
 	@Override
 	public void setRelativePosition(RocketComponent.Position position) {
 		super.setRelativePosition(position);
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
-	
-	
-	@Override
-	public void setPositionValue(double value) {
-		super.setPositionValue(value);
-		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
-	}
-	
-	
-	
 	
 	public double getTabHeight() {
 		return tabHeight;

--- a/core/src/net/sf/openrocket/rocketcomponent/InternalComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/InternalComponent.java
@@ -22,13 +22,6 @@ public abstract class InternalComponent extends RocketComponent {
 		super.setRelativePosition(position);
 		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
 	}
-
-	
-	@Override
-	public final void setPositionValue(double value) {
-		super.setPositionValue(value);
-		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
-	}
 	
 
 	/**

--- a/core/src/net/sf/openrocket/rocketcomponent/LaunchLug.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/LaunchLug.java
@@ -106,14 +106,6 @@ public class LaunchLug extends ExternalComponent implements Coaxial, LineInstanc
 	
 	
 	@Override
-	public void setPositionValue(double value) {
-		super.setPositionValue(value);
-		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
-	}
-	
-	
-	
-	@Override
 	protected void loadFromPreset(ComponentPreset preset) {
 		if (preset.has(ComponentPreset.OUTER_DIAMETER)) {
 			double outerDiameter = preset.get(ComponentPreset.OUTER_DIAMETER);

--- a/core/src/net/sf/openrocket/rocketcomponent/MassObject.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/MassObject.java
@@ -40,7 +40,7 @@ public abstract class MassObject extends InternalComponent {
 		this.radius = radius;
 		
 		this.setRelativePosition(Position.TOP);
-		this.setPositionValue(0.0);
+		this.setAxialOffset(0.0);
 	}
 	
 	@Override

--- a/core/src/net/sf/openrocket/rocketcomponent/ParallelStage.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/ParallelStage.java
@@ -190,13 +190,6 @@ public class ParallelStage extends AxialStage implements FlightConfigurableCompo
 	}
 	
 	@Override
-	public double getPositionValue() {
-		mutex.verify();
-		
-		return this.getAxialOffset();
-	}
-	
-	@Override
 	public boolean getAutoRadialOffset(){
 		return this.autoRadialPosition;
 	}

--- a/core/src/net/sf/openrocket/rocketcomponent/PodSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/PodSet.java
@@ -131,13 +131,6 @@ public class PodSet extends ComponentAssembly implements RingInstanceable {
 		return false;
 	}
 	
-	@Override
-	public double getPositionValue() {
-		mutex.verify();
-		
-		return this.getAxialOffset();
-	}
-	
 	/** 
 	 * Stages may be positioned relative to other stages. In that case, this will set the stage number 
 	 * against which this stage is positioned.

--- a/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
@@ -958,16 +958,6 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 		return result;
 	}
 	
-	/**
-	 * Get the position value of the component.  The exact meaning of the value is
-	 * dependent on the current relative positioning.
-	 *
-	 * @return  the positional value.
-	 */
-	public double getPositionValue() {
-		return this.getAxialOffset();
-	}
-	
 	public double getAxialOffset() {
 		mutex.verify();
 		return this.asPositionValue(this.relativePosition);
@@ -982,26 +972,6 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 			curComp = curComp.parent;
 		}
 		return false;
-	}
-	
-	/**
-	 * Set the position value of the component.  The exact meaning of the value
-	 * depends on the current relative positioning.
-	 * <p>
-	 * Mince many components do not support setting the relative position.  A component that does support
-	 * it should override this with a public method that simply calls this
-	 * supermethod AND fire a suitable ComponentChangeEvent.
-	 * 
-	 * @deprecated name is ambiguous in three-dimensional space: value may refer to any of the three dimensions.  Please use 'setAxialOffset' instead.
-	 * @param value		the position value of the component.
-	 */
-	@Deprecated
-	public void setPositionValue(double value) {
-		//		if (MathUtil.equals(this.position.x, value))
-		//			return;
-		//		//		checkState();
-		//		//		this.position = new Coordinate(value, 0, 0);
-		setAxialOffset(value);
 	}
 	
 	
@@ -1031,10 +1001,21 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 		this.position = new Coordinate(newAxialPosition, this.position.y, this.position.z);
 	}
 	
+	/**
+	 * Set the position value of the component.  The exact meaning of the value
+	 * depends on the current relative positioning.
+	 * <p>
+	 * Mince many components do not support setting the relative position.  A component that does support
+	 * it should override this with a public method that simply calls this
+	 * supermethod AND fire a suitable ComponentChangeEvent.
+	 * 
+	 * @param value		the position value of the component.
+	 */
 	public void setAxialOffset(double _value) {
 		this.setAxialOffset(this.relativePosition, _value);
 		this.fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
+	
 	
 	protected void setAxialOffset(final Position positionMethod, final double newOffset) {
 		checkState();

--- a/core/src/net/sf/openrocket/rocketcomponent/TubeFinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/TubeFinSet.java
@@ -227,13 +227,6 @@ public class TubeFinSet extends ExternalComponent {
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 	
-	
-	@Override
-	public void setPositionValue(double value) {
-		super.setPositionValue(value);
-		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
-	}
-	
 	@Override
 	public double getComponentVolume() {
 		double or = getOuterRadius();

--- a/core/src/net/sf/openrocket/simulation/listeners/example/DampingMoment.java
+++ b/core/src/net/sf/openrocket/simulation/listeners/example/DampingMoment.java
@@ -97,7 +97,7 @@ public class DampingMoment extends AbstractSimulationListener {
 			
 			double CNa = entry.getValue().getCNa(); //?
 			double Cp = entry.getValue().getCP().length();
-			double z = comp.getPositionValue(); //?
+			double z = comp.getAxialOffset();
 			
 			aerodynamicPart += CNa * Math.pow(z - Cp, 2);
 		}

--- a/core/src/net/sf/openrocket/util/TestRockets.java
+++ b/core/src/net/sf/openrocket/util/TestRockets.java
@@ -350,7 +350,7 @@ public class TestRockets {
 		if (c instanceof InternalComponent) {
 			InternalComponent i = (InternalComponent) c;
 			i.setRelativePosition((Position) randomEnum(Position.class));
-			i.setPositionValue(rnd(0.3));
+			i.setAxialOffset(rnd(0.3));
 		}
 	}
 	
@@ -672,7 +672,7 @@ public class TestRockets {
 			coupler.setThickness( bodyTubeThickness);
 			coupler.setLength(0.03);
 			coupler.setRelativePosition(Position.TOP);
-			coupler.setPositionValue(-1.5);
+			coupler.setAxialOffset(-1.5);
 			boosterTube.addChild(coupler);
 			
 			int finCount = 3;
@@ -683,14 +683,14 @@ public class TestRockets {
 			finset = new TrapezoidFinSet(finCount, finRootChord, finTipChord, finSweep, finHeight);
 			finset.setThickness( 0.0032);
 			finset.setRelativePosition(Position.BOTTOM);
-			finset.setPositionValue(1);
+			finset.setAxialOffset(1);
 			finset.setName("Booster Fins");
 			boosterTube.addChild(finset);
 			
 			// Motor mount
 			InnerTube boosterMMT = new InnerTube();
 			boosterMMT.setName("Booster MMT");
-			boosterMMT.setPositionValue(0.005);
+			boosterMMT.setAxialOffset(0.005);
 			boosterMMT.setRelativePosition(Position.BOTTOM);
 			boosterMMT.setOuterRadius(0.019 / 2);
 			boosterMMT.setInnerRadius(0.018 / 2);
@@ -805,7 +805,7 @@ public class TestRockets {
 		
 		mcomp = new MassComponent(0.2, 0.03, 0.045 + 0.060);
 		mcomp.setRelativePosition(Position.TOP);
-		mcomp.setPositionValue(0);
+		mcomp.setAxialOffset(0);
 		
 		// Stage construction
 		rocket.addChild(stage);
@@ -886,25 +886,25 @@ public class TestRockets {
 		coupler.setMassOverridden(true);
 		coupler.setOverrideMass(0.360);
 		coupler.setRelativePosition(Position.BOTTOM);
-		coupler.setPositionValue(-0.14);
+		coupler.setAxialOffset(-0.14);
 		tube1.addChild(coupler);
 		
 		// Parachute
 		MassComponent mass = new MassComponent(0.05, 0.05, 0.280);
 		mass.setRelativePosition(Position.TOP);
-		mass.setPositionValue(0.2);
+		mass.setAxialOffset(0.2);
 		tube1.addChild(mass);
 		
 		// Cord
 		mass = new MassComponent(0.05, 0.05, 0.125);
 		mass.setRelativePosition(Position.TOP);
-		mass.setPositionValue(0.2);
+		mass.setAxialOffset(0.2);
 		tube1.addChild(mass);
 		
 		// Payload
 		mass = new MassComponent(0.40, R, 1.500);
 		mass.setRelativePosition(Position.TOP);
-		mass.setPositionValue(0.25);
+		mass.setAxialOffset(0.25);
 		tube1.addChild(mass);
 		
 		auxfinset = new TrapezoidFinSet();
@@ -917,7 +917,7 @@ public class TestRockets {
 		auxfinset.setThickness(0.008);
 		auxfinset.setCrossSection(CrossSection.AIRFOIL);
 		auxfinset.setRelativePosition(Position.TOP);
-		auxfinset.setPositionValue(0.28);
+		auxfinset.setAxialOffset(0.28);
 		auxfinset.setBaseRotation(Math.PI / 2);
 		tube1.addChild(auxfinset);
 		
@@ -925,7 +925,7 @@ public class TestRockets {
 		coupler.setOuterRadiusAutomatic(true);
 		coupler.setLength(0.28);
 		coupler.setRelativePosition(Position.TOP);
-		coupler.setPositionValue(0.47);
+		coupler.setAxialOffset(0.47);
 		coupler.setMassOverridden(true);
 		coupler.setOverrideMass(0.360);
 		tube2.addChild(coupler);
@@ -933,7 +933,7 @@ public class TestRockets {
 		// Parachute
 		mass = new MassComponent(0.1, 0.05, 0.028);
 		mass.setRelativePosition(Position.TOP);
-		mass.setPositionValue(0.14);
+		mass.setAxialOffset(0.14);
 		tube2.addChild(mass);
 		
 		Bulkhead bulk = new Bulkhead();
@@ -941,13 +941,13 @@ public class TestRockets {
 		bulk.setMassOverridden(true);
 		bulk.setOverrideMass(0.050);
 		bulk.setRelativePosition(Position.TOP);
-		bulk.setPositionValue(0.27);
+		bulk.setAxialOffset(0.27);
 		tube2.addChild(bulk);
 		
 		// Chord
 		mass = new MassComponent(0.1, 0.05, 0.125);
 		mass.setRelativePosition(Position.TOP);
-		mass.setPositionValue(0.19);
+		mass.setAxialOffset(0.19);
 		tube2.addChild(mass);
 		
 		InnerTube inner = new InnerTube();
@@ -965,7 +965,7 @@ public class TestRockets {
 		center.setMassOverridden(true);
 		center.setOverrideMass(0.038);
 		center.setRelativePosition(Position.BOTTOM);
-		center.setPositionValue(0);
+		center.setAxialOffset(0);
 		tube3.addChild(center);
 		
 		center = new CenteringRing();
@@ -975,7 +975,7 @@ public class TestRockets {
 		center.setMassOverridden(true);
 		center.setOverrideMass(0.038);
 		center.setRelativePosition(Position.TOP);
-		center.setPositionValue(0.28);
+		center.setAxialOffset(0.28);
 		tube3.addChild(center);
 		
 		center = new CenteringRing();
@@ -985,7 +985,7 @@ public class TestRockets {
 		center.setMassOverridden(true);
 		center.setOverrideMass(0.038);
 		center.setRelativePosition(Position.TOP);
-		center.setPositionValue(0.83);
+		center.setAxialOffset(0.83);
 		tube3.addChild(center);
 		
 		finset = new TrapezoidFinSet();
@@ -995,7 +995,7 @@ public class TestRockets {
 		finset.setThickness(0.005);
 		finset.setSweep(0.3);
 		finset.setRelativePosition(Position.BOTTOM);
-		finset.setPositionValue(-0.03);
+		finset.setAxialOffset(-0.03);
 		finset.setBaseRotation(Math.PI / 2);
 		tube3.addChild(finset);
 		
@@ -1071,7 +1071,7 @@ public class TestRockets {
 				Parachute upperChute= new Parachute();
 				upperChute.setName("Parachute");
 				upperChute.setRelativePosition(Position.MIDDLE);
-				upperChute.setPositionValue(0.0);
+				upperChute.setAxialOffset(0.0);
 				upperChute.setDiameter(0.3);
 				upperChute.setLineCount(6);
 				upperChute.setLineLength(0.3);
@@ -1081,7 +1081,7 @@ public class TestRockets {
 				ShockCord cord = new ShockCord();
 				cord.setName("Shock Cord");
 				cord.setRelativePosition(Position.BOTTOM);
-				cord.setPositionValue(0.0);
+				cord.setAxialOffset(0.0);
 				cord.setCordLength(0.4);
 		    	upperStageBody.addChild( cord);
 			}
@@ -1116,7 +1116,7 @@ public class TestRockets {
 			coreFins.setName("Core Fins");
 			coreFins.setFinCount(4);
 			coreFins.setRelativePosition(Position.BOTTOM);
-			coreFins.setPositionValue(0.0);
+			coreFins.setAxialOffset(0.0);
 			coreFins.setBaseRotation( Math.PI / 4);
 			coreFins.setThickness(0.003);
 			coreFins.setCrossSection(CrossSection.ROUNDED);

--- a/core/test/net/sf/openrocket/file/rocksim/importt/ParachuteHandlerTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/importt/ParachuteHandlerTest.java
@@ -3,6 +3,10 @@
  */
 package net.sf.openrocket.file.rocksim.importt;
 
+import java.util.HashMap;
+
+import org.junit.Assert;
+
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
@@ -10,9 +14,6 @@ import net.sf.openrocket.material.Material;
 import net.sf.openrocket.rocketcomponent.BodyTube;
 import net.sf.openrocket.rocketcomponent.Parachute;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
-import org.junit.Assert;
-
-import java.util.HashMap;
 
 /**
  * ParachuteHandler Tester.
@@ -153,12 +154,12 @@ public class ParachuteHandlerTest extends RocksimTestBase {
         handler.closeElement("LocationMode", attributes, "1", warnings);
         handler.endHandler("Parachute", attributes, null, warnings);
         Assert.assertEquals(RocketComponent.Position.ABSOLUTE, component.getRelativePosition());
-        Assert.assertEquals(component.getPositionValue(), -10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, 0.001);
+        Assert.assertEquals(component.getAxialOffset(), -10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, 0.001);
 
         handler.closeElement("Xb", attributes, "-10", warnings);
         handler.closeElement("LocationMode", attributes, "2", warnings);
         handler.endHandler("Parachute", attributes, null, warnings);
         Assert.assertEquals(RocketComponent.Position.BOTTOM, component.getRelativePosition());
-        Assert.assertEquals(component.getPositionValue(), 10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, 0.001);
+        Assert.assertEquals(component.getAxialOffset(), 10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, 0.001);
     }
 }

--- a/core/test/net/sf/openrocket/file/rocksim/importt/RingHandlerTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/importt/RingHandlerTest.java
@@ -3,6 +3,11 @@
  */
 package net.sf.openrocket.file.rocksim.importt;
 
+import java.util.HashMap;
+
+import org.junit.Assert;
+import org.junit.Test;
+
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
@@ -14,10 +19,6 @@ import net.sf.openrocket.rocketcomponent.EngineBlock;
 import net.sf.openrocket.rocketcomponent.RingComponent;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.rocketcomponent.TubeCoupler;
-import org.junit.Assert;
-import org.junit.Test;
-
-import java.util.HashMap;
 
 /**
  * RingHandler Tester.
@@ -108,7 +109,7 @@ public class RingHandlerTest extends RocksimTestBase {
         Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, child.getLength(), 0.001);
         Assert.assertEquals("Test Name", child.getName());
         Assert.assertEquals(109.9/1000, child.getMass(), 0.001);
-        Assert.assertEquals(0, child.getPositionValue(), 0.0);
+        Assert.assertEquals(0, child.getAxialOffset(), 0.0);
         Assert.assertEquals(RocketComponent.Position.TOP, child.getRelativePosition());
         Assert.assertTrue(child instanceof Bulkhead);
 
@@ -144,7 +145,7 @@ public class RingHandlerTest extends RocksimTestBase {
         Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, child.getLength(), 0.001);
         Assert.assertEquals("Test Name", child.getName());
         Assert.assertEquals(109.9/1000, child.getMass(), 0.001);
-        Assert.assertEquals(0, child.getPositionValue(), 0.0);
+        Assert.assertEquals(0, child.getAxialOffset(), 0.0);
         Assert.assertEquals(RocketComponent.Position.TOP, child.getRelativePosition());
     }
 
@@ -179,7 +180,7 @@ public class RingHandlerTest extends RocksimTestBase {
         Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, child.getLength(), 0.001);
         Assert.assertEquals("Test Name", child.getName());
         Assert.assertEquals(109.9/1000, child.getMass(), 0.001);
-        Assert.assertEquals(0, child.getPositionValue(), 0.0);
+        Assert.assertEquals(0, child.getAxialOffset(), 0.0);
         Assert.assertEquals(RocketComponent.Position.TOP, child.getRelativePosition());
         Assert.assertEquals(4d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, child.getCG().x, 0.000001);
         
@@ -214,7 +215,7 @@ public class RingHandlerTest extends RocksimTestBase {
         Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, child.getLength(), 0.001);
         Assert.assertEquals("Test Name", child.getName());
         Assert.assertEquals(109.9/1000, child.getMass(), 0.001);
-        Assert.assertEquals(0, child.getPositionValue(), 0.0);
+        Assert.assertEquals(0, child.getAxialOffset(), 0.0);
         Assert.assertEquals(RocketComponent.Position.TOP, child.getRelativePosition());
         Assert.assertTrue(child instanceof CenteringRing);
     }

--- a/core/test/net/sf/openrocket/file/rocksim/importt/StreamerHandlerTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/importt/StreamerHandlerTest.java
@@ -3,6 +3,11 @@
  */
 package net.sf.openrocket.file.rocksim.importt;
 
+import java.util.HashMap;
+
+import org.junit.Assert;
+import org.junit.Test;
+
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
 import net.sf.openrocket.file.rocksim.RocksimDensityType;
@@ -11,10 +16,6 @@ import net.sf.openrocket.material.Material;
 import net.sf.openrocket.rocketcomponent.BodyTube;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.rocketcomponent.Streamer;
-import org.junit.Assert;
-import org.junit.Test;
-
-import java.util.HashMap;
 
 /**
  * StreamerHandler Tester.
@@ -149,13 +150,13 @@ public class StreamerHandlerTest extends RocksimTestBase {
         handler.closeElement("LocationMode", attributes, "1", warnings);
         handler.endHandler("Streamer", attributes, null, warnings);
         Assert.assertEquals(RocketComponent.Position.ABSOLUTE, component.getRelativePosition());
-        Assert.assertEquals(component.getPositionValue(), -10d/ RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, 0.001);
+        Assert.assertEquals(component.getAxialOffset(), -10d/ RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, 0.001);
 
         handler.closeElement("Xb", attributes, "-10", warnings);
         handler.closeElement("LocationMode", attributes, "2", warnings);
         handler.endHandler("Streamer", attributes, null, warnings);
         Assert.assertEquals(RocketComponent.Position.BOTTOM, component.getRelativePosition());
-        Assert.assertEquals(component.getPositionValue(), 10d/ RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, 0.001);
+        Assert.assertEquals(component.getAxialOffset(), 10d/ RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, 0.001);
 
         handler.closeElement("Thickness", attributes, "0.02", warnings);
         Assert.assertEquals(0.01848, handler.computeDensity(RocksimDensityType.ROCKSIM_BULK, 924d), 0.001);

--- a/core/test/net/sf/openrocket/rocketcomponent/FinSetTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/FinSetTest.java
@@ -234,7 +234,7 @@ public class FinSetTest extends BaseTestCase {
 		fin.setOverrideCGX(0.012);
 		fin.setOverrideMass(0.0123);
 		fin.setOverrideSubcomponents(true);
-		fin.setPositionValue(0.1);
+		fin.setAxialOffset(0.1);
 		fin.setRelativePosition(Position.ABSOLUTE);
 		fin.setTabHeight(0.01);
 		fin.setTabLength(0.02);

--- a/core/test/net/sf/openrocket/rocketcomponent/ParallelStageTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/ParallelStageTest.java
@@ -417,7 +417,7 @@ public class ParallelStageTest extends BaseTestCase {
 		
 		Coordinate resultantRelativePosition = booster.getOffset();
 		assertThat(" 'setAxialPosition(double)' failed: \n" + treeDump + " Relative position: ", resultantRelativePosition.x, equalTo(expectedX));
-		double resultantPositionValue = booster.getPositionValue();
+		double resultantPositionValue = booster.getAxialOffset();
 		assertThat(" 'setAxialPosition(double)' failed: \n" + treeDump + " PositionValue: ", resultantPositionValue, equalTo(targetX));
 		double resultantAxialPosition = booster.getAxialOffset();
 		assertThat(" 'setAxialPosition(double)' failed: \n" + treeDump + " Relative position: ", resultantAxialPosition, equalTo(targetX));
@@ -450,7 +450,7 @@ public class ParallelStageTest extends BaseTestCase {
 		Coordinate resultantRelativePosition = sustainer.getOffset();
 		assertThat(" 'setAxialPosition(double)' failed: \n" + treeDump + " Sustainer Relative position: ", resultantRelativePosition.x, equalTo(expectedX));
 		double expectedPositionValue = 0;
-		double resultantPositionValue = sustainer.getPositionValue();
+		double resultantPositionValue = sustainer.getAxialOffset();
 		assertThat(" 'setPositionValue()' failed: \n" + treeDump + " Sustainer Position Value: ", resultantPositionValue, equalTo(expectedPositionValue));
 		
 		double expectedAxialOffset = 0;
@@ -486,7 +486,7 @@ public class ParallelStageTest extends BaseTestCase {
 		double resultantAxialOffset = booster.getAxialOffset();
 		assertThat(" 'getAxialPosition()' failed: \n" + treeDump + "  Axial Offset: ", resultantAxialOffset, equalTo(targetOffset));
 		
-		double resultantPositionValue = booster.getPositionValue();
+		double resultantPositionValue = booster.getAxialOffset();
 		assertThat(" 'setPositionValue()' failed: \n" + treeDump + " Position Value: ", resultantPositionValue, equalTo(targetOffset));
 	}
 	
@@ -513,7 +513,7 @@ public class ParallelStageTest extends BaseTestCase {
 		Coordinate resultantAbsolutePosition = booster.getLocations()[0];
 		assertThat(" 'setAxialPosition(double)' failed: \n" + treeDump + " Absolute position: ", resultantAbsolutePosition.x, equalTo(expectedAbsoluteX));
 		
-		double resultantPositionValue = booster.getPositionValue();
+		double resultantPositionValue = booster.getAxialOffset();
 		assertThat(" 'setPositionValue()' failed: \n" + treeDump + " Position Value: ", resultantPositionValue, equalTo(targetOffset));
 		
 		double resultantAxialOffset = booster.getAxialOffset();
@@ -542,7 +542,7 @@ public class ParallelStageTest extends BaseTestCase {
 		Coordinate resultantAbsolutePosition = booster.getLocations()[0];
 		assertThat(" 'setAxialPosition(double)' failed: \n" + treeDump + " Absolute position: ", resultantAbsolutePosition.x, equalTo(expectedAbsoluteX));
 		
-		double resultantPositionValue = booster.getPositionValue();
+		double resultantPositionValue = booster.getAxialOffset();
 		assertThat(" 'setPositionValue()' failed: \n" + treeDump + " Position Value: ", resultantPositionValue, equalTo(targetOffset));
 		
 		double resultantAxialOffset = booster.getAxialOffset();

--- a/swing/src/net/sf/openrocket/gui/configdialog/EllipticalFinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/EllipticalFinSetConfig.java
@@ -123,7 +123,7 @@ public class EllipticalFinSetConfig extends FinSetConfig {
 		//// plus
 		panel.add(new JLabel(trans.get("EllipticalFinSetCfg.plus")), "right");
 		
-		m = new DoubleModel(component, "PositionValue", UnitGroup.UNITS_LENGTH);
+		m = new DoubleModel(component, "AxialOffset", UnitGroup.UNITS_LENGTH);
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		panel.add(spin, "growx");

--- a/swing/src/net/sf/openrocket/gui/configdialog/FreeformFinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/FreeformFinSetConfig.java
@@ -24,6 +24,9 @@ import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.table.AbstractTableModel;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.gui.SpinnerEditor;
@@ -51,9 +54,6 @@ import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
 import net.sf.openrocket.util.Coordinate;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class FreeformFinSetConfig extends FinSetConfig {
 	private static final long serialVersionUID = 2504130276828826021L;
@@ -145,7 +145,7 @@ public class FreeformFinSetConfig extends FinSetConfig {
 		//// plus
 		panel.add(new JLabel(trans.get("FreeformFinSetCfg.lbl.plus")), "right");
 		
-		m = new DoubleModel(component, "PositionValue", UnitGroup.UNITS_LENGTH);
+		m = new DoubleModel(component, "AxialOffset", UnitGroup.UNITS_LENGTH);
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		panel.add(spin, "growx");

--- a/swing/src/net/sf/openrocket/gui/configdialog/InnerTubeConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/InnerTubeConfig.java
@@ -153,7 +153,7 @@ public class InnerTubeConfig extends RocketComponentConfig {
 		panel.add(new JLabel(trans.get("ringcompcfg.plus")), "right");
 
 		//// PositionValue
-		m = new DoubleModel(component, "PositionValue", UnitGroup.UNITS_LENGTH);
+		m = new DoubleModel(component, "AxialOffset", UnitGroup.UNITS_LENGTH);
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		panel.add(spin, "growx");

--- a/swing/src/net/sf/openrocket/gui/configdialog/LaunchLugConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/LaunchLugConfig.java
@@ -124,7 +124,7 @@ public class LaunchLugConfig extends RocketComponentConfig {
 		//// plus
 		panel.add(new JLabel(trans.get("LaunchLugCfg.lbl.plus")), "right");
 		
-		m = new DoubleModel(component, "PositionValue", UnitGroup.UNITS_LENGTH);
+		m = new DoubleModel(component, "AxialOffset", UnitGroup.UNITS_LENGTH);
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		panel.add(spin, "growx");

--- a/swing/src/net/sf/openrocket/gui/configdialog/MassComponentConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/MassComponentConfig.java
@@ -120,7 +120,7 @@ public class MassComponentConfig extends RocketComponentConfig {
 		//// plus
 		panel.add(new JLabel(trans.get("MassComponentCfg.lbl.plus")), "right");
 		
-		m = new DoubleModel(component, "PositionValue", UnitGroup.UNITS_LENGTH);
+		m = new DoubleModel(component, "AxialOffset", UnitGroup.UNITS_LENGTH);
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		panel.add(spin, "growx");

--- a/swing/src/net/sf/openrocket/gui/configdialog/ParachuteConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/ParachuteConfig.java
@@ -151,7 +151,7 @@ public class ParachuteConfig extends RecoveryDeviceConfig {
 		//// plus
 		panel.add(new JLabel(trans.get("ParachuteCfg.lbl.plus")), "right");
 		
-		m = new DoubleModel(component, "PositionValue", UnitGroup.UNITS_LENGTH);
+		m = new DoubleModel(component, "AxialOffset", UnitGroup.UNITS_LENGTH);
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		panel.add(spin, "growx");

--- a/swing/src/net/sf/openrocket/gui/configdialog/RailButtonConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RailButtonConfig.java
@@ -93,7 +93,7 @@ public class RailButtonConfig extends RocketComponentConfig {
 		{ //// plus
 			final double parentLength = ((BodyTube)rbc.getParent()).getLength();
 			panel.add(new JLabel(trans.get("RailBtnCfg.lbl.Plus")), "right");
-			DoubleModel offsetModel = new DoubleModel(component, "PositionValue", UnitGroup.UNITS_LENGTH);
+			DoubleModel offsetModel = new DoubleModel(component, "AxialOffset", UnitGroup.UNITS_LENGTH);
 			JSpinner offsetSpinner = new JSpinner(offsetModel.getSpinnerModel());
 			offsetSpinner.setEditor(new SpinnerEditor(offsetSpinner));
 			panel.add(offsetSpinner, "growx");

--- a/swing/src/net/sf/openrocket/gui/configdialog/RingComponentConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RingComponentConfig.java
@@ -139,7 +139,7 @@ public class RingComponentConfig extends RocketComponentConfig {
 		panel.add(new JLabel(trans.get("ringcompcfg.plus")), "right");
 		
 		//// PositionValue
-		m = new DoubleModel(component, "PositionValue", UnitGroup.UNITS_LENGTH);
+		m = new DoubleModel(component, "AxialOffset", UnitGroup.UNITS_LENGTH);
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		panel.add(spin, "growx");

--- a/swing/src/net/sf/openrocket/gui/configdialog/ShockCordConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/ShockCordConfig.java
@@ -75,7 +75,7 @@ public class ShockCordConfig extends RocketComponentConfig {
 		//// plus
 		panel2.add(new JLabel(trans.get("ShockCordCfg.lbl.plus")), "right");
 		
-		m = new DoubleModel(component, "PositionValue", UnitGroup.UNITS_LENGTH);
+		m = new DoubleModel(component, "AxialOffset", UnitGroup.UNITS_LENGTH);
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		panel2.add(spin, "growx");

--- a/swing/src/net/sf/openrocket/gui/configdialog/StreamerConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/StreamerConfig.java
@@ -152,7 +152,7 @@ public class StreamerConfig extends RecoveryDeviceConfig {
 		//// plus
 		panel.add(new JLabel(trans.get("StreamerCfg.lbl.plus")), "right");
 		
-		m = new DoubleModel(component, "PositionValue", UnitGroup.UNITS_LENGTH);
+		m = new DoubleModel(component, "AxialOffset", UnitGroup.UNITS_LENGTH);
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		panel.add(spin, "growx");

--- a/swing/src/net/sf/openrocket/gui/configdialog/TrapezoidFinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/TrapezoidFinSetConfig.java
@@ -179,7 +179,7 @@ public class TrapezoidFinSetConfig extends FinSetConfig {
 		//// plus
 		panel.add(new JLabel(trans.get("TrapezoidFinSetCfg.lbl.plus")), "right");
 		
-		m = new DoubleModel(component, "PositionValue", UnitGroup.UNITS_LENGTH);
+		m = new DoubleModel(component, "AxialOffset", UnitGroup.UNITS_LENGTH);
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		panel.add(spin, "growx");

--- a/swing/src/net/sf/openrocket/gui/configdialog/TubeFinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/TubeFinSetConfig.java
@@ -137,7 +137,7 @@ public class TubeFinSetConfig extends RocketComponentConfig {
 		//// plus
 		panel.add(new JLabel(trans.get("LaunchLugCfg.lbl.plus")), "right");
 		
-		m = new DoubleModel(component, "PositionValue", UnitGroup.UNITS_LENGTH);
+		m = new DoubleModel(component, "AxialOffset", UnitGroup.UNITS_LENGTH);
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		panel.add(spin, "growx");

--- a/swing/test/net/sf/openrocket/gui/configdialog/FinSetConfigTest.java
+++ b/swing/test/net/sf/openrocket/gui/configdialog/FinSetConfigTest.java
@@ -4,15 +4,15 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
 import net.sf.openrocket.gui.adaptors.DoubleModel;
 import net.sf.openrocket.rocketcomponent.BodyTube;
 import net.sf.openrocket.rocketcomponent.CenteringRing;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.util.BaseTestCase.BaseTestCase;
-
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class FinSetConfigTest extends BaseTestCase {
 
@@ -56,11 +56,11 @@ public class FinSetConfigTest extends BaseTestCase {
         CenteringRing ring1 = new CenteringRing();
         ring1.setLength(0.004);
         ring1.setRelativePosition(RocketComponent.Position.TOP);
-        ring1.setPositionValue(0.43);
+        ring1.setAxialOffset(0.43);
         CenteringRing ring2 = new CenteringRing();
         ring2.setLength(0.004);
         ring2.setRelativePosition(RocketComponent.Position.TOP);
-        ring2.setPositionValue(0.45);
+        ring2.setAxialOffset(0.45);
         rings.add(ring1);
         rings.add(ring2);
         parent.addChild(ring1);
@@ -82,7 +82,7 @@ public class FinSetConfigTest extends BaseTestCase {
         CenteringRing ring1 = new CenteringRing();
         ring1.setLength(0.004);
         ring1.setRelativePosition(RocketComponent.Position.TOP);
-        ring1.setPositionValue(0.43);
+        ring1.setAxialOffset(0.43);
         rings.add(ring1);
 
         RocketComponent parent = new BodyTube();
@@ -103,11 +103,11 @@ public class FinSetConfigTest extends BaseTestCase {
         CenteringRing ring1 = new CenteringRing();
         ring1.setRelativePosition(RocketComponent.Position.TOP);
         ring1.setLength(0.004);
-        ring1.setPositionValue(0.43);
+        ring1.setAxialOffset(0.43);
         CenteringRing ring2 = new CenteringRing();
         ring2.setRelativePosition(RocketComponent.Position.TOP);
         ring2.setLength(0.004);
-        ring2.setPositionValue(0.45);
+        ring2.setAxialOffset(0.45);
         rings.add(ring1);
         rings.add(ring2);
 
@@ -130,11 +130,11 @@ public class FinSetConfigTest extends BaseTestCase {
         CenteringRing ring1 = new CenteringRing();
         ring1.setRelativePosition(RocketComponent.Position.TOP);
         ring1.setLength(0.004);
-        ring1.setPositionValue(0.43);
+        ring1.setAxialOffset(0.43);
         CenteringRing ring2 = new CenteringRing();
         ring2.setRelativePosition(RocketComponent.Position.TOP);
         ring2.setLength(0.004);
-        ring2.setPositionValue(0.48);
+        ring2.setAxialOffset(0.48);
         rings.add(ring1);
         rings.add(ring2);
 
@@ -155,11 +155,11 @@ public class FinSetConfigTest extends BaseTestCase {
         CenteringRing ring1 = new CenteringRing();
         ring1.setRelativePosition(RocketComponent.Position.TOP);
         ring1.setLength(0.004);
-        ring1.setPositionValue(0.4701);
+        ring1.setAxialOffset(0.4701);
         CenteringRing ring2 = new CenteringRing();
         ring2.setLength(0.004);
         ring2.setRelativePosition(RocketComponent.Position.TOP);
-        ring2.setPositionValue(0.48);
+        ring2.setAxialOffset(0.48);
         rings.add(ring1);
         rings.add(ring2);
         RocketComponent parent = new BodyTube(1.0d, 0.1d);
@@ -181,12 +181,12 @@ public class FinSetConfigTest extends BaseTestCase {
         CenteringRing ring1 = new CenteringRing();
         ring1.setRelativePosition(RocketComponent.Position.TOP);
         ring1.setLength(0.004);
-        ring1.setPositionValue(0.4701);
+        ring1.setAxialOffset(0.4701);
         parent.addChild(ring1);
         CenteringRing ring2 = new CenteringRing();
         ring2.setLength(0.004);
         ring2.setRelativePosition(RocketComponent.Position.TOP);
-        ring2.setPositionValue(0.4750);
+        ring2.setAxialOffset(0.4750);
         parent.addChild(ring2);
         rings.add(ring1);
         rings.add(ring2);
@@ -207,11 +207,11 @@ public class FinSetConfigTest extends BaseTestCase {
         CenteringRing ring1 = new CenteringRing();
         ring1.setRelativePosition(RocketComponent.Position.TOP);
         ring1.setLength(0.004);
-        ring1.setPositionValue(0.48);
+        ring1.setAxialOffset(0.48);
         CenteringRing ring2 = new CenteringRing();
         ring2.setRelativePosition(RocketComponent.Position.TOP);
         ring2.setLength(0.004);
-        ring2.setPositionValue(0.49);
+        ring2.setAxialOffset(0.49);
         rings.add(ring1);
         rings.add(ring2);
         RocketComponent parent = new BodyTube(1.0d, 0.1d);
@@ -233,20 +233,20 @@ public class FinSetConfigTest extends BaseTestCase {
         CenteringRing ring1 = new CenteringRing();
         ring1.setRelativePosition(RocketComponent.Position.ABSOLUTE);
         ring1.setLength(0.004);
-        ring1.setPositionValue(0.47);
+        ring1.setAxialOffset(0.47);
         CenteringRing ring2 = new CenteringRing();
         ring2.setRelativePosition(RocketComponent.Position.ABSOLUTE);
         ring2.setLength(0.004);
-        ring2.setPositionValue(0.4702);
+        ring2.setAxialOffset(0.4702);
         CenteringRing ring3 = new CenteringRing();
         ring3.setRelativePosition(RocketComponent.Position.ABSOLUTE);
         ring3.setLength(0.004);
-        ring3.setPositionValue(0.4770);
+        ring3.setAxialOffset(0.4770);
         rings.add(ring1);
         rings.add(ring2);
         rings.add(ring3);
         BodyTube parent = new BodyTube(1.0d, 0.1d);
-        parent.setPositionValue(0);
+        parent.setAxialOffset(0);
         parent.addChild(ring1);
         parent.addChild(ring2);
         parent.addChild(ring3);


### PR DESCRIPTION
- These two methods did the same thing, so this patch removes the former from RocketComponent and descendant classes
- Wherever used, "PositionValue(...)" was replace with "AxialOffset(...)"
- Removed some extraneous redirect definitions of PositionValue(...)
- Fixed some UI references to the old method

(apologies for where eclipse auto-organized the imports)