### PR TITLE
Alpha value for semi-transparent components saved/loaded and small bug fix

### DIFF
--- a/core/src/net/sf/openrocket/file/openrocket/importt/AppearanceHandler.java
+++ b/core/src/net/sf/openrocket/file/openrocket/importt/AppearanceHandler.java
@@ -51,7 +51,14 @@ class AppearanceHandler extends AbstractElementHandler {
 			int red = Integer.parseInt(attributes.get("red"));
 			int green = Integer.parseInt(attributes.get("green"));
 			int blue = Integer.parseInt(attributes.get("blue"));
-			builder.setPaint(new Color(red, green, blue));
+			int alpha = 255;//set default
+			// add a test if "alpha" was added to the XML / backwards compatibility
+			String a = attributes.get("alpha");
+			if (a != null){
+				// "alpha" string was present so load the value
+				alpha = Integer.parseInt(a);
+			}
+			builder.setPaint(new Color(red, green, blue, alpha));
 			return;
 		}
 		if ("shine".equals(element)) {

--- a/core/src/net/sf/openrocket/file/openrocket/savers/RocketComponentSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/savers/RocketComponentSaver.java
@@ -240,7 +240,7 @@ public class RocketComponentSaver {
 	private final static void emitColor(String elementName, List<String> elements, Color color) {
 		if (color != null) {
 			elements.add("<" + elementName + " red=\"" + color.getRed() + "\" green=\"" + color.getGreen()
-					+ "\" blue=\"" + color.getBlue() + "\"/>");
+					+ "\" blue=\"" + color.getBlue() + "\" alpha=\"" + color.getAlpha() + "\"/>");
 		}
 		
 	}

--- a/swing/src/net/sf/openrocket/gui/figure3d/RealisticRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/RealisticRenderer.java
@@ -112,8 +112,8 @@ public class RealisticRenderer extends RocketRenderer {
 		gl.glLightModeli(GL2.GL_LIGHT_MODEL_COLOR_CONTROL, GL2.GL_SEPARATE_SPECULAR_COLOR);
 		
 		
-		convertColor(a.getPaint(), color);//color now contains alpha value
-		
+		convertColor(a.getPaint(), color);
+		color[3] = alpha;//re-set to "alpha" so that Unfinished renderer will show interior parts.
 		gl.glMaterialfv(GL.GL_FRONT, GLLightingFunc.GL_DIFFUSE, color, 0);
 		gl.glMaterialfv(GL.GL_FRONT, GLLightingFunc.GL_AMBIENT, color, 0);
 		


### PR DESCRIPTION
Clear payload bays and clear fins(scale models) need alpha values saved to the file. The following allows any changes to a components transparency level to be saved/loaded from .ork files while maintaining backwards compatibility. Older versions will ignore alpha information from the newer file.
Also a small bug fix where the 3D Unfinished renderer wasn't showing internal parts, now body tubes are back to half-cutaway like before.