### PR TITLE
[fixes #463] Motors now rotate in RocketFigure side-view, back-view

### DIFF
--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketFigure.java
@@ -276,6 +276,9 @@ public class RocketFigure extends AbstractScaleFigure {
 			    Coordinate curMotorLocation = curMountLocation.add( mountLength - motorLength + mount.getMotorOverhang(), 0, 0);
 //		        System.err.println(String.format("        mount instance:   %s  =>  %s", curMountLocation.toString(), curMotorLocation.toString() )); 
 	        
+		        // rotate by figure's axial rotation:
+		        curMotorLocation = this.axialRotation.transform(curMotorLocation);
+
 				{
 					Shape s;
 					if (currentViewType == RocketPanel.VIEW_TYPE.SideView) {


### PR DESCRIPTION
Motors again rotate in main RocketFigure (with LHS rotation slider)