### PR TITLE
Stack stage simulations

### DIFF
--- a/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
+++ b/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
@@ -76,7 +76,7 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 			final String branchName = simulationConfig.getRocket().getTopmostStage().getName();
 			currentStatus.setFlightData(new FlightDataBranch( branchName, FlightDataType.TYPE_TIME));
 		}
-		toSimulate.add(currentStatus);
+		toSimulate.push(currentStatus);
 		
 		SimulationListenerHelper.fireStartSimulation(currentStatus);
 		do{
@@ -423,7 +423,7 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 				boosterStatus.setFlightData(new FlightDataBranch(boosterStage.getName(), FlightDataType.TYPE_TIME));
 				// Mark the booster status as only having the booster.
 				boosterStatus.getConfiguration().setOnlyStage(stageNumber);
-				toSimulate.add(boosterStatus);
+				toSimulate.push(boosterStatus);
 				log.info(String.format("==>> @ %g; from Branch: %s ---- Branching: %s ---- \n",
 						currentStatus.getSimulationTime(), 
 						currentStatus.getFlightData().getBranchName(), boosterStatus.getFlightData().getBranchName()));


### PR DESCRIPTION
Changed order of stage simulations to work from top down, resulting in the drop-down menus for plots and data exports to be in stage order.

Closes #459