### PR TITLE
Fixes #468: Freeform fins display correctly again.

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -1095,6 +1095,13 @@ public abstract class FinSet extends ExternalComponent implements RingInstanceab
 			
 			xCur += increment;
 		}
+
+		// correct last point, if beyond a rounding error from body's end.
+		final int lastIndex = points.length - 1;
+		if( body.getLength()-0.000001 < points[lastIndex].x) {
+			points[lastIndex] = points[lastIndex].setX(body.getLength()).setY(body.getAftRadius());
+		}
+
 		return points;
 	}
 


### PR DESCRIPTION
If a freeform fin was positioned near or past the end (due to rounding errors) of its mounting / parent component, then the parent would return 0 for the radius at that location, which would in turn glitch the display code in the main view.

A special case correction has been inserted into FinSet, to address this corner case. 