### PR TITLE
[fixes #502] Adjust RocketFigure Bounds

### DIFF
--- a/swing/src/net/sf/openrocket/gui/scalefigure/FinPointFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/FinPointFigure.java
@@ -371,7 +371,6 @@ public class FinPointFigure extends AbstractScaleFigure {
 	    final int finFrontX = (int)(subjectBounds_m.getX()*scale);
 	    final int subjectHeight = (int)(subjectBounds_m.getHeight()*scale);
 	    
-	    // the negative sign is to compensate for the mount's negative location.
         originLocation_px.width = borderThickness_px.width - finFrontX;
         
         if( visibleBounds_px.height > (subjectHeight+ 2*borderThickness_px.height)) {

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketFigure.java
@@ -474,6 +474,7 @@ public class RocketFigure extends AbstractScaleFigure {
 	 */
 	@Override
 	protected void updateCanvasOrigin() {
+	    final int subjectFront = (int)(subjectBounds_m.getMinX()*scale);
 	    final int subjectWidth = (int)(subjectBounds_m.getWidth()*scale);
 	    final int subjectHeight = (int)(subjectBounds_m.getHeight()*scale);
 	    
@@ -483,7 +484,7 @@ public class RocketFigure extends AbstractScaleFigure {
 	        
 	        originLocation_px = new Dimension(newOriginX, newOriginY);
     	}else if (currentViewType == RocketPanel.VIEW_TYPE.SideView){
-    	    final int newOriginX = borderThickness_px.width;
+            final int newOriginX = borderThickness_px.width - subjectFront;
     	    final int newOriginY = Math.max(getHeight(), subjectHeight + 2*borderThickness_px.height )/ 2;
             
     	    originLocation_px = new Dimension(newOriginX, newOriginY);


### PR DESCRIPTION
Accommodates negative-coordinate components (like fins ;)

note: the changes in FinPointFigure are not functional, merely cleanup. 