### PR TITLE
[fixes #387] Fixes one source of off-axis CP error

### DIFF
--- a/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
+++ b/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
@@ -202,15 +202,20 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 			AerodynamicForces componentForces = new AerodynamicForces().zero();
 			calcObj.calculateNonaxialForces(conditions, componentForces, warnings);
 			
-			Coordinate x_cp_comp = componentForces.getCP();
-			Coordinate x_cp_weighted = x_cp_comp.setWeight(x_cp_comp.weight);
-			Coordinate x_cp_absolute = component.toAbsolute(x_cp_weighted)[0];
-			componentForces.setCP(x_cp_absolute);
+			Coordinate cp_comp = componentForces.getCP();
+			
+			Coordinate cp_weighted = cp_comp.setWeight(cp_comp.weight);
+			Coordinate cp_absolute = component.toAbsolute(cp_weighted)[0];
+			if(1 < component.getInstanceCount()) {
+				cp_absolute = cp_absolute.setY(0.);
+			}
+			
+			componentForces.setCP(cp_absolute);
 			double CN_instanced = componentForces.getCN();
 			componentForces.setCm(CN_instanced * componentForces.getCP().x / conditions.getRefLength());
 		
-//			if( 0.0001 < Math.abs(0 - componentForces.getCNa())){
-//				System.err.println(String.format("%s....Component.CNa: %g   @ CPx: %g", indent, componentForces.getCNa(), componentForces.getCP().x));
+//			if( 0.0001 < Math.abs(componentForces.getCNa())){
+//				System.err.println(String.format("%s....Component.CNa: %g   @ CP: %g, %g", indent, componentForces.getCNa(), componentForces.getCP().x, componentForces.getCP().y));
 //			}
 			
 			assemblyForces.merge(componentForces);

--- a/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java
+++ b/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java
@@ -86,6 +86,7 @@ public class BarrowmanCalculatorTest {
 		
 		assertEquals(" Estes Alpha III CNa value is incorrect:", exp_cna, cp_calc.weight, EPSILON);
 		assertEquals(" Estes Alpha III cp x value is incorrect:", exp_cpx, cp_calc.x, EPSILON);
+		assertEquals(" Estes Alpha III cp x value is incorrect:", 0.0, cp_calc.y, EPSILON);
 	}
 	
 	@Test


### PR DESCRIPTION
Adds a patch to clamp off-axis CP errors.

Manually sets y-coordinate to zero, when multiple instances are present.

Further discussion available on mailing list.