### PR TITLE
Use AWTTextureIO for creating textures from jpegs

### DIFF
--- a/swing/src/net/sf/openrocket/gui/figure3d/TextureCache.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/TextureCache.java
@@ -1,22 +1,22 @@
 package net.sf.openrocket.gui.figure3d;
 
+import java.awt.image.BufferedImage;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.jogamp.opengl.GL;
-import com.jogamp.opengl.GLAutoDrawable;
-import com.jogamp.opengl.GLProfile;
-
-import net.sf.openrocket.appearance.Decal;
+import javax.imageio.ImageIO;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.jogamp.opengl.GLAutoDrawable;
+import com.jogamp.opengl.GLProfile;
 import com.jogamp.opengl.util.texture.Texture;
-import com.jogamp.opengl.util.texture.TextureData;
-import com.jogamp.opengl.util.texture.TextureIO;
+import com.jogamp.opengl.util.texture.awt.AWTTextureIO;
+
+import net.sf.openrocket.appearance.Decal;
 
 public class TextureCache {
 	private static final Logger log = LoggerFactory.getLogger(TextureCache.class);
@@ -83,8 +83,8 @@ public class TextureCache {
 		try {
 			log.debug("Loading texture " + uri);
 			InputStream is = uri.openStream();
-			TextureData data = TextureIO.newTextureData(GLProfile.getDefault(), is, GL.GL_RGBA, GL.GL_RGBA, true, null);
-			tex = TextureIO.newTexture(data);
+			BufferedImage img = ImageIO.read(is);
+			tex = AWTTextureIO.newTexture(GLProfile.getDefault(), img, true);
 		} catch (Throwable e) {
 			log.error("Error loading Texture", e);
 		}
@@ -118,8 +118,8 @@ public class TextureCache {
 		try {
 			log.debug("Loading texture " + decal);
 			InputStream is = decal.getImage().getBytes();
-			TextureData data = TextureIO.newTextureData(GLProfile.getDefault(), is, GL.GL_RGBA, GL.GL_RGBA, true, null);
-			tex = TextureIO.newTexture(data);
+			BufferedImage img = ImageIO.read(is);
+			tex = AWTTextureIO.newTexture(GLProfile.getDefault(), img, true);
 		} catch (Throwable e) {
 			log.error("Error loading Texture", e);
 		}

--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/exhaust/FlameRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/exhaust/FlameRenderer.java
@@ -114,29 +114,30 @@
  */
 package net.sf.openrocket.gui.figure3d.photo.exhaust;
 
+import java.awt.image.BufferedImage;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.util.Random;
 
+import javax.imageio.ImageIO;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.jogamp.common.nio.Buffers;
 import com.jogamp.opengl.GL;
 import com.jogamp.opengl.GL2;
 import com.jogamp.opengl.GLProfile;
 import com.jogamp.opengl.fixedfunc.GLLightingFunc;
 import com.jogamp.opengl.fixedfunc.GLMatrixFunc;
 import com.jogamp.opengl.glu.GLU;
+import com.jogamp.opengl.util.texture.Texture;
+import com.jogamp.opengl.util.texture.awt.AWTTextureIO;
 
 import net.sf.openrocket.motor.Motor;
 import net.sf.openrocket.util.Color;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.jogamp.common.nio.Buffers;
-import com.jogamp.opengl.util.texture.Texture;
-import com.jogamp.opengl.util.texture.TextureData;
-import com.jogamp.opengl.util.texture.TextureIO;
 
 public final class FlameRenderer {
 
@@ -308,18 +309,14 @@ public final class FlameRenderer {
 	public static void init(GL2 gl) {
 		try {
 			log.debug("Loading Textures");
-			TextureData data = TextureIO.newTextureData(GLProfile.getDefault(),
-					FlameRenderer.class.getResourceAsStream("/datafiles/flame/c-color.png"), GL.GL_RGBA, GL.GL_RGBA,
-					true, null);
-			smokeT = TextureIO.newTexture(data);
-			data = TextureIO.newTextureData(GLProfile.getDefault(),
-					FlameRenderer.class.getResourceAsStream("/datafiles/flame/c-normal.png"), GL.GL_RGBA, GL.GL_RGBA,
-					true, null);
-			smokeN = TextureIO.newTexture(data);
-			data = TextureIO.newTextureData(GLProfile.getDefault(),
-					FlameRenderer.class.getResourceAsStream("/datafiles/flame/smoke2.png"), GL.GL_RGBA, GL.GL_RGBA,
-					true, null);
-			flameT = TextureIO.newTexture(data);
+			BufferedImage img = ImageIO.read(FlameRenderer.class.getResourceAsStream("/datafiles/flame/c-color.png"));
+			smokeT = AWTTextureIO.newTexture(GLProfile.getDefault(), img, true);
+
+			img = ImageIO.read(FlameRenderer.class.getResourceAsStream("/datafiles/flame/c-normal.png"));
+			smokeN = AWTTextureIO.newTexture(GLProfile.getDefault(), img, true);
+
+			img = ImageIO.read(FlameRenderer.class.getResourceAsStream("/datafiles/flame/smoke2.png"));
+			flameT = AWTTextureIO.newTexture(GLProfile.getDefault(), img, true);
 
 			log.debug("Loading Shader");
 			String line;


### PR DESCRIPTION
The switch to using JOGL uses the current JPEGs, but these textures
cannot be read using the GL.GL_RGBA format which is eventually
propigated to the user by an error dialog showing a NullPointerException
for the texture which failed to load. Using GL.GL_RGB as the format when
loading the textures will resolve the texture loading issue, but the
images are inverted due to differences between AWT and JOGL
interpretation of where the image starts (top left vs bottom left).

Change instead to use the AWTTextureIO class to create the textures
which solves both problems - the loading of the texture as well as
presenting the image in the appropriate orientation.

Closes #573

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>