### PR TITLE
[fixes #499] prevents an exception after converting-to-freeform

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/FreeformFinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FreeformFinSet.java
@@ -4,7 +4,6 @@ import java.awt.geom.Line2D;
 import java.awt.geom.Point2D;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -19,8 +18,9 @@ import net.sf.openrocket.util.Coordinate;
 public class FreeformFinSet extends FinSet {
 	private static final Logger log = LoggerFactory.getLogger(FreeformFinSet.class);
 	private static final Translator trans = Application.getTranslator();
-	
-	private List<Coordinate> points = new ArrayList<>();
+
+	// this class uses certain features of 'ArrayList' which are not implemented in other 'List' implementations.
+	private ArrayList<Coordinate> points = new ArrayList<>();
 	
 	private static final double SNAP_SMALLER_THAN = 1e-6;
 	private static final double IGNORE_SMALLER_THAN = 1e-12;
@@ -47,8 +47,8 @@ public class FreeformFinSet extends FinSet {
 	public static FreeformFinSet convertFinSet(FinSet finset) {
 		final RocketComponent root = finset.getRoot();
 		FreeformFinSet freeform;
-		List<RocketComponent> toInvalidate = Collections.emptyList();
-		
+		List<RocketComponent> toInvalidate = new ArrayList<>();
+
 		try {
 			if (root instanceof Rocket) {
 				((Rocket) root).freeze();
@@ -67,7 +67,7 @@ public class FreeformFinSet extends FinSet {
 			// Create the freeform fin set
 			Coordinate[] finPoints = finset.getFinPoints();
 			freeform = new FreeformFinSet();
-			freeform.setPoints(Arrays.asList(finPoints));
+			freeform.setPoints(finPoints);
 			freeform.setAxialOffset(finset.getAxialMethod(), finset.getAxialOffset());
 			
 			// Copy component attributes
@@ -130,7 +130,7 @@ public class FreeformFinSet extends FinSet {
 		}
 		
 		// copy the old list in case the operation fails
-		List<Coordinate> copy = new ArrayList<>(this.points);
+		ArrayList<Coordinate> copy = new ArrayList<>(this.points);
 		
 		this.points.remove(index);
 		if (!validate()) {
@@ -163,15 +163,15 @@ public class FreeformFinSet extends FinSet {
 	 * 
 	 * @param newPoints New points to set as the exposed edges of the fin
 	 */
-	public void setPoints( List<Coordinate> newPoints) {
+	public void setPoints( ArrayList<Coordinate> newPoints) {
 		// copy the old points, in case validation fails
-		List<Coordinate> copy = new ArrayList<>(this.points);
+		ArrayList<Coordinate> copy = new ArrayList<>(this.points);
 		this.points = newPoints;
 		this.length = newPoints.get(newPoints.size() -1).x;		
 		
 		update();
 		
-//		StackTraceElement[] stacktrack = Thread.currentThread().getStackTrace();
+		//StackTraceElement[] stacktrack = Thread.currentThread().getStackTrace();
 		if("Canard fins, mounted to transition".equals(this.getName())) {
 			log.error(String.format("starting to set %d points @ %s", newPoints.size(), this.getName()), new NullPointerException());
 			System.err.println( toDebugDetail());

--- a/swing/src/net/sf/openrocket/gui/configdialog/FreeformFinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/FreeformFinSetConfig.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.JButton;
@@ -337,7 +338,7 @@ public class FreeformFinSetConfig extends FinSetConfig {
 		if (option == JFileChooser.APPROVE_OPTION) {
 			try {
 				CustomFinImporter importer = new CustomFinImporter();
-				List<Coordinate> points = importer.getPoints(chooser.getSelectedFile());
+				ArrayList<Coordinate> points = importer.getPoints(chooser.getSelectedFile());
 				document.startUndo(trans.get("CustomFinImport.undo"));
 				finset.setPoints( points);
 			} catch (IOException e) {

--- a/swing/src/net/sf/openrocket/gui/util/CustomFinImporter.java
+++ b/swing/src/net/sf/openrocket/gui/util/CustomFinImporter.java
@@ -24,7 +24,7 @@ public class CustomFinImporter {
 	
 	
 	
-	public List<Coordinate> getPoints(File file) throws IOException {
+	public ArrayList<Coordinate> getPoints(File file) throws IOException {
 		ArrayList<Coordinate> points = new ArrayList<Coordinate>();
 		
 		BufferedImage pic = ImageIO.read(file);


### PR DESCRIPTION

fix: enforce an implicit type dependency as an explicit type dependency.  Closes a mismatch in expected types that caused an exception after converting a fin from Trapezoidal to freeform, and then adding a point.