### PR TITLE
Fix 361

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -1693,7 +1693,7 @@ Warning.SUPERSONIC = Body calculations may not be entirely accurate at supersoni
 Warning.RECOVERY_LAUNCH_ROD = Recovery device device deployed while on the launch guide.
 Warning.RECOVERY_HIGH_SPEED = Recovery device deployment at high speed
 Warning.TUMBLE_UNDER_THRUST = Stage began to tumble under thrust.
-Warning.EVENT_REMAINING = Event still in queue at ground hit:  
+Warning.EVENT_AFTER_LANDING = Flight Event occurred after landing:  
 
 ! Scale dialog
 ScaleDialog.lbl.scaleRocket = Entire rocket

--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -1693,7 +1693,7 @@ Warning.SUPERSONIC = Body calculations may not be entirely accurate at supersoni
 Warning.RECOVERY_LAUNCH_ROD = Recovery device device deployed while on the launch guide.
 Warning.RECOVERY_HIGH_SPEED = Recovery device deployment at high speed
 Warning.TUMBLE_UNDER_THRUST = Stage began to tumble under thrust.
-
+Warning.EVENT_REMAINING = Event still in queue at ground hit:  
 
 ! Scale dialog
 ScaleDialog.lbl.scaleRocket = Entire rocket

--- a/core/src/net/sf/openrocket/aerodynamics/Warning.java
+++ b/core/src/net/sf/openrocket/aerodynamics/Warning.java
@@ -126,24 +126,32 @@ public abstract class Warning {
 	}
 
 	/**
-	 * A <code>Warning</code> indicating flight events remain in the event queue on ground hit.
+	 * A <code>Warning</code> indicating flight events occurred after ground hit
 	 *
 	 */
-	public static class EventRemaining extends Warning {
+	public static class EventAfterLanding extends Warning {
 		private FlightEvent event;
 		
 		/**
-		 * Sole constructor.  The argument is an event remaining in the queue
+		 * Sole constructor.  The argument is an event which has occurred after landing
 		 *
 		 * @param event the event that caused this warning
 		 */
-		public EventRemaining(FlightEvent _event)  {
+		public EventAfterLanding(FlightEvent _event)  {
 			this.event = _event;
 		}
 
+		// I want a warning on every event that occurs after we land,
+		// so severity of problem is clear to the user
+		@Override
+		public boolean equals(Object o) {
+			return false;
+		}
+		
+
 		@Override
 		public String toString() {
-			return trans.get("Warning.EVENT_REMAINING") + event.getType();
+			return trans.get("Warning.EVENT_AFTER_LANDING") + event.getType();
 		}
 
 		@Override
@@ -379,6 +387,6 @@ public abstract class Warning {
 	
 	public static final Warning TUMBLE_UNDER_THRUST = new Other(trans.get("Warning.TUMBLE_UNDER_THRUST"));
 
-	public static final Warning EVENT_REMAINING = new Other(trans.get("Warning.EVENT_REMAINING"));
+	public static final Warning EVENT_AFTER_LANDING = new Other(trans.get("Warning.EVENT_AFTER_LANDING"));
 	
 }

--- a/core/src/net/sf/openrocket/aerodynamics/Warning.java
+++ b/core/src/net/sf/openrocket/aerodynamics/Warning.java
@@ -3,6 +3,7 @@ package net.sf.openrocket.aerodynamics;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.motor.Motor;
 import net.sf.openrocket.startup.Application;
+import net.sf.openrocket.simulation.FlightEvent;
 import net.sf.openrocket.unit.UnitGroup;
 
 public abstract class Warning {
@@ -118,6 +119,33 @@ public abstract class Warning {
 			return trans.get("Warning.RECOVERY_HIGH_SPEED") + " (" + UnitGroup.UNITS_VELOCITY.toStringUnit(recoverySpeed) + ")";
 		}
 		
+		@Override
+		public boolean replaceBy(Warning other) {
+			return false;
+		}
+	}
+
+	/**
+	 * A <code>Warning</code> indicating flight events remain in the event queue on ground hit.
+	 *
+	 */
+	public static class EventRemaining extends Warning {
+		private FlightEvent event;
+		
+		/**
+		 * Sole constructor.  The argument is an event remaining in the queue
+		 *
+		 * @param event the event that caused this warning
+		 */
+		public EventRemaining(FlightEvent _event)  {
+			this.event = _event;
+		}
+
+		@Override
+		public String toString() {
+			return trans.get("Warning.EVENT_REMAINING") + event.getType();
+		}
+
 		@Override
 		public boolean replaceBy(Warning other) {
 			return false;
@@ -350,5 +378,7 @@ public abstract class Warning {
 	public static final Warning RECOVERY_LAUNCH_ROD = new Other(trans.get("Warning.RECOVERY_LAUNCH_ROD"));
 	
 	public static final Warning TUMBLE_UNDER_THRUST = new Other(trans.get("Warning.TUMBLE_UNDER_THRUST"));
+
+	public static final Warning EVENT_REMAINING = new Other(trans.get("Warning.EVENT_REMAINING"));
 	
 }

--- a/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
+++ b/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
@@ -487,6 +487,13 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 				break;
 			
 			case GROUND_HIT:
+				// have I hit the ground while I still have events in the queue?
+				for (FlightEvent e : currentStatus.getEventQueue()) {
+					if ((e.getType() != FlightEvent.Type.ALTITUDE) &&
+						(e.getType() != FlightEvent.Type.SIMULATION_END))
+						currentStatus.getWarnings().add(new Warning.EventRemaining(e));
+				}
+
 				currentStatus.getFlightData().addEvent(event);
 				break;
 			

--- a/core/src/net/sf/openrocket/simulation/GroundStepper.java
+++ b/core/src/net/sf/openrocket/simulation/GroundStepper.java
@@ -1,0 +1,85 @@
+package net.sf.openrocket.simulation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.sf.openrocket.models.atmosphere.AtmosphericConditions;
+import net.sf.openrocket.simulation.exception.SimulationException;
+import net.sf.openrocket.util.MathUtil;
+import net.sf.openrocket.util.Coordinate;
+
+public class GroundStepper extends AbstractSimulationStepper {
+	private static final Logger log = LoggerFactory.getLogger(GroundStepper.class);
+	
+	@Override
+	public SimulationStatus initialize(SimulationStatus original) {
+		log.trace("initializing GroundStepper");
+		SimulationStatus status = new SimulationStatus(original);
+
+		return status;
+	}
+
+	@Override
+	public void step(SimulationStatus status, double timeStep) throws SimulationException {
+		log.trace("step:  position=" + status.getRocketPosition() + ", velocity=" + status.getRocketVelocity());
+				
+		status.setRocketVelocity(Coordinate.ZERO);
+		status.setRocketRotationVelocity(Coordinate.ZERO);
+		status.setRocketPosition(status.getRocketPosition().setZ(0));
+		
+		// Store data
+		FlightDataBranch data = status.getFlightData();
+		boolean extra = status.getSimulationConditions().isCalculateExtras();
+		data.addPoint();
+		
+		data.setValue(FlightDataType.TYPE_TIME, status.getSimulationTime());
+		data.setValue(FlightDataType.TYPE_ALTITUDE, status.getRocketPosition().z);
+		data.setValue(FlightDataType.TYPE_POSITION_X, status.getRocketPosition().x);
+		data.setValue(FlightDataType.TYPE_POSITION_Y, status.getRocketPosition().y);
+		if (extra) {
+			data.setValue(FlightDataType.TYPE_POSITION_XY,
+						  MathUtil.hypot(status.getRocketPosition().x, status.getRocketPosition().y));
+			data.setValue(FlightDataType.TYPE_POSITION_DIRECTION,
+						  Math.atan2(status.getRocketPosition().y, status.getRocketPosition().x));
+			
+			data.setValue(FlightDataType.TYPE_VELOCITY_XY,
+						  MathUtil.hypot(status.getRocketVelocity().x, status.getRocketVelocity().y));
+			data.setValue(FlightDataType.TYPE_ACCELERATION_XY, 0.0);
+			
+			data.setValue(FlightDataType.TYPE_ACCELERATION_TOTAL, 0.0);
+			
+			data.setValue(FlightDataType.TYPE_REYNOLDS_NUMBER, Double.POSITIVE_INFINITY);
+		}
+		
+		data.setValue(FlightDataType.TYPE_LATITUDE, status.getRocketWorldPosition().getLatitudeRad());
+		data.setValue(FlightDataType.TYPE_LONGITUDE, status.getRocketWorldPosition().getLongitudeRad());
+		data.setValue(FlightDataType.TYPE_GRAVITY, modelGravity(status));
+		
+		data.setValue(FlightDataType.TYPE_CORIOLIS_ACCELERATION, 0.0);
+		
+		data.setValue(FlightDataType.TYPE_VELOCITY_Z, status.getRocketVelocity().z);
+		data.setValue(FlightDataType.TYPE_ACCELERATION_Z, 0.0);
+		
+		data.setValue(FlightDataType.TYPE_VELOCITY_TOTAL, 0.0);
+		data.setValue(FlightDataType.TYPE_MACH_NUMBER, 0.0);
+		
+		data.setValue(FlightDataType.TYPE_MASS, calculateStructureMass(status).getMass());
+		data.setValue(FlightDataType.TYPE_PROPELLANT_MASS, 0.0); // Is this a reasonable assumption? Probably.
+		
+		data.setValue(FlightDataType.TYPE_THRUST_FORCE, 0.0);
+		data.setValue(FlightDataType.TYPE_DRAG_FORCE, 0.0);
+		
+		data.setValue(FlightDataType.TYPE_WIND_VELOCITY, modelWindVelocity(status).length());
+		
+		AtmosphericConditions atmosphere = modelAtmosphericConditions(status);
+		data.setValue(FlightDataType.TYPE_AIR_TEMPERATURE, atmosphere.getTemperature());
+		data.setValue(FlightDataType.TYPE_AIR_PRESSURE, atmosphere.getPressure());
+		data.setValue(FlightDataType.TYPE_SPEED_OF_SOUND, atmosphere.getMachSpeed());
+		
+		data.setValue(FlightDataType.TYPE_TIME_STEP, timeStep);
+		data.setValue(FlightDataType.TYPE_COMPUTATION_TIME,
+					  (System.nanoTime() - status.getSimulationStartWallTime()) / 1000000000.0);
+
+		status.setSimulationTime(status.getSimulationTime() + timeStep);		
+	}
+}

--- a/core/src/net/sf/openrocket/simulation/SimulationStatus.java
+++ b/core/src/net/sf/openrocket/simulation/SimulationStatus.java
@@ -70,6 +70,9 @@ public class SimulationStatus implements Monitorable {
 	
 	/** Set to true to indicate the rocket is tumbling. */
 	private boolean tumbling = false;
+
+	/** Set to true to indicate rocket has landed */
+	private boolean landed = false;
 	
 	/** Contains a list of deployed recovery devices. */
 	private MonitorableSet<RecoveryDevice> deployedRecoveryDevices = new MonitorableSet<RecoveryDevice>();
@@ -179,6 +182,7 @@ public class SimulationStatus implements Monitorable {
 		this.launchRodCleared = orig.launchRodCleared;
 		this.apogeeReached = orig.apogeeReached;
 		this.tumbling = orig.tumbling;
+		this.landed = orig.landed;
 		
 		this.configuration.copyStages(orig.configuration);
 		
@@ -395,6 +399,15 @@ public class SimulationStatus implements Monitorable {
 	
 	public boolean isTumbling() {
 		return tumbling;
+	}
+
+	public void setLanded(boolean landed) {
+		this.landed = landed;
+		this.modID++;
+	}
+
+	public boolean isLanded() {
+		return landed;
 	}
 	
 	public double getMaxAlt() {


### PR DESCRIPTION
Run simulation to the bitter end, to better inform users of problems with models.  Previously, each simulation branch would end when the corresponding part of the rocket landed, even if there were still flight events to be processed.  It now processes all flight events, and posts a Warning for every event occurring after landing.