### PR TITLE
Set current configuration before creating simulation

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
@@ -463,10 +463,11 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
      * @return the new configuration
      */
     @Override
-    public FlightConfiguration copy( final FlightConfigurationId copyId ) {
+    public FlightConfiguration copy( final FlightConfigurationId newId ) {
         // Note the stages are updated in the constructor call.
-        FlightConfiguration copy= new FlightConfiguration( this.rocket, copyId );
-
+        FlightConfiguration copy= new FlightConfiguration( this.rocket, newId );
+		final FlightConfigurationId copyId = copy.getId();
+		
         // copy motor instances.
         for( final MotorConfiguration sourceMotor: motors.values() ){
             MotorConfiguration cloneMotor = sourceMotor.copy( copyId);


### PR DESCRIPTION
createSimulationForConfiguration() assumed addConfiguration() and
copyConfiguration() would set the new configuration as selected, but
they didn't resulting in simulation based on old configuration, not new
one.  Fixed.

addConfiguration() and copyConfiguration() had enough common code that
consolidating them and createSimulationForConfiguration() into a new method addOrCopyConfiguration() seemed like a good idea.

Let FlightConfiguration.copy() create new ID for consistency with
constructor.