### PR TITLE
Increase visibility of two functions...

### DIFF
--- a/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
+++ b/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
@@ -683,7 +683,7 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 	 * @param cd
 	 * @return
 	 */
-	private double calculateAxialDrag(FlightConditions conditions, double cd) {
+	static public double calculateAxialDrag(FlightConditions conditions, double cd) {
 		double aoa = MathUtil.clamp(conditions.getAOA(), 0, Math.PI);
 		double mul;
 		

--- a/core/src/net/sf/openrocket/file/motor/AbstractMotorLoader.java
+++ b/core/src/net/sf/openrocket/file/motor/AbstractMotorLoader.java
@@ -135,7 +135,7 @@ public abstract class AbstractMotorLoader implements MotorLoader {
 	/**
 	 * Helper method to tokenize a string using the given delimiter.
 	 */
-	protected static String[] split(String str, String delim) {
+	public static String[] split(String str, String delim) {
 		String[] pieces = str.split(delim);
 		if (pieces.length == 0 || !pieces[0].equals(""))
 			return pieces;


### PR DESCRIPTION
(Re-requested SpaceManMatt's changes to the the branch under active development.  (to `unstable` instead of to `master`))

The actual commit performs:
make split() in net.sf.openrocket.file.motor.AbstractMotorLoader and
calculateAxialDrag() in net.sf.openrocket.aerodynamics.BarrowmanCalculator public

This branch only shows some visibility changes.  It is unclear what the CD-Override is referring to.