### PR TITLE
Use a parent ClassLoader

### DIFF
--- a/swing/src/net/sf/openrocket/startup/jij/JarInJarStarter.java
+++ b/swing/src/net/sf/openrocket/startup/jij/JarInJarStarter.java
@@ -30,7 +30,7 @@ public class JarInJarStarter {
 		}
 		
 		URL[] urlArray = urls.toArray(new URL[0]);
-		ClassLoader loader = new URLClassLoader(urlArray, null);
+		ClassLoader loader = new URLClassLoader(urlArray);
 		try {
 			Thread.currentThread().setContextClassLoader(loader);
 			Class<?> c = Class.forName(mainClass, true, loader);


### PR DESCRIPTION
Before we explicitly set the parent to null, which caused classes to fail to load on Java 9.

I'm not entirely sure why this is and Sampo doesn't remember why a null parent was used to begin with.