### PR TITLE
[Refactor] Rocket now subclasses ComponentAssembly 

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/ComponentAssembly.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/ComponentAssembly.java
@@ -32,6 +32,11 @@ public abstract class ComponentAssembly extends RocketComponent {
 	}
 	
 	@Override
+	public boolean allowsChildren(){
+		return true;
+	}
+	
+	@Override
 	public double getAxialOffset() {
 		return super.asPositionValue(this.relativePosition);
 	}
@@ -49,7 +54,7 @@ public abstract class ComponentAssembly extends RocketComponent {
 	 */
 	@Override
 	public Coordinate getComponentCG() {
-		return Coordinate.NUL;
+		return Coordinate.ZERO;
 	}
 	
 	/**
@@ -122,10 +127,7 @@ public abstract class ComponentAssembly extends RocketComponent {
 	@Override
 	public void setAxialOffset(final double _pos) {
 		this.updateBounds();
-		//		System.err.println("updating axial position for boosters: " + this.getName() + " ( " + this.getComponentName() + ")");
-		//		System.err.println("       requesting offset: " + _pos + " via: " + this.relativePosition.name());
 		super.setAxialOffset(this.relativePosition, _pos);
-		//		System.err.println("       resultant offset: " + this.position.x + " via: " + this.relativePosition.name());
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 	

--- a/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
@@ -1,7 +1,6 @@
 package net.sf.openrocket.rocketcomponent;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.EventListener;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -14,7 +13,6 @@ import org.slf4j.LoggerFactory;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.ArrayList;
-import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.MathUtil;
 import net.sf.openrocket.util.StateChangeListener;
 import net.sf.openrocket.util.UniqueID;
@@ -30,7 +28,7 @@ import net.sf.openrocket.util.UniqueID;
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
 @SuppressWarnings("serial")
-public class Rocket extends RocketComponent {
+public class Rocket extends ComponentAssembly {
 	private static final Logger log = LoggerFactory.getLogger(Rocket.class);
 	private static final Translator trans = Application.getTranslator();
 	
@@ -76,7 +74,6 @@ public class Rocket extends RocketComponent {
 	/////////////  Constructor  /////////////
 	
 	public Rocket() {
-		super(RocketComponent.Position.AFTER);
 		modID = UniqueID.next();
 		massModID = modID;
 		aeroModID = modID;
@@ -765,45 +762,7 @@ public class Rocket extends RocketComponent {
 		return trans.get("Rocket.compname.Rocket");
 	}
 	
-	@Override
-	public Coordinate getComponentCG() {
-		return new Coordinate(0, 0, 0, 0);
-	}
-	
-	@Override
-	public double getComponentMass() {
-		return 0;
-	}
-	
-	@Override
-	public double getLongitudinalUnitInertia() {
-		return 0;
-	}
-	
-	@Override
-	public double getRotationalUnitInertia() {
-		return 0;
-	}
-	
-	@Override
-	public Collection<Coordinate> getComponentBounds() {
-		return Collections.emptyList();
-	}
-	
-	@Override
-	public boolean isAerodynamic() {
-		return false;
-	}
-	
-	@Override
-	public boolean isMassive() {
-		return false;
-	}
-	
-	@Override
-	public boolean allowsChildren() {
-		return true;
-	}
+
 	
 	/**
 	 * Allows only <code>AxialStage</code> components to be added to the type Rocket.


### PR DESCRIPTION
. . . instead of RocketComponent

Discussion:
Arguably this is a non-trivial change, but this simplifies overrides, specifically when debugging mass-calculation code, and locating components.  My case is:
1. conceptually, a rocket _IS A_ ComponentAssembly
2. rocket still inherits all the RocketComponent methods.
3. This change reduces code duplication:  
    \* 7 redundant functions
    \* lines: +8 / -47
4. Also:  changed Coordinate.NUL -> Coordinate.ZERO to better reflect our intent.

[edited for format.]
