### PR TITLE
[fixes #510] Fin tab now saves the correct offset

### DIFF
--- a/core/src/net/sf/openrocket/file/openrocket/savers/FinSetSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/savers/FinSetSaver.java
@@ -30,7 +30,7 @@ public class FinSetSaver extends ExternalComponentSaver {
 			elements.add("<tablength>" + fins.getTabLength() + "</tablength>");
 			elements.add("<tabposition relativeto=\"" +
 					fins.getTabOffsetMethod().name().toLowerCase(Locale.ENGLISH) + "\">" +
-					fins.getTabFrontEdge() + "</tabposition>");
+					fins.getTabOffset() + "</tabposition>");
 			
 		}
 		


### PR DESCRIPTION
oneliner.  Just correcting the expected function call name.