### PR TITLE
[fix #497] Disables Fin-Thickness-Warnings on Phantom Fins

### DIFF
--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/FinSetCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/FinSetCalc.java
@@ -65,7 +65,7 @@ public class FinSetCalc extends RocketComponentCalc {
 		FinSet fin = (FinSet) component;
 
 		thickness = fin.getThickness();
-		bodyRadius = fin.getFinFront().y;
+		bodyRadius = fin.getBodyRadius();
 		finCount = fin.getFinCount();
 		
 		baseRotation = fin.getBaseRotation();
@@ -101,7 +101,7 @@ public class FinSetCalc extends RocketComponentCalc {
 		}
 		
 		// Add warnings  (radius/2 == diameter/4)
-		if (thickness > bodyRadius / 2) {
+		if( (0 < bodyRadius) && (thickness > bodyRadius / 2)){
 			warnings.add(Warning.THICK_FIN);
 		}
 		warnings.addAll(geometryWarnings);

--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/TubeFinSetCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/TubeFinSetCalc.java
@@ -110,7 +110,7 @@ public class TubeFinSetCalc extends RocketComponentCalc {
 		}
 		
 		// Add warnings  (radius/2 == diameter/4)
-		if (thickness > bodyRadius / 2) {
+		if( (0 < bodyRadius) && (thickness > bodyRadius / 2)){
 			warnings.add(Warning.THICK_FIN);
 		}
 		warnings.add(new Other("Tube fin support is experimental"));


### PR DESCRIPTION
Original issue arises from fins attached to "phantom" body tubes.
The warning is generated if the fin is thicker than half of it's parents radius; and phantom tubes (often) have a zero radius. (and/or zero length, but the zero radius is what causes the issue) 

Users who implement phantom tubes are expected to be expert / power users -- i.e. they're already assumed to have sufficient experience to know better than the program what they're doing. 

Therefore this PR simply disables warnings for fins on phantom tubes.
