### PR TITLE
[fix] Redraw Rocket Figure when motors are added & removed

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
@@ -23,6 +23,7 @@ import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.formatting.RocketDescriptor;
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.l10n.Translator;
+import net.sf.openrocket.rocketcomponent.ComponentChangeEvent;
 import net.sf.openrocket.rocketcomponent.FlightConfigurableComponent;
 import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
 import net.sf.openrocket.rocketcomponent.Rocket;
@@ -54,6 +55,7 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 	public void fireTableDataChanged() {
 		int selectedRow = table.getSelectedRow();
 		int selectedColumn = table.getSelectedColumn();	
+		this.rocket.fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 		((AbstractTableModel)table.getModel()).fireTableDataChanged();
 		restoreSelection(selectedRow,selectedColumn);
 		updateButtonState();


### PR DESCRIPTION
This fixes a (minor) display bug where a user could add and remove motors without said changes showing up in the main rocket display. 

The redraw could be forced, of course, but a non-technical user would likely to interpret this cosmetic behavior as a bug.  Hence this fix PR.  --DMW
