### PR TITLE
Update .travis.yml to omit the extra jar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,8 @@ script:
 
 after_success:
   - ls -lh /home/travis/build/openrocket/openrocket/swing/build/jar/OpenRocket.jar
-  - ls -lh /home/travis/build/openrocket/openrocket/swing/build/jar/OpenRocket-Core.jar
   - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
   - bash upload.sh /home/travis/build/openrocket/openrocket/swing/build/jar/OpenRocket.jar
-  - bash upload.sh /home/travis/build/openrocket/openrocket/swing/build/jar/OpenRocket-Core.jar
 
 branches:
   except:


### PR DESCRIPTION
travis attempted to upload `swing/build/jar/OpenRocket-Core.jar`, which (a) doesn't exist at that path, and (b) isn't needed to run OpenRocket.jar