### PR TITLE
[version] bump version string to '19-xx-alpha10'

### DIFF
--- a/core/resources/build.properties
+++ b/core/resources/build.properties
@@ -1,7 +1,7 @@
 
 # The OpenRocket build version
 
-build.version=alpha8
+build.version=19-xx-alpha10
 
 
 # The source of the package.  When building a package for a specific


### PR DESCRIPTION
- last release candidate was alpha-9
- next round of bug fixes will be alpha-10