### PR TITLE
Remove OrangeExtensions-1.2.jar from eclipse classpath

### DIFF
--- a/swing/.classpath
+++ b/swing/.classpath
@@ -11,7 +11,6 @@
 	<classpathentry kind="lib" path="lib/iText-5.0.2.jar"/>
 	<classpathentry kind="lib" path="lib/jcommon-1.0.18.jar"/>
 	<classpathentry kind="lib" path="lib/jfreechart-1.0.15.jar"/>
-	<classpathentry kind="lib" path="lib/OrangeExtensions-1.2.jar"/>
 	<classpathentry kind="lib" path="lib/jogl/gluegen-rt.jar"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/OpenRocket Core"/>
 	<classpathentry kind="lib" path="/OpenRocket Core/lib/slf4j-api-1.7.30.jar"/>


### PR DESCRIPTION
Commit a7c0cb2 removed the OrangeExtensions-1.2.jar file from the
swing project, but failed to remove it from the eclipse classpath.
This fixes that.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>