### PR TITLE
Fixes #525; Main Figure display rocket diameter again.

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
@@ -173,7 +173,7 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 		
 		return stages.get(stageNumber).active;
 	}
-	
+
 	public Collection<RocketComponent> getAllComponents() {
 		Queue<RocketComponent> toProcess = new ArrayDeque<RocketComponent>();
 		toProcess.offer(this.rocket);
@@ -188,6 +188,43 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 				if (!(child instanceof AxialStage)) {
 					toProcess.offer(child);
 				}
+			}
+		}
+		
+		return toReturn;
+	}
+
+	/** Returns all the components on core stages (i.e. centerline)
+	 * 
+	 * NOTE: components, NOT instances
+	 */
+	public ArrayList<RocketComponent> getCoreComponents() {
+		Queue<RocketComponent> toProcess = new ArrayDeque<RocketComponent>();
+		toProcess.offer(this.rocket);
+		
+		ArrayList<RocketComponent> toReturn = new ArrayList<>();
+		
+		while (!toProcess.isEmpty()) {
+			RocketComponent comp = toProcess.poll();
+			
+			if (! comp.getClass().equals(Rocket.class)) {
+				toReturn.add(comp);
+			}
+			
+			for (RocketComponent child : comp.getChildren()) {
+				if (child.getClass().equals(AxialStage.class)) {
+					// recurse through AxialStage -- these are still centerline.
+				    // however -- insist on an exact type match to disallow off-core stages
+					if(isStageActive(child.getStageNumber())){
+						toProcess.offer(child);
+					}
+				}else if( child instanceof ComponentAssembly) {
+					// i.e. ParallelStage or PodSet
+					// pass
+				}else{
+					toProcess.offer(child);
+				}
+				
 			}
 		}
 		

--- a/core/src/net/sf/openrocket/util/TestRockets.java
+++ b/core/src/net/sf/openrocket/util/TestRockets.java
@@ -903,7 +903,7 @@ public class TestRockets {
 			// cp:(0.25665,0.00000,0.00000,w=-0.90366)
 			
 			BodyTube upperStageBody= new BodyTube(0.18, 0.0385, 0.001);
-			upperStageBody.setName("Upper Stage Body ");
+			upperStageBody.setName("Upper Stage Body");
 			payloadStage.addChild( upperStageBody);
 			// cp:(0.35400,0.00000,0.00000)
 			

--- a/core/test/net/sf/openrocket/rocketcomponent/FlightConfigurationTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/FlightConfigurationTest.java
@@ -1,10 +1,12 @@
 package net.sf.openrocket.rocketcomponent;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
@@ -472,6 +474,77 @@ public class FlightConfigurationTest extends BaseTestCase {
 		}
 	}
 	
+	@Test
+	public void testIterateCoreComponents_AllStagesActive() {
+		Rocket rocket = TestRockets.makeFalcon9Heavy();
+		FlightConfiguration selected = rocket.getSelectedConfiguration();
+
+		selected.setAllStages();
+		
+		// vvvv Test Target vvvv
+		ArrayList<RocketComponent> components = selected.getCoreComponents();
+		// ^^^^ Test Target ^^^^
+		
+		assertThat(components.size(), equalTo(10));
+		
+		final AxialStage payloadStage = (AxialStage)components.get(0);
+		assertThat(payloadStage.getName(), equalTo("Payload Fairing Stage"));
+		
+		final AxialStage coreStage = (AxialStage)components.get(1);
+		assertThat(coreStage.getName(), equalTo("Core Stage"));
+
+		assertThat(components.get(2), instanceOf(NoseCone.class));
+
+		assertThat(components.get(3), instanceOf(BodyTube.class));
+		assertThat(components.get(3).getName(), equalTo("PL Fairing Body"));
+
+		assertThat(components.get(4), instanceOf(Transition.class));
+		
+		assertThat(components.get(5), instanceOf(BodyTube.class));
+		assertThat(components.get(5).getName(), equalTo("Upper Stage Body"));
+
+		assertThat(components.get(6), instanceOf(BodyTube.class));
+		assertThat(components.get(6).getName(), equalTo("Interstage"));
+
+		assertThat(components.get(7), instanceOf(BodyTube.class));
+		assertThat(components.get(7).getName(), equalTo("Core Stage Body"));
+		
+		assertThat(components.get(8), instanceOf(Parachute.class));
+		assertThat(components.get(9), instanceOf(ShockCord.class));
+	}
+	
+	@Test
+	public void testIterateCoreComponents_ActiveOnly() {
+		Rocket rocket = TestRockets.makeFalcon9Heavy();
+		FlightConfiguration selected = rocket.getSelectedConfiguration();
+
+		selected.clearAllStages();
+		selected.toggleStage(2);  // booster only.
+		
+		// vvvv Test Target vvvv
+		ArrayList<RocketComponent> components = selected.getCoreComponents();
+		// ^^^^ Test Target ^^^^
+		
+		assertThat(components.size(), equalTo(0));
+		
+		
+		// =================================
+		selected.clearAllStages();
+		selected.toggleStage(1);  // booster only.
+		
+		// vvvv Test Target vvvv
+		components = selected.getCoreComponents();
+		// ^^^^ Test Target ^^^^
+		
+		assertThat(components.size(), equalTo(2));
+				
+		final AxialStage coreStage = (AxialStage)components.get(0);
+		assertThat(coreStage.getName(), equalTo("Core Stage"));
+		
+		assertThat(components.get(1), instanceOf(BodyTube.class));
+		assertThat(components.get(1).getName(), equalTo("Core Stage Body"));
+		
+	}
 }
 
 

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -607,7 +607,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		figure3d.setCP(cp);
 
 		// Length bound is assumed to be tight
-		double length = 0, diameter = 0;
+		double length = 0;
 		Collection<Coordinate> bounds = curConfig.getBounds();
 		if (!bounds.isEmpty()) {
 			double minX = Double.POSITIVE_INFINITY, maxX = Double.NEGATIVE_INFINITY;
@@ -620,7 +620,8 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 			length = maxX - minX;
 		}
 
-		for (RocketComponent c : curConfig.getAllComponents()) {
+		double diameter = Double.NaN;
+		for (RocketComponent c : curConfig.getCoreComponents()) {
 			if (c instanceof SymmetricComponent) {
 				double d1 = ((SymmetricComponent) c).getForeRadius() * 2;
 				double d2 = ((SymmetricComponent) c).getAftRadius() * 2;


### PR DESCRIPTION
The displayed diameter is also restricted to centerline components, now.
Also: corrects rocket length to be the overall max x span of the rocket. 