### PR TITLE
Motorfix v2 (corrects simulation thrust for motors in Boosters and Pods) fix: #351

### DIFF
--- a/core/src/net/sf/openrocket/simulation/AbstractSimulationStepper.java
+++ b/core/src/net/sf/openrocket/simulation/AbstractSimulationStepper.java
@@ -174,7 +174,7 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 	 * @param stepMotors				whether to step the motors forward or work on a clone object
 	 * @return							the average thrust during the time step.
 	 */
-	protected double calculateAvrageThrust(SimulationStatus status, double timestep,
+	protected double calculateAverageThrust(SimulationStatus status, double timestep,
 			double acceleration, AtmosphericConditions atmosphericConditions,
 			boolean stepMotors) throws SimulationException {
 		double thrust;

--- a/core/src/net/sf/openrocket/simulation/MotorClusterState.java
+++ b/core/src/net/sf/openrocket/simulation/MotorClusterState.java
@@ -129,7 +129,9 @@ public class MotorClusterState {
 		if( this.currentState.isThrusting() ) {
 			double motorStartTime = this.getMotorTime( startSimulationTime);
 			double motorEndTime = this.getMotorTime( endSimulationTime);
-			return this.motorCount * motor.getAverageThrust( motorStartTime, motorEndTime );
+			
+			int instanceCount = this.config.getMount().getLocations().length;
+			return instanceCount * motor.getAverageThrust( motorStartTime, motorEndTime );
 		}else{
 			return 0.00;
 		}

--- a/core/src/net/sf/openrocket/simulation/RK4SimulationStepper.java
+++ b/core/src/net/sf/openrocket/simulation/RK4SimulationStepper.java
@@ -111,7 +111,7 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 		/*
 		 * Compute the initial thrust estimate.  This is used for the first time step computation.
 		 */
-		store.thrustForce = calculateAvrageThrust(status, store.timestep, status.getPreviousAcceleration(),
+		store.thrustForce = calculateAverageThrust(status, store.timestep, status.getPreviousAcceleration(),
 				status.getPreviousAtmosphericConditions(), false);
 		
 
@@ -180,7 +180,7 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 		 * diminished by it affecting only 1/6th of the total, so it's an acceptable error.
 		 */
 		double thrustEstimate = store.thrustForce;
-		store.thrustForce = calculateAvrageThrust(status, store.timestep, store.longitudinalAcceleration,
+		store.thrustForce = calculateAverageThrust(status, store.timestep, store.longitudinalAcceleration,
 				store.atmosphericConditions, true);
 		log.trace("Thrust at time " + store.timestep + " thrustForce = " + store.thrustForce);
 		double thrustDiff = Math.abs(store.thrustForce - thrustEstimate);


### PR DESCRIPTION
@ChrisMickelson Updated the simulation-thrust-fix for your situation.  Both rockets now apogee at ~1090 ft.

Fixes: #351.  
Replaces PR: #353 .

(If you're curious, the other PR fixed the situation for clusters-in-boosters, but failed account for body-tube-mounted motors in pods & boosters.)