### PR TITLE
[fix] removed duplicate property keys in 'resources/l10n'

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -823,9 +823,6 @@ RocketCfg.lbl.Comments = Comments:
 RocketCfg.lbl.Revisionhistory = Revision history:
 RocketCfg.lbl.Material = Material:
 
-! ShockCordConfig
-ShockCordCfg.lbl.Shockcordlength = Shock cord length:
-
 ! RocketComponentConfig
 RocketCompCfg.lbl.Componentname = Component name:
 RocketCompCfg.ttip.Thecomponentname = The component name.
@@ -1037,13 +1034,11 @@ NoseConeCfg.tab.ttip.Shoulder = Shoulder properties
 ! ParachuteConfig
 ParachuteCfg.lbl.Canopy = Canopy:
 ParachuteCfg.lbl.Diameter = Diameter:
-ParachuteCfg.lbl.Material = Material:
 ParachuteCfg.combo.MaterialModel = The component material affects the weight of the component.
 ParachuteCfg.lbl.longA1 = <html>Drag coefficient C<sub>D</sub>:
 ParachuteCfg.lbl.longB1 = <html>The drag coefficient relative to the total area of the parachute.<br>
 ParachuteCfg.lbl.longB2 = A larger drag coefficient yields a slowed descent rate.
 ParachuteCfg.lbl.longB3 = A typical value for parachutes is 0.8.
-ParachuteCfg.but.Reset = Reset
 ParachuteCfg.lbl.Shroudlines = Shroud lines:
 ParachuteCfg.lbl.Numberoflines = Number of lines:
 ParachuteCfg.lbl.Linelength = Line length:


### PR DESCRIPTION
Non-functional change.  
Just cleaning up the internationalization file.