### PR TITLE
[fix] fixed some broken method (reflection) references

### DIFF
--- a/core/src/net/sf/openrocket/optimization/services/DefaultSimulationModifierService.java
+++ b/core/src/net/sf/openrocket/optimization/services/DefaultSimulationModifierService.java
@@ -215,7 +215,7 @@ public class DefaultSimulationModifierService implements SimulationModifierServi
 						trans.get("optimization.modifier.internalcomponent.position"),
 						trans.get("optimization.modifier.internalcomponent.position.desc"),
 						c, UnitGroup.UNITS_LENGTH,
-						1.0, c.getClass(), c.getID(), "PositionValue");
+						1.0, c.getClass(), c.getID(), "RelativePosition");
 				mod.setMinValue(0);
 				mod.setMaxValue(parent.getLength());
 				modifiers.add(mod);
@@ -229,7 +229,7 @@ public class DefaultSimulationModifierService implements SimulationModifierServi
 						trans.get("optimization.modifier.finset.position"),
 						trans.get("optimization.modifier.finset.position.desc"),
 						c, UnitGroup.UNITS_LENGTH,
-						1.0, c.getClass(), c.getID(), "PositionValue");
+						1.0, c.getClass(), c.getID(), "RelativePosition");
 				mod.setMinValue(0);
 				mod.setMaxValue(parent.getLength());
 				modifiers.add(mod);
@@ -243,7 +243,7 @@ public class DefaultSimulationModifierService implements SimulationModifierServi
 						trans.get("optimization.modifier.launchlug.position"),
 						trans.get("optimization.modifier.launchlug.position.desc"),
 						c, UnitGroup.UNITS_LENGTH,
-						1.0, c.getClass(), c.getID(), "PositionValue");
+						1.0, c.getClass(), c.getID(), "RelativePosition");
 				mod.setMinValue(0);
 				mod.setMaxValue(parent.getLength());
 				modifiers.add(mod);

--- a/swing/src/net/sf/openrocket/gui/dialogs/ScaleDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/ScaleDialog.java
@@ -82,7 +82,7 @@ public class ScaleDialog extends JDialog {
 		List<Scaler> list;
 		
 		// RocketComponent
-		addScaler(RocketComponent.class, "PositionValue");
+		addScaler(RocketComponent.class, "RelativePosition");
 		SCALERS.get(RocketComponent.class).add(new OverrideScaler());
 		
 		// BodyComponent


### PR DESCRIPTION
A function name was changed in RocketComponent... these changes update the reflection strings to match the "new" existing function name.