### PR TITLE
[fix][minor] May correctly adjust first fin point

### DIFF
--- a/swing/src/net/sf/openrocket/gui/configdialog/FreeformFinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/FreeformFinSetConfig.java
@@ -424,7 +424,8 @@ public class FreeformFinSetConfig extends FinSetConfig {
 			Point2D.Double point = getCoordinates(event);
 			finset.setPoint(dragIndex, point.x, point.y);
 
-			if(0 == dragIndex && 0 > point.x){
+			final double bodyFront = -finset.getAxialFront();
+			if(0 == dragIndex && bodyFront > point.x){
 				dragIndex = 1;
 			}
 


### PR DESCRIPTION
Addresses corner case, where control would (incorrectly) advance to the first point, if the first point was still within the mount's x-bounds.

edit: refines #488 