### PR TITLE
Notify all event listeners when DoubleModel.setValue called

### DIFF
--- a/swing/src/net/sf/openrocket/gui/adaptors/DoubleModel.java
+++ b/swing/src/net/sf/openrocket/gui/adaptors/DoubleModel.java
@@ -770,6 +770,8 @@ public class DoubleModel implements StateChangeListener, ChangeSource, Invalidat
 		
 		try {
 			setMethod.invoke(source, v / multiplier);
+			// Make sure to notify all the listeners that have registered
+			fireStateChanged();
 		} catch (IllegalArgumentException e) {
 			throw new BugException("Unable to invoke setMethod of " + this, e);
 		} catch (IllegalAccessException e) {


### PR DESCRIPTION
Previous refactoring of the event listeners lost notifications
to classes which care about changes to the DoubleModel. One
such example is the UnitSelector. Ensure that all the
ChangeEventListeners and StateChangeEventListeners are called
when the setValue method is invoked.

Closes #553

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>