### PR TITLE
[Feature] Freeform Fins may now be attached to cones and transitions

### DIFF
--- a/core/src/de/congrace/exp4j/AbstractExpression.java
+++ b/core/src/de/congrace/exp4j/AbstractExpression.java
@@ -26,7 +26,7 @@ import java.text.NumberFormat;
 abstract class AbstractExpression {
 	private final String expression;
 	private final Token[] tokens;
-	private final String[] variableStrings;
+	protected final String[] variableStrings;
 	private final NumberFormat numberFormat = NumberFormat.getInstance();
 
 	/**

--- a/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
+++ b/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
@@ -478,7 +478,7 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 				FinSet f = (FinSet) c;
 				double mac = ((FinSetCalc) calcMap.get(c)).getMACLength();
 				double cd = componentCf * (1 + 2 * f.getThickness() / mac) *
-						2 * f.getFinCount() * f.getFinArea();
+						2 * f.getFinCount() * f.getFinWettedArea();
 				finFriction += cd;
 				
 				if (map != null) {
@@ -718,7 +718,7 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 		for (RocketComponent c : configuration.getActiveComponents()) {
 			if (c instanceof FinSet) {
 				FinSet f = (FinSet) c;
-				mul += 0.6 * Math.min(f.getFinCount(), 4) * f.getFinArea() *
+				mul += 0.6 * Math.min(f.getFinCount(), 4) * f.getFinWettedArea() *
 						MathUtil.pow3(Math.abs(f.toAbsolute(new Coordinate(
 								((FinSetCalc) calcMap.get(f)).getMidchordPos()))[0].x
 								- cgx)) /

--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/FinSetCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/FinSetCalc.java
@@ -17,13 +17,8 @@ import net.sf.openrocket.util.LinearInterpolator;
 import net.sf.openrocket.util.MathUtil;
 import net.sf.openrocket.util.PolyInterpolator;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 public class FinSetCalc extends RocketComponentCalc {
-	
-	private final static Logger logger = LoggerFactory.getLogger(FinSetCalc.class);
 	
 	private static final double STALL_ANGLE = (20 * Math.PI / 180);
 	
@@ -65,12 +60,12 @@ public class FinSetCalc extends RocketComponentCalc {
 		
 		FinSet fin = (FinSet) component;
 		thickness = fin.getThickness();
-		bodyRadius = fin.getBodyRadius();
+		bodyRadius = fin.getBodyRadius(0);
 		finCount = fin.getFinCount();
 		baseRotation = fin.getBaseRotation();
 		cantAngle = fin.getCantAngle();
 		span = fin.getSpan();
-		finArea = fin.getFinArea();
+		finArea = fin.getFinWettedArea();
 		crossSection = fin.getCrossSection();
 		
 		calculateFinGeometry(fin);
@@ -248,7 +243,7 @@ public class FinSetCalc extends RocketComponentCalc {
 	protected void calculateFinGeometry(FinSet component) {
 		
 		span = component.getSpan();
-		finArea = component.getFinArea();
+		finArea = component.getFinWettedArea();
 		ar = 2 * pow2(span) / finArea;
 		
 		Coordinate[] points = component.getFinPoints();
@@ -341,7 +336,7 @@ public class FinSetCalc extends RocketComponentCalc {
 		cosGammaLead = 0;
 		rollSum = 0;
 		double area = 0;
-		double radius = component.getBodyRadius();
+		double radius = component.getBodyRadius(0);
 		
 		final double dy = span / (DIVISIONS - 1);
 		for (int i = 0; i < DIVISIONS; i++) {

--- a/core/src/net/sf/openrocket/communication/UpdateInfoRetriever.java
+++ b/core/src/net/sf/openrocket/communication/UpdateInfoRetriever.java
@@ -80,11 +80,14 @@ public class UpdateInfoRetriever {
 	 * @throws IOException	if an I/O exception occurs.
 	 */
 	/* package-private */
-	static UpdateInfo parseUpdateInput(Reader r) throws IOException {
+	static UpdateInfo parseUpdateInput(final Reader r) throws IOException {
 		BufferedReader reader;
 		if (r instanceof BufferedReader) {
 			reader = (BufferedReader) r;
 		} else {
+			// this is a bad idea... 
+			// creating readers which may or may not need to be closed within 
+			// this method is ambiguous
 			reader = new BufferedReader(r);
 		}
 		
@@ -226,7 +229,7 @@ public class UpdateInfoRetriever {
 					log.warn("Invalid version received, ignoring.");
 					return;
 				}
-				
+				reader.close(); 
 				
 				info = new UpdateInfo(version, updates);
 				log.info("Found update: " + info);

--- a/core/src/net/sf/openrocket/database/ComponentPresetDatabase.java
+++ b/core/src/net/sf/openrocket/database/ComponentPresetDatabase.java
@@ -5,16 +5,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import net.sf.openrocket.preset.ComponentPreset;
 import net.sf.openrocket.startup.Application;
 
 public class ComponentPresetDatabase extends Database<ComponentPreset> implements ComponentPresetDao {
 
-	private static final Logger logger = LoggerFactory.getLogger(ComponentPresetDatabase.class);
-	
 	public ComponentPresetDatabase() {
 		super();
 	}

--- a/core/src/net/sf/openrocket/file/openrocket/importt/FinSetPointHandler.java
+++ b/core/src/net/sf/openrocket/file/openrocket/importt/FinSetPointHandler.java
@@ -3,6 +3,8 @@ package net.sf.openrocket.file.openrocket.importt;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+import org.xml.sax.SAXException;
+
 import net.sf.openrocket.aerodynamics.Warning;
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.DocumentLoadingContext;
@@ -10,10 +12,7 @@ import net.sf.openrocket.file.simplesax.AbstractElementHandler;
 import net.sf.openrocket.file.simplesax.ElementHandler;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
 import net.sf.openrocket.rocketcomponent.FreeformFinSet;
-import net.sf.openrocket.rocketcomponent.IllegalFinPointException;
 import net.sf.openrocket.util.Coordinate;
-
-import org.xml.sax.SAXException;
 
 /**
  * A handler that reads the <point> specifications within the freeformfinset's
@@ -62,10 +61,7 @@ class FinSetPointHandler extends AbstractElementHandler {
 	@Override
 	public void endHandler(String element, HashMap<String, String> attributes,
 			String content, WarningSet warnings) {
-		try {
-			finset.setPoints(coordinates.toArray(new Coordinate[0]));
-		} catch (IllegalFinPointException e) {
-			warnings.add(Warning.fromString("Freeform fin set point definitions illegal, ignoring."));
-		}
+		finset.setPoints(coordinates.toArray(new Coordinate[0]));
+		
 	}
 }

--- a/core/src/net/sf/openrocket/file/openrocket/importt/FinTabPositionSetter.java
+++ b/core/src/net/sf/openrocket/file/openrocket/importt/FinTabPositionSetter.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.rocketcomponent.FinSet;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
-import net.sf.openrocket.rocketcomponent.FinSet.TabRelativePosition;
 import net.sf.openrocket.util.Reflection;
 
 class FinTabPositionSetter extends DoubleSetter {
@@ -23,23 +22,32 @@ class FinTabPositionSetter extends DoubleSetter {
 		}
 		
 		String relative = attributes.get("relativeto");
-		FinSet.TabRelativePosition position =
-				(TabRelativePosition) DocumentConfig.findEnum(relative,
-						FinSet.TabRelativePosition.class);
 		
-		if (position != null) {
-			
-			((FinSet) c).setTabRelativePosition(position);
-			
+		if (relative == null) {
+			warnings.add("Required attribute 'relativeto' not found for fin tab position.");
 		} else {
-			if (relative == null) {
-				warnings.add("Required attribute 'relativeto' not found for fin tab position.");
-			} else {
-				warnings.add("Illegal attribute value '" + relative + "' encountered.");
+			// translate from old enum names to current enum names
+			if( relative.contains("front")){
+				relative = "top";
+			}else if( relative.contains("center")){
+				relative = "middle";
+			}else if( relative.contains("end")){
+				relative = "bottom";
 			}
+			
+			RocketComponent.Position position =
+					(RocketComponent.Position) DocumentConfig.findEnum(relative,
+							RocketComponent.Position.class);
+			
+			if( null == position ){
+				warnings.add("Illegal attribute value '" + relative + "' encountered.");
+			}else{
+				((FinSet) c).setTabPositionMethod(position);
+				super.set(c, s, attributes, warnings);
+			}
+		
 		}
 		
-		super.set(c, s, attributes, warnings);
 	}
 	
 	

--- a/core/src/net/sf/openrocket/file/openrocket/savers/FinSetSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/savers/FinSetSaver.java
@@ -26,8 +26,8 @@ public class FinSetSaver extends ExternalComponentSaver {
 			elements.add("<tabheight>" + fins.getTabHeight() + "</tabheight>");
 			elements.add("<tablength>" + fins.getTabLength() + "</tablength>");
 			elements.add("<tabposition relativeto=\"" +
-					fins.getTabRelativePosition().name().toLowerCase(Locale.ENGLISH) + "\">" +
-					fins.getTabShift() + "</tabposition>");
+					fins.getTabPositionMethod().name().toLowerCase(Locale.ENGLISH) + "\">" +
+					fins.getTabFrontEdge() + "</tabposition>");
 			
 		}
 		

--- a/core/src/net/sf/openrocket/file/rocksim/importt/FinSetHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/FinSetHandler.java
@@ -8,6 +8,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
+import org.xml.sax.SAXException;
+
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.DocumentLoadingContext;
 import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
@@ -21,12 +23,9 @@ import net.sf.openrocket.rocketcomponent.EllipticalFinSet;
 import net.sf.openrocket.rocketcomponent.ExternalComponent;
 import net.sf.openrocket.rocketcomponent.FinSet;
 import net.sf.openrocket.rocketcomponent.FreeformFinSet;
-import net.sf.openrocket.rocketcomponent.IllegalFinPointException;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.rocketcomponent.TrapezoidFinSet;
 import net.sf.openrocket.util.Coordinate;
-
-import org.xml.sax.SAXException;
 
 /**
  * A SAX handler for Rocksim fin sets.  Because the type of fin may not be known first (in Rocksim file format, the fin
@@ -71,6 +70,7 @@ class FinSetHandler extends AbstractElementHandler {
 	/**
 	 * The length of the mid-chord (aka height).
 	 */
+	@SuppressWarnings("unused")  // stored from file, but not used.
 	private double midChordLen = 0.0d;
 	/**
 	 * The distance of the leading edge from root to top.
@@ -300,11 +300,8 @@ class FinSetHandler extends AbstractElementHandler {
 		else if (shapeCode == 2) {
 			
 			result = new FreeformFinSet();
-			try {
-				((FreeformFinSet) result).setPoints(toCoordinates(pointList, warnings));
-			} catch (IllegalFinPointException e) {
-				warnings.add("Illegal fin point set. " + e.getMessage() + " Ignoring.");
-			}
+			((FreeformFinSet) result).setPoints(toCoordinates(pointList, warnings));
+			
 		}
 		else {
 			return null;
@@ -314,7 +311,7 @@ class FinSetHandler extends AbstractElementHandler {
 		result.setFinCount(finCount);
 		result.setFinish(finish);
 		//All TTW tabs in Rocksim are relative to the front of the fin.
-		result.setTabRelativePosition(FinSet.TabRelativePosition.FRONT);
+		result.setTabPositionMethod( RocketComponent.Position.TOP);
 		result.setTabHeight(tabDepth);
 		result.setTabLength(tabLength);
 		result.setTabShift(taboffset);
@@ -329,16 +326,16 @@ class FinSetHandler extends AbstractElementHandler {
 	/**
 	 * Convert a Rocksim string that represents fin plan points into an array of OpenRocket coordinates.
 	 *
-	 * @param pointList a comma and pipe delimited string of X,Y coordinates from Rocksim.  This is of the format:
+	 * @param pointText a comma and pipe delimited string of X,Y coordinates from Rocksim.  This is of the format:
 	 *                  <pre>x0,y0|x1,y1|x2,y2|... </pre>
 	 * @param warnings  the warning set to convey incompatibilities to the user
 	 *
 	 * @return an array of OpenRocket Coordinates
 	 */
-	private Coordinate[] toCoordinates(String pointList, WarningSet warnings) {
+	private Coordinate[] toCoordinates(String pointText, WarningSet warnings) {
 		List<Coordinate> result = new ArrayList<Coordinate>();
-		if (pointList != null && pointList.length() > 0) {
-			String[] points = pointList.split("\\Q|\\E");
+		if (pointText != null && pointText.length() > 0) {
+			String[] points = pointText.split("\\Q|\\E");
 			for (String point : points) {
 				String[] aPoint = point.split(",");
 				try {

--- a/core/src/net/sf/openrocket/file/rocksim/importt/RockSimAppearanceBuilder.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/RockSimAppearanceBuilder.java
@@ -54,9 +54,11 @@ public class RockSimAppearanceBuilder extends AppearanceBuilder {
 		}
 		final String[] parts = s.split("\\|");
 		
+		@SuppressWarnings("unused")
 		boolean interpolate = false;
 		boolean flipr = false;
 		boolean flips = false;
+		@SuppressWarnings("unused")
 		boolean flipt = false;
 		
 		

--- a/core/src/net/sf/openrocket/file/simplesax/SimpleSAX.java
+++ b/core/src/net/sf/openrocket/file/simplesax/SimpleSAX.java
@@ -4,8 +4,7 @@ import java.io.IOException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
@@ -29,7 +28,6 @@ import net.sf.openrocket.aerodynamics.WarningSet;
 public class SimpleSAX {
 
 	static final XMLReaderCache cache = new XMLReaderCache(10);
-	private static final Logger log = LoggerFactory.getLogger(SimpleSAX.class);
 	
 	/**
 	 * Read a simple XML file.

--- a/core/src/net/sf/openrocket/masscalc/MassData.java
+++ b/core/src/net/sf/openrocket/masscalc/MassData.java
@@ -6,6 +6,7 @@ import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.util.BugException;
 import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.MathUtil;
+import net.sf.openrocket.util.PointWeight;
 
 /**
  * An immutable value object containing the mass data of a component, assembly or entire rocket.
@@ -160,6 +161,10 @@ public class MassData {
 		this.I_cm = new InertiaMatrix( Ix, It, It);
 	}
 	
+	public MassData( final PointWeight cm, final double newIxx, final double newIyy, final double newIzz){
+		this( cm.toCoordinate(), newIxx, newIyy, newIzz );
+	}
+	
 	public MassData(Coordinate newCM, double newIxx, double newIyy, double newIzz){
 		if (newCM == null) {
 			throw new IllegalArgumentException("CM is null");
@@ -168,6 +173,7 @@ public class MassData {
 		this.cm = newCM;
 		this.I_cm = new InertiaMatrix(newIxx, newIyy, newIzz);
 	}
+	
 	
 	public MassData(final Coordinate cg, final double rotationalInertia, final double longitudinalInertia) {
 		if (cg == null) {

--- a/core/src/net/sf/openrocket/optimization/rocketoptimization/modifiers/FlightConfigurationModifier.java
+++ b/core/src/net/sf/openrocket/optimization/rocketoptimization/modifiers/FlightConfigurationModifier.java
@@ -70,6 +70,7 @@ public class FlightConfigurationModifier<E extends FlightConfigurableParameter<E
 					+ " with correct ID");
 		}
 		
+		@SuppressWarnings("unchecked")
 		FlightConfigurableParameterSet<E> configs = (FlightConfigurableParameterSet<E>) configGetter.invoke(c);
 		return configs.get(simulation.getRocket().getSelectedConfiguration().getFlightConfigurationID());
 	}

--- a/core/src/net/sf/openrocket/optimization/services/DefaultSimulationModifierService.java
+++ b/core/src/net/sf/openrocket/optimization/services/DefaultSimulationModifierService.java
@@ -252,7 +252,7 @@ public class DefaultSimulationModifierService implements SimulationModifierServi
 			
 			// Recovery device deployment altitude and delay
 			if (c instanceof RecoveryDevice) {
-				RecoveryDevice device = (RecoveryDevice) c;
+				//RecoveryDevice device = (RecoveryDevice) c;
 				
 				SimulationModifier mod = new FlightConfigurationModifier<DeploymentConfiguration>(
 						trans.get("optimization.modifier.recoverydevice.deployDelay"),
@@ -283,8 +283,8 @@ public class DefaultSimulationModifierService implements SimulationModifierServi
 						"DeployAltitude") {
 					
 					@Override
-					public void initialize(Simulation simulation) throws OptimizationException {
-						DeploymentConfiguration config = getModifiedObject(simulation);
+					public void initialize(Simulation targetSimulation) throws OptimizationException {
+						DeploymentConfiguration config = getModifiedObject( targetSimulation);
 						config.setDeployEvent(DeployEvent.APOGEE);
 					}
 					

--- a/core/src/net/sf/openrocket/plugin/AnnotationFinderImpl.java
+++ b/core/src/net/sf/openrocket/plugin/AnnotationFinderImpl.java
@@ -36,6 +36,7 @@ public class AnnotationFinderImpl implements AnnotationFinder {
 				 * use the URLs from there, as java.class.path may not be up-to-date.
 				 */
 				
+				@SuppressWarnings("resource") // this method does not own resource
 				URLClassLoader urlClassLoader = (URLClassLoader) loader;
 				URL[] urls = urlClassLoader.getURLs();
 				

--- a/core/src/net/sf/openrocket/preset/loader/RocksimComponentFileLoader.java
+++ b/core/src/net/sf/openrocket/preset/loader/RocksimComponentFileLoader.java
@@ -131,6 +131,7 @@ public abstract class RocksimComponentFileLoader {
 				}
 				parseData(data);
 			}
+			
 			//Read the rest of the file as data rows.
 			return;
 		} catch (IOException e) {

--- a/core/src/net/sf/openrocket/rocketcomponent/ComponentAssembly.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/ComponentAssembly.java
@@ -30,6 +30,11 @@ public abstract class ComponentAssembly extends RocketComponent {
 	public ComponentAssembly() {
 		super(RocketComponent.Position.AFTER);
 	}
+
+	@Override
+	public boolean allowsChildren() {
+		return true;
+	}
 	
 	@Override
 	public double getAxialOffset() {
@@ -49,7 +54,7 @@ public abstract class ComponentAssembly extends RocketComponent {
 	 */
 	@Override
 	public Coordinate getComponentCG() {
-		return Coordinate.NUL;
+		return Coordinate.ZERO;
 	}
 	
 	/**
@@ -122,10 +127,7 @@ public abstract class ComponentAssembly extends RocketComponent {
 	@Override
 	public void setAxialOffset(final double _pos) {
 		this.updateBounds();
-		//		System.err.println("updating axial position for boosters: " + this.getName() + " ( " + this.getComponentName() + ")");
-		//		System.err.println("       requesting offset: " + _pos + " via: " + this.relativePosition.name());
 		super.setAxialOffset(this.relativePosition, _pos);
-		//		System.err.println("       resultant offset: " + this.position.x + " via: " + this.relativePosition.name());
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 	

--- a/core/src/net/sf/openrocket/rocketcomponent/ComponentChangeEvent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/ComponentChangeEvent.java
@@ -39,8 +39,8 @@ public class ComponentChangeEvent extends EventObject {
 	/** A change that affects the aerodynamic properties of the rocket */
 	public static final int AERODYNAMIC_CHANGE = TYPE.AERODYNAMIC.value;
 	/** A change that affects the mass and aerodynamic properties of the rocket */
-	public static final int AEROMASS_CHANGE = (TYPE.MASS.value | TYPE.AERODYNAMIC.value );
-	public static final int BOTH_CHANGE = AEROMASS_CHANGE;  // syntactic sugar / backward compatibility
+	public static final int AERO_MASS_CHANGE = (TYPE.MASS.value | TYPE.AERODYNAMIC.value );
+	public static final int BOTH_CHANGE = AERO_MASS_CHANGE;  // syntactic sugar / backward compatibility
 
 	
 	/** A change that affects the rocket tree structure */

--- a/core/src/net/sf/openrocket/rocketcomponent/EllipticalFinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/EllipticalFinSet.java
@@ -71,6 +71,7 @@ public class EllipticalFinSet extends FinSet {
 		if (MathUtil.equals(this.length, length))
 			return;
 		this.length = length;
+		validateFinTab();
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 	

--- a/core/src/net/sf/openrocket/rocketcomponent/FreeformFinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FreeformFinSet.java
@@ -1,5 +1,8 @@
 package net.sf.openrocket.rocketcomponent;
 
+import java.awt.geom.Line2D;
+import java.awt.geom.Point2D;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -9,7 +12,6 @@ import org.slf4j.LoggerFactory;
 
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
-import net.sf.openrocket.util.ArrayList;
 import net.sf.openrocket.util.BugException;
 import net.sf.openrocket.util.Coordinate;
 
@@ -17,6 +19,8 @@ import net.sf.openrocket.util.Coordinate;
 public class FreeformFinSet extends FinSet {
 	private static final Logger log = LoggerFactory.getLogger(FreeformFinSet.class);
 	private static final Translator trans = Application.getTranslator();
+	
+	public static final double MIN_ROOT_CHORD=0.01; // enforce this to prevent erroneous 'intersection' exceptions.
 	
 	private ArrayList<Coordinate> points = new ArrayList<Coordinate>();
 	
@@ -34,20 +38,6 @@ public class FreeformFinSet extends FinSet {
 		setPoints(finpoints);
 	}
 	
-	/*
-	public FreeformFinSet(FinSet finset) {
-		Coordinate[] finpoints = finset.getFinPoints();
-		this.copyFrom(finset);
-
-		points.clear();
-		for (Coordinate c: finpoints) {
-			points.add(c);
-		}
-		this.length = points.get(points.size()-1).x - points.get(0).x;
-	}
-	*/
-	
-	
 	/**
 	 * Convert an existing fin set into a freeform fin set.  The specified
 	 * fin set is taken out of the rocket tree (if any) and the new component
@@ -59,7 +49,6 @@ public class FreeformFinSet extends FinSet {
 	 * @return			the new freeform fin set.
 	 */
 	public static FreeformFinSet convertFinSet(FinSet finset) {
-		log.info("Converting " + finset.getComponentName() + " into freeform fin set");
 		final RocketComponent root = finset.getRoot();
 		FreeformFinSet freeform;
 		List<RocketComponent> toInvalidate = Collections.emptyList();
@@ -79,15 +68,13 @@ public class FreeformFinSet extends FinSet {
 				position = -1;
 			}
 			
-			
 			// Create the freeform fin set
 			Coordinate[] finpoints = finset.getFinPoints();
 			try {
 				freeform = new FreeformFinSet(finpoints);
 			} catch (IllegalFinPointException e) {
-				throw new BugException("Illegal fin points when converting existing fin to " +
-						"freeform fin, fin=" + finset + " points=" + Arrays.toString(finpoints),
-						e);
+				throw new BugException("Illegal fin points when converting existing fin to freeform fin, fin=" 
+						+finset + " points=" + Arrays.toString(finpoints), e);
 			}
 			
 			// Copy component attributes
@@ -121,8 +108,6 @@ public class FreeformFinSet extends FinSet {
 		return freeform;
 	}
 	
-	
-	
 	/**
 	 * Add a fin point between indices <code>index-1</code> and <code>index</code>.
 	 * The point is placed at the midpoint of the current segment.
@@ -141,7 +126,17 @@ public class FreeformFinSet extends FinSet {
 		// adding a point within the segment affects neither mass nor aerodynamics
 		fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 	}
-	
+
+	/** 
+	 * Returns the x dimesion of the fin-body base.  It is not a euclidean distance, but simply the x difference.
+	 * 
+	 * Base length may be larger OR smaller than the overall length, i.e. this.length
+	 * 
+	 * @return
+	 */
+	public double getBaseLength(){
+		return (points.get(points.size()-1).x - points.get(0).x);
+	}
 	
 	/**
 	 * Remove the fin point with the given index.  The first and last fin points
@@ -156,40 +151,90 @@ public class FreeformFinSet extends FinSet {
 			throw new IllegalFinPointException("cannot remove first or last point");
 		}
 		
-		ArrayList<Coordinate> copy = this.points.clone();
-		copy.remove(index);
-		validate(copy);
-		this.points = copy;
+		@SuppressWarnings("unchecked")
+		ArrayList<Coordinate> copy = (ArrayList<Coordinate>)this.points.clone();
 		
-		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
+		this.points.remove(index);
+		if( ! validate()){
+			// if error, rollback.  
+			this.points = copy;
+		}
+		
+		fireComponentChangeEvent(ComponentChangeEvent.AERO_MASS_CHANGE);
 	}
 	
 	
 	public int getPointCount() {
 		return points.size();
 	}
-	
-	public void setPoints(Coordinate[] points) throws IllegalFinPointException {
-		setPoints(Arrays.asList(points));
+
+	/**
+	 * The first point is assumed to be at the origin.  If it isn't, it will be moved there.
+	 * 
+	 * @param newPoints
+	 * @throws IllegalFinPointException
+	 */
+	public void setPoints(Coordinate[] newPoints) {
+		Coordinate p0 = newPoints[0];
+		newPoints = translatePoints( newPoints, p0.x, p0.y);
+		
+		ArrayList<Coordinate> newList = new ArrayList<Coordinate>();
+		newList.addAll( Arrays.asList( newPoints));
+		setPoints( newList );
 	}
 	
-	public void setPoints(List<Coordinate> points) throws IllegalFinPointException {
-		ArrayList<Coordinate> list = new ArrayList<Coordinate>(points);
-		validate(list);
-		this.points = list;
+
+	/**
+	 * The first point is assumed to be at the origin.  If it isn't, it will be moved there.
+	 * 
+	 * @param newPoints
+	 * @throws IllegalFinPointException
+	 */
+	// WARNING:  this is the Openrocket custom ArrayList instance.   not the standard one... 
+	public void setPoints( ArrayList<Coordinate> newPoints) {
+		
+		// copy the old points, in case validation fails
+		@SuppressWarnings("unchecked")
+		ArrayList<Coordinate> copy = (ArrayList<Coordinate>)this.points.clone();
+
+		this.points = newPoints;
+		update();
+		
+		if( ! validate()){
+			// on error, reset to the old points
+			this.points = copy;
+		}
 		
 		this.length = points.get(points.size() - 1).x;
-		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
+		fireComponentChangeEvent(ComponentChangeEvent.AERO_MASS_CHANGE);
 	}
 	
+	private double y_body( final double x){
+		return y_body( x, 0.0 );
+	}
+	
+	private double y_body( final double x_target, final double x_ref){
+		final SymmetricComponent sym = (SymmetricComponent)getParent();
+		return ( sym.getRadius(x_target) - sym.getRadius( x_ref));
+	}
+	
+	public void setPointRelToFin( final int index, final double x_request_fin, final double y_request_fin) throws IllegalFinPointException {
+		final double x_finStart_body = asPositionValue(Position.TOP); // x @ fin start, body frame
+		final double y_finStart_body = y_body( x_finStart_body);
+		
+		setPoint( index, x_request_fin + x_finStart_body , y_request_fin + y_finStart_body);
+	}
 	
 	/**
 	 * Set the point at position <code>i</code> to coordinates (x,y).
 	 * <p>
-	 * Note that this method enforces basic fin shape restrictions (non-negative y,
-	 * first and last point locations) silently, but throws an
-	 * <code>IllegalFinPointException</code> if the point causes fin segments to
-	 * intersect.
+	 * Note that this method silently enforces basic fin shape restrictions 
+	 *     - points may not be within the parent body.
+	 *     - first point occurs before last (and vice versa) 
+	 *     - first and last points must be on the parent body
+	 *     - non-self-intersecting fin shape (aborts set on invalid fin point)
+	 *     
+	 * 
 	 * <p>
 	 * Moving of the first point in the X-axis is allowed, but this actually moves
 	 * all of the other points the corresponding distance back.
@@ -197,101 +242,84 @@ public class FreeformFinSet extends FinSet {
 	 * @param index	the point index to modify.
 	 * @param x		the x-coordinate.
 	 * @param y		the y-coordinate.
-	 * @throws IllegalFinPointException	if the specified fin point would cause intersecting
-	 * 									segments
 	 */
-	public void setPoint(int index, double x, double y) throws IllegalFinPointException {
-		if (y < 0)
-			y = 0;
-		
-		double x0, y0, x1, y1;
-		
-		if (index == 0) {
-			
-			// Restrict point
-			x = Math.min(x, points.get(points.size() - 1).x);
-			y = 0;
-			x0 = Double.NaN;
-			y0 = Double.NaN;
-			x1 = points.get(1).x;
-			y1 = points.get(1).y;
-			
-		} else if (index == points.size() - 1) {
-			
-			// Restrict point
-			x = Math.max(x, 0);
-			y = 0;
-			x0 = points.get(index - 1).x;
-			y0 = points.get(index - 1).y;
-			x1 = Double.NaN;
-			y1 = Double.NaN;
-			
-		} else {
-			
-			x0 = points.get(index - 1).x;
-			y0 = points.get(index - 1).y;
-			x1 = points.get(index + 1).x;
-			y1 = points.get(index + 1).y;
-			
+	public void setPoint( final int index, final double x_request, final double y_request) {
+		final int lastPointIndex = this.points.size() - 1;
+		final SymmetricComponent body = (SymmetricComponent)getParent();
+		final double xFinStart = asPositionValue(Position.TOP); // x of fin start, body-frame
+		final double xFinEnd = points.get(lastPointIndex).x;
+		final double yFinStart = body.getRadius( xFinStart); // y of fin start, body-frame
+		final double xBodyStart = -xFinStart; // x-offset from fin to body; fin-frame
+
+	    // initial guess at these values.  Further checks take place below....
+		double xAgreed = x_request;
+		double yAgreed = y_request;
+
+		// clamp x coordinates:
+		// within bounds, and consistent with the rest of the fin (at this time).
+		if(  0 == index ) {
+			// restrict the first point to be between the parent's start, and the last fin point
+			xAgreed = Math.max( xBodyStart, Math.min( xAgreed, xFinEnd - MIN_ROOT_CHORD ));
+		}else if( lastPointIndex == index ){
+			// restrict the last point to be between the first fin point, and the parent's end length.
+			xAgreed = Math.max( MIN_ROOT_CHORD, Math.min( xAgreed, xBodyStart + body.getLength()));
 		}
 		
+		// adjust y-value to be consistent with body
+		final double yBody_atPoint= body.getRadius( xFinStart + xAgreed) - yFinStart;
+		if (index == 0 || index == lastPointIndex) {
+			// for the first and last points: set y-value to *exactly* match parent body:
+			yAgreed = yBody_atPoint;
+		}else{
+			// for all other points, merely insist that the point is outside the body...
+			yAgreed = Math.max( yAgreed, yBody_atPoint);
+		}
 		
+		// if moving either begin or end points, we'll probably have to update the position, as well.
+		final Position locationMethod = getRelativePositionMethod();
+		final double priorXOffset = getAxialOffset();
 		
-		// Check for intersecting
-		double px0, py0, px1, py1;
-		px0 = 0;
-		py0 = 0;
-		for (int i = 1; i < points.size(); i++) {
-			px1 = points.get(i).x;
-			py1 = points.get(i).y;
+		if( 0 == index){
+			movePoints( xAgreed);
+			this.length = points.get( points.size() -1 ).x;
 			
-			if (i != index - 1 && i != index && i != index + 1) {
-				if (intersects(x0, y0, x, y, px0, py0, px1, py1)) {
-					throw new IllegalFinPointException("segments intersect");
-				}
+			if( Position.TOP == locationMethod){ 
+				setAxialOffset( Position.TOP, priorXOffset + xAgreed );
+			}else if(Position.MIDDLE == locationMethod){
+				setAxialOffset( Position.MIDDLE, priorXOffset + xAgreed/2 );
 			}
-			if (i != index && i != index + 1 && i != index + 2) {
-				if (intersects(x, y, x1, y1, px0, py0, px1, py1)) {
-					throw new IllegalFinPointException("segments intersect");
-				}
-			}
+		}else if( lastPointIndex == index ){
+			points.set(index, new Coordinate( xAgreed, yAgreed ));
+			this.length = xAgreed;
 			
-			px0 = px1;
-			py0 = py1;
+			if( Position.MIDDLE == locationMethod){ 
+				setAxialOffset( Position.MIDDLE, priorXOffset + (xAgreed - xFinEnd)/2 );
+			}else if(Position.BOTTOM== locationMethod){
+				setAxialOffset( Position.BOTTOM, priorXOffset + (xAgreed - xFinEnd) );
+			}
+		}else{
+			points.set(index, new Coordinate( xAgreed, yAgreed ));			
 		}
 		
-		if (index == 0) {
-			
-			//System.out.println("Set point zero to x:" + x);
-			for (int i = 1; i < points.size(); i++) {
-				Coordinate c = points.get(i);
-				points.set(i, c.setX(c.x - x));
-			}
-			
-		} else {
-			
-			points.set(index, new Coordinate(x, y));
-			
+		// this maps the last index and the next-to-last-index to the same 'testIndex'
+		int testIndex = Math.min( index, (points.size() - 2));
+		if( intersects( testIndex)){
+			// intersection found!  log error and abort!
+			log.error(String.format("ERROR: found an intersection while setting fin point #%d to [%6.4g, %6.4g] <body frame> : ABORTING setPoint(..) !! ", index, x_request, y_request));
+			return;
 		}
-		if (index == 0 || index == points.size() - 1) {
-			this.length = points.get(points.size() - 1).x;
-		}
-		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
+
+		fireComponentChangeEvent(ComponentChangeEvent.AERO_MASS_CHANGE);
 	}
-	
-	
-	
-	private boolean intersects(double ax0, double ay0, double ax1, double ay1,
-			double bx0, double by0, double bx1, double by1) {
-		
-		double d = ((by1 - by0) * (ax1 - ax0) - (bx1 - bx0) * (ay1 - ay0));
-		
-		double ua = ((bx1 - bx0) * (ay0 - by0) - (by1 - by0) * (ax0 - bx0)) / d;
-		double ub = ((ax1 - ax0) * (ay0 - by0) - (ay1 - ay0) * (ax0 - bx0)) / d;
-		
-		return (ua >= 0) && (ua <= 1) && (ub >= 0) && (ub <= 1);
+
+	final private void movePoints( final double delta_x){
+		// skip 0th index -- it's the local origin and is always (0,0) 
+		for( int index=1; index < points.size(); ++index){
+			final Coordinate oldPoint = this.points.get( index);
+			final Coordinate newPoint = oldPoint.sub( delta_x,  0.0f,  0.0f);
+			points.set( index, newPoint);
+		}
 	}
-	
 	
 	@Override
 	public Coordinate[] getFinPoints() {
@@ -314,31 +342,217 @@ public class FreeformFinSet extends FinSet {
 		return trans.get("FreeformFinSet.FreeformFinSet");
 	}
 	
-	
+	@SuppressWarnings("unchecked")
 	@Override
 	protected RocketComponent copyWithOriginalID() {
 		RocketComponent c = super.copyWithOriginalID();
-		((FreeformFinSet) c).points = this.points.clone();
+		
+		((FreeformFinSet) c).points = (ArrayList<Coordinate>)this.points.clone();
+		
 		return c;
 	}
 	
-	private void validate(ArrayList<Coordinate> pts) throws IllegalFinPointException {
-		final int n = pts.size();
-		if (pts.get(0).x != 0 || pts.get(0).y != 0 ||
-				pts.get(n - 1).x < 0 || pts.get(n - 1).y != 0) {
-			throw new IllegalFinPointException("Start or end point illegal.");
+	@Override
+	public void setAxialOffset( final Position newPositionMethod, final double newOffsetRequest){
+		super.setAxialOffset( newPositionMethod, newOffsetRequest);
+
+		double newOffset = newOffsetRequest;
+		
+		// if the new position would cause fin overhang, only allow movement up to the end of the parent component.
+		// N.B. if you want a fin to overhang, add & adjust interior points.
+		final double backOverhang = asPositionValue(Position.BOTTOM);
+		if( 0 <  backOverhang ){
+			
+			newOffset -= backOverhang;
+			super.setAxialOffset( newPositionMethod, newOffset );
 		}
-		for (int i = 0; i < n - 1; i++) {
-			for (int j = i + 2; j < n - 1; j++) {
-				if (intersects(pts.get(i).x, pts.get(i).y, pts.get(i + 1).x, pts.get(i + 1).y,
-						pts.get(j).x, pts.get(j).y, pts.get(j + 1).x, pts.get(j + 1).y)) {
-					throw new IllegalFinPointException("segments intersect");
-				}
-			}
-			if (pts.get(i).z != 0) {
-				throw new IllegalFinPointException("z-coordinate not zero");
+		final double frontOverhang = asPositionValue(Position.TOP);
+		if( 0 > frontOverhang){
+			
+			newOffset -= frontOverhang;
+			super.setAxialOffset( newPositionMethod, newOffset );
+		}
+	}
+	
+	@Override
+	public void update(){
+		final int lastPointIndex = this.points.size() - 1;
+		this.length = points.get(lastPointIndex).x;
+		
+		this.setAxialOffset( this.relativePosition, this.x_offset);
+		
+		clampFirstPoint();
+		clampInteriorPoints();
+		clampLastPoint();
+		
+		validateFinTab();
+	}
+	
+	// if we translate the points, correct the first point, because it may be inconsistent
+	public void clampFirstPoint(){
+		double xFinStart = asPositionValue(Position.TOP); // x @ fin start, body frame
+		final double xFinOffset = getAxialOffset();
+		if( 0 > xFinStart ){
+			setAxialOffset( xFinOffset - xFinStart);
+			xFinStart = asPositionValue(Position.TOP);
+		}
+	}
+	
+	public void clampInteriorPoints(){
+		final double yFinStart = getBodyRadius( 0.0f );
+		
+		// omit end points index 
+		for( int index=1; index < (points.size()-1); ++index){
+			final Coordinate oldPoint = this.points.get( index);
+			
+			final double yBody = getBodyRadius( oldPoint.x);
+			final double yFinPoint = yFinStart + oldPoint.y;
+			
+			if( yBody > yFinPoint ){
+				final Coordinate newPoint = oldPoint.setY( yBody - yFinStart );
+				points.set( index, newPoint);
 			}
 		}
 	}
+		
+	// if we translate the points, the final point may become inconsistent
+	public void clampLastPoint(){
+		if( null == this.parent ){
+			// this is bad, but seems to only occur during unit tests.
+			return;
+		}
+		
+		final SymmetricComponent body = (SymmetricComponent)getParent();
+		// clamp the final x coord to the end of the parent body.
+		final int lastPointIndex = points.size() - 1;
+		final Coordinate oldPoint = points.get( lastPointIndex);
+		
+		final double xFinStart_body = asPositionValue(Position.TOP); // x @ fin start, body frame
+		final double xBodyEnd_fin = body.getLength() - xFinStart_body;
+		
+		double x_clamped = Math.min( oldPoint.x, xBodyEnd_fin); 
+		double y_clamped = body.getRadius( x_clamped+xFinStart_body) - body.getRadius( xFinStart_body); 
+		
+		
+ 		points.set( lastPointIndex, new Coordinate( x_clamped, y_clamped, 0));
+	}
+	
+	private boolean validate() {
+		final Coordinate firstPoint = this.points.get(0);
+		if (firstPoint.x != 0 || firstPoint.y != 0 ){
+			log.error("Start point illegal --  not located at (0,0): "+firstPoint+ " ("+ getName()+")");
+			return false;
+		}
+		final int lastIndex = this.points.size() - 1;
+		final Coordinate lastPoint = this.points.get( points.size() -1);
+		if( lastPoint.x < 0){
+			log.error("End point illegal: end point starts in front of start point: "+lastPoint.x);
+			return false;
+		}
+		
+		// the last point *is* restricted to be on the surface of its owning component:
+		SymmetricComponent symBody = (SymmetricComponent)this.getParent();
+		if( null != symBody ){
+			final double startOffset = getTop();
+			final Coordinate finStart = new Coordinate( startOffset, symBody.getRadius(startOffset) );
+			
+			// campare x-values 
+			final Coordinate finAtLast = lastPoint.add(finStart); 
+			if( symBody.getLength() < finAtLast.x ){
+				log.error("End point falls after parent body ends: ["+symBody.getName()+"].  Exception: ", new IllegalFinPointException("Fin ends after its parent body \""+symBody.getName()+"\". Ignoring."));
+				log.error(String.format("    ..fin position:    (x: %12.10f   via: %s)", this.x_offset, this.relativePosition.name()));
+				log.error(String.format("    ..Body Length: %12.10f  finLength: %12.10f", symBody.getLength(), this.getLength()));
+				log.error(String.format("    ..fin endpoint:    (x: %12.10f, y: %12.10f)", finAtLast.x, finAtLast.y));
+				return false;
+			}
+			
+			// compare the y-values
+			final Coordinate bodyAtLast = finAtLast.setY( symBody.getRadius( finAtLast.x ) ); 
+			if( 0.0001 < Math.abs( finAtLast.y - bodyAtLast.y) ){
+				String numbers = String.format( "finStart=(%6.2g,%6.2g) // fin_end=(%6.2g,%6.2g) // body=(%6.2g,%6.2g)", finStart.x, finStart.y, finAtLast.x, finAtLast.y, bodyAtLast.x, bodyAtLast.y );
+				log.error("End point does not touch its parent body ["+symBody.getName()+"].  exception: ", new IllegalFinPointException("End point does not touch its parent body! Expected: "+numbers));
+				log.error("    .."+numbers);
+				return false;
+			}
+		}
+
+		if( intersects()){
+			log.error("found intersection in finset points!");
+			return false;
+		}
+		
+		final ArrayList<Coordinate> pts = this.points;
+		for (int i = 0; i < lastIndex; i++) {
+			if (pts.get(i).z != 0) {
+				log.error("z-coordinate not zero");
+				return false;
+			}
+		}
+		
+		return true;
+	}
+	
+	/** 
+	 * Check if *any* of the fin-point line segments intersects with another.
+	 * 
+	 * @return  true if an intersection is found
+	 */
+	public boolean intersects( ){
+		for( int index=0; index < (this.points.size()-1); ++index ){
+			if( intersects( index )){
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	/** 
+	 * Check if the line segment from targetIndex to targetIndex+1 intersects with any other part of the fin.
+	 * 
+	 * 
+	 * 
+	 * @return  true if an intersection was found
+	 */
+	private boolean intersects( final int targetIndex){
+		if( (points.size()-2) < targetIndex ){
+			throw new IndexOutOfBoundsException("request validate of non-existent fin edge segment: "+ targetIndex + "/"+points.size());
+		}
+		
+		// (pre-check the indices above.)
+		Point2D.Double p1 = new Point2D.Double( points.get(targetIndex).x, points.get(targetIndex).y);
+		Point2D.Double p2 = new Point2D.Double( points.get(targetIndex+1).x, points.get(targetIndex+1).y);
+		Line2D.Double targetLine = new Line2D.Double( p1, p2);
+		
+		for (int comparisonIndex = 0; comparisonIndex < (points.size()-1); ++comparisonIndex ) {
+			if( 2 > Math.abs( targetIndex - comparisonIndex) ){
+				// a line segment will trivially not intersect with itself
+				// nor can adjacent line segments intersect with each other, because they share a common endpoint.
+				continue; 
+			}
+			
+			Line2D.Double comparisonLine = new Line2D.Double( points.get(comparisonIndex).x, points.get(comparisonIndex).y, // p1 
+															  points.get(comparisonIndex+1).x, points.get(comparisonIndex+1).y); // p2
+			
+			if ( targetLine.intersectsLine( comparisonLine ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	
+	@Override
+	public StringBuilder toDebugDetail(){
+		StringBuilder buf = new StringBuilder( ">> ====== " + this.getComponentName() + " ======\n" );
+		
+		buf.append("    points:[\n");
+		for( Coordinate pi : this.points ){
+			buf.append(String.format("        (%8.4g, %8.4g),\n", pi.x, pi.y));
+		}
+		buf.append("    ]");
+		
+		return buf;
+	}
+	
 	
 }

--- a/core/src/net/sf/openrocket/rocketcomponent/LaunchLug.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/LaunchLug.java
@@ -132,7 +132,7 @@ public class LaunchLug extends ExternalComponent implements Coaxial, LineInstanc
 	public Coordinate[] getInstanceOffsets(){
 		Coordinate[] toReturn = new Coordinate[this.getInstanceCount()];
 		
-		final double xOffset = this.position.x;
+		final double xOffset = getTop();
 		final double yOffset = Math.cos(radialDirection) * (radialDistance);
 		final double zOffset = Math.sin(radialDirection) * (radialDistance);
 		

--- a/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
@@ -1,7 +1,6 @@
 package net.sf.openrocket.rocketcomponent;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.EventListener;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -14,7 +13,6 @@ import org.slf4j.LoggerFactory;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.ArrayList;
-import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.MathUtil;
 import net.sf.openrocket.util.StateChangeListener;
 import net.sf.openrocket.util.UniqueID;
@@ -30,7 +28,7 @@ import net.sf.openrocket.util.UniqueID;
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
 @SuppressWarnings("serial")
-public class Rocket extends RocketComponent {
+public class Rocket extends ComponentAssembly {
 	private static final Logger log = LoggerFactory.getLogger(Rocket.class);
 	private static final Translator trans = Application.getTranslator();
 	
@@ -76,7 +74,6 @@ public class Rocket extends RocketComponent {
 	/////////////  Constructor  /////////////
 	
 	public Rocket() {
-		super(RocketComponent.Position.AFTER);
 		modID = UniqueID.next();
 		massModID = modID;
 		aeroModID = modID;
@@ -765,45 +762,7 @@ public class Rocket extends RocketComponent {
 		return trans.get("Rocket.compname.Rocket");
 	}
 	
-	@Override
-	public Coordinate getComponentCG() {
-		return new Coordinate(0, 0, 0, 0);
-	}
 	
-	@Override
-	public double getComponentMass() {
-		return 0;
-	}
-	
-	@Override
-	public double getLongitudinalUnitInertia() {
-		return 0;
-	}
-	
-	@Override
-	public double getRotationalUnitInertia() {
-		return 0;
-	}
-	
-	@Override
-	public Collection<Coordinate> getComponentBounds() {
-		return Collections.emptyList();
-	}
-	
-	@Override
-	public boolean isAerodynamic() {
-		return false;
-	}
-	
-	@Override
-	public boolean isMassive() {
-		return false;
-	}
-	
-	@Override
-	public boolean allowsChildren() {
-		return true;
-	}
 	
 	/**
 	 * Allows only <code>AxialStage</code> components to be added to the type Rocket.
@@ -829,7 +788,7 @@ public class Rocket extends RocketComponent {
 			return;
 		}else if( _enable ){
 			this.eventsEnabled = true;
-			this.fireComponentChangeEvent(ComponentChangeEvent.AEROMASS_CHANGE);
+			this.fireComponentChangeEvent(ComponentChangeEvent.AERO_MASS_CHANGE);
 		}else{
 			this.eventsEnabled = false;
 		}

--- a/core/src/net/sf/openrocket/rocketcomponent/Transition.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Transition.java
@@ -1,17 +1,17 @@
 package net.sf.openrocket.rocketcomponent;
 
+import static java.lang.Math.sin;
+import static net.sf.openrocket.util.MathUtil.pow2;
+import static net.sf.openrocket.util.MathUtil.pow3;
+
+import java.util.Collection;
+
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.preset.ComponentPreset;
 import net.sf.openrocket.preset.ComponentPreset.Type;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.MathUtil;
-
-import java.util.Collection;
-
-import static java.lang.Math.sin;
-import static net.sf.openrocket.util.MathUtil.pow2;
-import static net.sf.openrocket.util.MathUtil.pow3;
 
 
 public class Transition extends SymmetricComponent {
@@ -526,13 +526,16 @@ public class Transition extends SymmetricComponent {
 	 * Check whether the given type can be added to this component.  Transitions allow any
 	 * InternalComponents to be added.
 	 *
-	 * @param ctype  The RocketComponent class type to add.
+	 * @param comptype  The RocketComponent class type to add.
 	 * @return      Whether such a component can be added.
 	 */
 	@Override
-	public boolean isCompatible(Class<? extends RocketComponent> ctype) {
-		if (InternalComponent.class.isAssignableFrom(ctype))
+	public boolean isCompatible(Class<? extends RocketComponent> comptype) {
+		if (InternalComponent.class.isAssignableFrom(comptype)){
 			return true;
+		}else if ( FreeformFinSet.class.isAssignableFrom(comptype)){
+			return true;
+		}
 		return false;
 	}
 
@@ -932,4 +935,5 @@ public class Transition extends SymmetricComponent {
             return null;
         }
 	}
+
 }

--- a/core/src/net/sf/openrocket/rocketcomponent/TrapezoidFinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/TrapezoidFinSet.java
@@ -1,12 +1,12 @@
 package net.sf.openrocket.rocketcomponent;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.MathUtil;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * A set of trapezoidal fins.  The root and tip chords are perpendicular to the rocket
@@ -65,6 +65,7 @@ public class TrapezoidFinSet extends FinSet {
 		this.sweep = sweep;
 		this.height = height;
 		this.thickness = thickness;
+		
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 	
@@ -76,6 +77,7 @@ public class TrapezoidFinSet extends FinSet {
 		if (length == r)
 			return;
 		length = Math.max(r, 0);
+		validateFinTab();
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 	

--- a/core/src/net/sf/openrocket/rocketcomponent/TubeFinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/TubeFinSet.java
@@ -267,14 +267,9 @@ public class TubeFinSet extends ExternalComponent {
 		}
 		
 		// translate each to the center of mass.
-		final double hypot = getOuterRadius() + getBodyRadius();
-		final double finrotation = 2 * Math.PI / fins;
-		double angularoffset = 0.0;
 		double totalInertia = 0.0;
 		for (int i = 0; i < fins; i++) {
-			double offset = hypot * Math.cos(angularoffset);
-			totalInertia += inertia + MathUtil.pow2(offset);
-			angularoffset += finrotation;
+			totalInertia += inertia + MathUtil.pow2( this.x_offset);
 		}
 		return totalInertia;
 	}

--- a/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
+++ b/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
@@ -274,7 +274,6 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 			// Check for motor ignition events, add ignition events to queue
 			for (MotorClusterState state : currentStatus.getActiveMotors() ){
 				if( state.testForIgnition(event )){
-					final double simulationTime = currentStatus.getSimulationTime() ;
 					MotorClusterState sourceState = (MotorClusterState) event.getData();
 					double ignitionDelay = 0;
 					if(( event.getType() == FlightEvent.Type.BURNOUT)|| ( event.getType() == FlightEvent.Type.EJECTION_CHARGE)){

--- a/core/src/net/sf/openrocket/simulation/BasicTumbleStatus.java
+++ b/core/src/net/sf/openrocket/simulation/BasicTumbleStatus.java
@@ -55,7 +55,7 @@ public class BasicTumbleStatus extends SimulationStatus {
 			}
 			if (component instanceof FinSet) {
 				
-				double finComponent = ((FinSet) component).getFinArea();
+				double finComponent = ((FinSet) component).getFinWettedArea();
 				int finCount = ((FinSet) component).getFinCount();
 				// check bounds on finCount.
 				if (finCount >= finEff.length) {

--- a/core/src/net/sf/openrocket/simulation/customexpression/CustomExpressionSimulationListener.java
+++ b/core/src/net/sf/openrocket/simulation/customexpression/CustomExpressionSimulationListener.java
@@ -7,12 +7,8 @@ import net.sf.openrocket.simulation.SimulationStatus;
 import net.sf.openrocket.simulation.exception.SimulationException;
 import net.sf.openrocket.simulation.listeners.AbstractSimulationListener;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class CustomExpressionSimulationListener extends AbstractSimulationListener {
 	
-	private static final Logger log = LoggerFactory.getLogger(CustomExpressionSimulationListener.class);
 	private final List<CustomExpression> expressions;
 	
 	public CustomExpressionSimulationListener(List<CustomExpression> expressions) {

--- a/core/src/net/sf/openrocket/unit/Unit.java
+++ b/core/src/net/sf/openrocket/unit/Unit.java
@@ -178,14 +178,14 @@ public abstract class Unit {
 	 */
 	public abstract double getPreviousValue(double value);
 	
-	//public abstract ArrayList<Tick> getTicks(double start, double end, double scale);
-	
-	/**
-	 * Return ticks in the range start - end (in current units).  minor is the minimum
-	 * distance between minor, non-notable ticks and major the minimum distance between
-	 * major non-notable ticks.  The values are in current units, i.e. no conversion is
-	 * performed.
-	 */
+ 	/**
+	 * Return ticks in the range start - end (in current units).  
+	 * 
+	 * @param start start of interval to draw
+	 * @param end end of interval to draw
+	 * @param minor the minimum distance between minor, non-notable ticks 
+	 * @param major the minimum distance between major, non-notable ticks
+ 	 */
 	public abstract Tick[] getTicks(double start, double end, double minor, double major);
 	
 	/**

--- a/core/src/net/sf/openrocket/util/Bounds.java
+++ b/core/src/net/sf/openrocket/util/Bounds.java
@@ -1,0 +1,249 @@
+
+package net.sf.openrocket.util;
+
+import java.awt.geom.Point2D;
+
+public class Bounds {
+	
+	public final class DimensionBounds {
+		public double max;
+		public double min;
+		
+		public DimensionBounds(){
+			reset();}
+		
+		public DimensionBounds( final double _max, final double _min){
+			this.min = _min; this.max = _max;}
+		
+		public void reset(){
+			max = Double.MIN_VALUE;
+			min = Double.MAX_VALUE; }
+		
+		public void reset( final DimensionBounds other){
+			max = other.max;
+			min = other.min; }
+		
+		
+		public double center(){
+			return ((max-min)/2);
+		}
+		
+		/** 
+		 * Ensures that the bounds in this dimension cover NO MORE THAN these values
+		 */
+		public void clamp( final double _min, final double _max){
+			min = Math.max( min, _min);
+			max = Math.min( max, _max);}
+		
+		
+		public boolean contains( final double _testValue){
+			if(( min < _testValue ) && ( max > _testValue )){
+				return true;}
+			return false;}
+		
+		public boolean containsNAN(){
+			return ( Double.isNaN(max) & Double.isNaN(min));}
+		
+		/** 
+		 * Ensures the bounds in this dimension cover NO LESS THAN these values  
+		 * 
+		 * passing NaN for either value propogates NaN values to this bounds itself
+		 * 
+		 * @param newMin the min should be updated to this value or lower
+		 * @param newMax the min should be updated to this value or higher
+		 */
+		public void inflate( final double newMin, final double newMax){
+			min = Math.min( min, newMin);
+			max = Math.max( max, newMax);}
+		
+		public double span(){
+			return (max-min);}
+	
+		public void update( final double _newValue){
+			if( min > _newValue ){
+				min = _newValue;
+			}else if( max < _newValue ){
+				max = _newValue;}}
+		
+		@Override
+		public String toString(){
+			return String.format("{ min: %6.4g  max: %6.4g}", min, max);}
+		
+		public String toDebug(){
+			return String.format("{ min: %6.4g  max: %6.4g  span: %6.4g  ctr: %6.4g }", min, max, span(), center());}
+
+	}
+	
+	// ==== member variables
+	private final DimensionBounds[] boundList;
+	
+	public static final int X=0;
+	public static final int Y=1;
+	public static final int Z=2;
+	public static final int W=2;
+	
+	
+	public Bounds(){
+		this(3);
+	}
+	
+	public Bounds create2DBounds(){
+		return new Bounds(2);
+	}
+	
+	public Bounds create3DBounds(){
+		return new Bounds(3);
+	}
+	
+	public Bounds( final int dimensionCount){
+		boundList = new DimensionBounds[dimensionCount];
+		for( int i = 0; i < boundList.length; ++i){
+			boundList[i] = new DimensionBounds();}	
+	}
+	
+	public DimensionBounds getDim( final int dim ){
+		return boundList[dim];
+	}
+	
+	public DimensionBounds getX(){
+		return boundList[X];
+	}
+	public DimensionBounds getY(){
+		return boundList[Y];
+	}
+	public DimensionBounds getZ(){
+		return boundList[Z];
+	}
+	
+	public boolean contains( final Point2D.Double testPoint ){
+		return contains( testPoint.x, testPoint.y);
+	}
+	
+	public boolean contains( final double _x, final double _y ){
+		if( boundList[X].contains(_x) && boundList[Y].contains(_y) ){
+			return true;
+		}
+		return false;
+	}
+
+	public boolean contains( final double _x, final double _y, final double _z ){
+		if( boundList[X].contains(_x) && boundList[Y].contains(_y) && boundList[Z].contains(_z)){
+			return true;
+		}
+		return false;
+	}
+	
+	public boolean contains( final Coordinate c ){
+		return contains( c.x, c.y, c.z);
+	}
+
+	public void inflate( final int dimensionIndex, final double newMinimum, final double newMaximum){
+		getDim( dimensionIndex ).inflate(newMinimum, newMaximum);
+	}
+
+	public void update( final int dimensionIndex, final double newValue){
+		boundList[dimensionIndex].update(newValue); 
+	}
+	
+	public void update( final double _x, final double _y){
+		boundList[X].update(_x);
+		boundList[Y].update(_y);
+	}
+	
+	public void update( final Coordinate c ){
+		update( c.x, c.y, c.z);
+	}
+	
+	public void update( final double _x, final double _y, final double _z){
+		boundList[X].update(_x);
+		boundList[Y].update(_y);
+		boundList[Z].update(_z);
+	}
+	
+	public Point2D.Double getCenterAsPoint2D(){
+		double center_x = 0; 
+		double center_y = 0;
+		if( 0 < boundList.length ){
+			 center_x= boundList[X].center();
+		}
+	    if( 1 < boundList.length ){
+			center_y = boundList[Y].center();
+		}
+		return new Point2D.Double( center_x, center_y); 
+	}
+	
+	public Point2D.Double getSpanAsPoint2D(){
+		double span_x = 0;
+		double span_y = 0;
+		if( 0 < boundList.length ){
+			 span_x = boundList[X].span();
+		}
+	    if( 1 < boundList.length ){
+			span_y = boundList[Y].span();
+		}
+		return new Point2D.Double( span_x, span_y); 
+	}
+	
+	public double span(final int index){
+		return boundList[index].span();
+	}
+	
+	public Coordinate span(){
+		return getSpanAsCoordinate();
+	}
+	
+	public int getDimensionCount(){
+		return this.boundList.length;
+	}
+	
+	public Coordinate getCenterAsCoordinate(){
+		double center_x = 0; 
+		double center_y = 0;
+		double center_z = 0;
+		if( 0 < boundList.length ){
+			 center_x= boundList[X].center();
+		}
+	    if( 1 < boundList.length ){
+			center_y = boundList[Y].center();
+		}
+	    if( 2 < boundList.length ){
+			center_z = boundList[Z].center();
+		}
+		return new Coordinate( center_x, center_y, center_z, 0.0); 
+	}
+	
+	public Coordinate getSpanAsCoordinate(){
+		double span_x = 0;
+		double span_y = 0;
+		double span_z = 0;
+		if( 0 < boundList.length ){
+			 span_x = boundList[X].span();
+		}
+	    if( 1 < boundList.length ){
+			span_y = boundList[Y].span();
+		}
+	    if( 2 < boundList.length ){	
+			span_z = boundList[Z].span();
+		}
+	    return new Coordinate(span_x, span_y, span_z);
+	}
+	
+	public void reset(){
+		for( DimensionBounds b : boundList ){
+			b.reset();
+		}
+	}
+	
+	public void reset( final Bounds other){
+		int dimensionsToUpdate = Math.min( getDimensionCount(), other.getDimensionCount());
+		
+		for( int i=0; i < dimensionsToUpdate; ++i){
+			boundList[i].reset( other.boundList[i]);
+		}
+	}
+	
+	public void clamp( final int index, final double newMin, final double newMax ){
+		boundList[index].clamp( newMin, newMax);
+	}
+	
+}

--- a/core/src/net/sf/openrocket/util/PointWeight.java
+++ b/core/src/net/sf/openrocket/util/PointWeight.java
@@ -1,0 +1,173 @@
+package net.sf.openrocket.util;
+
+/**
+ * This class is intended to locate a quantity (the weight) at a location (x,y,z).  Therefore, if the quantity is nonexistent, the coordinates don't matter.   Use this class to represent a: area-centroid, point-PointWeight, or center-of-PointWeight.
+ * 
+ * This class is very similar to net.sf.openrocket.util.Coordinate, but behaves differently-- especially w.r.t. the resultant weight during certain operations.
+ * This class is implemented separately to preserve existing behavior of code which uses Coordinate, and is intended to eventually be a replacement for some cases.
+ * 
+ * @author Daniel Williams <equipoise@gmail.com>
+ *
+ */
+public class PointWeight {
+	public double x;
+	public double y;
+	public double z;
+	public double w;
+	
+	public PointWeight(){ 
+		this( Double.NaN);
+	}
+	
+	public PointWeight( final double _value ){
+		this( _value, _value, _value, _value);
+	}
+	
+	public PointWeight( final Coordinate source){
+		this( source.x, source.y, source.z, source.weight);
+	}
+	
+	public PointWeight( final double _x, final double _y, final double _z, final double _weight){
+		x=_x;
+		y=_y;
+		z=_z;
+		w=_weight;
+	}
+	
+	public boolean isNaN(){
+		return  Double.isNaN(w) &&
+				Double.isNaN(x) &&
+				Double.isNaN(y) &&
+				Double.isNaN(z);
+	}
+	
+	public PointWeight add( PointWeight other ){
+		if (other == null)
+				return this;
+		
+		PointWeight result = new PointWeight();
+		result.w = w + other.w;
+		
+		if ( Math.abs( result.w) < MathUtil.EPSILON) {
+			result.reset(0);
+		} else {
+			result.x = (this.x * this.w + other.x * other.w) / result.w;
+			result.y = (this.y * this.w + other.y * other.w) / result.w;
+			result.z = (this.z * this.w + other.z * other.w) / result.w;
+		}
+		
+		return result;
+	}
+	
+	public PointWeight subtract( PointWeight other ){
+		if (other == null)
+			return this;
+	
+		PointWeight result = new PointWeight();
+		result.w = w - other.w;
+		
+		if ( Math.abs( result.w ) < MathUtil.EPSILON ){
+			result.reset(0);
+		} else {
+			result.x = (this.x * this.w - other.x * other.w) / result.w;
+			result.y = (this.y * this.w - other.y * other.w) / result.w;
+			result.z = (this.z * this.w - other.z * other.w) / result.w;
+		}
+		return result;
+	}
+	
+
+	/**
+	 * Tests whether the coordinates are the equal.
+	 * 
+	 * @param other  Coordinate to compare to.
+	 * @return  true if the coordinates are equal (x, y, z and weight)
+	 */
+	@Override
+	public boolean equals(Object other) {
+		if (!(other instanceof PointWeight))
+			return false;
+		
+		final PointWeight om = (PointWeight) other;
+		return (MathUtil.equals(this.x, om.x) &&
+				MathUtil.equals(this.y, om.y) &&
+				MathUtil.equals(this.z, om.z) && 
+				MathUtil.equals(this.w, om.w));
+	}
+	
+	/**
+	 * Hash code method compatible with {@link #equals(Object)}.
+	 */
+	@Override
+	public int hashCode() {
+		return (int) (x*1000000 + y*10000 + z);
+	}
+
+	// move by the supplied deltas
+	public PointWeight move( final double x_delta, final double y_delta, final double z_delta){
+		this.x += x_delta; 
+		this.y += y_delta;
+		this.z += z_delta;
+		//this.w;  // do not change the weight
+		
+		return this;
+	}
+	
+	public PointWeight average( PointWeight other ){
+		if (other == null)
+				return this;
+		
+		PointWeight result = new PointWeight();
+		final double totalWeight = w + other.w;
+		
+		if ( Math.abs( totalWeight) < MathUtil.EPSILON ){
+			result.reset(0);
+		} else {
+			result.x = (this.x * this.w + other.x * other.w) / totalWeight;
+			result.y = (this.y * this.w + other.y * other.w) / totalWeight;
+			result.z = (this.z * this.w + other.z * other.w) / totalWeight;
+			result.w = (w + other.w)/2;
+		}
+		
+		return result;
+	}
+	
+	public void reset(){
+		reset(Double.NaN);
+	}
+	
+	public PointWeight reset( final double val){
+		x=val;
+		y=val;
+		z=val;
+		w=val;
+		
+		return this;
+	}
+
+	public PointWeight scaleWeight( final double scaleFactor ){
+		this.w *= scaleFactor;
+		return this;
+	}
+	
+	public Coordinate toCoordinate(){
+		return new Coordinate( x,y,z,w);
+	}
+	
+	@Override
+	public String toString() {
+		return String.format("(%.3f,%.3f,%.3f,w=%.3f)", x, y, z, w);
+	}
+
+	public static PointWeight empty() {
+		return new PointWeight(0.0);
+	}
+	
+	public static PointWeight nan() {
+		return new PointWeight( Double.NaN);
+	}
+
+	public PointWeight copy() {
+		return new PointWeight( x, y, z, w);
+	}
+}

--- a/core/src/net/sf/openrocket/util/TestRockets.java
+++ b/core/src/net/sf/openrocket/util/TestRockets.java
@@ -31,7 +31,6 @@ import net.sf.openrocket.rocketcomponent.FinSet.CrossSection;
 import net.sf.openrocket.rocketcomponent.FlightConfiguration;
 import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
 import net.sf.openrocket.rocketcomponent.FreeformFinSet;
-import net.sf.openrocket.rocketcomponent.IllegalFinPointException;
 import net.sf.openrocket.rocketcomponent.InnerTube;
 import net.sf.openrocket.rocketcomponent.InternalComponent;
 import net.sf.openrocket.rocketcomponent.LaunchLug;
@@ -563,6 +562,7 @@ public class TestRockets {
 			finset = new TrapezoidFinSet(finCount, finRootChord, finTipChord, finSweep, finHeight);
 			finset.setThickness( 0.0032);
 			finset.setRelativePosition(Position.BOTTOM);
+			finset.setAxialOffset(0.0);
 			finset.setName("3 Fin Set");
 			bodytube.addChild(finset);
 			
@@ -683,7 +683,8 @@ public class TestRockets {
 			finset = new TrapezoidFinSet(finCount, finRootChord, finTipChord, finSweep, finHeight);
 			finset.setThickness( 0.0032);
 			finset.setRelativePosition(Position.BOTTOM);
-			finset.setAxialOffset(1);
+			finset.setAxialOffset(0.0);
+
 			finset.setName("Booster Fins");
 			boosterTube.addChild(finset);
 			
@@ -769,6 +770,7 @@ public class TestRockets {
 	}
 	
 	
+	
 	public static Rocket makeBigBlue() {
 		Rocket rocket;
 		AxialStage stage;
@@ -786,17 +788,13 @@ public class TestRockets {
 		bodytube = new BodyTube(0.69, 0.033, 0.001);
 		
 		finset = new FreeformFinSet();
-		try {
-			finset.setPoints(new Coordinate[] {
+		finset.setPoints(new Coordinate[] {
 					new Coordinate(0, 0),
 					new Coordinate(0.115, 0.072),
 					new Coordinate(0.255, 0.072),
 					new Coordinate(0.255, 0.037),
-					new Coordinate(0.150, 0)
-			});
-		} catch (IllegalFinPointException e) {
-			e.printStackTrace();
-		}
+					new Coordinate(0.150, 0)	});
+		
 		finset.setThickness(0.003);
 		finset.setFinCount(4);
 		
@@ -1180,6 +1178,97 @@ public class TestRockets {
 		rocket.setSelectedConfiguration( selFCID);
 		rocket.getFlightConfiguration( selFCID).setAllStages();
 		
+		return rocket;
+	}
+	
+	// This a scale V2 rocket 
+	// WARNING:  as of February 1, 2016, this is not yet a valid rocket.  
+	//           may require changes to the FreeformFinSet class
+	public static final Rocket makeV2(){
+		Rocket rocket = new Rocket();
+		rocket.setName("V-2 Scale Model ");
+		
+		// make stage
+		AxialStage stage = new AxialStage();
+		stage.setName("Stage 1");
+		rocket.addChild(stage);
+		
+		final double SKIN_THICKNESS = 0.001;
+		
+		// make nose cone 
+		NoseCone nose = new NoseCone();
+		nose.setName("nose");
+		nose.setMassOverridden(true);
+		nose.setOverrideMass( 0.038 ); 
+		nose.setLength(0.21);
+		nose.setThickness( SKIN_THICKNESS);
+		nose.setType(Shape.OGIVE);
+		nose.setShapeParameter(1.0);
+		nose.setAftRadius(0.033);
+		nose.setAftShoulderRadius(0.031);
+		nose.setAftShoulderLength( 0.04 );
+        nose.setAftShoulderThickness(0.001);
+        nose.setAftShoulderCapped(false);
+        stage.addChild(nose);
+        
+		// make body tube 
+		BodyTube body = new BodyTube( 0.2, 0.33, SKIN_THICKNESS);
+		body.setName("body");
+		body.setOuterRadiusAutomatic( true);
+		stage.addChild(body );
+		
+		{ // make boat tail 
+			Transition boattail = new Transition();
+			boattail.setName("Transition");
+			boattail.setMassOverridden( true);
+	        boattail.setOverrideMass( 0.036);
+	        boattail.setLength( 0.14 );
+	        boattail.setThickness( SKIN_THICKNESS);
+	        boattail.setType(Shape.OGIVE);
+			boattail.setShapeParameter(1.0);
+			boattail.setForeRadiusAutomatic(true);
+			boattail.setAftRadius( 0.02);
+			
+			boattail.setForeShoulderRadius(0.031);
+			boattail.setForeShoulderLength( 0.04 );
+			boattail.setForeShoulderThickness(0.001);
+			boattail.setForeShoulderCapped(false);
+        
+			boattail.setAftShoulderLength( 0.0 );
+			boattail.setAftShoulderCapped(false);
+  		    stage.addChild( boattail);
+  		    
+  		    { // freeform fins -- on boattail
+  				FreeformFinSet fins = new FreeformFinSet();
+  				boattail.addChild( fins);
+  				fins.setName("fins");
+  				fins.setFinCount(4);
+  				Coordinate[] points = new Coordinate[] { 
+  					      new Coordinate( 0, 0)
+  						, new Coordinate( 0.09,   0.0587)
+  						, new Coordinate( 0.1666, 0.0590)
+  						, new Coordinate( 0.1668, 0.0294)
+  						, new Coordinate( 0.1568, 0.0257)
+  						, new Coordinate( 0.1565, 0.0082)
+  						, new Coordinate( 0.1388, 0.0)
+  				};
+  				fins.setPoints( points);
+  				
+  				fins.setRelativePosition( Position.TOP );
+  				fins.setAxialOffset(0);
+  				fins.setThickness(0.0024);
+  				fins.setCrossSection( CrossSection.AIRFOIL );
+  	                
+  				fins.setTabHeight( 0.020);
+  	            fins.setTabLength( 0.12 );
+  	            fins.setTabPositionMethod( RocketComponent.Position.TOP );
+  	            fins.setTabShift( 0.02 );
+  	            
+  		    }
+		}
+          
+		rocket.enableEvents();
+		rocket.getSelectedConfiguration().setAllStages();
 		return rocket;
 	}
 	

--- a/core/src/net/sf/openrocket/util/Transformation.java
+++ b/core/src/net/sf/openrocket/util/Transformation.java
@@ -43,6 +43,19 @@ public class Transformation implements java.io.Serializable {
 		rotation[Z][Z]=1;
 	}
 	
+	
+	/**
+	 * scale each axis by the supplied number
+	 *  
+	 * @param scalar double to scale coordinates by
+	 */
+	public Transformation( final double newScale ) {
+		translate = new Coordinate(0,0,0);
+		rotation[X][X]=newScale;
+		rotation[Y][Y]=newScale;
+		rotation[Z][Z]=newScale;
+	}
+	
 	/**
 	 * Create transformation with only translation.
 	 * @param x Translation in x-axis.
@@ -226,8 +239,17 @@ public class Transformation implements java.io.Serializable {
 				{Math.sin(theta),Math.cos(theta),0},
 				{0,0,1}});
 	}
+
 	
-	
+	/**
+	 * scale each axis by the supplied number 
+	 * @param newScale the new factor to scale by
+	 * @return  The transformation.
+	 */
+	public static Transformation scale( final double newScale){
+		return new Transformation(newScale);
+	}
+
 	
 	public void print(String... str) {
 		for (String s: str) {
@@ -256,5 +278,23 @@ public class Transformation implements java.io.Serializable {
 		}
 		return this.translate.equals(o.translate);
 	}
+
+	@Override
+	public int hashCode() {
+		int hash=0;
+		for (int i=0; i<3; i++) {
+			for (int j=0; j<3; j++) {
+				hash ^= (int)this.rotation[i][j];
+			}
+		}
+
+		hash ^= (int)this.translate.x;
+		hash ^= (int)this.translate.y;
+		hash ^= (int)this.translate.z;
+		
+		return hash; 
+	}
 	
 }
+	
+

--- a/core/test/net/sf/openrocket/file/openrocket/OpenRocketSaverTest.java
+++ b/core/test/net/sf/openrocket/file/openrocket/OpenRocketSaverTest.java
@@ -187,6 +187,7 @@ public class OpenRocketSaverTest {
 		StorageOptions options = new StorageOptions();
 		options.setSimulationTimeSkip(0.05);
 		
+		@SuppressWarnings("unused")
 		long estimatedSize = saver.estimateFileSize(rocketDoc, options);
 		
 		// TODO: fix estimateFileSize so that it's a lot more accurate

--- a/core/test/net/sf/openrocket/file/rocksim/export/RocksimDocumentDTOTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/export/RocksimDocumentDTOTest.java
@@ -44,7 +44,7 @@ public class RocksimDocumentDTOTest extends RocksimTestBase {
 		StringWriter stringWriter = new StringWriter();
 		marshaller.marshal(message, stringWriter);
 		
-		String response = stringWriter.toString();
+		//String response = stringWriter.toString();
 		
 		// TODO need checks here to validation that correct things were done
 		//System.err.println(response);

--- a/core/test/net/sf/openrocket/file/rocksim/importt/FinSetHandlerTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/importt/FinSetHandlerTest.java
@@ -3,29 +3,77 @@
  */
 package net.sf.openrocket.file.rocksim.importt;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.util.Modules;
+
+import net.sf.openrocket.ServicesForTesting;
 import net.sf.openrocket.aerodynamics.WarningSet;
+import net.sf.openrocket.l10n.DebugTranslator;
+import net.sf.openrocket.l10n.Translator;
+import net.sf.openrocket.plugin.PluginModule;
 import net.sf.openrocket.rocketcomponent.BodyTube;
 import net.sf.openrocket.rocketcomponent.EllipticalFinSet;
 import net.sf.openrocket.rocketcomponent.FinSet;
 import net.sf.openrocket.rocketcomponent.TrapezoidFinSet;
+import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.Coordinate;
+import net.sf.openrocket.util.MathUtil;
 
-import java.lang.reflect.Method;
-import java.util.HashMap;
 
 /**
  * FinSetHandler Tester.
  *
  */
-public class FinSetHandlerTest extends TestCase {
+public class FinSetHandlerTest {
 
+	final static double EPSILON = MathUtil.EPSILON;
+	
+	@BeforeClass
+	public static void setup() {
+		Module applicationModule = new ServicesForTesting();
+		
+		Module pluginModule = new PluginModule();
+		
+		Module debugTranslator = new AbstractModule() {
+			@Override
+			protected void configure() {
+				bind(Translator.class).toInstance(new DebugTranslator(null));
+			}
+		};
+				
+		Injector injector = Guice.createInjector(Modules.override(applicationModule).with(debugTranslator), pluginModule);
+		
+		Application.setInjector(injector);
+		
+		File tmpDir = new File("./tmp");
+		if (!tmpDir.exists()) {
+			boolean success = tmpDir.mkdirs();
+			assertTrue("Unable to create core/tmp dir needed for tests.", success);
+		}
+		
+	}
+	
+	
     /**
      * Method: asOpenRocket(WarningSet warnings)
      *
      * @throws Exception thrown if something goes awry
      */
-    @org.junit.Test
+    @Test
     public void testAsOpenRocket() throws Exception {
 
         FinSetHandler dto = new FinSetHandler(null, new BodyTube());
@@ -37,15 +85,15 @@ public class FinSetHandlerTest extends TestCase {
         dto.closeElement("ShapeCode", attributes, "0", warnings);
         dto.closeElement("Xb", attributes, "2", warnings);
         dto.closeElement("FinCount", attributes, "4", warnings);
-        dto.closeElement("RootChord", attributes, "10", warnings);
-        dto.closeElement("TipChord", attributes, "11", warnings);
+        dto.closeElement("RootChord", attributes, "100", warnings);
+        dto.closeElement("TipChord", attributes, "50", warnings);
         dto.closeElement("SemiSpan", attributes, "12", warnings);
         dto.closeElement("MidChordLen", attributes, "13", warnings);
         dto.closeElement("SweepDistance", attributes, "14", warnings);
         dto.closeElement("Thickness", attributes, "200", warnings);
         dto.closeElement("TipShapeCode", attributes, "1", warnings);
-        dto.closeElement("TabLength", attributes, "400", warnings);
-        dto.closeElement("TabDepth", attributes, "500", warnings);
+        dto.closeElement("TabLength", attributes, "40", warnings);
+        dto.closeElement("TabDepth", attributes, "50", warnings);
         dto.closeElement("TabOffset", attributes, "30", warnings);
         dto.closeElement("RadialAngle", attributes, ".123", warnings);
         dto.closeElement("PointList", attributes, "20,0|2,2|0,0", warnings);
@@ -55,34 +103,37 @@ public class FinSetHandlerTest extends TestCase {
         FinSet fins = dto.asOpenRocket(set);
         assertNotNull(fins);
         assertEquals(0, set.size());
+        
+	    String debugInfo = fins.toDebugDetail().toString();
 
         assertEquals("The name", fins.getName());
         assertTrue(fins instanceof TrapezoidFinSet);
-        assertEquals(4, fins.getFinCount());
+        assertEquals("imported fin count does not match.", 4, fins.getFinCount());
 
-        assertEquals(0.012d, ((TrapezoidFinSet) fins).getHeight());
-        assertEquals(0.012d, fins.getSpan());
+        assertEquals("imported fin height does not match.", 0.012d, ((TrapezoidFinSet) fins).getHeight(), EPSILON);
+        assertEquals("imported fin span does not match.", 0.012d, fins.getSpan(), EPSILON);
         
-        assertEquals(0.2d, fins.getThickness());
-        assertEquals(0.4d, fins.getTabLength());
-        assertEquals(0.5d, fins.getTabHeight());
-        assertEquals(0.03d, fins.getTabShift());
-        assertEquals(.123d, fins.getBaseRotation());
+        assertEquals("imported fin thickness does not match.", 0.2d, fins.getThickness(), EPSILON);
+        assertEquals("imported fin tab length does not match: "+debugInfo, 0.04d, fins.getTabLength(), EPSILON);
+        assertEquals("imported fin tab height does not match: "+debugInfo, 0.05d, fins.getTabHeight(), EPSILON);
+        assertEquals("imported fin shift does not match.", 0.03d, fins.getTabShift(), EPSILON);
+        assertEquals("imported fin rotation does not match.", .123d, fins.getBaseRotation(), EPSILON);
 
         dto.closeElement("ShapeCode", attributes, "1", warnings);
+        
         fins = dto.asOpenRocket(set);
         assertNotNull(fins);
         assertEquals(0, set.size());
 
         assertEquals("The name", fins.getName());
         assertTrue(fins instanceof EllipticalFinSet);
-        assertEquals(4, fins.getFinCount());
+        assertEquals("imported fin count does not match.", 4, fins.getFinCount());
 
-        assertEquals(0.2d, fins.getThickness());
-        assertEquals(0.4d, fins.getTabLength());
-        assertEquals(0.5d, fins.getTabHeight());
-        assertEquals(0.03d, fins.getTabShift());
-        assertEquals(.123d, fins.getBaseRotation());
+        assertEquals("imported fin thickness does not match.", 0.2d, fins.getThickness(), EPSILON);
+        assertEquals("imported fin tab length does not match.", 0.04d, fins.getTabLength(), EPSILON);
+        assertEquals("imported fin tab height does not match.", 0.05d, fins.getTabHeight(), EPSILON);
+        assertEquals("imported fin tab shift does not match.", 0.03d, fins.getTabShift(), EPSILON);
+        assertEquals("imported fin rotation does not match.", .123d, fins.getBaseRotation(), EPSILON);
     }
 
 

--- a/core/test/net/sf/openrocket/file/rocksim/importt/RingHandlerTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/importt/RingHandlerTest.java
@@ -88,7 +88,6 @@ public class RingHandlerTest extends RocksimTestBase {
     public void testBulkhead() throws Exception {
         BodyTube tube = new BodyTube();
         RingHandler handler = new RingHandler(null, tube, new WarningSet());
-        CenteringRing component = (CenteringRing) getField(handler, "ring");
         HashMap<String, String> attributes = new HashMap<String, String>();
         WarningSet warnings = new WarningSet();
 
@@ -225,7 +224,8 @@ public class RingHandlerTest extends RocksimTestBase {
      *
      * @throws Exception thrown if something goes awry
      */
-    @org.junit.Test
+
+	@org.junit.Test
     public void testConstructor() throws Exception {
 
         try {
@@ -238,6 +238,8 @@ public class RingHandlerTest extends RocksimTestBase {
 
         BodyTube tube = new BodyTube();
         RingHandler handler = new RingHandler(null, tube, new WarningSet());
+        
+        @SuppressWarnings("unused")
         CenteringRing component = (CenteringRing) getField(handler, "ring");
     }
 

--- a/core/test/net/sf/openrocket/masscalc/MassDataTest.java
+++ b/core/test/net/sf/openrocket/masscalc/MassDataTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 
 import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.MathUtil;
+import net.sf.openrocket.util.PointWeight;
 import net.sf.openrocket.util.BaseTestCase.BaseTestCase;
 
 public class MassDataTest extends BaseTestCase {
@@ -19,26 +20,27 @@ public class MassDataTest extends BaseTestCase {
 	@Test
 	public void testTwoPointInline() {
 		double m1 = 2.5;
-		Coordinate r1 = new Coordinate(0,-40, 0, m1);
+		PointWeight r1 = new PointWeight(0,-40, 0, m1);
 		double I1ax=28.7;
 		double I1t = I1ax/2;
-		MassData body1 = new MassData(r1, I1ax, I1t);
+		MassData body1 = new MassData( r1, I1ax, I1t, I1t);
 		
 		double m2 = 5.7;
-		Coordinate r2 = new Coordinate(0, 32, 0, m2);
+		PointWeight r2 = new PointWeight(0, 32, 0, m2);
 		double I2ax=20;
 		double I2t = I2ax/2;
-		MassData body2 = new MassData(r2, I2ax, I2t);
+		MassData body2 = new MassData( r2, I2ax, I2t, I2t);
 		
 		// point 3 is defined as the CM of bodies 1 and 2 combined.
 		MassData asbly3 = body1.add(body2);
 		
-		Coordinate cm3_expected = r1.average(r2);
-		assertEquals(" Center of Mass calculated incorrectly: ", cm3_expected, asbly3.getCM() );
+		PointWeight cm3_actual = new PointWeight( asbly3.getCM());
+		PointWeight cm3_expected = r1.add(r2);
+		assertEquals(" Center of Mass calculated incorrectly: ", cm3_expected, cm3_actual );
 				
 		// these are a bit of a hack, and depend upon all the bodies being along the y=0, z=0 line.
-		Coordinate delta13 = asbly3.getCM().sub( r1);
-		Coordinate delta23 = asbly3.getCM().sub( r2);
+		Coordinate delta13 = asbly3.getCM().sub( r1.toCoordinate());
+		Coordinate delta23 = asbly3.getCM().sub( r2.toCoordinate());
 		
 		double y13 = delta13.y;
 		double dy_13_2 = MathUtil.pow2( y13); // hack
@@ -54,37 +56,39 @@ public class MassDataTest extends BaseTestCase {
 		double expI3yy = I1t+I2t;
 		double expI3zz = I13zz+I23zz;
 		
-		assertEquals("x-axis MOI don't match: ", asbly3.getIxx(), expI3xx, EPSILON*10);
+		assertEquals("x-axis MOI doesn't match: ", asbly3.getIxx(), expI3xx, EPSILON*10);
 		
-		assertEquals("y-axis MOI don't match: ", asbly3.getIyy(), expI3yy, EPSILON*10);
+		assertEquals("y-axis MOI doesn't match: ", asbly3.getIyy(), expI3yy, EPSILON*10);
 		
-		assertEquals("z-axis MOI don't match: ", asbly3.getIzz(), expI3zz, EPSILON*10);
+		assertEquals("z-axis MOI doesn't match: ", asbly3.getIzz(), expI3zz, EPSILON*10);
 	}
 	
 	
 	@Test
 	public void testTwoPointGeneral() {
 		double m1 = 2.5;
-		Coordinate r1 = new Coordinate(0,-40, -10, m1);
+		PointWeight r1 = new PointWeight(0,-40, -10, m1);
 		double I1xx=28.7;
 		double I1t = I1xx/2;
-		MassData body1 = new MassData(r1, I1xx, I1t);
+		MassData body1 = new MassData(r1, I1xx, I1t, I1t);
 		
 		double m2 = 5.7;
-		Coordinate r2 = new Coordinate(0, 32, 15, m2);
+		PointWeight r2 = new PointWeight(0, 32, 15, m2);
 		double I2xx=20;
 		double I2t = I2xx/2;
-		MassData body2 = new MassData(r2, I2xx, I2t);
+		MassData body2 = new MassData(r2, I2xx, I2t, I2t);
 		
 		// point 3 is defined as the CM of bodies 1 and 2 combined.
 		MassData asbly3 = body1.add(body2);
+
 		
-		Coordinate cm3_expected = r1.average(r2);
-		assertEquals(" Center of Mass calculated incorrectly: ", cm3_expected, asbly3.getCM() );
-				
+		PointWeight cm3_actual = new PointWeight( asbly3.getCM());
+		PointWeight cm3_expected = r1.add(r2);
+		assertEquals(" Center of Mass calculated incorrectly: ", cm3_expected, cm3_actual );		
+		
 		// these are a bit of a hack, and depend upon all the bodies being along the y=0, z=0 line.
-		Coordinate delta13 = asbly3.getCM().sub( r1);
-		Coordinate delta23 = asbly3.getCM().sub( r2);
+		Coordinate delta13 = asbly3.getCM().sub( r1.toCoordinate());
+		Coordinate delta23 = asbly3.getCM().sub( r2.toCoordinate());
 		double x2, y2, z2;
 		
 		x2 = MathUtil.pow2( delta13.x);
@@ -102,44 +106,45 @@ public class MassDataTest extends BaseTestCase {
 		double I23zz = I2t + m2*(x2+y2);
 		
 		double expI3xx = I13xx + I23xx;
-		assertEquals("x-axis MOI don't match: ", asbly3.getIxx(), expI3xx, EPSILON*10);
+		assertEquals("x-axis MOI doesn't match: ", asbly3.getIxx(), expI3xx, EPSILON*10);
 		
 		double expI3yy = I13yy + I23yy;
-		assertEquals("y-axis MOI don't match: ", asbly3.getIyy(), expI3yy, EPSILON*10);
+		assertEquals("y-axis MOI doesn't match: ", asbly3.getIyy(), expI3yy, EPSILON*10);
 		
 		double expI3zz = I13zz + I23zz;
-		assertEquals("z-axis MOI don't match: ", asbly3.getIzz(), expI3zz, EPSILON*10);
+		assertEquals("z-axis MOI doesn't match: ", asbly3.getIzz(), expI3zz, EPSILON*10);
 	}
 	
 
 	@Test
 	public void testMassDataCompoundCalculations() {
 		double m1 = 2.5;
-		Coordinate r1 = new Coordinate(0,-40, 0, m1);
+		PointWeight r1 = new PointWeight(0,-40, 0, m1);
 		double I1ax=28.7;
 		double I1t = I1ax/2;
-		MassData body1 = new MassData(r1, I1ax, I1t);
+		MassData body1 = new MassData(r1, I1ax, I1t, I1t);
 		
 		double m2 = m1;
-		Coordinate r2 = new Coordinate(0, -2, 0, m2);
+		PointWeight r2 = new PointWeight(0, -2, 0, m2);
 		double I2ax=28.7;
 		double I2t = I2ax/2;
-		MassData body2 = new MassData(r2, I2ax, I2t);
+		MassData body2 = new MassData(r2, I2ax, I2t, I2t);
 		
 		double m5 = 5.7;
-		Coordinate r5 = new Coordinate(0, 32, 0, m5);
+		PointWeight r5 = new PointWeight(0, 32, 0, m5);
 		double I5ax=20;
 		double I5t = I5ax/2;
-		MassData body5 = new MassData(r5, I5ax, I5t);
+		MassData body5 = new MassData(r5, I5ax, I5t, I5t);
 		
 		// point 3 is defined as the CM of bodies 1 and 2 combined.
 		MassData asbly3 = body1.add(body2);
 		
 		// point 4 is defined as the CM of bodies 1, 2 and 5 combined.
 		MassData asbly4_indirect = asbly3.add(body5);
-		Coordinate cm4_expected = r1.average(r2).average(r5);
+		PointWeight cm4_expected = r1.add(r2).add(r5);
+		PointWeight cm4_actual = new PointWeight( 0, 7.233644859813085, 0, m1+m2+m5 );
 		
-		assertEquals(" Center of Mass calculated incorrectly: ", cm4_expected, new Coordinate( 0, 7.233644859813085, 0, m1+m2+m5 ) );
+		assertEquals(" Center of Mass calculated incorrectly: ", cm4_expected, cm4_actual);
 		
 		// these are a bit of a hack, and depend upon all the bodies being along the y=0, z=0 line.
 		double y4 = cm4_expected.y;
@@ -156,11 +161,11 @@ public class MassDataTest extends BaseTestCase {
 		double I4zz = I14zz+I24zz+I54zz;
 		MassData asbly4_expected = new MassData( cm4_expected, I4xx, I4yy, I4zz);
 
-		assertEquals("x-axis MOI don't match: ", asbly4_indirect.getIxx(), asbly4_expected.getIxx(), EPSILON*10);
+		assertEquals("x-axis MOI doesn't match: ", asbly4_indirect.getIxx(), asbly4_expected.getIxx(), EPSILON*10);
 
-		assertEquals("y-axis MOI don't match: ", asbly4_indirect.getIyy(), asbly4_expected.getIyy(), EPSILON*10);
+		assertEquals("y-axis MOI doesn't match: ", asbly4_indirect.getIyy(), asbly4_expected.getIyy(), EPSILON*10);
 		
-		assertEquals("z-axis MOI don't match: ", asbly4_indirect.getIzz(), asbly4_expected.getIzz(), EPSILON*10);
+		assertEquals("z-axis MOI doesn't match: ", asbly4_indirect.getIzz(), asbly4_expected.getIzz(), EPSILON*10);
 	}
 	
 	

--- a/core/test/net/sf/openrocket/rocketcomponent/FreeformFinSetTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/FreeformFinSetTest.java
@@ -1,0 +1,969 @@
+package net.sf.openrocket.rocketcomponent;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import net.sf.openrocket.aerodynamics.AerodynamicForces;
+import net.sf.openrocket.aerodynamics.FlightConditions;
+import net.sf.openrocket.aerodynamics.WarningSet;
+import net.sf.openrocket.aerodynamics.barrowman.FinSetCalc;
+import net.sf.openrocket.material.Material;
+import net.sf.openrocket.material.Material.Type;
+import net.sf.openrocket.rocketcomponent.ExternalComponent.Finish;
+import net.sf.openrocket.rocketcomponent.FinSet.CrossSection;
+import net.sf.openrocket.rocketcomponent.RocketComponent.Position;
+import net.sf.openrocket.rocketcomponent.Transition.Shape;
+import net.sf.openrocket.util.Color;
+import net.sf.openrocket.util.Coordinate;
+import net.sf.openrocket.util.LineStyle;
+import net.sf.openrocket.util.BaseTestCase.BaseTestCase;
+
+public class FreeformFinSetTest extends BaseTestCase {
+	final double EPSILON = 0.0001;
+	
+    public Rocket createFinsOnTube() {
+    	Rocket rkt = new Rocket();
+        AxialStage stg = new AxialStage();
+	    rkt.addChild(stg);
+	    BodyTube body = new BodyTube(1.0, 0.6);
+	    body.setLength(1.0);
+	    body.setOuterRadius(0.6);
+	    stg.addChild(body);
+	   
+	    // Fin length = 0.4
+	    // Body Length = 1.0
+	    //          +--+
+	    //         /   |
+	    //        /    |
+	    //   +---+-----+---+
+	    //
+	    FreeformFinSet fins = new FreeformFinSet();
+	    fins.setFinCount(1);
+	    Coordinate[] initPoints = new Coordinate[] {
+	                   new Coordinate(0.0, 0.0),
+	                   new Coordinate(0.2, 0.4),
+	                   new Coordinate(0.4, 0.4),
+	                   new Coordinate(0.4, 0.0)
+	    };
+	    body.addChild(fins);
+	    fins.setPoints(initPoints);
+	    fins.setAxialOffset( Position.TOP, 0.4);
+	    
+	    rkt.enableEvents();
+	    return rkt;
+    }
+    
+    public Rocket createFinsOnTransition() {
+    	Rocket rkt = new Rocket();
+        AxialStage stg = new AxialStage();
+	    rkt.addChild(stg);
+	    Transition body = new Transition();
+	    body.setType(Shape.CONICAL);
+	    body.setForeRadius(1.0);
+	    body.setLength(1.0);
+	    body.setAftRadius(0.5);
+	    // slope = .5/1.0 = 0.5
+	    body.setName("Transition Body");
+	    stg.addChild(body);
+	   
+	    // Fin length = 0.4
+	    // Body Length = 1.0
+	    //         +------+
+	    //       /       +
+	    //     /        +
+	    // +---+       +
+	    //     +---+  +
+	    //         +---+
+	    FreeformFinSet fins = new FreeformFinSet();
+	    body.addChild(fins);
+	    fins.setName("test-freeform-finset");
+	    fins.setFinCount(1);
+	    fins.setAxialOffset( Position.TOP, 0.4);
+	    Coordinate[] initPoints = new Coordinate[] {
+	                   new Coordinate( 0.0, 0.0),
+	                   new Coordinate( 0.3, 0.2),
+	                   new Coordinate( 0.6, 0.2),
+	                   new Coordinate( 0.4,-0.2)
+	    };
+	    fins.setPoints(initPoints);
+	    fins.setAxialOffset( Position.TOP, 0.4);
+	    
+	    rkt.enableEvents();
+	    return rkt;
+    }
+    
+    public Rocket createFinsOnBoattail(){
+    	Rocket rkt = new Rocket();
+        AxialStage stg = new AxialStage();
+	    rkt.addChild(stg);
+	    Transition body = new Transition();
+	    body.setForeRadius(0.1);
+	    body.setLength(0.1);
+	    body.setAftRadius(0.04);
+	    body.setType( Shape.ELLIPSOID );
+	    body.setShapeParameter(0.5);
+	    body.setName("Transition Body");
+	    stg.addChild(body);
+	   
+	    FreeformFinSet fins = new FreeformFinSet();
+	    body.addChild(fins);
+	    fins.setName("test-freeform-finset");
+	    fins.setFinCount(1);
+	    fins.setAxialOffset( Position.TOP, 0.02);
+	    fins.setPoints(new Coordinate[] {
+                new Coordinate( 0.0,   0.0),
+                new Coordinate( 0.06,  0.04),
+                new Coordinate( 0.08,  0.04),
+                new Coordinate( 0.06, -0.03029),
+	    });
+	    
+	    rkt.enableEvents();
+	    return rkt;
+    }
+    
+    
+    @Test
+    public void testSetPoint_firstPoint_boundsCheck() {
+    	// more transitions trigger more complicated positioning math:  
+		Rocket rkt = createFinsOnTransition();
+		FreeformFinSet fins = (FreeformFinSet) rkt.getChild(0).getChild(0).getChild(0);
+		assertEquals( 1, fins.getFinCount());
+		final int startIndex = 0;
+		final int lastIndex = fins.getPointCount()-1;
+		assertEquals( 3, lastIndex);
+
+    	Coordinate act_p_0;
+    	{ // first point x is restricted to the front of the parent body:
+		    fins.setPoint( startIndex, -1, 0);
+		    act_p_0 = fins.getFinPoints()[0];
+		    assertEquals( 0.0, act_p_0.x, EPSILON);
+		    assertEquals( Position.TOP, fins.getRelativePosition() );
+		    assertEquals( 0.0, fins.getAxialOffset(), EPSILON);
+    	}
+    	
+    	{// first point y is restricted to the body
+		    fins.setPoint( startIndex, 0, -1);
+		    act_p_0 = fins.getFinPoints()[0];
+			assertEquals( 0.0, act_p_0.y, EPSILON);
+    	}
+    }
+    
+    @Test
+    public void testSetFirstPoint() {
+    	// more transitions trigger more complicated positioning math:  
+		Rocket rkt = createFinsOnTransition();
+		Transition body = (Transition) rkt.getChild(0).getChild(0);
+		FreeformFinSet fins = (FreeformFinSet) rkt.getChild(0).getChild(0).getChild(0);
+		assertEquals( 1, fins.getFinCount());
+		final int startIndex = 0;
+		 // somewhat arbitrary index.  This point stands in for all of the interior points
+		final int compareIndex = 1;
+		final int lastIndex = fins.getPointCount()-1;
+		Coordinate[] initPoints = new Coordinate[] {new Coordinate( 0.0, 0.0),
+									                new Coordinate( 0.3, 0.2),
+									                new Coordinate( 0.6, 0.2),
+									                new Coordinate( 0.4,-0.2)};
+ 		assertEquals("precondition failed: ", 1.0, body.getLength(), EPSILON);
+		assertEquals("precondition failed: ", 0.4, fins.getLength(), EPSILON);
+
+		// set to these positions
+	    final Position[] methods={ Position.TOP, Position.TOP, Position.MIDDLE, Position.MIDDLE, Position.BOTTOM, Position.BOTTOM};	    
+	    final double[] finOffsets = {       0.1,          0.1,             0.0,             0.0,             0.0,             0.0};
+	    
+	    // set first point to this location...
+	    final double[] xDelta = {           0.2,         -0.2,             0.1,            -0.1,             0.1,            -0.1};
+	    
+	    // and check against these expected values:
+	    final double[] expectedFinStart={   0.3,          0.0,             0.4,             0.2,             0.7,             0.5};
+	    final double[] expectedFinLength={  0.2,          0.5,             0.3,             0.5,             0.3,             0.5};
+	    final double[] expectedFinOffset={  0.3,          0.0,             0.05,           -0.05,            0.0,             0.0};
+	    
+	    for( int caseIndex=0; caseIndex < methods.length; ++caseIndex ){
+	    	fins.setPoints(initPoints);
+	    	fins.setAxialOffset( methods[caseIndex], finOffsets[caseIndex]);
+	    	
+	    	StringBuilder buf = new StringBuilder();
+	    	
+	    	final double priorFinStart = fins.getTop();
+	    	final Coordinate[] priorPoints = fins.getFinPoints();
+	    	final Coordinate priorInterior = priorPoints[ compareIndex].add( priorFinStart, 0, 0);
+	    	final double priorLastX = priorPoints[ lastIndex].x + priorFinStart;
+	    	
+	    	buf.append(String.format("\n## For Case #%d: [%s]@%4.2f \n", caseIndex, methods[caseIndex].name(), finOffsets[caseIndex]));
+	    	buf.append(String.format("       >> setting point #0 to: ( %6.4f, %6.4f) \n", xDelta[caseIndex], 0.0f)); 
+
+	    	// vvvv function under test vvvv
+	    	fins.setPoint( startIndex, xDelta[caseIndex], 0.0f);	
+	    	// ^^^^ function under test ^^^^
+	    	
+	    	final double postFinStart = fins.getTop();
+	    	final double postFinOffset = fins.getAxialOffset();
+	    	final Coordinate[] postPoints = fins.getFinPoints();
+	    	final Coordinate postInterior = postPoints[ compareIndex].add( postFinStart, 0, 0);
+	    	final double postLastX = postPoints[ lastIndex].x+postFinStart;
+	    	final double postFinLength = fins.getLength();
+	    	
+	    	final String dump = buf.toString();
+	    	assertEquals("Fin front not updated as expected..."+dump,  expectedFinStart[caseIndex], postFinStart, EPSILON);
+	    	assertEquals("Fin offset not updated as expected..."+dump,  expectedFinOffset[caseIndex], postFinOffset, EPSILON);
+	    	assertEquals("Fin length not updated as expected..."+dump,  expectedFinLength[caseIndex], postFinLength, EPSILON);
+	    	
+	    	assertEquals("Fin points have moved! (changed absolute location): "+dump, priorInterior.x, postInterior.x, EPSILON);
+	    	assertEquals("Fin points have moved! (changed absolute location): "+dump, priorInterior.y, postInterior.y, EPSILON);
+	    	
+	    	// verify the last point is where it should be
+	    	assertEquals("Final fin points did not move as expected... "+dump, priorLastX, postLastX, EPSILON);
+    	}	
+    }
+
+    @Test
+    public void testSetLastPoint() {
+    	// more transitions trigger more complicated positioning math:  
+		Rocket rkt = createFinsOnTransition();
+		Transition body = (Transition) rkt.getChild(0).getChild(0);
+		FreeformFinSet fins = (FreeformFinSet) rkt.getChild(0).getChild(0).getChild(0);
+		 // a somewhat arbitrary interior index.  This point stands in for all interior points
+		final int compareIndex = 1;
+		final int lastIndex = fins.getPointCount()-1;
+		Coordinate[] initPoints = new Coordinate[] {new Coordinate( 0.0, 0.0),
+                new Coordinate( 0.3, 0.2),
+                new Coordinate( 0.6, 0.2),
+                new Coordinate( 0.4,-0.2)};
+		assertEquals("precondition failed: ", 1.0, body.getLength(), EPSILON);
+		assertEquals("procendition failed: ", 0.4, fins.getLength(), EPSILON);
+
+
+		// set to these positions
+	    final Position[] methods={Position.TOP, Position.TOP, Position.MIDDLE, Position.MIDDLE, Position.BOTTOM, Position.BOTTOM};	    
+	    final double[] finOffsets = {      0.0,          0.0,             0.0,             0.0,             0.0,             0.0};
+	    
+	    // set first point to this location...
+	    final double xPriorLast = 0.4;
+	    final double yPriorLast = -0.2;
+	    final double[] xDelta= {            0.1,         -0.1,             0.1,            -0.1,             0.1,           -0.1};
+	    
+	    // and check against these expected values:
+	    final double[] expectedFinStart={  0.0,          0.0,             0.3,             0.3,             0.6,             0.6};
+	    final double[] expectedFinOffset={ 0.0,          0.0,             0.05,           -0.05,            0.0,            -0.1};
+	    final double[] expectedLastX = {   0.5,          0.3,             0.8,             0.6,             1.0,             0.9};     
+	    
+	    for( int caseIndex=0; caseIndex < methods.length; ++caseIndex ){
+	    	fins.setPoints(initPoints);
+	    	fins.setAxialOffset( methods[caseIndex], finOffsets[caseIndex]);
+	    	
+	    	StringBuilder buf = new StringBuilder();
+	    	
+	    	final double priorFinStart = fins.getTop();
+	    	final Coordinate[] priorPoints = fins.getFinPoints();
+	    	final double priorComparisonX = priorPoints[ compareIndex].x + priorFinStart;
+	    	
+	    	final double xRequest = xPriorLast + xDelta[caseIndex];
+	    	final double yRequest = yPriorLast; // wrong value; will be clamped to the body regardless
+	    	
+	    	buf.append(String.format("\n## For Case #%d: [%s]@%4.2f \n", caseIndex, methods[caseIndex].name(), finOffsets[caseIndex]));
+	    	buf.append(String.format("       >> setting point #%d to: ( %6.4f, %6.4f) \n", lastIndex, xRequest, yRequest)); 
+
+	    	// vvvv function under test vvvv
+	    	fins.setPoint( lastIndex, xRequest, yRequest);
+	    	// ^^^^ function under test ^^^^
+	    	
+	    	final double postFinStart = fins.getTop();
+	    	final double postFinOffset = fins.getAxialOffset();
+	    	final Coordinate[] postPoints = fins.getFinPoints();
+	    	final double postComparisonX = postPoints[ compareIndex].x+postFinStart;
+	    	final double postLastX = postPoints[ lastIndex].x+postFinStart;
+	    	
+	    	final String dump = buf.toString();
+	    	assertEquals("Fin front not updated as expected..."+dump,  expectedFinStart[caseIndex], postFinStart, EPSILON);
+	    	
+	    	assertEquals("Fin offset not updated as expected..."+dump,  expectedFinOffset[caseIndex], postFinOffset, EPSILON);
+	    	
+	    	assertEquals("Fin points have moved (changed absolute location: "+dump, priorComparisonX, postComparisonX, EPSILON);
+	    	
+	    	// verify the last point is where it should be
+	    	assertEquals("Final fin points did not move as expected... "+dump, expectedLastX[caseIndex], postLastX, EPSILON);
+    	}
+    }
+
+    @Test
+    public void testSetFirstPoint_testNonIntersection() {
+    	// more transitions trigger more complicated positioning math:  
+		Rocket rkt = createFinsOnTransition();
+		FreeformFinSet fins = (FreeformFinSet) rkt.getChild(0).getChild(0).getChild(0);
+		assertEquals( 1, fins.getFinCount());
+		final int startIndex = 0;
+		final int lastIndex = fins.getPointCount()-1;
+		assertEquals( 3, lastIndex);
+		final double initXOffset = fins.getAxialOffset();
+		assertEquals( 0.4, initXOffset, EPSILON); // pre-condition
+		
+		final double attemptedDelta = 0.6;
+		fins.setPoint( startIndex, attemptedDelta, 0);
+		// fin offset: 0.4 -> 0.59  (just short of prev fin end)
+		// fin end:    0.4 ~> min root chord  
+    
+		Coordinate act_p_0 = fins.getFinPoints()[ startIndex];
+		assertEquals( 0.0, act_p_0.x, EPSILON);
+		assertEquals( 0.0, act_p_0.y, EPSILON);
+		
+	    // setting the first point actually offsets the whole fin by that amount:
+		final double expFinOffset = 0.79;
+	    assertEquals("Resultant fin offset does not match!", expFinOffset, fins.getAxialOffset(), EPSILON);
+	    
+	    // SHOULD NOT CHANGE (in this case):
+	    Coordinate actualLastPoint = fins.getFinPoints()[ lastIndex];
+		assertEquals("last point did not adjust correctly: ", FreeformFinSet.MIN_ROOT_CHORD, actualLastPoint.x, EPSILON);
+		assertEquals("last point did not adjust correctly: ", -0.005, actualLastPoint.y, EPSILON); // magic number
+		assertEquals("New fin length is wrong: ", FreeformFinSet.MIN_ROOT_CHORD, fins.getLength(), EPSILON);
+    }
+    
+
+    @Test
+    public void testSetLastPoint_TubeBody() {
+    	// combine the simple case with the complicated to ensure that the simple case is flagged, tested, and debugged before running the more complicated case...
+    	{ // setting points on a Tube Body is the simpler case. Test this first:
+    		Rocket rkt = createFinsOnTube();
+    		FreeformFinSet fins = (FreeformFinSet) rkt.getChild(0).getChild(0).getChild(0); 
+    		
+    		// last point is restricted to the body
+    		final int lastIndex = fins.getPointCount()-1; 
+    		Coordinate exp_p_l = new Coordinate( 0.6, 0.0, 0.0);
+    		fins.setPoint(lastIndex, 1, -1);
+    		
+    		Coordinate act_p_l = fins.getFinPoints()[lastIndex];
+    		assertEquals( exp_p_l.x, act_p_l.x, EPSILON);
+    		assertEquals( exp_p_l.y, act_p_l.y, EPSILON);
+		}
+    	
+    	{ // a transitions will trigger more complicated positioning math:  
+			Rocket rkt = createFinsOnTransition();
+			FreeformFinSet fins = (FreeformFinSet) rkt.getChild(0).getChild(0).getChild(0);
+			
+			assertEquals( 1, fins.getFinCount());
+			final int lastIndex = fins.getPointCount()-1;
+			assertEquals( 3, lastIndex);
+    	
+	    	Coordinate act_p_l;
+	    	Coordinate exp_p_l;
+	    	{ // this is where the point starts off at: 
+	    		act_p_l = fins.getFinPoints()[lastIndex];
+	    		assertEquals( 0.4, act_p_l.x, EPSILON);
+	    		assertEquals( -0.2, act_p_l.y, EPSILON);
+	    	}
+	    	
+	    	{ // (1):  move point within bounds
+	    		// move last point, and verify that its y-value is still clamped to the body ( at the new location) 
+	    		exp_p_l = new Coordinate( 0.6, -0.3, 0.0);
+	    		fins.setPoint(lastIndex, 0.6, 0.0); // w/ incorrect y-val.  The function should correct the y-value as above. 
+	    		
+	    		act_p_l = fins.getFinPoints()[lastIndex];
+	    		assertEquals( exp_p_l.x, act_p_l.x, EPSILON);
+	    		assertEquals( exp_p_l.y, act_p_l.y, EPSILON);
+	    	}
+		}
+	}
+    
+    @Test
+    public void testSetPoint_otherPoint() {
+    	// combine the simple case with the complicated to ensure that the simple case is flagged, tested, and debugged before running the more complicated case...
+    	{ // setting points on a Tube Body is the simpler case. Test this first: 
+	    	Rocket rkt = createFinsOnTube();
+	    	FreeformFinSet fins = (FreeformFinSet) rkt.getChild(0).getChild(0).getChild(0); 
+	    	
+	    	// all points are restricted to be outside the parent body:
+		    Coordinate exp_pt = fins.getFinPoints()[0];
+		    fins.setPoint(0, -0.6, 0);
+		    Coordinate act_pt = fins.getFinPoints()[0];
+		    assertEquals( exp_pt.x, act_pt.x, EPSILON);
+		    // the last point is already clamped to the body; It should remain so.
+		    assertEquals( 0.0, act_pt.y, EPSILON);
+    	}
+    	{ // more transitions trigger more complicated positioning math:  
+    		Rocket rkt = createFinsOnTransition();
+			FreeformFinSet fins = (FreeformFinSet) rkt.getChild(0).getChild(0).getChild(0);
+			assertEquals( 1, fins.getFinCount());
+			
+			Coordinate act_p_l;
+	    	Coordinate exp_p_l;
+	    	
+	    	final int testIndex = 1;
+	    	// move point, and verify that it is coerced to be outside the parent body:
+    		exp_p_l = new Coordinate( 0.2, -0.1, 0.0);
+    		fins.setPoint( testIndex, 0.2, -0.2); // incorrect y-val.  The function should correct the y-value to above. 
+    		
+    		act_p_l = fins.getFinPoints()[ testIndex ];
+    		assertEquals( exp_p_l.x, act_p_l.x, EPSILON);
+    		assertEquals( exp_p_l.y, act_p_l.y, EPSILON);
+    	}
+    }
+
+    @Test
+    public void testSetOffset_triggerClampCorrection() {
+		// test correction of last point due to moving entire fin:
+		Rocket rkt = createFinsOnTransition();
+		Transition body = (Transition) rkt.getChild(0).getChild(0);
+		FreeformFinSet fins = (FreeformFinSet) rkt.getChild(0).getChild(0).getChild(0);
+		assertEquals( 1, fins.getFinCount());
+		final int lastIndex = fins.getPointCount()-1;
+		assertEquals( 3, lastIndex);
+		
+		final double initXOffset = fins.getAxialOffset();
+		assertEquals( 0.4, initXOffset, EPSILON); // pre-condition
+		final double newXTop = 0.85;
+		final double expFinOffset = 0.6;
+		final double expLength = body.getLength() - expFinOffset;
+		fins.setAxialOffset( Position.TOP, newXTop);
+		// fin start: 0.4 => 0.8  [body]
+		// fin end:   0.8 => 0.99 [body]  
+	    assertEquals( expFinOffset, fins.getAxialOffset(), EPSILON);
+	    assertEquals( expLength, fins.getLength(), EPSILON);
+	    
+	    // SHOULD DEFINITELY CHANGE
+	    Coordinate actualLastPoint = fins.getFinPoints()[ lastIndex];
+		assertEquals( 0.4, actualLastPoint.x, EPSILON);
+		assertEquals( -0.2, actualLastPoint.y, EPSILON);
+    }
+    
+	@Test
+	public void testComputeCM_ZeroSweepSimpleTrapezoid() throws Exception {
+			// This is a trapezoid.  Height 1, root 1, tip 1/2 no sweep.
+			// It can be decomposed into a rectangle followed by a triangle
+			//  +---+
+			//  |    \
+			//  |     \
+			//  +------+
+			FreeformFinSet fins = new FreeformFinSet();
+			fins.setFinCount(1);
+			Coordinate[] points = new Coordinate[] {
+					new Coordinate(0, 0),
+					new Coordinate(0, 1),
+					new Coordinate(.5, 1),
+					new Coordinate(1, 0)
+			};
+			fins.setPoints(points);
+			Coordinate coords = fins.getCG();
+			assertEquals(0.75, fins.getFinWettedArea(), 0.001);
+			assertEquals(0.3889, coords.x, 0.001);
+			assertEquals(0.4444, coords.y, 0.001);
+	}
+	
+	@Test
+	public void testComputeCM_ZeroSweepComplicatedTrapezoid() throws Exception {
+			// This is the same trapezoid as previous free form, but it has
+			// some extra points along the lines.
+			FreeformFinSet fins = new FreeformFinSet();
+			fins.setFinCount(1);
+			Coordinate[] points = new Coordinate[] {
+					new Coordinate(0, 0),
+					new Coordinate(0, .5),
+					new Coordinate(0, 1),
+					new Coordinate(.25, 1),
+					new Coordinate(.5, 1),
+					new Coordinate(.75, .5),
+					new Coordinate(1, 0)
+			};
+			fins.setPoints(points);
+			Coordinate coords = fins.getCG();
+			assertEquals(0.75, fins.getFinWettedArea(), 0.001);
+			assertEquals(0.3889, coords.x, 0.001);
+			assertEquals(0.4444, coords.y, 0.001);
+	}
+		
+	@Test
+	public void testComputeCM_CoincidentPoints() throws Exception {
+			// This is the same trapezoid as previous free form, but it has
+			// some extra points which are very close to previous points.
+			// in particular for points 0 & 1,
+			// y0 + y1 is very small.
+			FreeformFinSet fins = new FreeformFinSet();
+			fins.setFinCount(1);
+			Coordinate[] points = new Coordinate[] {
+					new Coordinate(0, 0),
+					new Coordinate(0, 1E-15),
+					new Coordinate(0, 1),
+					new Coordinate(1E-15, 1),
+					new Coordinate(.5, 1),
+					new Coordinate(.5, 1 - 1E-15),
+					new Coordinate(1, 1E-15),
+					new Coordinate(1, 0)
+			};
+			fins.setPoints(points);
+			Coordinate coords = fins.getCG();
+			assertEquals(0.75, fins.getFinWettedArea(), 0.001);
+			assertEquals(0.3889, coords.x, 0.001);
+			assertEquals(0.4444, coords.y, 0.001);
+		
+		
+	}
+	
+    @Test
+    public void testTranslatePoints() throws IllegalFinPointException {
+    	final Rocket rkt = new Rocket();
+        final AxialStage stg = new AxialStage();
+	    rkt.addChild(stg);
+	    BodyTube body = new BodyTube(2.0, 0.01);
+	    stg.addChild(body);
+	   
+	    // Fin length = 1
+	    // Body Length = 2
+	    //          +--+
+	    //         /   |
+	    //        /    |
+	    //   +---+-----+---+
+	    //
+	    FreeformFinSet fins = new FreeformFinSet();
+	    fins.setFinCount(1);
+	    Coordinate[] initPoints = new Coordinate[] {
+	                   new Coordinate(0, 0),
+	                   new Coordinate(0.5, 1),
+	                   new Coordinate(1, 1),
+	                   new Coordinate(1, 0)
+	    };
+	    fins.setPoints(initPoints);
+	    body.addChild(fins);
+	    
+	    final Position[] pos={Position.TOP, Position.MIDDLE, Position.MIDDLE, Position.BOTTOM};
+	    final double[] offs = {1.0, 0.0, 0.4, -0.2};
+	    final double[] expOffs = {1.0, 0.5, 0.9, 0.8};
+	    for( int caseIndex=0; caseIndex < pos.length; ++caseIndex ){
+	    	fins.setAxialOffset( pos[caseIndex], offs[caseIndex]);
+	    	final double x_delta = fins.asPositionValue(Position.TOP);
+	           
+	    	Coordinate actualPoints[] = fins.getFinPoints();
+	                   
+	    	final String rawPointDescr = "\n"+fins.toDebugDetail().toString()+"\n>> axial offset: "+x_delta;
+	       
+	    	Coordinate[] displayPoints = FinSet.translatePoints( actualPoints, x_delta, 0);	    
+	    	for( int index=0; index < displayPoints.length; ++index){
+	    		assertEquals(String.format("Bad Fin Position.x (%6.2g via:%s at point: %d) %s\n",offs[caseIndex], pos[caseIndex].name(), index, rawPointDescr),
+	    				(initPoints[index].x + expOffs[caseIndex]), displayPoints[index].x, EPSILON);
+	    		assertEquals(String.format("Bad Fin Position.y (%6.2g via:%s at point: %d) %s\n",offs[caseIndex], pos[caseIndex].name(), index, rawPointDescr),
+	    				initPoints[index].y, displayPoints[index].y, EPSILON);
+       		}
+    	}
+	                   
+	}
+
+	
+    @Test
+    public void testForNonIntersection() throws IllegalFinPointException {
+           final Rocket rkt = new Rocket();
+           final AxialStage stg = new AxialStage();
+           rkt.addChild(stg);
+           BodyTube body = new BodyTube(2.0, 0.01);
+           stg.addChild(body);
+           
+           // Fin length = 1
+           // Body Length = 2
+           //          +--+
+           //         /   |
+           //        /    |
+           //   +---+-----+---+
+           //
+           FreeformFinSet fins = new FreeformFinSet();
+           fins.setFinCount(1);
+           Coordinate[] initPoints = new Coordinate[] {
+                           new Coordinate(0, 0),
+                           new Coordinate(0.5, 1),
+                           new Coordinate(1, 1),
+                           new Coordinate(1, 0)
+           };
+           fins.setPoints(initPoints);
+           body.addChild(fins);
+           
+           assertFalse( " Fin detects false positive intersection in fin points: ", fins.intersects());
+   }
+    
+    @Test
+    public void testForIntersection() throws IllegalFinPointException {
+    	final Rocket rkt = new Rocket();
+    	final AxialStage stg = new AxialStage();
+    	rkt.addChild(stg);
+    	BodyTube body = new BodyTube(2.0, 0.01);
+    	stg.addChild(body);
+	   
+    	// An obviously intersecting fin:
+    	//        +---+
+    	//         \ /   
+    	//         / \   
+    	//   +----+---+---+
+    	//
+    	FreeformFinSet fins = new FreeformFinSet();
+    	fins.setFinCount(1);
+    	Coordinate[] initPoints = new Coordinate[] {
+	                   new Coordinate(0, 0),
+	                   new Coordinate(1, 1),
+	                   new Coordinate(0, 1),
+	                   new Coordinate(1, 0)
+    	};
+    	// this line throws an exception? 
+    	fins.setPoints(initPoints);
+    	body.addChild(fins);
+	   
+    	// this *already* has detected the intersection, and aborted...
+    	Coordinate p1 = fins.getFinPoints()[1];
+    	// ... which makes a rather hard-to-test functionality...
+    	assertThat( "Fin Set failed to detect an intersection! ", p1.x, not(equalTo(initPoints[1].x)));
+    	assertThat( "Fin Set failed to detect an intersection! ", p1.y, not(equalTo(initPoints[1].y)));
+    }
+	
+	@Test
+	public void testWildmanVindicatorShape() throws Exception {
+		// This fin shape is similar to the aft fins on the Wildman Vindicator.
+		// A user noticed that if the y values are similar but not equal,
+		// the computation of CP was incorrect because of numerical instability.
+		//
+		//     +-----------------+
+		//      \                 \
+		//       \                 \
+		//        +                 \         +x
+		//       /                   \        <=+
+		//      +---------------------+
+		//
+		FreeformFinSet fins = new FreeformFinSet();
+		fins.setFinCount(1);
+		Coordinate[] points = new Coordinate[] {
+				new Coordinate(0, 0),
+				new Coordinate(0.02143125, 0.01143),
+				new Coordinate(0.009524999999999999, 0.032543749999999996),
+				new Coordinate(0.041275, 0.032537399999999994),
+				new Coordinate(0.066675, 0)
+		};
+		fins.setPoints(points);
+		Coordinate coords = fins.getCG();
+		assertEquals(0.00130, fins.getFinWettedArea(), 0.00001);
+		assertEquals(0.03423, coords.x, 0.00001);
+		assertEquals(0.01427, coords.y, 0.00001);
+		
+		BodyTube bt = new BodyTube();
+		bt.addChild(fins);
+		FinSetCalc calc = new FinSetCalc(fins);
+		FlightConditions conditions = new FlightConditions(null);
+		AerodynamicForces forces = new AerodynamicForces();
+		WarningSet warnings = new WarningSet();
+		calc.calculateNonaxialForces(conditions, forces, warnings);
+		//System.out.println(forces);
+		assertEquals(0.023409, forces.getCP().x, 0.0001);
+	}
+	
+	@Test
+	public void testGenerateBodyPoints_conicalTransition_fromFin(){
+		Rocket rkt = createFinsOnTransition();
+		FinSet fins = (FreeformFinSet) rkt.getChild(0).getChild(0).getChild(0); 
+
+		Coordinate[] finPoints = FinSet.translatePoints( fins.getFinPoints_fromFin(),  0.0, fins.getBodyRadius(0));
+		final Coordinate exp_startp = finPoints[0];
+		final Coordinate exp_endp = finPoints[ finPoints.length-1];
+
+		final Coordinate[] bodyPoints = fins.getBodyPoints();
+
+		assertEquals("Method should only generate minimal points for a conical transition fin body! ", 2, bodyPoints.length );
+		assertEquals("incorrect body points! ", exp_startp.x, bodyPoints[0].x, EPSILON);
+		assertEquals("incorrect body points! ", exp_startp.y, bodyPoints[0].y, EPSILON);
+		assertEquals("incorrect body points! ", exp_endp.x, bodyPoints[1].x, EPSILON);
+		assertEquals("incorrect body points! ", exp_endp.y, bodyPoints[1].y, EPSILON);
+	}
+	
+	@Test
+	public void testGenerateBodyPoints_ConicalTransition_fromParent(){
+		Rocket rkt = createFinsOnTransition();
+		FinSet fins = (FreeformFinSet) rkt.getChild(0).getChild(0).getChild(0); 
+
+		final double yFinFront = fins.getBodyRadius(0);
+		final Coordinate[] finPoints = FinSet.translatePoints( fins.getFinPoints(), 0.0, yFinFront );
+		final Coordinate exp_startp = finPoints[0];
+		final Coordinate exp_endp = finPoints[ finPoints.length-1];
+		
+		final Coordinate[] bodyPoints = fins.getBodyPoints();
+		
+		assertEquals("Method should only generate minimal points for a conical transition fin body! ", 2, bodyPoints.length );
+		assertEquals("incorrect body points! ", exp_startp.x, bodyPoints[0].x, EPSILON);
+		assertEquals("incorrect body points! ", exp_startp.y, bodyPoints[0].y, EPSILON);
+		assertEquals("incorrect body points! ", exp_endp.x, bodyPoints[1].x, EPSILON);
+		assertEquals("incorrect body points! ", exp_endp.y, bodyPoints[1].y, EPSILON);
+	}
+	
+	
+
+	@Test
+	public void testGenerateBodyPoints_GenericBase(){
+		{
+			Rocket rkt = createFinsOnBoattail();
+			FinSet fins = (FreeformFinSet) rkt.getChild(0).getChild(0).getChild(0); 
+
+			final double yFinFront = fins.getBodyRadius(0);
+			final Coordinate[] finPoints = FinSet.translatePoints( fins.getFinPoints(), 0.0, yFinFront );
+			
+			final Coordinate exp_startp = finPoints[0];
+			final Coordinate exp_endp = finPoints[ finPoints.length-1];
+			
+			final Coordinate[] bodyPoints = fins.getBodyPoints();
+			
+			// trivial, and uninteresting:
+			assertEquals("incorrect body points! ", exp_startp.x, bodyPoints[0].x, EPSILON);
+			assertEquals("incorrect body points! ", exp_startp.y, bodyPoints[0].y, EPSILON);
+			
+			// n.b.: This should match EXACTLY the end point of the fin. (in fin coordinates)
+			assertEquals("incorrect body points! ",  exp_endp.x, bodyPoints[bodyPoints.length-1].x, EPSILON);
+			assertEquals("incorrect body points! ",  exp_endp.y, bodyPoints[bodyPoints.length-1].y, EPSILON);
+			
+			{// the tests within this scope is are rather fragile, and may break for reasons other than bugs :(
+				// the number of points is somewhat arbitrary, but if this test fails, the rest *definitely* will.
+				assertEquals("Method is generating how many points, in general? ", 13, bodyPoints.length );
+
+				assertEquals("incorrect body points! ", 0.01, bodyPoints[2].x, EPSILON);
+				assertEquals("incorrect body points! ", 0.09615, bodyPoints[2].y, EPSILON);
+				
+				assertEquals("incorrect body points! ", 0.04, bodyPoints[8].x, EPSILON);
+				assertEquals("incorrect body points! ", 0.08353, bodyPoints[8].y, EPSILON);
+				
+				assertEquals("incorrect body points! ", 0.055, bodyPoints[11].x, EPSILON);
+				assertEquals("incorrect body points! ", 0.07264, bodyPoints[11].y, EPSILON);
+			}
+			
+		}
+	}
+
+	@Test
+	public void testFinCentroid_simpleBase(){
+		// Start with a simple fin, on a simple body.  
+		final Rocket rkt = createFinsOnTube();
+		assertTrue(" Expected a 'straight' BodyTube as parent!: ", ( rkt.getChild(0).getChild(0) instanceof BodyTube));
+		FreeformFinSet fins = (FreeformFinSet) rkt.getChild(0).getChild(0).getChild(0); 
+		assertEquals("Calculated fin count is wrong: ", 1, fins.getFinCount() );
+		
+		// fin is a simple trapezoid against a "flat" parent body:
+	    //          +--+        Fin length = 0.4
+	    //         /   |        Fin Height = 0.4
+	    //        /    |        Fin Sweep =  0.2
+	    //   +---+-----+---+
+	    final double avgChord = 0.3;
+		final double expFinArea = 0.4*avgChord;
+		assertEquals("Calculated fin area is wrong: ", expFinArea, fins.getFinWettedArea(), EPSILON);
+		
+	}
+
+	@Test
+	public void testFinCentroid_conicBase(){
+		// next, calculate with a more complicated fin, and with a linearly-varying body:  
+		final Rocket rkt = createFinsOnTransition();
+		Transition body = (Transition) rkt.getChild(0).getChild(0); 
+		FinSet fins = (FreeformFinSet) rkt.getChild(0).getChild(0).getChild(0); 
+					
+		assertEquals("Calculated fin count is wrong: ", 1, fins.getFinCount() );
+		assertEquals("Transition does not have a conical shape! ", Shape.CONICAL, body.getType());
+		
+	    // Fin length = 0.4
+	    // Body Length = 1.0       
+	    //           +----+        
+	    //        /      +		   
+	    //     /        +           
+	    // +---+       +           
+	    //     +---+  +            
+	    //         +---+           
+		//
+		// Coordinate( 0.0, 0.0),
+		// Coordinate( 0.3, 0.2),
+		// Coordinate( 0.6, 0.2),
+		// Coordinate( 0.4,-0.2)
+
+		
+		// fin is a simple trapezoid against a linearly changing body...
+		final double expectedWettedArea = 0.13;
+		final double actualWettedArea = fins.getFinWettedArea();
+		Coordinate wcg = fins.getCG(); // relative to parent
+		assertEquals("Calculated fin area is wrong: ", expectedWettedArea, actualWettedArea, EPSILON);
+		assertEquals("Calculated fin centroid is wrong! ", 0.3256, wcg.x, EPSILON);
+		assertEquals("Calculated fin centroid is wrong! ", 0.830769, wcg.y, EPSILON);
+	
+		{
+			fins.setTabHeight(0.1);
+			fins.setTabLength(0.1);
+			fins.setTabPositionMethod(Position.TOP);
+			fins.setTabShift(0.2);
+			
+			// fin is a simple trapezoid against a linearly changing body...
+			// height is set s.t. the tab trailing edge height == 0 
+			final double expectedTabArea = (fins.getTabHeight())*3/4 * fins.getTabLength();
+			final double expectedTotalVolume = (expectedWettedArea + expectedTabArea)*fins.getThickness();
+			final double actualTotalVolume = fins.getComponentVolume();
+			assertEquals("Calculated fin volume is wrong: ", expectedTotalVolume, actualTotalVolume, EPSILON);
+			
+			Coordinate tcg = fins.getCG(); // relative to parent.  also includes fin tab CG.
+			assertEquals("Calculated fin centroid is wrong! ", 0.32121212, tcg.x, EPSILON);
+			assertEquals("Calculated fin centroid is wrong! ", 0.820303, tcg.y, EPSILON);
+		}
+	}
+
+	@Test
+	public void testFinCentroid_genericBase (){
+		Rocket rkt = createFinsOnBoattail();
+		Transition body = (Transition) rkt.getChild(0).getChild(0);
+		FreeformFinSet fins = (FreeformFinSet) rkt.getChild(0).getChild(0).getChild(0); 
+					
+		assertEquals("Calculated fin count is wrong: ", 1, fins.getFinCount() );
+		assertEquals("Transition does not have an ellipsoidal shape! ", Shape.ELLIPSOID, body.getType());
+		assertEquals("Transition has unexpected shape parameter: ", 0.5, body.getShapeParameter(), EPSILON);
+		
+		assertEquals("Fin Offset doesn't match! ", 0.02, fins.getAxialOffset(), EPSILON);
+		assertThat(" Fin Offset Method doesn't match!", Position.TOP, equalTo(fins.getRelativePositionMethod()));
+		
+	    //           +----+        
+	    //        /      +
+	    //     /        +           
+	    // +------     +           
+	    //        --- +            
+	    //           --+           
+		//body.setForeRadius(0.1);
+		//body.setLength(0.1);
+		//body.setAftRadius(0.04);
+		//
+		//fins.setAxialOffset( Position.TOP, 0.02);
+		//fins.setPoints(new Coordinate[] {
+		//        new Coordinate( 0.0,   0.0),
+		//        new Coordinate( 0.06,  0.04),
+		//        new Coordinate( 0.08,  0.04),
+		//        new Coordinate( 0.06, -0.03029),
+		
+		final double expectedFinArea = 0.0025813603; // estimate
+		final double actualFinArea = fins.getFinWettedArea();
+		Coordinate centroid = fins.getCG(); // relative to parent
+		assertEquals("Calculated fin area is wrong: ", expectedFinArea, actualFinArea, EPSILON);
+		assertEquals("Calculated fin centroid is wrong! ", 0.04806, centroid.x, EPSILON);
+		assertEquals("Calculated fin centroid is wrong! ", 0.1066543, centroid.y, EPSILON);
+	}
+	
+	@Test
+	public void testFreeFormCGWithNegativeY() throws Exception {
+		// A user submitted an ork file which could not be simulated because the fin
+		// was constructed on a tail cone.  It so happened that for one pair of points
+		// y_n = - y_(n+1) which caused a divide by zero and resulted in CGx = NaN.
+		
+		// This Fin set is constructed to have the same problem.  It is a square and rectangle
+		// where the two trailing edge corners of the rectangle satisfy y_0 = -y_1
+		//
+		//    +=> +x
+		//    0    1    2    3  
+		//    |    |    |    |
+		//     
+		//    +---------+      - +1
+		//    |         |             ^ 
+		//    |         |             | +y    
+		//----+----+    |      -  0   +  
+		//         |    |
+		//         |    |
+		//         +----+      - -1
+		//         |
+		//         |		
+		FreeformFinSet fins = new FreeformFinSet();
+		fins.setCrossSection( CrossSection.SQUARE );  // to ensure uniform density
+		fins.setFinCount(1);
+		// fins.setAxialOffset( Position.BOTTOM, 1.0);  // ERROR: no parent!
+		Coordinate[] points = new Coordinate[] {
+				new Coordinate(0, 0),
+				new Coordinate(0, 1),
+				new Coordinate(2, 1),
+				new Coordinate(2, -1),
+				new Coordinate(1, -1),
+				new Coordinate(1, 0)
+		};
+		fins.setPoints( points);
+		fins.setFilletRadius( 0.0);
+		fins.setTabHeight( 0.0);
+		fins.setMaterial( Material.newMaterial(Type.BULK, "dummy", 1.0, true));
+
+//		assertEquals( 3.0, fins.getFinWettedArea(), EPSILON);		
+//		
+//		Coordinate cg = fins.getCG();
+//		assertEquals( 1.1666, cg.x, EPSILON);
+//		assertEquals( 0.1666, cg.y, EPSILON);
+//		assertEquals( 0.0, cg.z, EPSILON);
+//		assertEquals( 0.009, cg.weight, EPSILON);
+
+	}
+	
+	
+	@Test
+	public void testConvertTrapezoidToFreeform() {
+		final FinSet sourceSet = new EllipticalFinSet();
+		sourceSet.setName("fins-to-convert");
+		Material mat = Material.newMaterial(Type.BULK, "foo", 0.1, true);
+		sourceSet.setBaseRotation(1.1);
+		sourceSet.setCantAngle(0.001);
+		sourceSet.setCGOverridden(true);
+		sourceSet.setColor(Color.BLACK);
+		sourceSet.setComment("cmt");
+		sourceSet.setCrossSection(CrossSection.ROUNDED);
+		sourceSet.setFinCount(5);
+		sourceSet.setFinish(Finish.ROUGH);
+		sourceSet.setLineStyle(LineStyle.DASHDOT);
+		sourceSet.setMassOverridden(true);
+		sourceSet.setMaterial(mat);
+		sourceSet.setOverrideCGX(0.012);
+		sourceSet.setOverrideMass(0.0123);
+		sourceSet.setOverrideSubcomponents(true);
+
+		sourceSet.setAxialOffset(Position.ABSOLUTE, 0.1);
+		
+
+		sourceSet.setTabHeight(0.01);
+		sourceSet.setTabLength(0.02);
+		sourceSet.setTabPositionMethod( Position.BOTTOM);
+		sourceSet.setTabShift(0.015);
+		sourceSet.setThickness(0.005);
+		
+		BodyTube dummyTube = new BodyTube( 0.2, 0.01, 0.001 );
+		dummyTube.addChild( sourceSet);
+		
+		FreeformFinSet destSet = FreeformFinSet.convertFinSet( sourceSet);
+		
+		assertEquals( sourceSet.getName(), destSet.getName());
+		
+	}
+	
+	@Test
+	public void testConvertEllipticaToFreeform() {
+		final FinSet sourceSet = new EllipticalFinSet();
+		sourceSet.setName("fins-to-convert");
+	
+		Material mat = Material.newMaterial(Type.BULK, "foo", 0.1, true);
+		
+		sourceSet.setBaseRotation(1.1);
+		sourceSet.setCantAngle(0.001);
+		sourceSet.setCGOverridden(true);
+		sourceSet.setColor(Color.BLACK);
+		sourceSet.setComment("cmt");
+		sourceSet.setCrossSection(CrossSection.ROUNDED);
+		sourceSet.setFinCount(5);
+		sourceSet.setFinish(Finish.ROUGH);
+		sourceSet.setLineStyle(LineStyle.DASHDOT);
+		sourceSet.setMassOverridden(true);
+		sourceSet.setMaterial(mat);
+		sourceSet.setOverrideCGX(0.012);
+		sourceSet.setOverrideMass(0.0123);
+		sourceSet.setOverrideSubcomponents(true);
+		sourceSet.setAxialOffset(Position.ABSOLUTE, 0.1);
+		
+		sourceSet.setTabHeight(0.01);
+		sourceSet.setTabLength(0.02);
+		sourceSet.setTabPositionMethod( Position.BOTTOM);
+		sourceSet.setTabShift(0.015);
+		sourceSet.setThickness(0.005);
+		
+		FreeformFinSet destSet= FreeformFinSet.convertFinSet((FinSet) sourceSet.copy());
+		
+		assertEquals( sourceSet.getName(), destSet.getName());
+
+		
+		
+	}
+	
+
+	
+}

--- a/core/test/net/sf/openrocket/rocketcomponent/RocketTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/RocketTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 
+import net.sf.openrocket.rocketcomponent.RocketComponent.Position;
 import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.MathUtil;
 import net.sf.openrocket.util.TestRockets;
@@ -59,9 +60,8 @@ public class RocketTest extends BaseTestCase {
 		final double EPSILON = MathUtil.EPSILON;
 		Rocket rocket = TestRockets.makeEstesAlphaIII();
 			
-//		String treeDump = rocket.toDebugTree();
-//		System.err.println(treeDump);
-		
+		String treeDump = rocket.toDebugTree();
+
 		AxialStage stage= (AxialStage)rocket.getChild(0);
 		
 		NoseCone nose = (NoseCone)stage.getChild(0);
@@ -90,19 +90,19 @@ public class RocketTest extends BaseTestCase {
 			
 			{	
 				cc = fins;
-				expLoc = new Coordinate(0.22,0,0);
+				expLoc = new Coordinate(0.22,  body.getOuterRadius(), 0);
 				actLoc = cc.getLocations()[0];
-				assertThat(cc.getName()+" not positioned correctly: ", actLoc, equalTo(expLoc));
+				assertThat(cc.getName()+" not positioned correctly: "+treeDump, actLoc, equalTo(expLoc));
 				
 				cc = lug;
 				expLoc = new Coordinate(0.181, 0.015, 0);
 				actLoc = cc.getLocations()[0];
-				assertThat(cc.getName()+" not positioned correctly: ", actLoc, equalTo(expLoc));
+				assertThat(cc.getName()+" not positioned correctly: "+treeDump, actLoc, equalTo(expLoc));
 				
 				cc = mmt;
 				expLoc = new Coordinate(0.203,0,0);
 				actLoc = cc.getLocations()[0];
-				assertThat(cc.getName()+" not positioned correctly: ", actLoc, equalTo(expLoc));
+				assertThat(cc.getName()+" not positioned correctly: "+treeDump, actLoc, equalTo(expLoc));
 				{
 					cc = block;
 					expLoc = new Coordinate(0.203,0,0);
@@ -149,4 +149,51 @@ public class RocketTest extends BaseTestCase {
 		}
 	}
 	
+	@Test
+	public void testRelativePositioning(){
+		final double EPSILON = MathUtil.EPSILON;
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		
+		AxialStage stage= (AxialStage)rocket.getChild(0);
+		
+		//NoseCone nose = (NoseCone)stage.getChild(0);
+		BodyTube body = (BodyTube)stage.getChild(1);
+		FinSet fins = (FinSet)body.getChild(0);
+//		LaunchLug lug = (LaunchLug)body.getChild(1);
+//		InnerTube mmt = (InnerTube)body.getChild(2);
+//		EngineBlock block = (EngineBlock)mmt.getChild(0);
+//		Parachute chute = (Parachute)body.getChild(3);
+//		CenteringRing center = (CenteringRing)body.getChild(4);
+		
+//		String treeDump = rocket.toDebugTree();
+//		System.err.println(treeDump);
+
+		// less test, more documentation of existing lengths
+		final double expBodyLength = 0.2;
+		final double actBodyLength = body.getLength();
+		assertEquals( body.getName()+" has an unexpected length: ", expBodyLength, actBodyLength, EPSILON);
+		
+		final double expFinLength = 0.05;
+		final double actFinLength = fins.getLength();
+		assertEquals( fins.getName()+" has an unexpected length: ", expFinLength, actFinLength, EPSILON);
+		
+		// diff = 0.15 = (0.2 - 0.05)
+		
+		// vv ACTUAL Test vv
+		RocketComponent cc = fins;
+		final Position[] pos={Position.TOP, Position.MIDDLE, Position.MIDDLE, Position.BOTTOM};
+        final double[] expOffs = {0.10, 0.0, 0.04, -0.02};
+        final double[] expPos =  {0.10, 0.075, 0.115, 0.13};
+        for( int caseIndex=0; caseIndex < pos.length; ++caseIndex ){
+            cc.setAxialOffset( pos[caseIndex], expOffs[caseIndex]);
+            		
+            final double actOffset = cc.getAxialOffset();
+            assertEquals(String.format(" Relative Positioning doesn't match for: (%6.2g via:%s)\n", expOffs[caseIndex], pos[caseIndex].name()),
+           		 expOffs[caseIndex], actOffset, EPSILON);
+            
+            final double actPos = cc.asPositionValue(Position.TOP);
+            assertEquals(String.format(" Relative Positioning doesn't match for: (%6.2g via:%s)\n", expOffs[caseIndex], pos[caseIndex].name()),
+           		 expPos[caseIndex], actPos, EPSILON);
+        }
+	}
 }

--- a/core/test/net/sf/openrocket/simulation/customexpression/TestExpressions.java
+++ b/core/test/net/sf/openrocket/simulation/customexpression/TestExpressions.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 public class TestExpressions extends BaseTestCase {
 	
+	@SuppressWarnings("unused")
 	@Test
 	public void testExpressions() {
 		// TODO Auto-generated constructor stub

--- a/core/test/net/sf/openrocket/util/PointWeightTest.java
+++ b/core/test/net/sf/openrocket/util/PointWeightTest.java
@@ -1,0 +1,57 @@
+package net.sf.openrocket.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import net.sf.openrocket.util.MathUtil;
+
+public class PointWeightTest {
+	
+	private static final double EPSILON = MathUtil.EPSILON;
+
+	@Test
+	public void testAdd() {
+
+		PointWeight x = new PointWeight(1,2,1,1);
+		PointWeight y = new PointWeight(2,1,1,2);
+		
+		PointWeight sum = x.add(y);
+		
+		assertEquals( 3.0, sum.w, EPSILON);
+		assertEquals( 1.66666667, sum.x, EPSILON);
+		assertEquals( 1.33333333, sum.y, EPSILON);
+		assertEquals( 1.0, sum.z, EPSILON);
+	}
+
+	@Test
+	public void testAverage() {
+
+		PointWeight x = new PointWeight(1,2,1,1);
+		PointWeight y = new PointWeight(2,1,1,2);
+		
+		PointWeight sum = x.average(y);
+		
+		assertEquals( 1.5, sum.w, EPSILON);
+		assertEquals( 1.66666667, sum.x, EPSILON);
+		assertEquals( 1.33333333, sum.y, EPSILON);
+		assertEquals( 1.0, sum.z, EPSILON);
+	}
+
+	@Test
+	public void testSubtract() {
+		PointWeight p1 = new PointWeight(1,2,1,1);
+		PointWeight p2 = new PointWeight(2,1,1,2);
+		
+		final PointWeight sum = p1.add(p2);
+		
+		final PointWeight result = sum.subtract( p2); 
+		
+		assertEquals( p1.w, result.w, EPSILON);
+		assertEquals( p1.x, result.x, EPSILON);
+		assertEquals( p1.y, result.y, EPSILON);
+		assertEquals( p1.z, result.z, EPSILON);
+	}
+
+	
+}

--- a/swing/src/net/sf/openrocket/gui/SpinnerEditor.java
+++ b/swing/src/net/sf/openrocket/gui/SpinnerEditor.java
@@ -11,7 +11,9 @@ import javax.swing.text.DefaultFormatterFactory;
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
 
+// because this editor isn't *always* used as a number editor --> see MotorConfigurationPanel
 //public class SpinnerEditor extends JSpinner.NumberEditor {
+@SuppressWarnings("serial")
 public class SpinnerEditor extends JSpinner.DefaultEditor {
 
 	public SpinnerEditor(JSpinner spinner) {

--- a/swing/src/net/sf/openrocket/gui/adaptors/DoubleModel.java
+++ b/swing/src/net/sf/openrocket/gui/adaptors/DoubleModel.java
@@ -1,15 +1,11 @@
 package net.sf.openrocket.gui.adaptors;
 
-import java.awt.event.ActionEvent;
-import java.beans.PropertyChangeEvent;
-import java.beans.PropertyChangeListener;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.EventListener;
 import java.util.EventObject;
 
-import javax.swing.AbstractAction;
 import javax.swing.AbstractSpinnerModel;
 import javax.swing.Action;
 import javax.swing.BoundedRangeModel;
@@ -68,6 +64,7 @@ public class DoubleModel implements StateChangeListener, ChangeSource, Invalidat
 	public class ValueSpinnerModel extends AbstractSpinnerModel implements Invalidatable {
 		
 		private ExpressionParser parser = new ExpressionParser();
+		
 		
 		@Override
 		public Object getValue() {
@@ -411,6 +408,9 @@ public class DoubleModel implements StateChangeListener, ChangeSource, Invalidat
 				mid.setValue(midValue);
 				updateExponentialParameters();
 			}
+			
+			DoubleModel.this.update();
+			
 			// Fire if not already firing
 			if (firing == 0)
 				fireStateChanged();
@@ -445,14 +445,16 @@ public class DoubleModel implements StateChangeListener, ChangeSource, Invalidat
 	////////////  Action model  ////////////
 	
 	@SuppressWarnings("serial")
-	private class AutomaticActionModel extends AbstractAction implements StateChangeListener, Invalidatable {
-		private boolean oldValue = false;
+	private class AutoActionModel extends BooleanModel implements StateChangeListener, Invalidatable {
 		
-		public AutomaticActionModel() {
-			oldValue = isAutomatic();
-			addChangeListener(this);
+		public AutoActionModel() {
+		    super( isAutomatic());
 		}
 		
+		public AutoActionModel( ChangeSource source, String valueName) {
+	        super( source, valueName);
+	        this.setValue( isAutomatic() );
+		}	        
 		
 		@Override
 		public boolean isEnabled() {
@@ -462,70 +464,43 @@ public class DoubleModel implements StateChangeListener, ChangeSource, Invalidat
 		@Override
 		public Object getValue(String key) {
 			if (key.equals(Action.SELECTED_KEY)) {
-				oldValue = isAutomatic();
-				return oldValue;
+				return super.getValue();
 			}
 			return super.getValue(key);
 		}
 		
 		@Override
 		public void putValue(String key, Object value) {
-			if (firing > 0) {
-				log.trace("Ignoring call to ActionModel putValue for " + DoubleModel.this.toString() +
+		    if (firing > 0) {
+				log.trace("Ignoring call to AutoActionModel putValue for " + DoubleModel.this.toString() +
 						" key=" + key + " value=" + value + ", currently firing events");
 				return;
 			}
+			
 			if (key.equals(Action.SELECTED_KEY) && (value instanceof Boolean)) {
-				log.info(Markers.USER_MARKER, "ActionModel putValue called for " + DoubleModel.this.toString() +
+				log.info(Markers.USER_MARKER, "AutoActionModel putValue called for " + DoubleModel.this.toString() +
 						" key=" + key + " value=" + value);
-				oldValue = (Boolean) value;
-				setAutomatic((Boolean) value);
+				// calls the backing BooleanModel, which is also tied to DoubleModel.this
+				super.setValue( (Boolean) value );
 			} else {
-				log.debug("Passing ActionModel putValue call to supermethod for " + DoubleModel.this.toString() +
+				log.debug("Passing AutoActionModel putValue call to supermethod for " + DoubleModel.this.toString() +
 						" key=" + key + " value=" + value);
 				super.putValue(key, value);
 			}
 		}
 		
-		// Implement a wrapper to the ChangeListeners
-		ArrayList<PropertyChangeListener> propertyChangeListeners =
-				new ArrayList<PropertyChangeListener>();
-		
-		@Override
-		public void addPropertyChangeListener(PropertyChangeListener listener) {
-			propertyChangeListeners.add(listener);
-			DoubleModel.this.addChangeListener(this);
-		}
-		
-		@Override
-		public void removePropertyChangeListener(PropertyChangeListener listener) {
-			propertyChangeListeners.remove(listener);
-			if (propertyChangeListeners.isEmpty())
-				DoubleModel.this.removeChangeListener(this);
-		}
-		
 		// If the value has changed, generate an event to the listeners
 		@Override
-		public void stateChanged(EventObject e) {
-			boolean newValue = isAutomatic();
-			if (oldValue == newValue)
-				return;
-			PropertyChangeEvent event = new PropertyChangeEvent(this, Action.SELECTED_KEY,
-					oldValue, newValue);
-			oldValue = newValue;
-			Object[] l = propertyChangeListeners.toArray();
-			for (int i = 0; i < l.length; i++) {
-				((PropertyChangeListener) l[i]).propertyChange(event);
-			}
-		}
-		
-		@Override
-		public void actionPerformed(ActionEvent e) {
-			// Setting performed in putValue
+		public void stateChanged(EventObject eo) {
+		    DoubleModel.this.update();
+			// necessary to change enabled components
+		    super.stateChanged(eo);
+		    
 		}
 		
 		@Override
 		public void invalidate() {
+		    super.invalidate();
 			DoubleModel.this.invalidate();
 		}
 	}
@@ -536,11 +511,9 @@ public class DoubleModel implements StateChangeListener, ChangeSource, Invalidat
 	 * 
 	 * @return  A compatibility layer for an Action.
 	 */
-	public Action getAutomaticAction() {
-		return new AutomaticActionModel();
+	public AutoActionModel getAutomaticAction() {
+	    return new AutoActionModel( DoubleModel.this, "Automatic");
 	}
-	
-	
 	
 	
 	
@@ -765,6 +738,7 @@ public class DoubleModel implements StateChangeListener, ChangeSource, Invalidat
 		
 		try {
 			setMethod.invoke(source, v / multiplier);
+			fireStateChanged();
 		} catch (IllegalArgumentException e) {
 			throw new BugException("Unable to invoke setMethod of " + this, e);
 		} catch (IllegalAccessException e) {
@@ -972,15 +946,26 @@ public class DoubleModel implements StateChangeListener, ChangeSource, Invalidat
 	 */
 	@Override
 	public void stateChanged(EventObject e) {
+    	update();    
+	}
+	
+    /**
+     * Called when the component changes.  Checks whether the modeled value has changed, and if
+     * it has, updates lastValue and generates ChangeEvents for all listeners of the model.
+     * 
+     * @return  returns whether this object changed or not.
+     */	
+	public boolean update(){
 		checkState(true);
 		
 		double v = getValue();
 		boolean b = isAutomatic();
 		if (lastValue == v && lastAutomatic == b)
-			return;
+			return false;
 		lastValue = v;
 		lastAutomatic = b;
 		fireStateChanged();
+		return true;
 	}
 	
 	

--- a/swing/src/net/sf/openrocket/gui/adaptors/IntegerModel.java
+++ b/swing/src/net/sf/openrocket/gui/adaptors/IntegerModel.java
@@ -23,6 +23,7 @@ import net.sf.openrocket.util.Reflection;
 import net.sf.openrocket.util.StateChangeListener;
 
 
+@SuppressWarnings("serial")
 public class IntegerModel implements StateChangeListener {
 	private static final Logger log = LoggerFactory.getLogger(IntegerModel.class);
 	

--- a/swing/src/net/sf/openrocket/gui/adaptors/PresetModel.java
+++ b/swing/src/net/sf/openrocket/gui/adaptors/PresetModel.java
@@ -23,6 +23,7 @@ import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.BugException;
 
+@SuppressWarnings("serial")
 public class PresetModel extends AbstractListModel implements ComboBoxModel, ComponentChangeListener, DatabaseListener<ComponentPreset> {
 	
 	private static final Logger log = LoggerFactory.getLogger(PresetModel.class);

--- a/swing/src/net/sf/openrocket/gui/adaptors/ValueColumn.java
+++ b/swing/src/net/sf/openrocket/gui/adaptors/ValueColumn.java
@@ -27,7 +27,7 @@ public abstract class ValueColumn extends Column {
 	}
 
 	@Override
-	public Comparator getComparator() {
+	public Comparator<Value> getComparator() {
 		return ValueComparator.INSTANCE;
 	}
 

--- a/swing/src/net/sf/openrocket/gui/components/ImageDisplayComponent.java
+++ b/swing/src/net/sf/openrocket/gui/components/ImageDisplayComponent.java
@@ -20,6 +20,7 @@ import net.sf.openrocket.util.MathUtil;
  * 
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
+@SuppressWarnings("serial")
 public class ImageDisplayComponent extends JPanel {
 	
 	private BufferedImage image;

--- a/swing/src/net/sf/openrocket/gui/components/SelectableLabel.java
+++ b/swing/src/net/sf/openrocket/gui/components/SelectableLabel.java
@@ -7,6 +7,7 @@ import javax.swing.JTextField;
 import javax.swing.UIManager;
 import javax.swing.plaf.basic.BasicTextFieldUI;
 
+@SuppressWarnings("serial")
 public class SelectableLabel extends JTextField {
 
 	public SelectableLabel() {

--- a/swing/src/net/sf/openrocket/gui/components/StarCheckBox.java
+++ b/swing/src/net/sf/openrocket/gui/components/StarCheckBox.java
@@ -7,9 +7,8 @@ import javax.swing.JLabel;
 
 import net.sf.openrocket.gui.util.Icons;
 
+@SuppressWarnings("serial")
 public class StarCheckBox extends JCheckBox {
-	
-	
 	
 	@Override
 	public void paint(Graphics g) {

--- a/swing/src/net/sf/openrocket/gui/components/StyledLabel.java
+++ b/swing/src/net/sf/openrocket/gui/components/StyledLabel.java
@@ -16,6 +16,7 @@ import javax.swing.SwingConstants;
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
 
+@SuppressWarnings("serial")
 public class StyledLabel extends JLabel {
 	
 	public enum Style {

--- a/swing/src/net/sf/openrocket/gui/components/URLLabel.java
+++ b/swing/src/net/sf/openrocket/gui/components/URLLabel.java
@@ -23,6 +23,7 @@ import net.sf.openrocket.util.BugException;
  * 
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
+@SuppressWarnings("serial")
 public class URLLabel extends SelectableLabel {
 	private static final Logger log = LoggerFactory.getLogger(URLLabel.class);
 	

--- a/swing/src/net/sf/openrocket/gui/components/UnitSelector.java
+++ b/swing/src/net/sf/openrocket/gui/components/UnitSelector.java
@@ -36,6 +36,7 @@ import net.sf.openrocket.util.StateChangeListener;
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
 
+@SuppressWarnings("serial")
 public class UnitSelector extends StyledLabel implements StateChangeListener, MouseListener,
 		ItemSelectable {
 

--- a/swing/src/net/sf/openrocket/gui/components/compass/CompassSelectionButton.java
+++ b/swing/src/net/sf/openrocket/gui/components/compass/CompassSelectionButton.java
@@ -41,8 +41,6 @@ public class CompassSelectionButton extends FlatButton implements Resettable {
 	
 	private static int minWidth = -1;
 	
-
-	@SuppressWarnings("hiding")
 	private final DoubleModel model;
 	
 	private final ChangeListener listener;

--- a/swing/src/net/sf/openrocket/gui/configdialog/AxialStageConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/AxialStageConfig.java
@@ -48,8 +48,8 @@ public class AxialStageConfig extends ComponentAssemblyConfig {
 			sepConfig = new StageSeparationConfiguration();
 			stage.getSeparationConfigurations().set( flConfig.getId(), sepConfig );
 		}
-		@SuppressWarnings("unchecked")
-		JComboBox<?> combo = new JComboBox<StageSeparationConfiguration.SeparationEvent>(
+
+		JComboBox<StageSeparationConfiguration.SeparationEvent> combo = new JComboBox<StageSeparationConfiguration.SeparationEvent>(
 				new EnumModel<StageSeparationConfiguration.SeparationEvent>( sepConfig, "SeparationEvent", 
 					new StageSeparationConfiguration.SeparationEvent[] {
 						StageSeparationConfiguration.SeparationEvent.UPPER_IGNITION,

--- a/swing/src/net/sf/openrocket/gui/configdialog/BodyTubeConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/BodyTubeConfig.java
@@ -1,6 +1,7 @@
 package net.sf.openrocket.gui.configdialog;
 
 
+import javax.swing.BoundedRangeModel;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -23,7 +24,7 @@ import net.sf.openrocket.unit.UnitGroup;
 @SuppressWarnings("serial")
 public class BodyTubeConfig extends RocketComponentConfig {
 
-	private DoubleModel maxLength;
+	
 	private static final Translator trans = Application.getTranslator();
 
 	public BodyTubeConfig(OpenRocketDocument d, RocketComponent c) {
@@ -31,72 +32,91 @@ public class BodyTubeConfig extends RocketComponentConfig {
 
 		JPanel panel = new JPanel(new MigLayout("gap rel unrel", "[][65lp::][30lp::][]", ""));
 
-
-
 		////  Body tube length
 		panel.add(new JLabel(trans.get("BodyTubecfg.lbl.Bodytubelength")));
 
-		maxLength = new DoubleModel(2.0);
-		DoubleModel length = new DoubleModel(component, "Length", UnitGroup.UNITS_LENGTH, 0);
+		final DoubleModel maxLengthModel = new DoubleModel(2.0);
+		final DoubleModel lengthModel = new DoubleModel(component, "Length", UnitGroup.UNITS_LENGTH, 0);
+		final JSpinner lengthSpinner = new JSpinner(lengthModel.getSpinnerModel());
+		lengthSpinner.setEditor(new SpinnerEditor(lengthSpinner));
+		panel.add(lengthSpinner, "growx");
 
-		JSpinner spin = new JSpinner(length.getSpinnerModel());
-		spin.setEditor(new SpinnerEditor(spin));
-		panel.add(spin, "growx");
-
-		panel.add(new UnitSelector(length), "growx");
-		panel.add(new BasicSlider(length.getSliderModel(0, 0.5, maxLength)), "w 100lp, wrap");
-
-
+		final UnitSelector lengthUnits = new UnitSelector(lengthModel);
+		panel.add( lengthUnits, "growx");
+		
+		final BoundedRangeModel lengthSliderModel = lengthModel.getSliderModel(0, 0.5, maxLengthModel);
+		final BasicSlider lengthSlider = new BasicSlider( lengthSliderModel );
+		
+		panel.add( lengthSlider, "w 100lp, wrap");
+		
+		
 		//// Body tube diameter
 		panel.add(new JLabel(trans.get("BodyTubecfg.lbl.Outerdiameter")));
+		
+		final DoubleModel outerRadiusModel = new DoubleModel(component, "OuterRadius", 2, UnitGroup.UNITS_LENGTH, 0);
+		final JSpinner orSpinner = new JSpinner(outerRadiusModel.getSpinnerModel());
+		orSpinner.setEditor(new SpinnerEditor(orSpinner));
+		panel.add(orSpinner, "growx");
 
-		DoubleModel od = new DoubleModel(component, "OuterRadius", 2, UnitGroup.UNITS_LENGTH, 0);
-		// Diameter = 2*Radius
+		final UnitSelector orUnits = new UnitSelector(outerRadiusModel);
+		panel.add( orUnits, "growx");
+		final BasicSlider orSlider = new BasicSlider(outerRadiusModel.getSliderModel(0, 0.04, 0.2));
+		panel.add( orSlider, "w 100lp, wrap 0px");
 
-		spin = new JSpinner(od.getSpinnerModel());
-		spin.setEditor(new SpinnerEditor(spin));
-		panel.add(spin, "growx");
-
-		panel.add(new UnitSelector(od), "growx");
-		panel.add(new BasicSlider(od.getSliderModel(0, 0.04, 0.2)), "w 100lp, wrap 0px");
-
-		JCheckBox check = new JCheckBox(od.getAutomaticAction());
-		//// Automatic
+        //// Automatic ?
+		final BooleanModel autoRadius = outerRadiusModel.getAutomaticAction();
+		autoRadius.addEnableComponent( orSpinner, false);
+		autoRadius.addEnableComponent( orUnits, false);
+		autoRadius.addEnableComponent( orSlider, false);
+		
+		final JCheckBox check = new JCheckBox( autoRadius);
 		check.setText(trans.get("BodyTubecfg.checkbox.Automatic"));
-		panel.add(check, "skip, span 2, wrap");
+		panel.add( check, "skip, span 2, wrap");
+	
 
+		////  Inner diameter (Diameter = 2*Radius
+        panel.add(new JLabel(trans.get("BodyTubecfg.lbl.Innerdiameter")));
+		
+		final DoubleModel innerRadiusModel = new DoubleModel(component, "InnerRadius", 2, UnitGroup.UNITS_LENGTH, 0);
+		final JSpinner irSpinner = new JSpinner(innerRadiusModel.getSpinnerModel());
+		irSpinner.setEditor(new SpinnerEditor(irSpinner));
+		panel.add(irSpinner, "growx");
 
-		////  Inner diameter
-		panel.add(new JLabel(trans.get("BodyTubecfg.lbl.Innerdiameter")));
-
-		// Diameter = 2*Radius
-		DoubleModel m = new DoubleModel(component, "InnerRadius", 2, UnitGroup.UNITS_LENGTH, 0);
-
-
-		spin = new JSpinner(m.getSpinnerModel());
-		spin.setEditor(new SpinnerEditor(spin));
-		panel.add(spin, "growx");
-
-		panel.add(new UnitSelector(m), "growx");
-		panel.add(new BasicSlider(m.getSliderModel(new DoubleModel(0), od)), "w 100lp, wrap");
-
-
+		final UnitSelector irUnits = new UnitSelector(innerRadiusModel);
+		panel.add( irUnits, "growx");
+		final BasicSlider irSlider = new BasicSlider(innerRadiusModel.getSliderModel(new DoubleModel(0), outerRadiusModel));
+		panel.add( irSlider, "w 100lp, wrap");
+		
+		
 		////  Wall thickness
 		panel.add(new JLabel(trans.get("BodyTubecfg.lbl.Wallthickness")));
+		
+		final DoubleModel thicknessModel = new DoubleModel(component, "Thickness", UnitGroup.UNITS_LENGTH, 0);
+		innerRadiusModel.addChangeListener( thicknessModel);
+		thicknessModel.addChangeListener( innerRadiusModel);
+		
+		final JSpinner thicknessSpinner = new JSpinner(thicknessModel.getSpinnerModel());
+		thicknessSpinner.setEditor(new SpinnerEditor(thicknessSpinner));
+		panel.add( thicknessSpinner, "growx");
 
-		m = new DoubleModel(component, "Thickness", UnitGroup.UNITS_LENGTH, 0);
-
-		spin = new JSpinner(m.getSpinnerModel());
-		spin.setEditor(new SpinnerEditor(spin));
-		panel.add(spin, "growx");
-
-		panel.add(new UnitSelector(m), "growx");
-		panel.add(new BasicSlider(m.getSliderModel(0, 0.01)), "w 100lp, wrap 0px");
-
+		final UnitSelector thicknessUnits = new UnitSelector(thicknessModel);
+		panel.add( thicknessUnits );
+		final BasicSlider thicknessSlider = new BasicSlider(thicknessModel.getSliderModel(0, 0.01));
+		panel.add( thicknessSlider, "w 100lp, wrap 0px");
+		
+		
 		//// Filled
-		check = new JCheckBox(new BooleanModel(component, "Filled"));
-		check.setText(trans.get("BodyTubecfg.checkbox.Filled"));
-		panel.add(check, "skip, span 2, wrap");
+		final BooleanModel filledModel = new BooleanModel(component, "Filled");
+		final JCheckBox filledCheckBox = new JCheckBox( filledModel );
+		filledCheckBox.setText(trans.get("BodyTubecfg.checkbox.Filled"));
+		panel.add( filledCheckBox, "skip, span 2, wrap");
+		// add all the inner radius, thickness components to this enabler
+		filledModel.addEnableComponent( irSpinner, false);
+		filledModel.addEnableComponent( irUnits, false);
+		filledModel.addEnableComponent( irSlider, false );
+		filledModel.addEnableComponent( thicknessSpinner, false );
+		filledModel.addEnableComponent( thicknessUnits, false );
+		filledModel.addEnableComponent( thicknessSlider, false );
 
 		//// Material
 		panel.add(materialPanel(Material.Type.BULK),
@@ -114,11 +134,6 @@ public class BodyTubeConfig extends RocketComponentConfig {
 				trans.get("BodyTubecfg.tab.Motormountconf"), 1);
 
 
-	}
-
-	@Override
-	public void updateFields() {
-		super.updateFields();
 	}
 
 }

--- a/swing/src/net/sf/openrocket/gui/configdialog/FinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/FinSetConfig.java
@@ -16,6 +16,9 @@ import javax.swing.JPanel;
 import javax.swing.JSpinner;
 import javax.swing.SwingUtilities;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.gui.SpinnerEditor;
@@ -38,10 +41,8 @@ import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-
+@SuppressWarnings("serial")
 public abstract class FinSetConfig extends RocketComponentConfig {
 	private static final Logger log = LoggerFactory.getLogger(FinSetConfig.class);
 	private static final Translator trans = Application.getTranslator();
@@ -177,21 +178,21 @@ public abstract class FinSetConfig extends RocketComponentConfig {
 				"w 100lp, growx 5, wrap");
 		
 
-		////  Tab length
+		////  Tab:
 		//// Tab height:
 		label = new JLabel(trans.get("FinSetConfig.lbl.Tabheight"));
 		//// The spanwise height of the fin tab.
 		label.setToolTipText(trans.get("FinSetConfig.ttip.Tabheight"));
 		panel.add(label, "gapleft para");
 		
-		final DoubleModel mth = new DoubleModel(component, "TabHeight", UnitGroup.UNITS_LENGTH, 0);
-		
-		spin = new JSpinner(mth.getSpinnerModel());
+		final DoubleModel tabHeightModel = new DoubleModel(component, "TabHeight", UnitGroup.UNITS_LENGTH, 0);
+		component.addChangeListener( tabHeightModel );
+		spin = new JSpinner(tabHeightModel.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		panel.add(spin, "growx");
 		
-		panel.add(new UnitSelector(mth), "growx");
-		panel.add(new BasicSlider(mth.getSliderModel(DoubleModel.ZERO, length2)),
+		panel.add(new UnitSelector(tabHeightModel), "growx");
+		panel.add(new BasicSlider(tabHeightModel.getSliderModel(DoubleModel.ZERO, length2)),
 				"w 100lp, growx 5, wrap");
 		
 		////  Tab position:
@@ -201,7 +202,7 @@ public abstract class FinSetConfig extends RocketComponentConfig {
 		panel.add(label, "gapleft para");
 		
 		final DoubleModel mts = new DoubleModel(component, "TabShift", UnitGroup.UNITS_LENGTH);
-		
+		component.addChangeListener( mts);
 		spin = new JSpinner(mts.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		panel.add(spin, "growx");
@@ -209,17 +210,19 @@ public abstract class FinSetConfig extends RocketComponentConfig {
 		panel.add(new UnitSelector(mts), "growx");
 		panel.add(new BasicSlider(mts.getSliderModel(length_2, length2)), "w 100lp, growx 5, wrap");
 		
-
 		//// relative to
 		label = new JLabel(trans.get("FinSetConfig.lbl.relativeto"));
 		panel.add(label, "right, gapright unrel");
 		
-		final EnumModel<FinSet.TabRelativePosition> em =
-				new EnumModel<FinSet.TabRelativePosition>(component, "TabRelativePosition");
+		final EnumModel<RocketComponent.Position> em = new EnumModel<RocketComponent.Position>(component, "TabPositionMethod",
+                                                                new RocketComponent.Position[] {
+                                                                        RocketComponent.Position.TOP,
+                                                                        RocketComponent.Position.MIDDLE,
+                                                                        RocketComponent.Position.BOTTOM
+                                                                });
+		panel.add(new JComboBox<RocketComponent.Position>(em), "spanx 3, growx, wrap para");
+    	
 		
-		panel.add(new JComboBox(em), "spanx 3, growx, wrap para");
-		
-
 		// Calculate fin tab height, length, and position
 		autoCalc = new JButton(trans.get("FinSetConfig.but.AutoCalc"));
 		
@@ -244,8 +247,8 @@ public abstract class FinSetConfig extends RocketComponentConfig {
 									double depth = ((Coaxial) parent).getOuterRadius() - it.getOuterRadius();
 									//Set fin tab depth
 									if (depth >= 0.0d) {
-										mth.setValue(depth);
-										mth.setCurrentUnit(UnitGroup.UNITS_LENGTH.getDefaultUnit());
+										tabHeightModel.setValue(depth);
+										tabHeightModel.setCurrentUnit(UnitGroup.UNITS_LENGTH.getDefaultUnit());
 									}
 								}
 							} else if (rocketComponent instanceof CenteringRing) {
@@ -254,8 +257,8 @@ public abstract class FinSetConfig extends RocketComponentConfig {
 						}
 						//Figure out position and length of the fin tab
 						if (!rings.isEmpty()) {
-							FinSet.TabRelativePosition temp = (FinSet.TabRelativePosition) em.getSelectedItem();
-							em.setSelectedItem(FinSet.TabRelativePosition.FRONT);
+							RocketComponent.Position temp = (RocketComponent.Position) em.getSelectedItem();
+							em.setSelectedItem(RocketComponent.Position.TOP);
 							double len = computeFinTabLength(rings, component.asPositionValue(RocketComponent.Position.TOP),
 										component.getLength(), mts, parent);
 							mtl.setValue(len);
@@ -506,10 +509,10 @@ public abstract class FinSetConfig extends RocketComponentConfig {
 	    label.setToolTipText(trans.get("RocketCompCfg.lbl.ttip.componentmaterialaffects"));
 	    filletPanel.add(label, "spanx 4, wrap rel");
 		
-	    JComboBox combo = new JComboBox(new MaterialModel(filletPanel, component, Material.Type.BULK, "FilletMaterial"));
+	    JComboBox<Material> materialCombo = new JComboBox<Material>(new MaterialModel(filletPanel, component, Material.Type.BULK, "FilletMaterial"));
 	    //// The component material affects the weight of the component.
-	    combo.setToolTipText(trans.get("RocketCompCfg.combo.ttip.componentmaterialaffects"));
-	    filletPanel.add(combo, "spanx 4, growx, wrap paragraph");
+	    materialCombo.setToolTipText(trans.get("RocketCompCfg.combo.ttip.componentmaterialaffects"));
+	    filletPanel.add( materialCombo, "spanx 4, growx, wrap paragraph");
 	    filletPanel.setToolTipText(tip);
 	    return filletPanel;
 	}

--- a/swing/src/net/sf/openrocket/gui/configdialog/MassComponentConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/MassComponentConfig.java
@@ -23,6 +23,7 @@ import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
 
 
+@SuppressWarnings("serial")
 public class MassComponentConfig extends RocketComponentConfig {
 	private static final Translator trans = Application.getTranslator();
 	
@@ -34,8 +35,7 @@ public class MassComponentConfig extends RocketComponentConfig {
 		
 		//// Mass component type
 		panel.add(new JLabel(trans.get("MassComponentCfg.lbl.type")));
-		@SuppressWarnings("unchecked")
-		JComboBox typecombo = new JComboBox(
+		JComboBox<MassComponent.MassComponentType> typecombo = new JComboBox<MassComponent.MassComponentType>(
 				new EnumModel<MassComponent.MassComponentType>(component, "MassComponentType",
 						new MassComponent.MassComponentType[] {
 								MassComponent.MassComponentType.MASSCOMPONENT,
@@ -108,7 +108,7 @@ public class MassComponentConfig extends RocketComponentConfig {
 		//// Position relative to:
 		panel.add(new JLabel(trans.get("MassComponentCfg.lbl.PosRelativeto")));
 		
-		JComboBox combo = new JComboBox(
+		JComboBox<RocketComponent.Position> positionCombo = new JComboBox<RocketComponent.Position>(
 				new EnumModel<RocketComponent.Position>(component, "RelativePosition",
 						new RocketComponent.Position[] {
 								RocketComponent.Position.TOP,
@@ -116,7 +116,7 @@ public class MassComponentConfig extends RocketComponentConfig {
 								RocketComponent.Position.BOTTOM,
 								RocketComponent.Position.ABSOLUTE
 						}));
-		panel.add(combo, "spanx, growx, wrap");
+		panel.add( positionCombo, "spanx, growx, wrap");
 		//// plus
 		panel.add(new JLabel(trans.get("MassComponentCfg.lbl.plus")), "right");
 		

--- a/swing/src/net/sf/openrocket/gui/configdialog/NoseConeConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/NoseConeConfig.java
@@ -27,9 +27,10 @@ import net.sf.openrocket.rocketcomponent.Transition;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
 
+@SuppressWarnings("serial")
 public class NoseConeConfig extends RocketComponentConfig {
 	
-	private JComboBox typeBox;
+	private JComboBox<Transition.Shape> typeBox;
 	
 	private DescriptionArea description;
 	
@@ -54,7 +55,7 @@ public class NoseConeConfig extends RocketComponentConfig {
 		Transition.Shape selected = ((NoseCone) component).getType();
 		Transition.Shape[] typeList = Transition.Shape.values();
 		
-		typeBox = new JComboBox(typeList);
+		typeBox = new JComboBox<Transition.Shape>(typeList);
 		typeBox.setEditable(false);
 		typeBox.setSelectedItem(selected);
 		typeBox.addActionListener(new ActionListener() {

--- a/swing/src/net/sf/openrocket/gui/configdialog/ParallelStageConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/ParallelStageConfig.java
@@ -79,7 +79,6 @@ public class ParallelStageConfig extends AxialStageConfig {
 		motherPanel.add( positionLabel);
 		
 		//	EnumModel(ChangeSource source, String valueName, Enum<T>[] values) {
-		@SuppressWarnings("unchecked")
 		ComboBoxModel<RocketComponent.Position> relativePositionMethodModel = new EnumModel<RocketComponent.Position>(component, "RelativePositionMethod",
 				new RocketComponent.Position[] {
 						RocketComponent.Position.TOP,

--- a/swing/src/net/sf/openrocket/gui/configdialog/RailButtonConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RailButtonConfig.java
@@ -22,21 +22,14 @@ import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
 
+@SuppressWarnings("serial")
 public class RailButtonConfig extends RocketComponentConfig {
 	
-	private MotorConfig motorConfigPane = null;
 	private static final Translator trans = Application.getTranslator();
 	
 	public RailButtonConfig( OpenRocketDocument document, RocketComponent component) {
 		super(document, component);
 	
-		// For DEBUG purposes
-//		if( component instanceof AxialStage ){
-//			System.err.println(" Dumping AxialStage tree info for devel / debugging.");
-//			System.err.println(component.toDebugTree());
-//		}
-				
-
 		//// General and General properties
 		tabbedPane.insertTab( trans.get("RailBtnCfg.tab.General"), null, buttonTab( (RailButton)component ), trans.get("RailBtnCfg.tab.GeneralProp"), 0);
 		tabbedPane.setSelectedIndex(0);
@@ -78,7 +71,6 @@ public class RailButtonConfig extends RocketComponentConfig {
 		
 		{ //// Position relative to:
 			panel.add(new JLabel(trans.get("RailBtnCfg.lbl.PosRelativeTo")));
-			@SuppressWarnings("unchecked")
 			JComboBox<RocketComponent.Position> relToCombo = new JComboBox<RocketComponent.Position>(
 					(ComboBoxModel<RocketComponent.Position>) new EnumModel<RocketComponent.Position>(component, "RelativePosition",
 							new RocketComponent.Position[] {

--- a/swing/src/net/sf/openrocket/gui/configdialog/RingComponentConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RingComponentConfig.java
@@ -22,6 +22,7 @@ import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
 
+@SuppressWarnings("serial")
 public class RingComponentConfig extends RocketComponentConfig {
 	private static final Translator trans = Application.getTranslator();
 	
@@ -125,7 +126,7 @@ public class RingComponentConfig extends RocketComponentConfig {
 		//// Position relative to:
 		panel.add(new JLabel(trans.get("ringcompcfg.Positionrelativeto")));
 		
-		JComboBox combo = new JComboBox(
+		JComboBox<RocketComponent.Position> positionCombo = new JComboBox<RocketComponent.Position>(
 				new EnumModel<RocketComponent.Position>(component, "RelativePosition",
 						new RocketComponent.Position[] {
 								RocketComponent.Position.TOP,
@@ -133,7 +134,7 @@ public class RingComponentConfig extends RocketComponentConfig {
 								RocketComponent.Position.BOTTOM,
 								RocketComponent.Position.ABSOLUTE
 						}));
-		panel.add(combo, "spanx 3, growx, wrap");
+		panel.add( positionCombo, "spanx 3, growx, wrap");
 		
 		//// plus
 		panel.add(new JLabel(trans.get("ringcompcfg.plus")), "right");

--- a/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
@@ -98,7 +98,7 @@ public class RocketComponentConfig extends JPanel {
 			// If the component supports a preset, show the preset selection box.
 			presetModel = new PresetModel(this, document, component);
 			((ComponentPresetDatabase) Application.getComponentPresetDao()).addDatabaseListener(presetModel);
-			presetComboBox = new JComboBox(presetModel);
+			presetComboBox = new JComboBox<ComponentPreset>(presetModel);
 			presetComboBox.setEditable(false);
 			this.add(presetComboBox, "");
 		}

--- a/swing/src/net/sf/openrocket/gui/configdialog/RocketConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RocketConfig.java
@@ -18,6 +18,7 @@ import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.startup.Application;
 
+@SuppressWarnings("serial")
 public class RocketConfig extends RocketComponentConfig {
 	private static final Translator trans = Application.getTranslator();
 	

--- a/swing/src/net/sf/openrocket/gui/configdialog/ShockCordConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/ShockCordConfig.java
@@ -19,6 +19,7 @@ import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
 
+@SuppressWarnings("serial")
 public class ShockCordConfig extends RocketComponentConfig {
 	private static final Translator trans = Application.getTranslator();
 	
@@ -62,7 +63,7 @@ public class ShockCordConfig extends RocketComponentConfig {
 		//// Position relative to:
 		panel2.add(new JLabel(trans.get("ShockCordCfg.lbl.Posrelativeto")));
 		
-		JComboBox combo = new JComboBox(
+		JComboBox<RocketComponent.Position> combo = new JComboBox<RocketComponent.Position>(
 				new EnumModel<RocketComponent.Position>(component, "RelativePosition",
 						new RocketComponent.Position[] {
 								RocketComponent.Position.TOP,

--- a/swing/src/net/sf/openrocket/gui/configdialog/SleeveConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/SleeveConfig.java
@@ -10,6 +10,7 @@ import net.sf.openrocket.startup.Application;
 
 
 
+@SuppressWarnings("serial")
 public class SleeveConfig extends RingComponentConfig {
 	private static final Translator trans = Application.getTranslator();
 	

--- a/swing/src/net/sf/openrocket/gui/configdialog/ThicknessRingComponentConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/ThicknessRingComponentConfig.java
@@ -9,7 +9,7 @@ import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.startup.Application;
 
 
-
+@SuppressWarnings("serial")
 public class ThicknessRingComponentConfig extends RingComponentConfig {
 	private static final Translator trans = Application.getTranslator();
 	

--- a/swing/src/net/sf/openrocket/gui/customexpression/ExpressionBuilderDialog.java
+++ b/swing/src/net/sf/openrocket/gui/customexpression/ExpressionBuilderDialog.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 
+@SuppressWarnings("serial")
 public class ExpressionBuilderDialog extends JDialog {
 
 	private static final Translator trans = Application.getTranslator();

--- a/swing/src/net/sf/openrocket/gui/customexpression/OperatorSelector.java
+++ b/swing/src/net/sf/openrocket/gui/customexpression/OperatorSelector.java
@@ -35,7 +35,7 @@ public class OperatorSelector extends JDialog {
 	private static final Translator trans = Application.getTranslator();
 	private static final Logger log = LoggerFactory.getLogger(OperatorSelector.class);
 	
-	private final Window parentWindow;
+	protected final Window parentWindow;
 	
 	private final JTable table;
 	private final OperatorTableModel tableModel;

--- a/swing/src/net/sf/openrocket/gui/customexpression/OperatorTableModel.java
+++ b/swing/src/net/sf/openrocket/gui/customexpression/OperatorTableModel.java
@@ -6,6 +6,7 @@ import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.simulation.customexpression.Functions;
 import net.sf.openrocket.startup.Application;
 
+@SuppressWarnings("serial")
 public class OperatorTableModel extends AbstractTableModel {
 
 	private static final Translator trans = Application.getTranslator();

--- a/swing/src/net/sf/openrocket/gui/customexpression/VariableSelector.java
+++ b/swing/src/net/sf/openrocket/gui/customexpression/VariableSelector.java
@@ -44,7 +44,6 @@ public class VariableSelector extends JDialog {
 	private final VariableTableModel tableModel;
 	private final ExpressionBuilderDialog parentBuilder;
 
-	@SuppressWarnings("serial")
 	public VariableSelector(Window parent, final ExpressionBuilderDialog parentBuilder, final OpenRocketDocument doc){
 
 		super(parent, trans.get("CustomVariableSelector.title"), JDialog.ModalityType.DOCUMENT_MODAL);

--- a/swing/src/net/sf/openrocket/gui/customexpression/VariableTableModel.java
+++ b/swing/src/net/sf/openrocket/gui/customexpression/VariableTableModel.java
@@ -15,6 +15,7 @@ import net.sf.openrocket.startup.Application;
  * @author Richard Graham
  *
  */
+@SuppressWarnings("serial")
 public class VariableTableModel extends AbstractTableModel {
 
 	private static final Translator trans = Application.getTranslator();

--- a/swing/src/net/sf/openrocket/gui/dialogs/CustomMaterialDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/CustomMaterialDialog.java
@@ -25,13 +25,14 @@ import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.material.Material;
 import net.sf.openrocket.startup.Application;
 
+@SuppressWarnings("serial")
 public class CustomMaterialDialog extends JDialog {
 	private static final Translator trans = Application.getTranslator();
 	
 	private final Material originalMaterial;
 	
 	private boolean okClicked = false;
-	private JComboBox typeBox;
+	private JComboBox<Material.Type> typeBox;
 	private JTextField nameField;
 	private DoubleModel density;
 	private JSpinner densitySpinner;
@@ -76,7 +77,7 @@ public class CustomMaterialDialog extends JDialog {
 		// Material type (if not known)
 		panel.add(new JLabel(trans.get("custmatdlg.lbl.Materialtype")));
 		if (material == null) {
-			typeBox = new JComboBox(Material.Type.values());
+			typeBox = new JComboBox<Material.Type>(Material.Type.values());
 			typeBox.setSelectedItem(Material.Type.BULK);
 			typeBox.setEditable(false);
 			typeBox.addActionListener(new ActionListener() {

--- a/swing/src/net/sf/openrocket/gui/dialogs/DebugLogDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/DebugLogDialog.java
@@ -108,7 +108,6 @@ public class DebugLogDialog extends JDialog {
 	private final SelectableLabel messageLabel;
 	private final JTextArea stackTraceLabel;
 	
-	@SuppressWarnings("serial")
 	public DebugLogDialog(Window parent) {
 		//// OpenRocket debug log
 		super(parent, trans.get("debuglogdlg.OpenRocketdebuglog"));

--- a/swing/src/net/sf/openrocket/gui/dialogs/LicenseDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/LicenseDialog.java
@@ -20,6 +20,7 @@ import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
 
+@SuppressWarnings("serial")
 public class LicenseDialog extends JDialog {
 	private static final String LICENSE_FILENAME = "LICENSE.TXT";
 	private static final Translator trans = Application.getTranslator();

--- a/swing/src/net/sf/openrocket/gui/dialogs/PrintDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/PrintDialog.java
@@ -48,6 +48,7 @@ import net.sf.openrocket.startup.Application;
 /**
  * This class isolates the Swing components used to create a panel that is added to a standard Java print dialog.
  */
+@SuppressWarnings("serial")
 public class PrintDialog extends JDialog implements TreeSelectionListener {
 	
 	private static final Logger log = LoggerFactory.getLogger(PrintDialog.class);

--- a/swing/src/net/sf/openrocket/gui/dialogs/PrintSettingsDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/PrintSettingsDialog.java
@@ -30,6 +30,7 @@ import net.sf.openrocket.startup.Application;
 /**
  * This class is a dialog for displaying advanced settings for printing rocket related info.
  */
+@SuppressWarnings("serial")
 public class PrintSettingsDialog extends JDialog {
 	private static final Logger log = LoggerFactory.getLogger(PrintSettingsDialog.class);
 	private static final Translator trans = Application.getTranslator();
@@ -75,16 +76,17 @@ public class PrintSettingsDialog extends JDialog {
 		
 
 
-		JComboBox combo = new JComboBox(new EnumModel<PaperSize>(settings, "PaperSize"));
+		JComboBox<PaperSize> sizeCombo = new JComboBox<PaperSize>(new EnumModel<PaperSize>(settings, "PaperSize"));
 		////Paper size:
 		panel.add(new JLabel(trans.get("lbl.Papersize")));
-		panel.add(combo, "growx, wrap para");
+		panel.add( sizeCombo, "growx, wrap para");
 		
 
-		combo = new JComboBox(new EnumModel<PaperOrientation>(settings, "PaperOrientation"));
+		JComboBox<PaperOrientation> orientCombo = 
+				new JComboBox<PaperOrientation>(new EnumModel<PaperOrientation>(settings, "PaperOrientation"));
 		//// Paper orientation:
 		panel.add(new JLabel(trans.get("lbl.Paperorientation")));
-		panel.add(combo, "growx, wrap para*2");
+		panel.add( orientCombo, "growx, wrap para*2");
 		
 
 

--- a/swing/src/net/sf/openrocket/gui/dialogs/ScaleDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/ScaleDialog.java
@@ -4,7 +4,6 @@ import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,7 +35,6 @@ import net.sf.openrocket.rocketcomponent.BodyTube;
 import net.sf.openrocket.rocketcomponent.EllipticalFinSet;
 import net.sf.openrocket.rocketcomponent.FinSet;
 import net.sf.openrocket.rocketcomponent.FreeformFinSet;
-import net.sf.openrocket.rocketcomponent.IllegalFinPointException;
 import net.sf.openrocket.rocketcomponent.InnerTube;
 import net.sf.openrocket.rocketcomponent.LaunchLug;
 import net.sf.openrocket.rocketcomponent.MassComponent;
@@ -82,7 +80,7 @@ public class ScaleDialog extends JDialog {
 		List<Scaler> list;
 		
 		// RocketComponent
-		addScaler(RocketComponent.class, "PositionValue");
+		addScaler(RocketComponent.class, "AxialOffset");
 		SCALERS.get(RocketComponent.class).add(new OverrideScaler());
 		
 		// BodyComponent
@@ -616,11 +614,8 @@ public class ScaleDialog extends JDialog {
 			for (int i = 0; i < points.length; i++) {
 				points[i] = points[i].multiply(multiplier);
 			}
-			try {
-				finset.setPoints(points);
-			} catch (IllegalFinPointException e) {
-				throw new BugException("Failed to set points after scaling, original=" + Arrays.toString(finset.getFinPoints()) + " scaled=" + Arrays.toString(points), e);
-			}
+			finset.setPoints(points);
+			
 		}
 		
 	}

--- a/swing/src/net/sf/openrocket/gui/dialogs/SwingWorkerDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/SwingWorkerDialog.java
@@ -32,6 +32,7 @@ import net.sf.openrocket.util.MathUtil;
  * 
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
+@SuppressWarnings("serial")
 public class SwingWorkerDialog extends JDialog implements PropertyChangeListener {
 	private static final Logger log = LoggerFactory.getLogger(SwingWorkerDialog.class);
 	private static final Translator trans = Application.getTranslator();

--- a/swing/src/net/sf/openrocket/gui/dialogs/UpdateInfoDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/UpdateInfoDialog.java
@@ -22,6 +22,7 @@ import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.Chars;
 import net.sf.openrocket.util.ComparablePair;
 
+@SuppressWarnings("serial")
 public class UpdateInfoDialog extends JDialog {
 	
 	private final JCheckBox remind;

--- a/swing/src/net/sf/openrocket/gui/dialogs/WarningDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/WarningDialog.java
@@ -10,14 +10,15 @@ import javax.swing.JScrollPane;
 import net.sf.openrocket.aerodynamics.Warning;
 import net.sf.openrocket.aerodynamics.WarningSet;
 
+@SuppressWarnings("serial")
 public class WarningDialog extends JDialog {
 
 	public static void showWarnings(Component parent, Object message, String title, 
 			WarningSet warnings) {
 		
 		Warning[] w = warnings.toArray(new Warning[0]);
-		JList list = new JList(w);
-		JScrollPane pane = new JScrollPane(list);
+		JList<Warning> warningList = new JList<Warning>(w);
+		JScrollPane pane = new JScrollPane(warningList);
 		
 		JOptionPane.showMessageDialog(parent, new Object[] { message, pane }, 
 				title, JOptionPane.WARNING_MESSAGE);

--- a/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/DeploymentSelectionDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/DeploymentSelectionDialog.java
@@ -78,12 +78,12 @@ public class DeploymentSelectionDialog extends JDialog {
 		//// Deploys at:
 		panel.add(new JLabel(trans.get("ParachuteCfg.lbl.Deploysat")), "");
 		
-		final JComboBox<?> event = new JComboBox(new EnumModel<DeployEvent>(newConfiguration, "DeployEvent"));
+		final JComboBox<DeployEvent> deployEvent = new JComboBox<DeployEvent>(new EnumModel<DeployEvent>(newConfiguration, "DeployEvent"));
 		if( (component.getStageNumber() + 1 ) == rocket.getStageCount() ){
 			//	This is the bottom stage:  Restrict deployment options.
-			event.removeItem( DeployEvent.LOWER_STAGE_SEPARATION );
+			deployEvent.removeItem( DeployEvent.LOWER_STAGE_SEPARATION );
 		}
-		panel.add(event, "spanx 3, growx, wrap");
+		panel.add( deployEvent, "spanx 3, growx, wrap");
 		
 		// ... and delay
 		//// plus
@@ -111,7 +111,7 @@ public class DeploymentSelectionDialog extends JDialog {
 		altSlider = new BasicSlider(alt.getSliderModel(100, 1000));
 		panel.add(altSlider, "w 100lp, wrap");
 		
-		event.addActionListener(new ActionListener() {
+		deployEvent.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				updateState();

--- a/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/MotorMountConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/MotorMountConfigurationPanel.java
@@ -14,15 +14,9 @@ import net.sf.openrocket.rocketcomponent.Rocket;
 
 @SuppressWarnings("serial")
 public abstract class MotorMountConfigurationPanel extends JPanel {
-
-	private final Rocket rocket;
-	private final Component parent;
 	
 	public MotorMountConfigurationPanel( Component parent, Rocket rocket ) {
 		super(new MigLayout("") );
-		
-		this.parent = parent;
-		this.rocket = rocket;
 		
 		//// Motor Mount selection 
 		JTable table = new JTable(new MotorMountTableModel(this, rocket));

--- a/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/MotorMountTableModel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/MotorMountTableModel.java
@@ -16,9 +16,8 @@ import net.sf.openrocket.util.ArrayList;
 /**
  * The table model for selecting whether components are motor mounts or not.
  */
+@SuppressWarnings("serial")
 class MotorMountTableModel extends AbstractTableModel implements ComponentChangeListener {
-	
-	private final MotorMountConfigurationPanel motorConfigurationPanel;
 	
 	private final List<MotorMount> potentialMounts = new ArrayList<MotorMount>();
 	
@@ -28,7 +27,7 @@ class MotorMountTableModel extends AbstractTableModel implements ComponentChange
 	 * @param motorConfigurationPanel
 	 */
 	MotorMountTableModel(MotorMountConfigurationPanel motorConfigurationPanel, Rocket rocket) {
-		this.motorConfigurationPanel = motorConfigurationPanel;
+		//this.motorConfigurationPanel = motorConfigurationPanel;
 		this.rocket = rocket;
 		
 		initialize();

--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorDatabaseModel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorDatabaseModel.java
@@ -6,6 +6,7 @@ import javax.swing.table.AbstractTableModel;
 
 import net.sf.openrocket.database.motor.ThrustCurveMotorSet;
 
+@SuppressWarnings("serial")
 class ThrustCurveMotorDatabaseModel extends AbstractTableModel {
 	private final List<ThrustCurveMotorSet> database;
 	

--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorPlotDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorPlotDialog.java
@@ -28,6 +28,7 @@ import org.jfree.chart.renderer.xy.StandardXYItemRenderer;
 import org.jfree.data.xy.XYSeries;
 import org.jfree.data.xy.XYSeriesCollection;
 
+@SuppressWarnings("serial")
 public class ThrustCurveMotorPlotDialog extends JDialog {
 	private static final Translator trans = Application.getTranslator();
 	

--- a/swing/src/net/sf/openrocket/gui/dialogs/optimization/OptimizationPlotDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/optimization/OptimizationPlotDialog.java
@@ -58,6 +58,7 @@ import org.slf4j.LoggerFactory;
  * 
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
+@SuppressWarnings("serial")
 public class OptimizationPlotDialog extends JDialog {
 	private static final Logger log = LoggerFactory.getLogger(OptimizationPlotDialog.class);
 	private static final Translator trans = Application.getTranslator();

--- a/swing/src/net/sf/openrocket/gui/dialogs/preferences/DesignPreferencesPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preferences/DesignPreferencesPanel.java
@@ -14,6 +14,7 @@ import net.sf.openrocket.gui.adaptors.DoubleModel;
 import net.sf.openrocket.startup.Preferences;
 import net.sf.openrocket.unit.UnitGroup;
 
+@SuppressWarnings("serial")
 public class DesignPreferencesPanel extends PreferencesPanel {
 
 	public DesignPreferencesPanel() {

--- a/swing/src/net/sf/openrocket/gui/dialogs/preferences/LaunchPreferencesPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preferences/LaunchPreferencesPanel.java
@@ -22,6 +22,7 @@ import net.sf.openrocket.simulation.SimulationOptions;
 import net.sf.openrocket.unit.UnitGroup;
 import net.sf.openrocket.util.Chars;
 
+@SuppressWarnings("serial")
 public class LaunchPreferencesPanel extends PreferencesPanel {
 
 	public LaunchPreferencesPanel(JDialog parent, LayoutManager layout) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/preferences/PreferencesDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preferences/PreferencesDialog.java
@@ -6,7 +6,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.io.File;
 
 import javax.swing.JButton;
 import javax.swing.JDialog;
@@ -19,14 +18,10 @@ import net.sf.openrocket.gui.util.SwingPreferences;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("serial")
 public class PreferencesDialog extends JDialog {
-	private static final Logger log = LoggerFactory
-			.getLogger(PreferencesDialog.class);
 
-	private File defaultDirectory = null;
 	private static final Translator trans = Application.getTranslator();
 
 	private final SwingPreferences preferences = (SwingPreferences) Application

--- a/swing/src/net/sf/openrocket/gui/dialogs/preferences/UnitsPreferencesPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preferences/UnitsPreferencesPanel.java
@@ -14,6 +14,7 @@ import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.components.StyledLabel.Style;
 import net.sf.openrocket.unit.UnitGroup;
 
+@SuppressWarnings("serial")
 public class UnitsPreferencesPanel extends PreferencesPanel {
 
 	public UnitsPreferencesPanel(JDialog parent) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/preset/XTableColumnModel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preset/XTableColumnModel.java
@@ -6,6 +6,7 @@ import java.util.Vector;
 import javax.swing.table.DefaultTableColumnModel;
 import javax.swing.table.TableColumn;
 
+@SuppressWarnings("serial")
 public class XTableColumnModel extends DefaultTableColumnModel {
 	
 	/** Array of TableColumn objects in this model.

--- a/swing/src/net/sf/openrocket/gui/figure3d/RocketRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/RocketRenderer.java
@@ -20,7 +20,6 @@ import net.sf.openrocket.gui.figure3d.geometry.Geometry.Surface;
 import net.sf.openrocket.motor.Motor;
 import net.sf.openrocket.motor.MotorConfiguration;
 import net.sf.openrocket.rocketcomponent.FlightConfiguration;
-import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
 import net.sf.openrocket.rocketcomponent.MotorMount;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.util.Coordinate;
@@ -166,27 +165,6 @@ public abstract class RocketRenderer {
 	}
 	
 	private void renderMotors(GL2 gl, FlightConfiguration configuration) {
-		FlightConfigurationId motorID = configuration.getFlightConfigurationID();
-		
-//		for( RocketComponent comp : configuration.getActiveComponents()){
-//			if( comp instanceof MotorMount){
-//			
-//				MotorMount mount = (MotorMount) comp;
-//				Motor motor = mount.getMotorInstance(motorID).getMotor();
-//				if( null == motor )???;
-//				double length = motor.getLength();
-//			
-//				Coordinate[] position = ((RocketComponent) mount).toAbsolute(new Coordinate(((RocketComponent) mount)
-//						.getLength() + mount.getMotorOverhang() - length));
-//			
-//				for (int i = 0; i < position.length; i++) {
-//					gl.glPushMatrix();
-//					gl.glTranslated(position[i].x, position[i].y, position[i].z);
-//					renderMotor(gl, motor);
-//					gl.glPopMatrix();
-//				}
-//			}
-//		}
 		
 		for( MotorConfiguration curMotor : configuration.getActiveMotors()){
 			MotorMount mount = curMotor.getMount();

--- a/swing/src/net/sf/openrocket/gui/figure3d/geometry/FinRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/geometry/FinRenderer.java
@@ -36,7 +36,7 @@ public class FinRenderer {
 		gl.glMatrixMode(GL.GL_TEXTURE);
 		gl.glPushMatrix();
 		gl.glScaled(1 / (maxX - minX), 1 / (maxY - minY), 0);
-		gl.glTranslated(-minX, -minY - fs.getBodyRadius(), 0);
+		gl.glTranslated(-minX, -minY - fs.getBodyRadius(0), 0);
 		gl.glMatrixMode(GLMatrixFunc.GL_MODELVIEW);
 		
 		gl.glRotated(fs.getBaseRotation() * (180.0 / Math.PI), 1, 0, 0);
@@ -77,7 +77,7 @@ public class FinRenderer {
 			gl.glNormal3f(0, 0, 1);
 			for (int i = finPoints.length - 1; i >= 0; i--) {
 				Coordinate c = finPoints[i];
-				double[] p = new double[] { c.x, c.y + fs.getBodyRadius(),
+				double[] p = new double[] { c.x, c.y + fs.getBodyRadius(0),
 						c.z + fs.getThickness() / 2.0 };
 				GLU.gluTessVertex(tobj, p, 0, p);
 				
@@ -90,7 +90,7 @@ public class FinRenderer {
 			gl.glNormal3f(0, 0, -1);
 			for (int i = 0; i < finPoints.length; i++) {
 				Coordinate c = finPoints[i];
-				double[] p = new double[] { c.x, c.y + fs.getBodyRadius(),
+				double[] p = new double[] { c.x, c.y + fs.getBodyRadius(0),
 						c.z - fs.getThickness() / 2.0 };
 				GLU.gluTessVertex(tobj, p, 0, p);
 				
@@ -109,10 +109,10 @@ public class FinRenderer {
 						% finPoints.length];
 				gl.glNormal3d(c2.y - c.y, c.x - c2.x, 0);
 				// }
-				gl.glTexCoord2d(c.x, c.y + fs.getBodyRadius());
-				gl.glVertex3d(c.x, c.y + fs.getBodyRadius(),
+				gl.glTexCoord2d(c.x, c.y + fs.getBodyRadius(0));
+				gl.glVertex3d(c.x, c.y + fs.getBodyRadius(0),
 						c.z - fs.getThickness() / 2.0);
-				gl.glVertex3d(c.x, c.y + fs.getBodyRadius(),
+				gl.glVertex3d(c.x, c.y + fs.getBodyRadius(0),
 						c.z + fs.getThickness() / 2.0);
 			}
 			gl.glEnd();

--- a/swing/src/net/sf/openrocket/gui/figureelements/RocketInfo.java
+++ b/swing/src/net/sf/openrocket/gui/figureelements/RocketInfo.java
@@ -326,6 +326,15 @@ public class RocketInfo implements FigureElement {
         return flightData;
     }
     
+    /**
+     * Return the reference Mach number
+     * 
+     * @return Mach number
+     */
+	public double getMach() {
+		return this.mach;
+	}
+    
     private void drawWarnings() {
 		if (warnings == null || warnings.isEmpty())
 			return;

--- a/swing/src/net/sf/openrocket/gui/help/tours/SlideShowComponent.java
+++ b/swing/src/net/sf/openrocket/gui/help/tours/SlideShowComponent.java
@@ -17,9 +17,9 @@ import net.sf.openrocket.gui.components.ImageDisplayComponent;
  * 
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
+@SuppressWarnings("serial")
 public class SlideShowComponent extends JSplitPane {
 	
-	@SuppressWarnings("hiding")
 	private final int WIDTH = 600;
 	private final int HEIGHT_IMAGE = 400;
 	private final int HEIGHT_TEXT = 100;

--- a/swing/src/net/sf/openrocket/gui/main/ComponentAddButtons.java
+++ b/swing/src/net/sf/openrocket/gui/main/ComponentAddButtons.java
@@ -128,17 +128,17 @@ public class ComponentAddButtons extends JPanel implements Scrollable {
 				//// Transition
 				new BodyComponentButton(Transition.class, trans.get("compaddbuttons.Transition")),
 				//// Trapezoidal
-				new FinButton(TrapezoidFinSet.class, trans.get("compaddbuttons.Trapezoidal")), // TODO: MEDIUM: freer fin placing
+				new ComponentButton(TrapezoidFinSet.class, trans.get("compaddbuttons.Trapezoidal")), // TODO: MEDIUM: freer fin placing
 				//// Elliptical
-				new FinButton(EllipticalFinSet.class, trans.get("compaddbuttons.Elliptical")),
+				new ComponentButton(EllipticalFinSet.class, trans.get("compaddbuttons.Elliptical")),
 				//// Freeform
-				new FinButton(FreeformFinSet.class, trans.get("compaddbuttons.Freeform")),
+				new ComponentButton(FreeformFinSet.class, trans.get("compaddbuttons.Freeform")),
 				//// Freeform
-				new FinButton(TubeFinSet.class, trans.get("compaddbuttons.Tubefin")),
-				//// Rail Button // TODO: implement drawing graphics for the component
-				new FinButton( RailButton.class, trans.get("compaddbuttons.RailButton")),
+				new ComponentButton(TubeFinSet.class, trans.get("compaddbuttons.Tubefin")),
+				//// Rail Button
+				new ComponentButton( RailButton.class, trans.get("compaddbuttons.RailButton")),
 				//// Launch lug
-				new FinButton(LaunchLug.class, trans.get("compaddbuttons.Launchlug")));
+				new ComponentButton(LaunchLug.class, trans.get("compaddbuttons.Launchlug")));
 			row++;
 		
 		/////////////////////////////////////////////
@@ -624,38 +624,7 @@ public class ComponentAddButtons extends JPanel implements Scrollable {
 		}
 		
 	}
-	
-	
 
-	/**
-	 * Class for fin sets, that attach only to BodyTubes.
-	 */
-	private class FinButton extends ComponentButton {
-		/**
-		 * 
-		 */
-		private static final long serialVersionUID = -219204844803871258L;
-
-		public FinButton(Class<? extends RocketComponent> c, String text) {
-			super(c, text);
-		}
-		
-		public FinButton(String text, Icon enabled, Icon disabled) {
-			super(text, enabled, disabled);
-		}
-		
-		public FinButton(String text) {
-			super(text);
-		}
-		
-		@Override
-		public boolean isAddable(RocketComponent c) {
-			if (c == null)
-				return false;
-			return (c.getClass().equals(BodyTube.class));
-		}
-	}
-	
 	
 
 	/////////  Scrolling functionality

--- a/swing/src/net/sf/openrocket/gui/main/ExampleDesignFileAction.java
+++ b/swing/src/net/sf/openrocket/gui/main/ExampleDesignFileAction.java
@@ -56,7 +56,7 @@ public final class ExampleDesignFileAction extends JMenu {
     private Action createAction(final ExampleDesignFile example) {
         Action action = new AbstractAction() {
             public void actionPerformed(ActionEvent e) {
-                String command = e.getActionCommand();
+                //String command = e.getActionCommand();
                 BasicFrame.open(example.getURL(), parent);
             }
         };

--- a/swing/src/net/sf/openrocket/gui/main/SaveAsFileChooser.java
+++ b/swing/src/net/sf/openrocket/gui/main/SaveAsFileChooser.java
@@ -15,10 +15,9 @@ import net.sf.openrocket.gui.util.SwingPreferences;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
 
+@SuppressWarnings("serial")
 public class SaveAsFileChooser extends JFileChooser {
 
-	private final FileType type;
-	private final OpenRocketDocument document;
 	private final StorageOptionChooser storageChooser;
 
 	private static final Translator trans = Application.getTranslator();
@@ -28,8 +27,6 @@ public class SaveAsFileChooser extends JFileChooser {
 	}
 
 	private SaveAsFileChooser( OpenRocketDocument document, FileType type ) {
-		this.document = document;
-		this.type = type;
 
 		this.setAcceptAllFileFilterUsed(true);
 

--- a/swing/src/net/sf/openrocket/gui/main/SwingExceptionHandler.java
+++ b/swing/src/net/sf/openrocket/gui/main/SwingExceptionHandler.java
@@ -424,12 +424,8 @@ public class SwingExceptionHandler implements Thread.UncaughtExceptionHandler, E
 	}
 
 
-	@SuppressWarnings("unused")
+	@SuppressWarnings("serial")
 	private static class InternalException extends Exception {
-		public InternalException() {
-			super();
-		}
-
 		public InternalException(String message, Throwable cause) {
 			super(message, cause);
 		}
@@ -438,8 +434,5 @@ public class SwingExceptionHandler implements Thread.UncaughtExceptionHandler, E
 			super(message);
 		}
 
-		public InternalException(Throwable cause) {
-			super(cause);
-		}
 	}
 }

--- a/swing/src/net/sf/openrocket/gui/main/UndoRedoAction.java
+++ b/swing/src/net/sf/openrocket/gui/main/UndoRedoAction.java
@@ -18,6 +18,7 @@ import net.sf.openrocket.util.BugException;
 /**
  * Inner class to implement undo/redo actions.
  */
+@SuppressWarnings("serial")
 public class UndoRedoAction extends AbstractAction implements UndoRedoListener {
 	
 	// Use Factory mechanism because we want to register the new instance as an

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
@@ -24,9 +24,11 @@ import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
 
+@SuppressWarnings("serial")
 public class RecoveryConfigurationPanel extends FlightConfigurablePanel<RecoveryDevice> {
 
 	Translator trans = Application.getTranslator();
+	@SuppressWarnings("unused")
 	private RocketDescriptor descriptor = Application.getInjector().getInstance(RocketDescriptor.class);
 
 	private FlightConfigurableTableModel<RecoveryDevice> recoveryTableModel;

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
@@ -23,9 +23,11 @@ import net.sf.openrocket.rocketcomponent.StageSeparationConfiguration;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
 
+@SuppressWarnings("serial")
 public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialStage> {
-	private static final long serialVersionUID = -1556652925279847316L;
 	static final Translator trans = Application.getTranslator();
+	
+	@SuppressWarnings("unused")
 	private RocketDescriptor descriptor = Application.getInjector().getInstance(RocketDescriptor.class);
 
 	private FlightConfigurableTableModel<AxialStage> separationTableModel;

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationChart.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationChart.java
@@ -33,6 +33,7 @@ import com.jogamp.newt.event.InputEvent;
  * @author kruland
  *
  */
+@SuppressWarnings("serial")
 public class SimulationChart extends ChartPanel {
 	
 	private Point2D panLast;

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlot.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlot.java
@@ -157,7 +157,7 @@ public class SimulationPlot {
 			int axis = filled.getAxis(i);
 			String name = getLabel(type, unit);
 			
-			List<String> seriesNames = Util.generateSeriesLabels(simulation);
+			//List<String> seriesNames = Util.generateSeriesLabels(simulation);
 			
 			// Populate data for each branch.
 			

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
@@ -31,6 +31,7 @@ import org.jfree.chart.ChartPanel;
  * 
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
+@SuppressWarnings("serial")
 public class SimulationPlotDialog extends JDialog {
 	
 	private static final Translator trans = Application.getTranslator();
@@ -113,7 +114,7 @@ public class SimulationPlotDialog extends JDialog {
 		stages.add("All");
 		stages.addAll(Util.generateSeriesLabels(simulation));
 		
-		final JComboBox stageSelection = new JComboBox(stages.toArray(new String[0]));
+		final JComboBox<String> stageSelection = new JComboBox<String>(stages.toArray(new String[0]));
 		stageSelection.addItemListener(new ItemListener() {
 			
 			@Override

--- a/swing/src/net/sf/openrocket/gui/preset/ImagePreviewPanel.java
+++ b/swing/src/net/sf/openrocket/gui/preset/ImagePreviewPanel.java
@@ -11,6 +11,7 @@ import java.io.File;
 /**
  * From a JavaLobby article by Michael Urban:  http://www.javalobby.org/java/forums/t49462.html
  */
+@SuppressWarnings("serial")
 public class ImagePreviewPanel extends JPanel
         implements PropertyChangeListener {
 

--- a/swing/src/net/sf/openrocket/gui/print/PrintableCenteringRing.java
+++ b/swing/src/net/sf/openrocket/gui/print/PrintableCenteringRing.java
@@ -20,6 +20,7 @@ import java.util.Set;
  * This class creates a renderable centering ring.  It depends only on AWT/Swing and can be called from other actors
  * (like iText handlers) to render the centering ring on different graphics contexts.
  */
+@SuppressWarnings("serial")
 public class PrintableCenteringRing extends AbstractPrintable<CenteringRing> {
     /**
      * If the component to be drawn is a centering ring, save a reference to it.

--- a/swing/src/net/sf/openrocket/gui/print/PrintableComponent.java
+++ b/swing/src/net/sf/openrocket/gui/print/PrintableComponent.java
@@ -15,6 +15,7 @@ import java.awt.print.PrinterException;
  *
  * @author Jason Blood <dyster2000@gmail.com>
  */
+@SuppressWarnings("serial")
 public class PrintableComponent extends JPanel implements Printable, Comparable<PrintableComponent> {
 
     /**

--- a/swing/src/net/sf/openrocket/gui/print/PrintableFinSet.java
+++ b/swing/src/net/sf/openrocket/gui/print/PrintableFinSet.java
@@ -14,6 +14,7 @@ import java.awt.geom.GeneralPath;
  * modified) and rendering it within a JPanel.  The JPanel is not actually visualized on a display, but instead renders
  * it to a print device.
  */
+@SuppressWarnings("serial")
 public class PrintableFinSet extends AbstractPrintable<FinSet> {
 
     /**

--- a/swing/src/net/sf/openrocket/gui/print/PrintableTransition.java
+++ b/swing/src/net/sf/openrocket/gui/print/PrintableTransition.java
@@ -18,6 +18,7 @@ import java.awt.geom.Point2D;
  * Note: Currently nose cones are only supported by drawing the 2D projection of the profile.  A more useful approach
  * may be to draw a myriahedral projection that can be cut out and bent to form the shape.
  */
+@SuppressWarnings("serial")
 public class PrintableTransition extends AbstractPrintable<Transition> {
 
 	/**

--- a/swing/src/net/sf/openrocket/gui/print/components/RocketPrintTree.java
+++ b/swing/src/net/sf/openrocket/gui/print/components/RocketPrintTree.java
@@ -164,7 +164,7 @@ public class RocketPrintTree extends JTree {
 	 *
 	 * @return a NamedVector suitable for adding to a JTree
 	 */
-	private static Vector createNamedVector(String name, CheckBoxNode[] nodes, int stage) {
+	private static NamedVector createNamedVector(String name, CheckBoxNode[] nodes, int stage) {
 		return new NamedVector(name, nodes, stage);
 	}
 	
@@ -231,6 +231,7 @@ public class RocketPrintTree extends JTree {
 /**
  * JTree's work off of Vector's (unfortunately).  This class is tailored for use with check boxes in the JTree.
  */
+@SuppressWarnings("serial")
 class NamedVector extends Vector<CheckBoxNode> {
 	String name;
 	

--- a/swing/src/net/sf/openrocket/gui/print/components/Rule.java
+++ b/swing/src/net/sf/openrocket/gui/print/components/Rule.java
@@ -12,6 +12,7 @@ import java.awt.Graphics2D;
  * This class creates a Swing ruler.  The ruler has both vertical and horizontal rules, as well as divisions for both
  * inches and centimeters.
  */
+@SuppressWarnings("serial")
 public class Rule extends PrintableComponent {
 
     public static enum Orientation {

--- a/swing/src/net/sf/openrocket/gui/print/visitor/PageFitPrintStrategy.java
+++ b/swing/src/net/sf/openrocket/gui/print/visitor/PageFitPrintStrategy.java
@@ -12,9 +12,6 @@ import java.util.Set;
 import net.sf.openrocket.gui.print.PrintUnit;
 import net.sf.openrocket.gui.print.PrintableComponent;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.itextpdf.text.Document;
 import com.itextpdf.text.pdf.PdfContentByte;
 import com.itextpdf.text.pdf.PdfWriter;
@@ -28,11 +25,6 @@ public class PageFitPrintStrategy {
 
     /** The margin. */
     public final static int MARGIN = (int)(PrintUnit.POINTS_PER_INCH * 0.3f);
-
-    /**
-     * The logger.
-     */
-    private static final Logger log = LoggerFactory.getLogger(PageFitPrintStrategy.class);
 
     /**
      * The iText document.

--- a/swing/src/net/sf/openrocket/gui/rocketfigure/FinSetShapes.java
+++ b/swing/src/net/sf/openrocket/gui/rocketfigure/FinSetShapes.java
@@ -2,77 +2,124 @@ package net.sf.openrocket.gui.rocketfigure;
 
 import java.awt.Shape;
 import java.awt.geom.Path2D;
+import java.util.ArrayList;
 
+import net.sf.openrocket.rocketcomponent.FinSet;
+import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.MathUtil;
 import net.sf.openrocket.util.Transformation;
 
-
 public class FinSetShapes extends RocketComponentShape {
 
-	// TODO: LOW:  Clustering is ignored (FinSet cannot currently be clustered)
 
+    
 	public static RocketComponentShape[] getShapesSide(
-			net.sf.openrocket.rocketcomponent.RocketComponent component, 
+			RocketComponent component, 
 			Transformation transformation,
 			Coordinate componentAbsoluteLocation) {
-		net.sf.openrocket.rocketcomponent.FinSet finset = (net.sf.openrocket.rocketcomponent.FinSet)component;
-
+		FinSet finset = (FinSet)component;
 		
 		int finCount = finset.getFinCount();
-		Transformation cantRotation = finset.getCantRotation();
+        // TODO: MEDIUM: sloping radius
+        double radius = finset.getBodyRadius(0);
+        
+        Transformation cantRotation = finset.getCantRotation();
 		Transformation baseRotation = finset.getBaseRotationTransformation(); // rotation about x-axis
+		Transformation radialTranslation = new Transformation( 0, radius, 0);
 		Transformation finRotation = finset.getFinRotationTransformation();
-		
+		Transformation scale = Transformation.scale(S);
+		Transformation compositeTransform = baseRotation
+		                                        .applyTransformation( radialTranslation)
+		                                        .applyTransformation( cantRotation)
+		                                        .applyTransformation( transformation);
+		                                        
+
 		Coordinate finSetFront = componentAbsoluteLocation;
-		Coordinate finPoints[] = finset.getFinPointsWithTab();
+		Coordinate finPoints[] = finset.getFinPoints_fromFin();
+        Coordinate tabPoints[] = finset.getTabPoints();
+        Coordinate basePoints[] = finset.getRootPoints();
 		
-		// TODO: MEDIUM: sloping radius
-		double radius = finset.getBodyRadius();
-		
-		// Translate & rotate the coordinates
-		for (int i=0; i<finPoints.length; i++) {
-			finPoints[i] = cantRotation.transform(finPoints[i]);
-			finPoints[i] = baseRotation.transform(finPoints[i].add(0,radius,0));
-		}
-		
-
+		// Translate & rotate points into place
+        finPoints = compositeTransform.transform( finPoints );
+        tabPoints = compositeTransform.transform( tabPoints);
+        basePoints = compositeTransform.transform( basePoints );
+        
 		// Generate shapes
-		RocketComponentShape[] finShape = new RocketComponentShape[ finCount];
-		for (int finNum=0; finNum<finCount; finNum++) {
-			Coordinate a;
-			Path2D.Float p;
-			
-			// Make polygon
-			p = new Path2D.Float();
-			for (int i=0; i<finPoints.length; i++) {
-				// previous version
-				// a = transformation.transform(finset.toAbsolute(finPoints[i])[0]);
-				a = transformation.transform(finSetFront.add(finPoints[i]));
-				
-				if (i==0)
-					p.moveTo(a.x*S, a.y*S);
-				else
-					p.lineTo(a.x*S, a.y*S);			
-			}
-			
-			p.closePath();
-			finShape[finNum] = new RocketComponentShape( p, finset);
+        ArrayList<RocketComponentShape> shapeList = new ArrayList<>();
+        for (int finNum=0; finNum<finCount; finNum++) {
+            Coordinate curPoint;
+            
+            // Make fin polygon
+            Path2D.Float finShape = new Path2D.Float();
+            for (int i=0; i<finPoints.length; i++) {
+                curPoint = scale.transform( finSetFront.add(finPoints[i]));
+                
+                if (i==0)
+                    finShape.moveTo(curPoint.x, curPoint.y);
+                else
+                    finShape.lineTo(curPoint.x, curPoint.y);         
+            }
+            shapeList.add( new RocketComponentShape( finShape, finset));
 
-			// Rotate fin coordinates
-			for (int i=0; i<finPoints.length; i++)
-				finPoints[i] = finRotation.transform(finPoints[i]);
-		}
-		
-		return finShape;
+            // draw fin-body intersection line
+            double angle_rad = finset.getBaseRotation() + ((double)finNum) / ((double)finCount) *2*Math.PI;
+            // only draw body-root intersection line if it's not hidden-- i.e. is not at {0,PI/2,PI,3/2*PI} angles
+            final boolean drawRoot= (0.05 < Math.abs( angle_rad % (Math.PI/2.0)));
+            boolean simpleRoot = finset.isRootStraight( );
+            if( drawRoot){
+                if( simpleRoot){
+                    // draws a straight-line connection from the end back to the start
+                    finShape.closePath();
+                }else{
+                    // this implies a curved fin-body intersection 
+                    // ... which is more complicated.
+                    Path2D.Float rootShape = new Path2D.Float();
+                    for (int i=0; i< basePoints.length; i++) {
+                        curPoint = scale.transform( finSetFront.add( basePoints[i]));
+                        
+                        if (i==0)
+                            rootShape.moveTo(curPoint.x, curPoint.y);
+                        else
+                            rootShape.lineTo(curPoint.x, curPoint.y);   
+                    }
+                    
+                    shapeList.add( new RocketComponentShape( rootShape, finset));
+                }
+            }
+            
+            // Make tab polygon
+            Path2D.Float tabShape = new Path2D.Float();
+            if( 0 < tabPoints.length ){
+                for (int i=0; i<tabPoints.length; i++) {
+                    curPoint = scale.transform( finSetFront.add(tabPoints[i]));
+                    
+                    if (i==0)
+                        tabShape.moveTo(curPoint.x, curPoint.y);
+                    else
+                        tabShape.lineTo(curPoint.x, curPoint.y);         
+                }
+                
+                // the fin tab / body surface line should lay on the fin-root line above 
+            
+                shapeList.add( new RocketComponentShape( tabShape, finset));
+            }
+
+            // Rotate fin, tab coordinates
+            finPoints = finRotation.transform(finPoints);
+            tabPoints = finRotation.transform(tabPoints);
+            basePoints = finRotation.transform( basePoints);
+        }
+        
+		return shapeList.toArray(new RocketComponentShape[0]);
 	}
 	
 	public static RocketComponentShape[] getShapesBack(
-			net.sf.openrocket.rocketcomponent.RocketComponent component, 
+			RocketComponent component, 
 			Transformation transformation,
 			Coordinate location) {
 	
-		net.sf.openrocket.rocketcomponent.FinSet finset = (net.sf.openrocket.rocketcomponent.FinSet)component; 
+		FinSet finset = (FinSet)component; 
 		
 		Shape[] toReturn;
 
@@ -87,12 +134,12 @@ public class FinSetShapes extends RocketComponentShape {
 	}
 	
 	
-	private static Shape[] uncantedShapesBack(net.sf.openrocket.rocketcomponent.FinSet finset,
+	private static Shape[] uncantedShapesBack(FinSet finset,
 			Transformation transformation,
 			Coordinate location) {
 		
 		int fins = finset.getFinCount();
-		double radius = finset.getBodyRadius();
+		double radius = finset.getBodyRadius(0);
 		double thickness = finset.getThickness();
 		double height = finset.getSpan();
 		Coordinate compCenter = location;
@@ -138,12 +185,12 @@ public class FinSetShapes extends RocketComponentShape {
 	
 	
 	// TODO: LOW:  Jagged shapes from back draw incorrectly.
-	private static Shape[] cantedShapesBack(net.sf.openrocket.rocketcomponent.FinSet finset,
+	private static Shape[] cantedShapesBack(FinSet finset,
 			Transformation transformation,
 			Coordinate location) {
 		int i;
 		int fins = finset.getFinCount();
-		double radius = finset.getBodyRadius();
+		double radius = finset.getBodyRadius(0);
 		double thickness = finset.getThickness();
 		
 		Transformation baseRotation = finset.getBaseRotationTransformation();
@@ -224,7 +271,7 @@ public class FinSetShapes extends RocketComponentShape {
 		}
 	}
 	
-	private static Shape makePolygonBack(Coordinate[] array, net.sf.openrocket.rocketcomponent.FinSet finset, 
+	private static Shape makePolygonBack(Coordinate[] array, FinSet finset, 
 			Transformation t, Coordinate location) {
 		Path2D.Float p;
 

--- a/swing/src/net/sf/openrocket/gui/scalefigure/FinPointFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/FinPointFigure.java
@@ -1,5 +1,6 @@
 package net.sf.openrocket.gui.scalefigure;
 
+
 import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -13,94 +14,188 @@ import java.awt.geom.NoninvertibleTransformException;
 import java.awt.geom.Path2D;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
+import java.util.EventListener;
+import java.util.EventObject;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.swing.JPanel;
 
 import net.sf.openrocket.rocketcomponent.FreeformFinSet;
+import net.sf.openrocket.rocketcomponent.RocketComponent;
+import net.sf.openrocket.rocketcomponent.RocketComponent.Position;
+import net.sf.openrocket.rocketcomponent.SymmetricComponent;
+import net.sf.openrocket.rocketcomponent.Transition;
 import net.sf.openrocket.unit.Tick;
 import net.sf.openrocket.unit.Unit;
 import net.sf.openrocket.unit.UnitGroup;
+import net.sf.openrocket.util.Bounds;
 import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.MathUtil;
-
-
-// TODO: MEDIUM:  the figure jumps and bugs when using automatic fitting
+import net.sf.openrocket.util.StateChangeListener;
 
 @SuppressWarnings("serial")
-public class FinPointFigure extends AbstractScaleFigure {
+public class FinPointFigure extends JPanel implements ScaleFigure {
 	
-	private static final int BOX_SIZE = 4;
+
+	// Number of pixels to leave at edges when fitting figure
+	protected static final int DEFAULT_BORDER_PIXELS = 32;	
+	
+	protected static final float MINIMUM_CANVAS_SIZE_METERS = 0.01f; // i.e. 1 cm
+	
+	private static final Color GRID_LINE_COLOR = new Color( 137, 137, 137, 32);
+	private static final float GRID_LINE_BASE_WIDTH = 0.001f;
+	
+	private static final int LINE_WIDTH_PIXELS = 1;
+	// the size of the boxes around each fin point vertex
+	private static final float BOX_WIDTH_PIXELS = 12; 
+	
+	private static final double MINOR_TICKS = 0.05;
+	private static final double MAJOR_TICKS = 0.1;
 	
 	private final FreeformFinSet finset;
 	private int modID = -1;
 	
-	private double minX, maxX, maxY;
-	private double figureWidth = 0;
-	private double figureHeight = 0;
-	private double translateX = 0;
-	private double translateY = 0;
+	// whatever this figure is drawing, in real-space coordinates:  meters
+
+	protected Bounds subjectBounds_m = new Bounds(2);	
 	
+	protected Dimension originLocation_px = new Dimension(0,0);
+
+	// actual size of panel in pixels; this panel may or may not be fully drawn
+	protected Dimension preferredFigureSize_px = new Dimension(100,100);
+	
+ 	
+	// ========= lower-abstraction level variables
+	protected int borderThickness_px = DEFAULT_BORDER_PIXELS;
+	
+	// actual number to multiply against rocket coordinates to display in UI
+	// y'know, this *really* is a magic number of abritrary magnitude...
+	protected final static double scale = 1000.0;
+	
+	// zoom factor, in the traditional % zoom units
+	// 1.0 === 100% === no scaling.
+	protected double zoom = 1.0;
+	
+	protected final List<StateChangeListener> listeners = new LinkedList<StateChangeListener>();
+	
+	// combines the translation and scale in one place: 
+	// which frames does this transform between ?  
 	private AffineTransform transform;
-	private Rectangle2D.Double[] handles = null;
 	
+ 	private Rectangle2D.Double[] finPointHandles = null;
+ 	
 	
 	public FinPointFigure(FreeformFinSet finset) {
 		this.finset = finset;
+
+		this.zoom = 1.0;
+		// this.scale = scaleSubjectToCanvas_dpm * zoom;
+		
+		// useful for debugging -- shows a contrast against un-drawn space.
+		setBackground(Color.WHITE);
+		setOpaque(true);
+		
+		updateTransform();
+	}
+
+	@SuppressWarnings("unused")
+    private void dumpState( final String locationName ){
+		System.err.println("dumpState from: "+this.getClass().getSimpleName()+"."+locationName);
+		{
+			System.err.println("    subjectBounds (m) X:"+subjectBounds_m.getX().toDebug());
+			System.err.println("    subjectBounds (m) Y:"+subjectBounds_m.getY().toDebug());
+		}
+		System.err.println("    subclass.getPreferredSize(px):"+preferredFigureSize_px.width+", "+preferredFigureSize_px.height);
+		System.err.println("    actual.getPreferredSize(px):"+getPreferredSize().width+", "+getPreferredSize().height);
+		System.err.println("    act. size (px):"+this.getWidth()+", "+this.getHeight());
+		System.err.println("  ");
+		System.err.println(String.format("    current zoom= %6.4g%%)", this.zoom*100));
+		System.err.println("    current scale = "+FinPointFigure.scale+")");
 	}
 	
+	@Override
+	public double getZoom() {
+		return zoom;
+	}
+	
+	@Override
+	public double getAbsoluteScale() {
+		return scale*zoom;
+	}
+	
+	@Override
+	public void setZoom( final double newZoomRequest) {
+		if (Double.isInfinite(newZoomRequest) || Double.isNaN(newZoomRequest)){
+			return;}
+		
+		final double newZoom = MathUtil.clamp( newZoomRequest, MINIMUM_ZOOM, MAXIMUM_ZOOM);
+		
+		if (Math.abs(this.zoom - newZoom) < MINIMUM_ZOOM){
+			return;}
+		
+		this.zoom = newZoom;
+		
+		
+		updateTransform();
+		repaint();
+	}
+	
+	@Override 
+	public void zoomToSize( final Dimension requestedBounds ){
+	    if( ( 0 == requestedBounds.width)||( 0 == requestedBounds.height)){
+	        // invalid request values
+	        return; 
+	    }
+	    
+	    // in canvas-space
+		Point2D.Double requestedSize_px = new Point2D.Double( requestedBounds.width - 2*borderThickness_px, requestedBounds.height - 2*borderThickness_px);
+		
+	    double widthZoom = requestedSize_px.x / scale / subjectBounds_m.getX().span();
+	    double heightZoom = requestedSize_px.y / scale / subjectBounds_m.getY().span();
+		double minZoom = Math.min( widthZoom, heightZoom);
+        double clampedZoom = MathUtil.clamp( minZoom, MINIMUM_ZOOM, MAXIMUM_ZOOM);
+		
+        this.setZoom( clampedZoom );    
+	}
+	
+	@Override
+	public Dimension getBorderPixels() {
+		return new Dimension(borderThickness_px, borderThickness_px);
+	}
+	
+	@Override
+	public void setBorderPixels( final int width, final int height) {
+		this.borderThickness_px = Math.max( width, height);
+	}
+	
+	@Override
+	public void addChangeListener(StateChangeListener listener) {
+		listeners.add( listener);
+	}
+	
+	@Override
+	public void removeChangeListener(StateChangeListener listener) {
+		listeners.remove(listener);
+	}
+	
+	protected void fireChangeEvent() {
+		EventObject changeEvent = new EventObject(this);
+		for (EventListener l : listeners) {
+			((StateChangeListener) l).stateChanged(changeEvent);
+		}
+	}
 	
 	@Override
 	public void paintComponent(Graphics g) {
 		super.paintComponent(g);
-		Graphics2D g2 = (Graphics2D) g;
+		Graphics2D g2 = (Graphics2D) g.create();
 		
 		if (modID != finset.getRocket().getAerodynamicModID()) {
 			modID = finset.getRocket().getAerodynamicModID();
-			calculateDimensions();
-		}
-		
 
-		double tx, ty;
-		// Calculate translation for figure centering
-		if (figureWidth * scale + 2 * borderPixelsWidth < getWidth()) {
-			
-			// Figure fits in the viewport
-			tx = (getWidth() - figureWidth * scale) / 2 - minX * scale;
-			
-		} else {
-			
-			// Figure does not fit in viewport
-			tx = borderPixelsWidth - minX * scale;
-			
+			updateTransform();
 		}
-		
-
-		if (figureHeight * scale + 2 * borderPixelsHeight < getHeight()) {
-			ty = getHeight() - borderPixelsHeight;
-		} else {
-			ty = borderPixelsHeight + figureHeight * scale;
-		}
-		
-		if (Math.abs(translateX - tx) > 1 || Math.abs(translateY - ty) > 1) {
-			// Origin has changed, fire event
-			translateX = tx;
-			translateY = ty;
-			fireChangeEvent();
-		}
-		
-
-		if (Math.abs(translateX - tx) > 1 || Math.abs(translateY - ty) > 1) {
-			// Origin has changed, fire event
-			translateX = tx;
-			translateY = ty;
-			fireChangeEvent();
-		}
-		
-
-		// Calculate and store the transformation used
-		transform = new AffineTransform();
-		transform.translate(translateX, translateY);
-		transform.scale(scale / EXTRA_SCALE, -scale / EXTRA_SCALE);
-		
-		// TODO: HIGH:  border Y-scale upwards
 		
 		g2.transform(transform);
 		
@@ -111,22 +206,26 @@ public class FinPointFigure extends AbstractScaleFigure {
 				RenderingHints.VALUE_RENDER_QUALITY);
 		g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
 				RenderingHints.VALUE_ANTIALIAS_ON);
+
+		paintBackgroundGrid( g2);
 		
-
-
+		paintRocketBody(g2);
+		
+		paintFinShape(g2);
+	}
+	
+	public void paintBackgroundGrid( Graphics2D g2){
 		Rectangle visible = g2.getClipBounds();
-		double x0 = ((double) visible.x - 3) / EXTRA_SCALE;
-		double x1 = ((double) visible.x + visible.width + 4) / EXTRA_SCALE;
-		double y0 = ((double) visible.y - 3) / EXTRA_SCALE;
-		double y1 = ((double) visible.y + visible.height + 4) / EXTRA_SCALE;
+		int x0 = visible.x - 3;
+		int x1 = visible.x + visible.width + 4;
+		int y0 = visible.y - 3;
+		int y1 = visible.y + visible.height + 4;
 		
-
-		// Background grid
-		
-		g2.setStroke(new BasicStroke((float) (1.0 * EXTRA_SCALE / scale),
+		final float grid_line_width = (float)(FinPointFigure.GRID_LINE_BASE_WIDTH/zoom);
+		g2.setStroke(new BasicStroke( grid_line_width,
 				BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL));
-		g2.setColor(new Color(0, 0, 255, 30));
-		
+		g2.setColor(FinPointFigure.GRID_LINE_COLOR);
+	
 		Unit unit;
 		if (this.getParent() != null &&
 				this.getParent().getParent() instanceof ScaleScrollPane) {
@@ -134,74 +233,121 @@ public class FinPointFigure extends AbstractScaleFigure {
 		} else {
 			unit = UnitGroup.UNITS_LENGTH.getDefaultUnit();
 		}
-		
+	
 		// vertical
-		Tick[] ticks = unit.getTicks(x0, x1,
-				ScaleScrollPane.MINOR_TICKS / scale,
-				ScaleScrollPane.MAJOR_TICKS / scale);
+		Tick[] verticalTicks = unit.getTicks(x0, x1, MINOR_TICKS, MAJOR_TICKS);
 		Line2D.Double line = new Line2D.Double();
-		for (Tick t : ticks) {
+		for (Tick t : verticalTicks) {
 			if (t.major) {
-				line.setLine(t.value * EXTRA_SCALE, y0 * EXTRA_SCALE,
-						t.value * EXTRA_SCALE, y1 * EXTRA_SCALE);
+				line.setLine( t.value, y0, t.value, y1);
 				g2.draw(line);
 			}
 		}
 		
 		// horizontal
-		ticks = unit.getTicks(y0, y1,
-				ScaleScrollPane.MINOR_TICKS / scale,
-				ScaleScrollPane.MAJOR_TICKS / scale);
-		for (Tick t : ticks) {
+		Tick[] horizontalTicks = unit.getTicks(y0, y1, MINOR_TICKS, MAJOR_TICKS);
+		for (Tick t : horizontalTicks) {
 			if (t.major) {
-				line.setLine(x0 * EXTRA_SCALE, t.value * EXTRA_SCALE,
-						x1 * EXTRA_SCALE, t.value * EXTRA_SCALE);
+				line.setLine( x0, t.value, x1, t.value);
 				g2.draw(line);
 			}
 		}
+	}
+
+	private void paintFinShape(Graphics2D g2){
+        // excludes fin tab points
+		final Coordinate[] drawPoints = finset.getFinPoints();
 		
-
-
-
-
-		// Base rocket line
-		g2.setStroke(new BasicStroke((float) (3.0 * EXTRA_SCALE / scale),
-				BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL));
-		g2.setColor(Color.GRAY);
-		
-		g2.drawLine((int) (x0 * EXTRA_SCALE), 0, (int) (x1 * EXTRA_SCALE), 0);
-		
-
-		// Fin shape
-		Coordinate[] points = finset.getFinPoints();
 		Path2D.Double shape = new Path2D.Double();
-		shape.moveTo(0, 0);
-		for (int i = 1; i < points.length; i++) {
-			shape.lineTo(points[i].x * EXTRA_SCALE, points[i].y * EXTRA_SCALE);
+		Coordinate startPoint= drawPoints[0];
+		shape.moveTo( startPoint.x, startPoint.y);
+		for (int i = 1; i < drawPoints.length; i++) {
+			shape.lineTo( drawPoints[i].x, drawPoints[i].y);
 		}
-		
-		g2.setStroke(new BasicStroke((float) (1.0 * EXTRA_SCALE / scale),
-				BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL));
-		g2.setColor(Color.BLACK);
+
+		final float finEdgeWidth_m = (float) (LINE_WIDTH_PIXELS / scale / zoom );
+		g2.setStroke(new BasicStroke( finEdgeWidth_m, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL));
+		g2.setColor(Color.BLUE);
 		g2.draw(shape);
 		
-
 		// Fin point boxes
-		g2.setColor(new Color(150, 0, 0));
-		double s = BOX_SIZE * EXTRA_SCALE / scale;
-		handles = new Rectangle2D.Double[points.length];
-		for (int i = 0; i < points.length; i++) {
-			Coordinate c = points[i];
-			handles[i] = new Rectangle2D.Double(c.x * EXTRA_SCALE - s, c.y * EXTRA_SCALE - s, 2 * s, 2 * s);
-			g2.draw(handles[i]);
-		}
+		final float boxWidth = (float) (BOX_WIDTH_PIXELS / scale / zoom);
+		final float boxEdgeWidth_m = (float) ( LINE_WIDTH_PIXELS / scale / zoom );
+        g2.setStroke(new BasicStroke( boxEdgeWidth_m, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL));
+        g2.setColor(new Color(150, 0, 0));
 		
+		final double boxHalfWidth = boxWidth/2;
+		finPointHandles = new Rectangle2D.Double[ drawPoints.length];
+		for (int i = 0; i < drawPoints.length; i++) {
+			Coordinate c = drawPoints[i];
+			finPointHandles[i] = new Rectangle2D.Double(c.x - boxHalfWidth, c.y - boxHalfWidth, boxWidth, boxWidth);
+			g2.draw(finPointHandles[i]);
+		}
 	}
 	
+	private void paintRocketBody( Graphics2D g2){
+		RocketComponent comp = finset.getParent();
+		if( comp instanceof Transition ){
+			paintBodyTransition(g2);
+		}else{
+			paintBodyTube(g2);			
+		}
+	}
 	
+	// NOTE:  This function drawns relative to the reference point of the BODY component
+	// In other words: 0,0 == the front, foreRadius of the body component
+	private void paintBodyTransition( Graphics2D g2){	
+	    //Rectangle visible = g2.getClipBounds();
+        
+        // setup lines 
+        final float bodyLineWidth = (float) ( LINE_WIDTH_PIXELS / scale / zoom ); 
+        g2.setStroke(new BasicStroke( bodyLineWidth, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL));
+        g2.setColor(Color.BLACK);
 
+        Transition body = (Transition) finset.getParent();
+        final float xResolution_m = 0.01f; // distance between draw points, in meters
+        
+        final double xFinStart = finset.asPositionValue(Position.TOP); //<<  in body frame
+        // vv in fin-frame == draw-frame vv
+        final double xOffset = -xFinStart;
+        final double yOffset = -body.getRadius(xFinStart);
+                
+        Path2D.Double bodyShape = new Path2D.Double();
+        // draw front-cap: 
+        bodyShape.moveTo( xOffset, yOffset);
+        bodyShape.lineTo( xOffset, yOffset + body.getForeRadius());
+
+        final float length_m = (float)( body.getLength());
+        Point2D.Double cur = new Point2D.Double ();
+        for( double xBody = xResolution_m ; xBody < length_m;  xBody += xResolution_m ){
+            // xBody is distance from front of parent body
+            cur.x = xOffset + xBody; // offset from origin (front of fin)
+            cur.y = yOffset + body.getRadius( xBody); // offset from origin ( fin-front-point ) 
+            
+            bodyShape.lineTo( cur.x, cur.y);
+        }
+        
+        // draw end-cap
+        bodyShape.lineTo( xOffset + length_m, yOffset + body.getAftRadius());
+        bodyShape.lineTo( xOffset + length_m, yOffset);
+        
+        g2.draw(bodyShape);
+	}
+	
+	private void paintBodyTube( Graphics2D g2){
+		Rectangle visible = g2.getClipBounds();
+		int x0 = visible.x - 3;
+		int x1 = visible.x + visible.width + 4;
+		
+		final float bodyLineWidth = (float) ( LINE_WIDTH_PIXELS / scale / zoom ); 
+		g2.setStroke(new BasicStroke( bodyLineWidth, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL));
+		g2.setColor(Color.BLACK);
+
+		g2.drawLine((int) x0, 0, (int)x1, 0);
+	}
+	
 	public int getIndexByPoint(double x, double y) {
-		if (handles == null)
+		if (finPointHandles == null)
 			return -1;
 		
 		// Calculate point in shapes' coordinates
@@ -212,8 +358,8 @@ public class FinPointFigure extends AbstractScaleFigure {
 			return -1;
 		}
 		
-		for (int i = 0; i < handles.length; i++) {
-			if (handles[i].contains(p))
+		for (int i = 0; i < finPointHandles.length; i++) {
+			if (finPointHandles[i].contains(p))
 				return i;
 		}
 		return -1;
@@ -221,7 +367,7 @@ public class FinPointFigure extends AbstractScaleFigure {
 	
 	
 	public int getSegmentByPoint(double x, double y) {
-		if (handles == null)
+		if (finPointHandles == null)
 			return -1;
 		
 		// Calculate point in shapes' coordinates
@@ -232,9 +378,9 @@ public class FinPointFigure extends AbstractScaleFigure {
 			return -1;
 		}
 		
-		double x0 = p.x / EXTRA_SCALE;
-		double y0 = p.y / EXTRA_SCALE;
-		double delta = BOX_SIZE / scale;
+		double x0 = p.x;
+		double y0 = p.y;
+		double delta = BOX_WIDTH_PIXELS / scale;
 		
 		//System.out.println("Point: " + x0 + "," + y0);
 		//System.out.println("delta: " + (BOX_SIZE / scale));
@@ -268,78 +414,89 @@ public class FinPointFigure extends AbstractScaleFigure {
 			return new Point2D.Double(0, 0);
 		}
 		
-		p.setLocation(p.x / EXTRA_SCALE, p.y / EXTRA_SCALE);
+		p.setLocation(p.x, p.y);
 		return p;
 	}
 	
-	
-
+	// N.B. this method tells the rulers where to drawn themselves
 	@Override
 	public Dimension getOrigin() {
 		if (modID != finset.getRocket().getAerodynamicModID()) {
 			modID = finset.getRocket().getAerodynamicModID();
-			calculateDimensions();
+			updateTransform();
 		}
-		return new Dimension((int) translateX, (int) translateY);
+		
+		return new Dimension(originLocation_px.width, originLocation_px.height);
 	}
-	
-	@Override
-	public double getFigureWidth() {
-		if (modID != finset.getRocket().getAerodynamicModID()) {
-			modID = finset.getRocket().getAerodynamicModID();
-			calculateDimensions();
-		}
-		return figureWidth;
-	}
-	
-	@Override
-	public double getFigureHeight() {
-		if (modID != finset.getRocket().getAerodynamicModID()) {
-			modID = finset.getRocket().getAerodynamicModID();
-			calculateDimensions();
-		}
-		return figureHeight;
-	}
-	
 	
 	private void calculateDimensions() {
-		minX = 0;
-		maxX = 0;
-		maxY = 0;
-		
-		for (Coordinate c : finset.getFinPoints()) {
-			if (c.x < minX)
-				minX = c.x;
-			if (c.x > maxX)
-				maxX = c.x;
-			if (c.y > maxY)
-				maxY = c.y;
-		}
-		
-		if (maxX < 0.01)
-			maxX = 0.01;
-		
-		figureWidth = maxX - minX;
-		figureHeight = maxY;
-		
 
-		Dimension d = new Dimension((int) (figureWidth * scale + 2 * borderPixelsWidth),
-				(int) (figureHeight * scale + 2 * borderPixelsHeight));
+        // update subject bounds
+		subjectBounds_m.reset();
+		// subsequent updates can only increase the size of the bounds, so this is the minimum size.
+        subjectBounds_m.update( MINIMUM_CANVAS_SIZE_METERS, MINIMUM_CANVAS_SIZE_METERS);
+        
+        SymmetricComponent parent = (SymmetricComponent)this.finset.getParent();
+        
+        // N.B.: (0,0) is the fin front-- where it meets the parent body.
+        final double xFinFront = finset.getFinFront().x;
+        
+        // update to bound the parent body:
+        final double xParentFront = -xFinFront;
+        subjectBounds_m.getX().update( xParentFront);
+        final double xParentBack = -xFinFront + parent.getLength();
+        subjectBounds_m.getX().update( xParentBack );
+        final double yParentCenterline = -parent.getRadius(xFinFront); // from parent centerline to fin front.
+        subjectBounds_m.getY().update( yParentCenterline );
+        // in 99% of fins, this bound is redundant, buuuuut just in case.  
+        final double yParentMax = yParentCenterline + Math.max( parent.getForeRadius(), parent.getAftRadius());
+        subjectBounds_m.getY().update( yParentMax );
+        
+        // update to bounds the fin points:
+        for (Coordinate c : finset.getFinPoints()) {
+			// ignore the z coordinates; fins are treated as 2-D objects here.
+			subjectBounds_m.update( c.x,  c.y);
+		}
+
+	}
+	
+	private void calculateFigureSize(){
+		// update preferred figure Size
+		//final double INCHES_PER_METER = 39.3701;
+		// dots     dots     inch
+		// ----  = ------ * -----
+		// meter    inch    meter
+		//final double scale_dpm = GUIUtil.getDPI()* INCHES_PER_METER * zoom;
+		final double figureSizeScale = scale*zoom;
 		
-		if (!d.equals(getPreferredSize()) || !d.equals(getMinimumSize())) {
-			setPreferredSize(d);
-			setMinimumSize(d);
+		preferredFigureSize_px.width = (int)(subjectBounds_m.getX().span()*figureSizeScale) + 2*borderThickness_px;
+		preferredFigureSize_px.height = (int)(subjectBounds_m.getY().span()*figureSizeScale) + 2*borderThickness_px;
+
+		if( !preferredFigureSize_px.equals( getPreferredSize()) ){
+			setPreferredSize( preferredFigureSize_px);
 			revalidate();
 		}
+		
 	}
 	
-	
+	private void updateTransform(){
+        
+		calculateDimensions();
+		calculateFigureSize();
 
-	@Override
-	public void updateFigure() {
+		this.originLocation_px.width = borderThickness_px + (int)(-1*subjectBounds_m.getX().min*scale*zoom);
+		this.originLocation_px.height = borderThickness_px + (int)(subjectBounds_m.getY().max*scale*zoom);
+		
+		// Calculate and store the transformation used
+		transform = new AffineTransform();
+		transform.translate((double)originLocation_px.width, (double)originLocation_px.height);
+		transform.scale(scale*zoom , -scale*zoom );
+	}
+	
+	public void updateFigure(){
+		updateTransform();
+		revalidate();
 		repaint();
 	}
-	
-
 
 }

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketFigure.java
@@ -18,9 +18,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import net.sf.openrocket.gui.figureelements.FigureElement;
 import net.sf.openrocket.gui.rocketfigure.RocketComponentShape;
 import net.sf.openrocket.gui.util.ColorConversion;
@@ -33,7 +30,6 @@ import net.sf.openrocket.rocketcomponent.FlightConfiguration;
 import net.sf.openrocket.rocketcomponent.MotorMount;
 import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
-import net.sf.openrocket.simulation.BasicEventSimulationEngine;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.BugException;
 import net.sf.openrocket.util.Coordinate;
@@ -51,8 +47,6 @@ import net.sf.openrocket.util.Transformation;
  */
 @SuppressWarnings("serial")
 public class RocketFigure extends AbstractScaleFigure {
-	
-	private static final Logger log = LoggerFactory.getLogger(BasicEventSimulationEngine.class);
 	
 	private static final String ROCKET_FIGURE_PACKAGE = "net.sf.openrocket.gui.rocketfigure";
 	private static final String ROCKET_FIGURE_SUFFIX = "Shapes";

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -120,7 +120,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 	private TreeSelectionModel selectionModel = null;
 
 	private BasicSlider rotationSlider;
-	private ScaleSelector scaleSelector;
+	private ZoomSelector scaleSelector;
 
 	/* Calculation of CP and CG */
 	private AerodynamicCalculator aerodynamicCalculator;
@@ -188,7 +188,6 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		figureHolder = new JPanel(new BorderLayout());
 
 		scrollPane = new ScaleScrollPane(figure) {
-			private static final long serialVersionUID = 1L;
 
 			@Override
 			public void mouseClicked(MouseEvent event) {
@@ -305,7 +304,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		add(new JComboBox<VIEW_TYPE>(cm));
 
 		// Zoom level selector
-		scaleSelector = new ScaleSelector(scrollPane);
+		scaleSelector = new ZoomSelector(scrollPane);
 		add(scaleSelector);
 
 		// Stage selector

--- a/swing/src/net/sf/openrocket/gui/scalefigure/ScaleFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/ScaleFigure.java
@@ -16,29 +16,30 @@ public interface ScaleFigure extends ChangeSource {
 	 * in the figures must be multiplied by this factor.
 	 */
 	public static final double EXTRA_SCALE = 1000;
+
+	public static final double INCHES_PER_METER = 39.3701;
+	public static final double METERS_PER_INCH = 0.0254;
+
+	public static final double MINIMUM_ZOOM = 0.01; // ==        1 %
+	public static final double MAXIMUM_ZOOM = 1000;  // == 100,000 %
 	
-	/**
-	 * Shorthand for {@link #EXTRA_SCALE}.
-	 */
-	public static final double S = EXTRA_SCALE;
 	
 	
 	/**
 	 * Set the scale level of the figure.  A scale value of 1.0 indicates an original
 	 * size when using the current DPI level.
 	 * 
-	 * @param scale   the scale level.
+	 * @param newZoom the zoom level.
 	 */
-	public void setScaling(double scale);
+	public void setZoom( final double newZoom );
 	
 	
 	/**
-	 * Set the scale level so that the figure fits into the given bounds.
+	 * Set the zoom level so that the figure fits into the given bounds.
 	 * 
-	 * @param bounds  the bounds of the figure.
+	 * @param bounds the dimension 
 	 */
-	public void setScaling(Dimension bounds);
-	
+	public void zoomToSize( final Dimension bounds );
 	
 	/**
 	 * Return the scale level of the figure.  A scale value of 1.0 indicates an original
@@ -46,7 +47,7 @@ public interface ScaleFigure extends ChangeSource {
 	 * 
 	 * @return   the current scale level.
 	 */
-	public double getScaling();
+	public double getZoom();
 	
 	
 	/**
@@ -64,7 +65,6 @@ public interface ScaleFigure extends ChangeSource {
 	 */
 	public Dimension getOrigin();
 	
-	
 	/**
 	 * Get the amount of blank space left around the figure.
 	 * 
@@ -78,5 +78,5 @@ public interface ScaleFigure extends ChangeSource {
 	 * @param width		the amount of horizontal space left on both sides of the figure.
 	 * @param height	the amount of vertical space left on both sides of the figure.
 	 */
-	public void setBorderPixels(int width, int height);
+	public void setBorderPixels( final int width, final int height);
 }

--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationConditionsPanel.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationConditionsPanel.java
@@ -27,6 +27,7 @@ import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
 import net.sf.openrocket.util.Chars;
 
+@SuppressWarnings("serial")
 public class SimulationConditionsPanel extends JPanel {
 	private static final Translator trans = Application.getTranslator();
 	

--- a/swing/src/net/sf/openrocket/gui/util/CheckList.java
+++ b/swing/src/net/sf/openrocket/gui/util/CheckList.java
@@ -94,7 +94,7 @@ public class CheckList<T> {
 		
 		if (!isEditorAttached())
 			list.addMouseListener(checkBoxEditor);
-		this.list.setCellRenderer(new CheckListRenderer());
+		this.list.setCellRenderer(new CheckListRenderer<T>());
 		
 		setupKeyboardActions(list);
 		

--- a/swing/src/net/sf/openrocket/gui/util/CheckListRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/util/CheckListRenderer.java
@@ -46,7 +46,7 @@ import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 
 @SuppressWarnings("serial")
-public class CheckListRenderer extends JCheckBox implements ListCellRenderer, Serializable {
+public class CheckListRenderer<E> extends JCheckBox implements ListCellRenderer<E>, Serializable {
 		
 	private static final Border NO_FOCUS_BORDER = new EmptyBorder(1, 1, 1, 1);
 	private static final Border SAFE_NO_FOCUS_BORDER = NO_FOCUS_BORDER; // may change in the feature
@@ -68,7 +68,7 @@ public class CheckListRenderer extends JCheckBox implements ListCellRenderer, Se
 		}
 	}
 	
-	public Component getListCellRendererComponent(JList list, Object value, int index, boolean isSelected,
+	public Component getListCellRendererComponent(JList<? extends E> list, E value, int index, boolean isSelected,
 			boolean cellHasFocus) {
 		
 		setComponentOrientation(list.getComponentOrientation());
@@ -126,7 +126,7 @@ public class CheckListRenderer extends JCheckBox implements ListCellRenderer, Se
 		return (obj == null) ? "" : obj.toString();
 	}
 	
-	private boolean isChecked(JList list, int index) {
+	private boolean isChecked(JList<? extends E> list, int index) {
 		
 		if (list.getModel() instanceof DefaultCheckListModel<?>) {
 			return ((DefaultCheckListModel<?>) list.getModel()).isCheckedIndex(index);
@@ -220,7 +220,6 @@ public class CheckListRenderer extends JCheckBox implements ListCellRenderer, Se
 	public void firePropertyChange(String propertyName, boolean oldValue, boolean newValue) {
 	}
 	
-	@SuppressWarnings("serial")
 	public static class UIResource extends DefaultListCellRenderer implements javax.swing.plaf.UIResource {
 	}
 	

--- a/swing/src/net/sf/openrocket/gui/util/CustomFinImporter.java
+++ b/swing/src/net/sf/openrocket/gui/util/CustomFinImporter.java
@@ -3,7 +3,6 @@ package net.sf.openrocket.gui.util;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
 import java.util.ListIterator;
 
 import javax.imageio.ImageIO;
@@ -24,7 +23,7 @@ public class CustomFinImporter {
 	
 	
 	
-	public List<Coordinate> getPoints(File file) throws IOException {
+	public ArrayList<Coordinate> getPoints(File file) throws IOException {
 		ArrayList<Coordinate> points = new ArrayList<Coordinate>();
 		
 		BufferedImage pic = ImageIO.read(file);

--- a/swing/src/net/sf/openrocket/gui/widgets/MultiSliderUI.java
+++ b/swing/src/net/sf/openrocket/gui/widgets/MultiSliderUI.java
@@ -474,7 +474,7 @@ class MultiSliderUI extends BasicSliderUI {
 				if (bounded) {
 					int[] neighbours = new int[2];
 					int idx = -1;
-					int diff = e.getY() - firstXY[1];
+					//int diff = e.getY() - firstXY[1];
 					//System.out.println("diff = " + diff);
 					if (e.getY() - firstXY[1] > 0) {
 						idx = minmaxIndices[0];
@@ -566,6 +566,7 @@ class MultiSliderUI extends BasicSliderUI {
 	/***
 	 * A static version of the above.
 	 */
+	@SuppressWarnings("serial")
 	static class SharedActionScroller extends AbstractAction {
 		int _dir;
 		boolean _block;

--- a/swing/src/net/sf/openrocket/startup/providers/BlockingComponentPresetDatabaseProvider.java
+++ b/swing/src/net/sf/openrocket/startup/providers/BlockingComponentPresetDatabaseProvider.java
@@ -4,15 +4,10 @@ import net.sf.openrocket.database.ComponentPresetDatabase;
 import net.sf.openrocket.database.ComponentPresetDatabaseLoader;
 import net.sf.openrocket.l10n.Translator;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
 public class BlockingComponentPresetDatabaseProvider implements Provider<ComponentPresetDatabase> {
-	
-	private final static Logger log = LoggerFactory.getLogger(BlockingComponentPresetDatabaseProvider.class);
 	
 	@Inject
 	private Translator trans;

--- a/swing/src/net/sf/openrocket/startup/providers/BlockingMotorDatabaseProvider.java
+++ b/swing/src/net/sf/openrocket/startup/providers/BlockingMotorDatabaseProvider.java
@@ -97,6 +97,7 @@ public class BlockingMotorDatabaseProvider implements Provider<ThrustCurveMotorS
 	}
 	
 	
+	@SuppressWarnings("serial")
 	private class LoadingDialog extends JDialog {
 		private LoadingDialog() {
 			super(null, trans.get("MotorDbLoadDlg.title"), ModalityType.APPLICATION_MODAL);


### PR DESCRIPTION
[Fix] FinSet now implements the Ring-Instanceable interface
[Refactor] Rocket inherits from ComponentAssembly instead of RocketComponent
[Fix][Refactor] Fin tabs are now correctly validated upon change
[Fix] Fin tabs are now corrected to be no-bigger-than their fins
[Refactor] FinSet.getBodyRadius(..) now requires an argument
[Fix] restricted fin tab positioning to be strictly top/middle/bottom
[Refactor] Reimplement FreeformFinSet.setPoint(...)
[Refactor] DoubleModel.AutoActionModel new inherits from BooleanModel
[Fix] Prevent Freeform Fins movement past parent's top/front
[refine] FinPointFigure now draws relative to the fin-front point
[bugfix] Fin point Figure now displays y-rulers in the correct direction.
[bugfix] Fins are now addable to transitions from the GUI
[Fix] Fins, Transitions are now drawn correctly in fin-design window
[Refactor] Simplified FinPointFigure internal code
[Refactor] Added Bounds class, used for FinPointFigure
[Minor] Added FreeformFinSetTest class
[Minor] Added makeV2 rocket to TestRockets