### PR TITLE
Maintain component position when changing axial method. Fixes #541

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
@@ -89,6 +89,9 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 	 * Defaults to (0,0,0)
 	 */
 	protected Coordinate position = new Coordinate();
+
+	// A flag to signal the axial method has changed
+	private boolean axialMethodChange = false;
 	
 	// Color of the component, null means to use the default color
 	private Color color = null;
@@ -104,8 +107,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 	private boolean cdOverriden = false;
 	
 	private boolean overrideSubcomponents = false;
-	
-	
+
 	// User-given name of the component
 	private String name = null;
 	
@@ -938,6 +940,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 		// this variable does not change the internal representation
 		// the relativePosition (method) is just the lens through which external code may view this component's position. 
 		this.axialMethod = newAxialMethod;
+		this.axialMethodChange = true;
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 
@@ -1035,6 +1038,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 		checkState();
 
 		double newX = Double.NaN;
+		double newOffset = requestedOffset;
 
 		if (null == this.parent) {
 			// best-effort approximation.  this should be corrected later on in the initialization process.
@@ -1045,6 +1049,10 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 		} else if ( this.isAfter()){
 			this.setAfter();
 			return;
+		} else if (axialMethodChange){
+			newX = this.position.x;
+			newOffset = newX - requestedMethod.getAsPosition(0, this.length, this.parent.getLength());
+			axialMethodChange = false;
 		} else {
 			newX = requestedMethod.getAsPosition(requestedOffset, this.length, this.parent.getLength());
 		}
@@ -1058,8 +1066,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 		}
 
 		// store for later:
-		this.axialMethod = requestedMethod;
-		this.axialOffset = requestedOffset;
+		this.axialOffset = newOffset;
 		this.position = this.position.setX( newX );
 	}
 	

--- a/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
@@ -1066,6 +1066,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 		}
 
 		// store for later:
+		this.axialMethod = requestedMethod;
 		this.axialOffset = newOffset;
 		this.position = this.position.setX( newX );
 	}


### PR DESCRIPTION
This addresses #541. It keeps the component in the same location and modifies the offset value when the axial method is changed. It also maintains the current behavior for events such as parent length changes.

I don't like the use of `axialMethodChange`, but as far as I can tell, within `setAxialOffset()` there is no other way to tell that the axial method was changed. My first thought was to check if `this.axialMethod == requestedMethod`. However, `axialMethod` has already been changed before that function is called, so they are always the same.

Still getting acquainted with the code base. Thoughts?

Edit: `this.axialMethod = requestedMethod;` was left out in `setAxialOffset()`, cause of the majority of failed tests.