### PR TITLE
Fix Configuration name in motor configuration panel.

### DIFF
--- a/core/src/net/sf/openrocket/motor/MotorConfiguration.java
+++ b/core/src/net/sf/openrocket/motor/MotorConfiguration.java
@@ -62,11 +62,11 @@ public class MotorConfiguration implements FlightConfigurableParameter<MotorConf
 		return ignitionOveride;
 	}
 
-	public String toMotorDescription(){
+	public String toMotorDesignation(){
 		if( motor == null ){
 			return trans.get("empty");
 		}else{
-			return this.motor.getDesignation() + "-" + (int)this.getEjectionDelay();
+			return this.motor.getDesignation(this.getEjectionDelay());
 		}
 	}
 	
@@ -235,7 +235,7 @@ public class MotorConfiguration implements FlightConfigurableParameter<MotorConf
 	}
 
 	public String toDescription(){
-		return ( this.toMotorDescription()+
+		return ( this.toMotorDesignation()+
 				" in: "+mount.getDebugName()+
 				" ign@: "+this.toIgnitionDescription() );
 	}
@@ -251,7 +251,7 @@ public class MotorConfiguration implements FlightConfigurableParameter<MotorConf
 				mount.getDebugName(),
 				fcid.toShortKey(),
 				mid.toDebug(),
-				toMotorDescription(),
+				toMotorDesignation(),
 				toIgnitionDescription() ));
 		
 		return buf.toString();

--- a/core/src/net/sf/openrocket/motor/MotorConfigurationSet.java
+++ b/core/src/net/sf/openrocket/motor/MotorConfigurationSet.java
@@ -58,7 +58,7 @@ public class MotorConfigurationSet extends FlightConfigurableParameterSet<MotorC
 					loopFCID.toShortKey(),
 					curConfig.getFCID().toShortKey(),
 					curConfig.getMID().toShortKey(),
-					curConfig.toMotorDescription(),
+					curConfig.toMotorDesignation(),
 					curConfig.toIgnitionDescription() ));
 						
 		}

--- a/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
@@ -307,7 +307,7 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 				}
 				
 				if( ! motorConfig.isEmpty()){
-					buff.append( motorConfig.toMotorDescription());
+					buff.append(motorConfig.toMotorDesignation());
 					++activeMotorCount;
 				}
 			}


### PR DESCRIPTION
Formerly just used delay value directly, resulting in huge delay for
plugged motors; now uses motor.getDesignation so it translates to "P" as
expected.

Changed name of toMotorDescription method to toMotorDesignation to match
usage of getDesignation() in ThrustCurveMotor.java

Changed toMotorDesignation() to use motor.getDesignation()