### PR TITLE
Deploy continuous builds to GitHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,15 @@ jdk:
   - openjdk8
 script:
  - "ant -buildfile build.xml clean check jar unittest"
+
+after_success:
+  - ls -lh /home/travis/build/openrocket/openrocket/swing/build/jar/OpenRocket.jar
+  - ls -lh /home/travis/build/openrocket/openrocket/swing/build/jar/OpenRocket-Core.jar
+  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  - bash upload.sh /home/travis/build/openrocket/openrocket/swing/build/jar/OpenRocket.jar
+  - bash upload.sh /home/travis/build/openrocket/openrocket/swing/build/jar/OpenRocket-Core.jar
+
+branches:
+  except:
+    - # Do not build tags that we create when we upload to GitHub Releases
+    - /^(?i:continuous)$/


### PR DESCRIPTION
Details - https://github.com/probonopd/uploadtool

This script is designed to be called from Travis CI after a successful build. By default, this script will _delete_ any pre-existing release tagged with `continuous`, tag the current state with the name `continuous`, create a new release with that name, and upload the specified binaries there. For pull requests, it will upload the binaries to transfer.sh instead and post the resulting download URL to the pull request page on GitHub.

### TODO

Before merging this pull request you should do next:

 - On https://github.com/settings/tokens, click on "Generate new token" and generate a token with at least the `public_repo`, `repo:status`, and `repo_deployment` scopes
 - On Travis CI, go to the settings of your project at `https://travis-ci.org/yourusername/yourrepository/settings`
 - Under "Environment Variables", add key `GITHUB_TOKEN` and the token you generated above as the value. **Make sure that "Display value in build log" is set to "OFF"!**