### PR TITLE
Update eclipse .classpath files

### DIFF
--- a/core/.classpath
+++ b/core/.classpath
@@ -4,6 +4,9 @@
 	<classpathentry kind="src" path="src-extra"/>
 	<classpathentry kind="src" path="test"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
 		<accessrules>
 			<accessrule kind="nonaccessible" pattern="com/sun/**"/>
 			<accessrule kind="nonaccessible" pattern="java/awt/List"/>
@@ -11,21 +14,22 @@
 	</classpathentry>
 	<classpathentry kind="lib" path="lib-extra/RXTXcomm.jar"/>
 	<classpathentry kind="lib" path="resources"/>
-	<classpathentry kind="lib" path="lib/opencsv-2.3.jar"/>
-	<classpathentry kind="lib" path="lib/guice-3.0.jar"/>
-	<classpathentry kind="lib" path="lib/guice-multibindings-3.0.jar"/>
 	<classpathentry kind="lib" path="lib/javax.inject.jar"/>
 	<classpathentry kind="lib" path="lib/aopalliance.jar"/>
 	<classpathentry kind="lib" path="lib/slf4j-api-1.7.5.jar"/>
-	<classpathentry kind="lib" path="lib/annotation-detector-3.0.2.jar"/>
-	<classpathentry kind="lib" path="/OpenRocket Test Libraries/hamcrest-core-1.3.0RC1.jar"/>
-	<classpathentry kind="lib" path="/OpenRocket Test Libraries/hamcrest-library-1.3.0RC1.jar"/>
-	<classpathentry kind="lib" path="/OpenRocket Test Libraries/jmock-2.6.0-RC2.jar"/>
-	<classpathentry kind="lib" path="/OpenRocket Test Libraries/jmock-junit4-2.6.0-RC2.jar"/>
-	<classpathentry kind="lib" path="/OpenRocket Test Libraries/junit-dep-4.8.2.jar"/>
 	<classpathentry kind="lib" path="/OpenRocket Test Libraries/test-plugin.jar"/>
-	<classpathentry kind="lib" path="/OpenRocket Test Libraries/uispec4j-2.3-jdk16.jar"/>
-	<classpathentry kind="lib" path="/OpenRocket Swing/lib/logback-classic-1.0.12.jar"/>
-	<classpathentry kind="lib" path="/OpenRocket Swing/lib/logback-core-1.0.12.jar"/>
+	<classpathentry kind="lib" path="lib/annotation-detector-3.0.5.jar"/>
+	<classpathentry kind="lib" path="lib/guice-4.2.1.jar"/>
+	<classpathentry kind="lib" path="lib/logback-classic-1.2.3.jar"/>
+	<classpathentry kind="lib" path="lib/logback-core-1.2.3.jar"/>
+	<classpathentry kind="lib" path="lib/opencsv-4.3.2.jar"/>
+	<classpathentry kind="lib" path="/OpenRocket Test Libraries/hamcrest-core-1.3.jar"/>
+	<classpathentry kind="lib" path="/OpenRocket Test Libraries/hamcrest-library-1.3.jar"/>
+	<classpathentry kind="lib" path="/OpenRocket Test Libraries/jmock-2.9.0.jar"/>
+	<classpathentry kind="lib" path="/OpenRocket Test Libraries/jmock-junit4-2.9.0.jar"/>
+	<classpathentry kind="lib" path="/OpenRocket Test Libraries/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="lib/jaxb-api.2.3.1.jar"/>
+	<classpathentry kind="lib" path="lib/jaxb-runtime.2.3.1.jar"/>
+	<classpathentry kind="lib" path="lib/guava-26.0-jre.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/lib-test/.classpath
+++ b/lib-test/.classpath
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="lib" path="hamcrest-core-1.3.0RC1.jar"/>
-	<classpathentry kind="lib" path="hamcrest-library-1.3.0RC1.jar"/>
-	<classpathentry kind="lib" path="jmock-2.6.0-RC2.jar"/>
-	<classpathentry kind="lib" path="jmock-junit4-2.6.0-RC2.jar"/>
-	<classpathentry kind="lib" path="junit-dep-4.8.2.jar"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="lib" path="test-plugin.jar"/>
-	<classpathentry kind="lib" path="uispec4j-2.3-jdk16.jar"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="lib" path="hamcrest-core-1.3.jar"/>
+	<classpathentry kind="lib" path="hamcrest-library-1.3.jar"/>
+	<classpathentry kind="lib" path="jmock-2.9.0.jar"/>
+	<classpathentry kind="lib" path="jmock-junit4-2.9.0.jar"/>
+	<classpathentry kind="lib" path="junit-4.12.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/swing/.classpath
+++ b/swing/.classpath
@@ -2,7 +2,11 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="test"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="lib" path="lib/jogl/jogl-all.jar"/>
 	<classpathentry kind="lib" path="lib/iText-5.0.2.jar"/>
 	<classpathentry kind="lib" path="lib/jcommon-1.0.18.jar"/>
@@ -12,23 +16,24 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/OpenRocket Core"/>
 	<classpathentry kind="lib" path="/OpenRocket Core/lib/slf4j-api-1.7.5.jar"/>
 	<classpathentry kind="lib" path="/OpenRocket Core/lib/aopalliance.jar"/>
-	<classpathentry kind="lib" path="/OpenRocket Core/lib/guice-3.0.jar"/>
-	<classpathentry kind="lib" path="/OpenRocket Core/lib/guice-multibindings-3.0.jar"/>
 	<classpathentry kind="lib" path="/OpenRocket Core/lib/javax.inject.jar"/>
-	<classpathentry kind="lib" path="/OpenRocket Core/lib/opencsv-2.3.jar"/>
-	<classpathentry kind="lib" path="lib/logback-classic-1.0.12.jar"/>
-	<classpathentry kind="lib" path="lib/logback-core-1.0.12.jar"/>
 	<classpathentry kind="lib" path="/OpenRocket Core/resources"/>
 	<classpathentry kind="lib" path="resources"/>
-	<classpathentry kind="lib" path="/OpenRocket Core/lib/annotation-detector-3.0.2.jar"/>
 	<classpathentry kind="lib" path="lib/miglayout-4.0-swing.jar" sourcepath="reference/miglayout-4.0-sources.jar"/>
 	<classpathentry kind="lib" path="lib/rsyntaxtextarea-2.5.6.jar"/>
-	<classpathentry kind="lib" path="/OpenRocket Test Libraries/hamcrest-core-1.3.0RC1.jar"/>
-	<classpathentry kind="lib" path="/OpenRocket Test Libraries/hamcrest-library-1.3.0RC1.jar"/>
-	<classpathentry kind="lib" path="/OpenRocket Test Libraries/jmock-2.6.0-RC2.jar"/>
-	<classpathentry kind="lib" path="/OpenRocket Test Libraries/jmock-junit4-2.6.0-RC2.jar"/>
-	<classpathentry kind="lib" path="/OpenRocket Test Libraries/junit-dep-4.8.2.jar"/>
 	<classpathentry kind="lib" path="/OpenRocket Test Libraries/test-plugin.jar"/>
-	<classpathentry kind="lib" path="/OpenRocket Test Libraries/uispec4j-2.3-jdk16.jar"/>
+	<classpathentry kind="lib" path="/OpenRocket Core/lib/annotation-detector-3.0.5.jar"/>
+	<classpathentry kind="lib" path="/OpenRocket Core/lib/guice-4.2.1.jar"/>
+	<classpathentry kind="lib" path="/OpenRocket Core/lib/logback-classic-1.2.3.jar"/>
+	<classpathentry kind="lib" path="/OpenRocket Core/lib/logback-core-1.2.3.jar"/>
+	<classpathentry kind="lib" path="/OpenRocket Test Libraries/hamcrest-core-1.3.jar"/>
+	<classpathentry kind="lib" path="/OpenRocket Test Libraries/hamcrest-library-1.3.jar"/>
+	<classpathentry kind="lib" path="/OpenRocket Core/lib/opencsv-4.3.2.jar"/>
+	<classpathentry kind="lib" path="/OpenRocket Test Libraries/jmock-2.9.0.jar"/>
+	<classpathentry kind="lib" path="/OpenRocket Test Libraries/jmock-junit4-2.9.0.jar"/>
+	<classpathentry kind="lib" path="/OpenRocket Test Libraries/junit-4.12.jar"/>
+	<classpathentry kind="lib" path="/OpenRocket Core/lib/jaxb-api.2.3.1.jar"/>
+	<classpathentry kind="lib" path="/OpenRocket Core/lib/jaxb-runtime.2.3.1.jar"/>
+	<classpathentry kind="lib" path="/OpenRocket Core/lib/guava-26.0-jre.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
Update the eclipse .classpath files to point to the new and updated
jar files that were merged as part of the recent upgrade to Java 11/
Java 13 commits.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>