### PR TITLE
Hide Buggy UI Dialogs

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -684,18 +684,20 @@ public class BasicFrame extends JFrame {
 		menu.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.analyze.desc"));
 		menubar.add(menu);
 
-		//// Component analysis
-		item = new JMenuItem(trans.get("main.menu.analyze.componentAnalysis"), KeyEvent.VK_C);
-		//// Analyze the rocket components separately
-		item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.analyze.componentAnalysis.desc"));
-		item.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				log.info(Markers.USER_MARKER, "Component analysis selected");
-				ComponentAnalysisDialog.showDialog(rocketpanel);
-			}
-		});
-		menu.add(item);
+
+//      TODO: reimplement this
+//		//// Component analysis
+//		item = new JMenuItem(trans.get("main.menu.analyze.componentAnalysis"), KeyEvent.VK_C);
+//		//// Analyze the rocket components separately
+//		item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.analyze.componentAnalysis.desc"));
+//		item.addActionListener(new ActionListener() {
+//			@Override
+//			public void actionPerformed(ActionEvent e) {
+//				log.info(Markers.USER_MARKER, "Component analysis selected");
+//				ComponentAnalysisDialog.showDialog(rocketpanel);
+//			}
+//		});
+//		menu.add(item);
 
 		//// Optimize
 		item = new JMenuItem(trans.get("main.menu.analyze.optimization"), KeyEvent.VK_O);

--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -699,17 +699,18 @@ public class BasicFrame extends JFrame {
 //		});
 //		menu.add(item);
 
-		//// Optimize
-		item = new JMenuItem(trans.get("main.menu.analyze.optimization"), KeyEvent.VK_O);
-		item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.analyze.optimization.desc"));
-		item.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				log.info(Markers.USER_MARKER, "Rocket optimization selected");
-				new GeneralOptimizationDialog(document, BasicFrame.this).setVisible(true);
-			}
-		});
-		menu.add(item);
+// TODO: reimplement this dialog
+//		//// Optimize
+//		item = new JMenuItem(trans.get("main.menu.analyze.optimization"), KeyEvent.VK_O);
+//		item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.analyze.optimization.desc"));
+//		item.addActionListener(new ActionListener() {
+//			@Override
+//			public void actionPerformed(ActionEvent e) {
+//				log.info(Markers.USER_MARKER, "Rocket optimization selected");
+//				new GeneralOptimizationDialog(document, BasicFrame.this).setVisible(true);
+//			}
+//		});
+//		menu.add(item);
 
 		//// Custom expressions
 		item = new JMenuItem(trans.get("main.menu.analyze.customExpressions"), KeyEvent.VK_E);


### PR DESCRIPTION
Both the 'Component Analysis' and 'Optimization' Dialogs threw exceptions when started.

This PR hides them for the next release.