### PR TITLE
[fix][oneline] both Create Stage buttons now create stages with the same name

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -37,7 +37,6 @@ RocketActions.EditAct.Edit = Edit
 RocketActions.EditAct.ttip.Edit = Edit the selected component.
 RocketActions.NewStageAct.Newstage = New stage
 RocketActions.NewStageAct.ttip.Newstage = Add a new stage to the rocket design.
-RocketActions.ActBoosterstage = Booster stage
 RocketActions.MoveUpAct.Moveup = Move up
 RocketActions.MoveUpAct.ttip.Moveup = Move this component upwards.
 RocketActions.MoveDownAct.Movedown = Move down

--- a/swing/src/net/sf/openrocket/gui/main/RocketActions.java
+++ b/swing/src/net/sf/openrocket/gui/main/RocketActions.java
@@ -619,8 +619,7 @@ public class RocketActions {
 			ComponentConfigDialog.hideDialog();
 
 			RocketComponent stage = new AxialStage();
-			//// Booster stage
-			stage.setName(trans.get("RocketActions.ActBoosterstage"));
+
 			//// Add stage
 			document.addUndoPosition("Add stage");
 			rocket.addChild(stage);


### PR DESCRIPTION
- reads the value of `Stage.Stage` from 'core/resources/l10n/messages.properties'
- currently "Stage"

Addresses inconsistent naming issue present on openrocket-dev mailing list.