### PR TITLE
Close input streams after use to avoid build crashing due to resource leak.

### DIFF
--- a/core/src/net/sf/openrocket/utils/SerializeMotors.java
+++ b/core/src/net/sf/openrocket/utils/SerializeMotors.java
@@ -48,6 +48,8 @@ public class SerializeMotors {
 				InputStream is = f.getV();
 				
 				List<Motor> motors = loader.load(is, fileName);
+
+				is.close();
 				
 				allMotors.addAll(motors);
 			}
@@ -56,6 +58,7 @@ public class SerializeMotors {
 		oos.writeObject(allMotors);
 		
 		oos.flush();
+		oos.close();
 		ofs.flush();
 		ofs.close();
 	}


### PR DESCRIPTION
Also closes stream oos, to match ofs which was already being closed.

Closes issue #434