### PR TITLE
[test] Change which JDKs we plan to support -- by changing which ones we test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 language: java
-dist: trusty
+dist: bionic
 sudo: false
 addons:
   apt:
     packages:
+      - ant
       - ant-optional
+
 jdk:
   - openjdk11
   - openjdk13
+  - oraclejdk11
+  - oraclejdk13
+
 script:
- - "ant -buildfile build.xml clean check jar unittest"
+  - "ant -buildfile build.xml clean check jar unittest"


### PR DESCRIPTION
New list: (see `$GT/.travis.yml`)
- OracleJDK and OpenJDK
- Versions 11,13
- move underlying image to Ubuntu 18.04 LTS / Bionic Beaver