### PR TITLE
[Request Review] Corrects the cp calculations for Split-fin rockets.  Fixes #600.

### DIFF
--- a/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
+++ b/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
@@ -192,27 +192,24 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 			if (null != calcObj) {
 				// iterate across component instances
 				final ArrayList<InstanceContext> contextList = entry.getValue();
-
 				for(InstanceContext context: contextList ) {
 					AerodynamicForces instanceForces = new AerodynamicForces().zero();
 					
 					calcObj.calculateNonaxialForces(conditions, context.transform, instanceForces, warnings);
-					Coordinate cp_comp = instanceForces.getCP();
 					
-					Coordinate cp_abs = context.transform.transform(cp_comp);
+					Coordinate cp_inst = instanceForces.getCP();
+					Coordinate cp_abs = context.transform.transform(cp_inst);
 					if ((comp instanceof FinSet) && (((FinSet)comp).getFinCount() > 2))
 						cp_abs = cp_abs.setY(0.0).setZ(0.0);
 					
 					instanceForces.setCP(cp_abs);
 					double CN_instanced = instanceForces.getCN();
 					instanceForces.setCm(CN_instanced * instanceForces.getCP().x / conditions.getRefLength());
-					// System.err.println("instanceForces=" + instanceForces);
 					assemblyForces.merge(instanceForces);
 				}
 			}
 		}
 
-		// System.err.println("assemblyForces=" + assemblyForces);
 		return assemblyForces;
 	}
 	

--- a/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
+++ b/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
@@ -180,9 +180,11 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 		}
 		
 		final InstanceMap imap = configuration.getActiveInstances();
-
+		
 		final AerodynamicForces assemblyForces= new AerodynamicForces().zero();
 
+//		System.err.println("======================================");
+//		System.err.println("==== Iterating through components ====");
 		// iterate through all components
 	    for(Map.Entry<RocketComponent, ArrayList<InstanceContext>> entry: imap.entrySet() ) {
 			final RocketComponent comp = entry.getKey();
@@ -192,8 +194,11 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 			if (null != calcObj) {
 				// iterate across component instances
 				final ArrayList<InstanceContext> contextList = entry.getValue();
+
 				for(InstanceContext context: contextList ) {
 					AerodynamicForces instanceForces = new AerodynamicForces().zero();
+//					System.err.println(String.format("@ [%s]:[%d/%d]", comp.getName(), context.instanceNumber + 1, comp.getInstanceCount()));
+//					System.err.println("_________ inst/ctxt: xrotation: " + context.transform.getXrotation());
 					
 					calcObj.calculateNonaxialForces(conditions, context.transform, instanceForces, warnings);
 					
@@ -202,14 +207,21 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 					if ((comp instanceof FinSet) && (((FinSet)comp).getFinCount() > 2))
 						cp_abs = cp_abs.setY(0.0).setZ(0.0);
 					
+//					if( 1e-6 < cp_inst.weight) {
+//						System.err.println("_________ cp:inst: (rel): " + cp_inst.toString());
+//						System.err.println("_________ cp:inst: (abs): " + cp_abs.toString());
+//					}
+					
 					instanceForces.setCP(cp_abs);
 					double CN_instanced = instanceForces.getCN();
 					instanceForces.setCm(CN_instanced * instanceForces.getCP().x / conditions.getRefLength());
 					assemblyForces.merge(instanceForces);
+					
 				}
 			}
 		}
 
+//		System.err.println("____ cp:asbly: " + assemblyForces.getCP().toString());
 		return assemblyForces;
 	}
 	

--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/FinSetCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/FinSetCalc.java
@@ -49,7 +49,6 @@ public class FinSetCalc extends RocketComponentCalc {
 	private final double thickness;
 	private final double bodyRadius;
 	private final int finCount;
-	private final double baseRotation;
 	private final double cantAngle;
 	private final FinSet.CrossSection crossSection;
 	
@@ -68,7 +67,6 @@ public class FinSetCalc extends RocketComponentCalc {
 		bodyRadius = fin.getBodyRadius();
 		finCount = fin.getFinCount();
 		
-		baseRotation = fin.getBaseRotation();
 		cantAngle = fin.getCantAngle();
 		span = fin.getSpan();
 		finArea = fin.getPlanformArea();
@@ -114,10 +112,12 @@ public class FinSetCalc extends RocketComponentCalc {
 		// Multiple fins with fin-fin interference
 		double cna;
 		double theta = conditions.getTheta();
-		double angle = baseRotation + transform.getXrotation();
-		
+		double angle = transform.getXrotation();
+
 		// Compute basic CNa without interference effects
 		cna = cna1 * MathUtil.pow2(Math.sin(theta - angle));
+//		final double cna_x = cna1 * MathUtil.pow2(Math.sin(theta - angle));
+//		final double cna_y = cna1 * MathUtil.pow2(Math.sin(theta - angle));
 		
 		//		logger.debug("Component cna = {}", cna);
 		
@@ -166,7 +166,6 @@ public class FinSetCalc extends RocketComponentCalc {
 		// (Barrowman thesis pdf-page 40)
 		
 		// TODO: LOW: fin-fin mach cone effect, MIL-HDBK page 5-25
-		
 		// Calculate CP position
 		double x = macLead + calculateCPPos(conditions) * macLength;
 		//		logger.debug("Component macLead = {}", macLead);

--- a/core/src/net/sf/openrocket/util/TestRockets.java
+++ b/core/src/net/sf/openrocket/util/TestRockets.java
@@ -530,19 +530,22 @@ public class TestRockets {
 		return rocket;
 	}
 	
-	// This function is used for unit, integration tests, DO NOT CHANGE (without updating tests).
-	public static final void splitRocketFins( BodyTube body, FinSet fins, int finCount){
+	public static final void splitRocketFins( BodyTube body, TrapezoidFinSet fins, int finCount){
 		// actually remove the fins
 		body.removeChild(fins);
 
-		FinSet template = fins; 
+		TrapezoidFinSet template = fins; 
 		template.setFinCount(1);
-		// and manually add in the equivalent:
-		for(int finNumber=0; finNumber<finCount; ++finNumber){
-			final TrapezoidFinSet singleFin = new TrapezoidFinSet(1, 0.05, 0.03, 0.02, 0.05);
+		// and manually add in the equivalent the others
+		for(int finNumber=1; finNumber<finCount; ++finNumber){
+			final double rootChord = template.getRootChord();
+			final double tipChord = template.getTipChord();
+			final double sweep = template.getSweep();
+			final double height = template.getHeight();
+			final TrapezoidFinSet singleFin = new TrapezoidFinSet(1, rootChord, tipChord, sweep, height);
 			singleFin.setAngleOffset( finNumber * Math.PI * 2.0 / finCount);
-			singleFin.setThickness( 0.0032);
-			singleFin.setAxialMethod(AxialMethod.BOTTOM);
+			singleFin.setThickness( template.getThickness());
+			singleFin.setAxialMethod( template.getAxialMethod());
 			singleFin.setName(String.format("Single Fin #%d", finNumber));
 			body.addChild(singleFin);
 		}

--- a/core/src/net/sf/openrocket/util/TestRockets.java
+++ b/core/src/net/sf/openrocket/util/TestRockets.java
@@ -28,6 +28,7 @@ import net.sf.openrocket.rocketcomponent.CenteringRing;
 import net.sf.openrocket.rocketcomponent.ClusterConfiguration;
 import net.sf.openrocket.rocketcomponent.DeploymentConfiguration;
 import net.sf.openrocket.rocketcomponent.DeploymentConfiguration.DeployEvent;
+import net.sf.openrocket.rocketcomponent.EllipticalFinSet;
 import net.sf.openrocket.rocketcomponent.EngineBlock;
 import net.sf.openrocket.rocketcomponent.ExternalComponent;
 import net.sf.openrocket.rocketcomponent.ExternalComponent.Finish;
@@ -66,6 +67,12 @@ import net.sf.openrocket.startup.Application;
 
 public class TestRockets {
 	
+	public final static FlightConfigurationId TEST_FCID_0 = new FlightConfigurationId("d010716e-ce0e-469d-ae46-190f3653ebbf");
+	public final static FlightConfigurationId TEST_FCID_1 = new FlightConfigurationId("f41bee5b-ebb8-4d92-bce7-53001577a313");
+	public final static FlightConfigurationId TEST_FCID_2 = new FlightConfigurationId("3e8d1280-53c2-4234-89a7-de215ef5cd69");
+	public final static FlightConfigurationId TEST_FCID_3 = new FlightConfigurationId("415a5485-f2da-4c2a-8803-394220ae58b8");
+	public final static FlightConfigurationId TEST_FCID_4 = new FlightConfigurationId("5abc18ec-a200-46f1-90c4-60b6995fc933");
+
 	private final String key;
 	private final Random rnd;
 	
@@ -376,15 +383,7 @@ public class TestRockets {
 			
 		return values[rnd.nextInt(values.length)];
 	}
-	
-	final static FlightConfigurationId ESTES_ALPHA_III_FCID[] = { 
-			null, // treat the array as 1-indexed.   
-			new FlightConfigurationId("test_config #1: A8-0"), 
-			new FlightConfigurationId("test_config #2: B4-3"),
-			new FlightConfigurationId("test_config #3: C6-3"),
-			new FlightConfigurationId("test_config #4: C6-5"),
-			new FlightConfigurationId("test_config #5: C6-7"),
-	};
+
 	
 	// This is a Estes Alpha III 
 	// http://www.rocketreviews.com/alpha-iii---estes-221256.html
@@ -392,13 +391,12 @@ public class TestRockets {
 	// This function is used for unit, integration tests, DO NOT CHANGE (without updating tests).
 	public static final Rocket makeEstesAlphaIII(){
 		Rocket rocket = new Rocket();
-		FlightConfigurationId fcid[] = new FlightConfigurationId[5];
-		fcid[0] = rocket.createFlightConfiguration( ESTES_ALPHA_III_FCID[1] );
-		fcid[1] = rocket.createFlightConfiguration( ESTES_ALPHA_III_FCID[2] );
-		fcid[2] = rocket.createFlightConfiguration( ESTES_ALPHA_III_FCID[3] );
-		fcid[3] = rocket.createFlightConfiguration( ESTES_ALPHA_III_FCID[4] );
-		fcid[4] = rocket.createFlightConfiguration( ESTES_ALPHA_III_FCID[5] );
 		
+		rocket.createFlightConfiguration( TEST_FCID_0 );
+		rocket.createFlightConfiguration( TEST_FCID_1 );
+		rocket.createFlightConfiguration( TEST_FCID_2 );
+		rocket.createFlightConfiguration( TEST_FCID_3 );
+		rocket.createFlightConfiguration( TEST_FCID_4 );
 		
 		rocket.setName("Estes Alpha III / Code Verification Rocket");
 		AxialStage stage = new AxialStage();
@@ -463,41 +461,41 @@ public class TestRockets {
 				thrustBlock.setName("Engine Block");
 				inner.addChild(thrustBlock);
 				inner.setMotorMount( true);
-				
+			
 				{
-					MotorConfiguration motorConfig = new MotorConfiguration(inner,fcid[0]);
+					MotorConfiguration motorConfig = new MotorConfiguration(inner, TEST_FCID_0);
 					Motor mtr =	TestRockets.generateMotor_A8_18mm();
 					motorConfig.setMotor( mtr);
 					motorConfig.setEjectionDelay(0.0);
-					inner.setMotorConfig( motorConfig, fcid[0]);
+					inner.setMotorConfig( motorConfig, TEST_FCID_0);
 				}
 				{
-					MotorConfiguration motorConfig = new MotorConfiguration(inner,fcid[1]);
+					MotorConfiguration motorConfig = new MotorConfiguration(inner,TEST_FCID_1);
 					Motor mtr =	TestRockets.generateMotor_B4_18mm();
 					motorConfig.setMotor( mtr);
 					motorConfig.setEjectionDelay(3.0);
-					inner.setMotorConfig( motorConfig, fcid[1]);
+					inner.setMotorConfig( motorConfig, TEST_FCID_1);
 				}
 				{
-					MotorConfiguration motorConfig = new MotorConfiguration(inner,fcid[2]);
+					MotorConfiguration motorConfig = new MotorConfiguration(inner, TEST_FCID_2);
 					Motor mtr =	TestRockets.generateMotor_C6_18mm();
 					motorConfig.setEjectionDelay(3.0);
 					motorConfig.setMotor( mtr);
-					inner.setMotorConfig( motorConfig, fcid[2]);
+					inner.setMotorConfig( motorConfig, TEST_FCID_2);
 				}
 				{
-					MotorConfiguration motorConfig = new MotorConfiguration(inner,fcid[3]);
+					MotorConfiguration motorConfig = new MotorConfiguration(inner,TEST_FCID_3);
 					Motor mtr =	TestRockets.generateMotor_C6_18mm();
 					motorConfig.setEjectionDelay(5.0);
 					motorConfig.setMotor( mtr);
-					inner.setMotorConfig( motorConfig, fcid[3]);
+					inner.setMotorConfig( motorConfig, TEST_FCID_3);
 				}
 				{
-					MotorConfiguration motorConfig = new MotorConfiguration(inner,fcid[4]);
+					MotorConfiguration motorConfig = new MotorConfiguration(inner,TEST_FCID_4);
 					Motor mtr =	TestRockets.generateMotor_C6_18mm();
 					motorConfig.setEjectionDelay(7.0);
 					motorConfig.setMotor( mtr);
-					inner.setMotorConfig( motorConfig, fcid[4]);
+					inner.setMotorConfig( motorConfig, TEST_FCID_4);
 				}
 			}
 		
@@ -525,7 +523,6 @@ public class TestRockets {
 		nosecone.setMaterial(material);
 		bodytube.setMaterial(material);
 		finset.setMaterial(material);
-		
 		
 		// preserve default default configuration of rocket -- to test what the default is set to upon initialization.
 		
@@ -586,16 +583,16 @@ public class TestRockets {
 				boosterMMT.setLength(0.05);
 				boosterMMT.setMotorMount(true);
 				{
-					MotorConfiguration motorConfig= new MotorConfiguration(boosterMMT, ESTES_ALPHA_III_FCID[1] );
+					MotorConfiguration motorConfig= new MotorConfiguration(boosterMMT, TEST_FCID_1 );
 					Motor mtr = generateMotor_D21_18mm();
 					motorConfig.setMotor(mtr);
-					boosterMMT.setMotorConfig( motorConfig, ESTES_ALPHA_III_FCID[1]);
+					boosterMMT.setMotorConfig( motorConfig, TEST_FCID_1);
 				}
 				boosterBody.addChild(boosterMMT);
 			}
 		}
 
-		rocket.setSelectedConfiguration( ESTES_ALPHA_III_FCID[1] );
+		rocket.setSelectedConfiguration( TEST_FCID_1 );
 		rocket.getSelectedConfiguration().setAllStages();
 		rocket.enableEvents();
 		
@@ -748,7 +745,7 @@ public class TestRockets {
 		auxfinset.setCrossSection(CrossSection.AIRFOIL);
 		auxfinset.setAxialMethod(AxialMethod.TOP);
 		auxfinset.setAxialOffset(0.28);
-		auxfinset.setBaseRotation(Math.PI / 2);
+		auxfinset.setAngleOffset(Math.PI / 2);
 		tube1.addChild(auxfinset);
 		
 		coupler = new TubeCoupler();
@@ -826,7 +823,7 @@ public class TestRockets {
 		finset.setSweep(0.3);
 		finset.setAxialMethod(AxialMethod.BOTTOM);
 		finset.setAxialOffset(-0.03);
-		finset.setBaseRotation(Math.PI / 2);
+		finset.setAngleOffset(Math.PI / 2);
 		tube3.addChild(finset);
 		
 		finset.setCantAngle(0 * Math.PI / 180);
@@ -1012,7 +1009,7 @@ public class TestRockets {
 						boosterBody.addChild(boosterFins);
 						boosterFins.setName("Booster Fins");
 						boosterFins.setFinCount(3);
-						boosterFins.setBaseRotation( Math.PI / 4);
+						boosterFins.setAngleOffset( Math.PI / 4);
 						boosterFins.setThickness(0.003);
 						boosterFins.setCrossSection(CrossSection.ROUNDED);
 						boosterFins.setRootChord(0.32);
@@ -1148,7 +1145,7 @@ public class TestRockets {
 		TrapezoidFinSet endPlate = new TrapezoidFinSet(endPlateCount, endPlateRootChord, endPlateTipChord, endPlateSweep, endPlateHeight);
 		phantom.addChild(endPlate);
 		endPlate.setName("End plates");
-		endPlate.setBaseRotation(endPlateRotation);
+		endPlate.setAngleOffset(endPlateRotation);
 		endPlate.setAxialMethod(endPlateAxialMethod);
 		endPlate.setAxialOffset(endPlateAxialOffset);
 		endPlate.setThickness(endPlateThickness);

--- a/core/src/net/sf/openrocket/util/TestRockets.java
+++ b/core/src/net/sf/openrocket/util/TestRockets.java
@@ -530,6 +530,24 @@ public class TestRockets {
 		return rocket;
 	}
 	
+	// This function is used for unit, integration tests, DO NOT CHANGE (without updating tests).
+	public static final void splitRocketFins( BodyTube body, FinSet fins, int finCount){
+		// actually remove the fins
+		body.removeChild(fins);
+
+		FinSet template = fins; 
+		template.setFinCount(1);
+		// and manually add in the equivalent:
+		for(int finNumber=0; finNumber<finCount; ++finNumber){
+			final TrapezoidFinSet singleFin = new TrapezoidFinSet(1, 0.05, 0.03, 0.02, 0.05);
+			singleFin.setAngleOffset( finNumber * Math.PI * 2.0 / finCount);
+			singleFin.setThickness( 0.0032);
+			singleFin.setAxialMethod(AxialMethod.BOTTOM);
+			singleFin.setName(String.format("Single Fin #%d", finNumber));
+			body.addChild(singleFin);
+		}
+	}
+
 	// This is an extra stage tacked onto the end of an Estes Alpha III 
 	// http://www.rocketreviews.com/alpha-iii---estes-221256.html
 	// 

--- a/core/src/net/sf/openrocket/util/TestRockets.java
+++ b/core/src/net/sf/openrocket/util/TestRockets.java
@@ -1036,12 +1036,6 @@ public class TestRockets {
 						boosterFins.setSweep(0.18);
 						boosterFins.setAxialMethod(AxialMethod.BOTTOM);
 						boosterFins.setAxialOffset(0.0);
-						// cp:(1.17873,0.10422,0.02722,w=6.07405) (1 fin case)
-						// cp:(1.17873,-0.10422,-0.02722,w=6.07405) (1 fin case)
-						// cp:(1.17873,0.10422,0.02722,w=12.14810) (2 fin case)
-						// cp:(1.17873,-0.10422,-0.02722,w=12.14810) (2 fin case)
-						// cp:(1.17873,0.00000,0.00000,w=9.11107) (3 fin case)
-						// cp:(1.17873,0.00000,0.00000,w=9.11107) (3 fin case)
 					}
 				}
 				

--- a/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java
+++ b/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java
@@ -190,7 +190,7 @@ public class BarrowmanCalculatorTest {
 			assertEquals("Split-Fin Rocket CP x value is incorrect:", 0.22351541, wholeRocketCP.x, EPSILON);
 		}{
 			final BodyTube body = (BodyTube)rocket.getChild(0).getChild(1);
-			final FinSet fins = (FinSet)body.getChild(0);
+			final TrapezoidFinSet fins = (TrapezoidFinSet)body.getChild(0);
 			fins.setAngleOffset(0);
 			TestRockets.splitRocketFins(body, fins, 3);
 
@@ -216,7 +216,7 @@ public class BarrowmanCalculatorTest {
 			assertEquals("Split-Fin Rocket CP x value is incorrect:", 0.22724, wholeRocketCP.x, EPSILON);
 		}{
 			final BodyTube body = (BodyTube)rocket.getChild(0).getChild(1);
-			final FinSet fins = (FinSet)body.getChild(0);
+			final TrapezoidFinSet fins = (TrapezoidFinSet)body.getChild(0);
 			TestRockets.splitRocketFins(body, fins, 4);
 
 			final Coordinate wholeRocketCP = calc.getCP(config, conditions, warnings);

--- a/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java
+++ b/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java
@@ -15,6 +15,7 @@ import net.sf.openrocket.ServicesForTesting;
 import net.sf.openrocket.plugin.PluginModule;
 import net.sf.openrocket.rocketcomponent.AxialStage;
 import net.sf.openrocket.rocketcomponent.BodyTube;
+import net.sf.openrocket.rocketcomponent.FinSet;
 import net.sf.openrocket.rocketcomponent.FlightConfiguration;
 import net.sf.openrocket.rocketcomponent.NoseCone;
 import net.sf.openrocket.rocketcomponent.ParallelStage;
@@ -142,6 +143,31 @@ public class BarrowmanCalculatorTest {
 			assertEquals(" Falcon 9 Heavy CP z value is incorrect:", 0f, cp_1fin.z, EPSILON);
 		}{
 			// absent -- 3.28901627g @[0.31469937,0.05133333,0.00000000]
+		}
+	}
+
+	@Test
+	public void testCpSplitTripleFin() {
+		final BarrowmanCalculator calc = new BarrowmanCalculator();
+		final WarningSet warnings = new WarningSet();
+
+		final Rocket rocket = TestRockets.makeEstesAlphaIII();
+		final FlightConfiguration config = rocket.getSelectedConfiguration();
+		final FlightConditions conditions = new FlightConditions(config);
+
+		{
+			final Coordinate wholeRocketCP = calc.getCP(config, conditions, warnings);
+			assertEquals("Split-Fin Rocket CNa value is incorrect:", 26.14693374, wholeRocketCP.weight, EPSILON);
+			assertEquals("Split-Fin Rocket CP x value is incorrect:", 0.22351541, wholeRocketCP.x, EPSILON);
+		}{
+			final BodyTube body = (BodyTube)rocket.getChild(0).getChild(1);
+			final FinSet fins = (FinSet)body.getChild(0);
+			fins.setAngleOffset(0);
+			TestRockets.splitRocketFins(body, fins, 3);
+			
+			final Coordinate wholeRocketCP = calc.getCP(config, conditions, warnings);
+			assertEquals("Split-Fin Rocket CNa value is incorrect:", 26.14693374, wholeRocketCP.weight, EPSILON);
+			assertEquals("Split-Fin Rocket CP x value is incorrect:", 0.22351541, wholeRocketCP.x, EPSILON);
 		}
 	}
 

--- a/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java
+++ b/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java
@@ -130,22 +130,51 @@ public class BarrowmanCalculatorTest {
 		}{
 			boosterFins.setFinCount(2);
 			final Coordinate cp_2fin = calc.getCP(config, conditions, warnings);
-			assertEquals(" Falcon 9 Heavy CNa value is incorrect:", 27.585207667168696, cp_2fin.weight, EPSILON);
-			assertEquals(" Falcon 9 Heavy CP x value is incorrect:", 1.0757127676940474, cp_2fin.x, EPSILON);
+			assertEquals(" Falcon 9 Heavy CNa value is incorrect:", 15.43711196967902, cp_2fin.weight, EPSILON);
+			assertEquals(" Falcon 9 Heavy CP x value is incorrect:", 0.9946423753010524, cp_2fin.x, EPSILON);
 			assertEquals(" Falcon 9 Heavy CP y value is incorrect:", 0.0, cp_2fin.y, EPSILON);
 			assertEquals(" Falcon 9 Heavy CP z value is incorrect:", 0.0, cp_2fin.z, EPSILON);
 		}{
 			boosterFins.setFinCount(1);
 			final Coordinate cp_1fin = calc.getCP(config, conditions, warnings);
-			assertEquals(" Falcon 9 Heavy CNa value is incorrect:", 15.43711196967902, cp_1fin.weight, EPSILON);
-			assertEquals(" Falcon 9 Heavy CP x value is incorrect:", 0.99464, cp_1fin.x, EPSILON);
+			assertEquals(" Falcon 9 Heavy CNa value is incorrect:", 9.36306412, cp_1fin.weight, EPSILON);
+			assertEquals(" Falcon 9 Heavy CP x value is incorrect:", 0.87521867, cp_1fin.x, EPSILON);
 			assertEquals(" Falcon 9 Heavy CP y value is incorrect:", 0f, cp_1fin.y, EPSILON);
 			assertEquals(" Falcon 9 Heavy CP z value is incorrect:", 0f, cp_1fin.z, EPSILON);
-		}{
-			// absent -- 3.28901627g @[0.31469937,0.05133333,0.00000000]
 		}
 	}
 
+	@Test
+	public void testFinCountEffect() {
+		final BarrowmanCalculator calc = new BarrowmanCalculator();
+		final WarningSet warnings = new WarningSet();
+
+		final Rocket rocket = TestRockets.makeEstesAlphaIII();
+		final FlightConfiguration config = rocket.getSelectedConfiguration();
+		final FlightConditions conditions = new FlightConditions(config);
+		{
+			((FinSet)rocket.getChild(0).getChild(1).getChild(0)).setFinCount(4);
+			final Coordinate wholeRocketCP = calc.getCP(config, conditions, warnings);
+			assertEquals("Split-Fin Rocket CNa value is incorrect:", 34.19591165, wholeRocketCP.weight, EPSILON);
+			assertEquals("Split-Fin Rocket CP x value is incorrect:", 0.22724216, wholeRocketCP.x, EPSILON);
+		}{
+			((FinSet)rocket.getChild(0).getChild(1).getChild(0)).setFinCount(3);
+			final Coordinate wholeRocketCP = calc.getCP(config, conditions, warnings);
+			assertEquals("Split-Fin Rocket CNa value is incorrect:", 26.14693374, wholeRocketCP.weight, EPSILON);
+			assertEquals("Split-Fin Rocket CP x value is incorrect:", 0.22351541, wholeRocketCP.x, EPSILON);
+		}{
+			((FinSet)rocket.getChild(0).getChild(1).getChild(0)).setFinCount(2);
+			final Coordinate wholeRocketCP = calc.getCP(config, conditions, warnings);
+			assertEquals("Split-Fin Rocket CNa value is incorrect:", 2.0, wholeRocketCP.weight, EPSILON);
+			assertEquals("Split-Fin Rocket CP x value is incorrect:", 0.032356, wholeRocketCP.x, EPSILON);
+		}{
+			((FinSet)rocket.getChild(0).getChild(1).getChild(0)).setFinCount(1);
+			final Coordinate wholeRocketCP = calc.getCP(config, conditions, warnings);
+			assertEquals("Split-Fin Rocket CNa value is incorrect:", 2.0, wholeRocketCP.weight, EPSILON);
+			assertEquals("Split-Fin Rocket CP x value is incorrect:", 0.032356, wholeRocketCP.x, EPSILON);
+		}
+	}
+	
 	@Test
 	public void testCpSplitTripleFin() {
 		final BarrowmanCalculator calc = new BarrowmanCalculator();
@@ -164,13 +193,37 @@ public class BarrowmanCalculatorTest {
 			final FinSet fins = (FinSet)body.getChild(0);
 			fins.setAngleOffset(0);
 			TestRockets.splitRocketFins(body, fins, 3);
-			
+
 			final Coordinate wholeRocketCP = calc.getCP(config, conditions, warnings);
 			assertEquals("Split-Fin Rocket CNa value is incorrect:", 26.14693374, wholeRocketCP.weight, EPSILON);
 			assertEquals("Split-Fin Rocket CP x value is incorrect:", 0.22351541, wholeRocketCP.x, EPSILON);
 		}
 	}
 
+	@Test
+	public void testCpSplitQuadrupleFin() {
+		final BarrowmanCalculator calc = new BarrowmanCalculator();
+		final WarningSet warnings = new WarningSet();
+
+		final Rocket rocket = TestRockets.makeEstesAlphaIII();
+		final FlightConfiguration config = rocket.getSelectedConfiguration();
+		final FlightConditions conditions = new FlightConditions(config);
+
+		{
+			((FinSet)rocket.getChild(0).getChild(1).getChild(0)).setFinCount(4);
+			final Coordinate wholeRocketCP = calc.getCP(config, conditions, warnings);
+			assertEquals("Split-Fin Rocket CNa value is incorrect:", 34.19591165, wholeRocketCP.weight, EPSILON);
+			assertEquals("Split-Fin Rocket CP x value is incorrect:", 0.22724, wholeRocketCP.x, EPSILON);
+		}{
+			final BodyTube body = (BodyTube)rocket.getChild(0).getChild(1);
+			final FinSet fins = (FinSet)body.getChild(0);
+			TestRockets.splitRocketFins(body, fins, 4);
+
+			final Coordinate wholeRocketCP = calc.getCP(config, conditions, warnings);
+			assertEquals("Split-Fin Rocket CNa value is incorrect:", 34.19591165, wholeRocketCP.weight, EPSILON);
+			assertEquals("Split-Fin Rocket CP x value is incorrect:", 0.22724, wholeRocketCP.x, EPSILON);
+		}
+	}
 	// test rocket with endplates on fins.  Comments tracing
 	// calculation of CP are in TestRockets.makeEndPlateRocket().
 	@Test


### PR DESCRIPTION
### Inciting Example
[simple_split_fins.ork.zip](https://github.com/openrocket/openrocket/files/4365711/simple_split_fins.ork.zip)

### Relevant Unit Tests:

https://github.com/teyrana/openrocket/blob/2c1daea9d1eea139eb5d55e6ac397e4ec67ef61d/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java#L114-L226

(prebuilt jar available on request)

Fixes:  #600
May help with: #571, #538 