### PR TITLE
[Fixes 568] Consider all instances of components when calculating drag

### DIFF
--- a/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
+++ b/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
@@ -388,7 +388,7 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 		
 		double finFriction = 0;
 		double bodyFriction = 0;
-		double maxR = 0, len = 0;
+		double maxR = 0, minX = Double.MAX_VALUE, maxX = 0;
 		
 		double[] roughnessLimited = new double[Finish.values().length];
 		Arrays.fill(roughnessLimited, Double.NaN);
@@ -453,11 +453,15 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 						map.get(c).setFrictionCD(componentCf * s.getComponentWetArea()
 												 / conditions.getRefArea());
 					}
-				
-					double r = Math.max(s.getForeRadius(), s.getAftRadius());
-					if (r > maxR)
-						maxR = r;
-					len += c.getLength();
+
+					final double componentMinX = context.getLocation().x;
+					minX = Math.min(minX, componentMinX);
+
+					final double componentMaxX = componentMinX + c.getLength();
+					maxX = Math.max(maxX, componentMaxX);
+
+					final double componentMaxR = Math.max(s.getForeRadius(), s.getAftRadius());
+					maxR = Math.max(maxR, componentMaxR);
 					
 				} else if (c instanceof FinSet) {
 				
@@ -477,7 +481,7 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 		}
 		
 		// fB may be POSITIVE_INFINITY, but that's ok for us
-		double fB = (len + 0.0001) / maxR;
+		double fB = (maxX - minX + 0.0001) / maxR;
 		double correction = (1 + 1.0 / (2 * fB));
 		
 		// Correct body data in map

--- a/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
+++ b/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
@@ -537,7 +537,8 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 					map.get(c).setPressureCD(cd);
 				}
 				
-				if(c.isCDOverridden()) continue;					
+				if(c.isCDOverridden())
+					continue;					
 				
 				// Stagnation drag
 				if (c instanceof SymmetricComponent) {

--- a/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
+++ b/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
@@ -402,7 +402,7 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 					!(c instanceof FinSet))
 				continue;
 
-				// iterate across component instances
+			// iterate across component instances
 			final ArrayList<InstanceContext> contextList = entry.getValue();
 			for(InstanceContext context: contextList ) {
 			
@@ -515,39 +515,46 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 		base = calculateBaseCD(conditions.getMach());
 		
 		total = 0;
-		for (RocketComponent c : configuration.getActiveComponents()) {
+		final InstanceMap imap = configuration.getActiveInstances();
+	    for(Map.Entry<RocketComponent, ArrayList<InstanceContext>> entry: imap.entrySet() ) {
+			final RocketComponent c = entry.getKey();
 			if (!c.isAerodynamic())
 				continue;
-			
-			// Pressure fore drag
-			double cd = calcMap.get(c).calculatePressureDragForce(conditions, stagnation, base,
-					warnings);
-			total += cd;
-			
-			if (map != null) {
-				map.get(c).setPressureCD(cd);
-			}
-			
-			if(c.isCDOverridden()) continue;					
 
-	
-			// Stagnation drag
-			if (c instanceof SymmetricComponent) {
-				SymmetricComponent s = (SymmetricComponent) c;
+			// iterate across component instances
+			final ArrayList<InstanceContext> contextList = entry.getValue();
+			for(InstanceContext context: contextList ) {
 				
-				if (radius < s.getForeRadius()) {
-					double area = Math.PI * (pow2(s.getForeRadius()) - pow2(radius));
-					cd = stagnation * area / conditions.getRefArea();
-					total += cd;
-					if (map != null) {
-						map.get(c).setPressureCD(map.get(c).getPressureCD() + cd);
-					}
+				// Pressure fore drag
+				double cd = calcMap.get(c).calculatePressureDragForce(conditions, stagnation, base,
+																	  warnings);
+				total += cd;
+				
+				if (map != null) {
+					map.get(c).setPressureCD(cd);
 				}
 				
-				radius = s.getAftRadius();
+				if(c.isCDOverridden()) continue;					
+				
+				
+				// Stagnation drag
+				if (c instanceof SymmetricComponent) {
+					SymmetricComponent s = (SymmetricComponent) c;
+					
+					if (radius < s.getForeRadius()) {
+						double area = Math.PI * (pow2(s.getForeRadius()) - pow2(radius));
+						cd = stagnation * area / conditions.getRefArea();
+						total += cd;
+						if (map != null) {
+							map.get(c).setPressureCD(map.get(c).getPressureCD() + cd);
+						}
+					}
+					
+					radius = s.getAftRadius();
+				}
 			}
 		}
-		
+			
 		return total;
 	}
 	

--- a/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
+++ b/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
@@ -506,7 +506,6 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 			Map<RocketComponent, AerodynamicForces> map, WarningSet warnings) {
 		
 		double stagnation, base, total;
-		double radius = 0;
 		
 		if (calcMap == null)
 			buildCalcMap(configuration);
@@ -524,33 +523,36 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 			// iterate across component instances
 			final ArrayList<InstanceContext> contextList = entry.getValue();
 			for(InstanceContext context: contextList ) {
-				
+
 				// Pressure fore drag
 				double cd = calcMap.get(c).calculatePressureDragForce(conditions, stagnation, base,
 																	  warnings);
 				total += cd;
-				
+
 				if (map != null) {
 					map.get(c).setPressureCD(cd);
 				}
 				
 				if(c.isCDOverridden()) continue;					
 				
-				
 				// Stagnation drag
 				if (c instanceof SymmetricComponent) {
 					SymmetricComponent s = (SymmetricComponent) c;
+
+					double radius = 0;
+					final SymmetricComponent prevComponent = s.getPreviousSymmetricComponent();
+					if (prevComponent != null)
+						radius = prevComponent.getAftRadius();
 					
 					if (radius < s.getForeRadius()) {
 						double area = Math.PI * (pow2(s.getForeRadius()) - pow2(radius));
 						cd = stagnation * area / conditions.getRefArea();
 						total += cd;
+						
 						if (map != null) {
 							map.get(c).setPressureCD(map.get(c).getPressureCD() + cd);
 						}
 					}
-					
-					radius = s.getAftRadius();
 				}
 			}
 		}
@@ -558,7 +560,7 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 		return total;
 	}
 	
-	
+
 	/**
 	 * Calculation of drag coefficient due to base
 	 * 

--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/FinSetCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/FinSetCalc.java
@@ -645,7 +645,7 @@ public class FinSetCalc extends RocketComponentCalc {
 		// Airfoil assumed to have zero base drag
 		
 		// Scale to correct reference area
-		drag *= finCount * span * thickness / conditions.getRefArea();
+		drag *= span * thickness / conditions.getRefArea();
 		
 		return drag;
 	}

--- a/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.List;
 
 import net.sf.openrocket.preset.ComponentPreset;
+import net.sf.openrocket.rocketcomponent.PodSet;
 import net.sf.openrocket.rocketcomponent.position.AxialMethod;
 import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.MathUtil;
@@ -561,34 +562,37 @@ public abstract class SymmetricComponent extends BodyComponent implements Radial
 
 	/**
 	 * Return the previous symmetric component, or null if none exists.
-	 * NOTE: This method currently assumes that there are no external
-	 * "pods".
 	 * 
 	 * @return	the previous SymmetricComponent, or null.
 	 */
 	public final SymmetricComponent getPreviousSymmetricComponent() {
 		RocketComponent c;
 		for (c = this.getPreviousComponent(); c != null; c = c.getPreviousComponent()) {
+			if (c instanceof PodSet) {
+				return null;
+			}
 			if (c instanceof SymmetricComponent) {
 				return (SymmetricComponent) c;
 			}
 			if (!(c instanceof AxialStage) &&
-					(c.axialMethod == AxialMethod.AFTER))
+				(c.axialMethod == AxialMethod.AFTER)) {
 				return null; // Bad component type as "parent"
+			}
 		}
 		return null;
 	}
 	
 	/**
 	 * Return the next symmetric component, or null if none exists.
-	 * NOTE: This method currently assumes that there are no external
-	 * "pods".
 	 * 
 	 * @return	the next SymmetricComponent, or null.
 	 */
-	protected final SymmetricComponent getNextSymmetricComponent() {
+	public final SymmetricComponent getNextSymmetricComponent() {
 		RocketComponent c;
 		for (c = this.getNextComponent(); c != null; c = c.getNextComponent()) {
+			if (c instanceof PodSet) {
+				return null;
+			}
 			if (c instanceof SymmetricComponent) {
 				return (SymmetricComponent) c;
 			}

--- a/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
@@ -566,7 +566,7 @@ public abstract class SymmetricComponent extends BodyComponent implements Radial
 	 * 
 	 * @return	the previous SymmetricComponent, or null.
 	 */
-	protected final SymmetricComponent getPreviousSymmetricComponent() {
+	public final SymmetricComponent getPreviousSymmetricComponent() {
 		RocketComponent c;
 		for (c = this.getPreviousComponent(); c != null; c = c.getPreviousComponent()) {
 			if (c instanceof SymmetricComponent) {

--- a/core/src/net/sf/openrocket/util/TestRockets.java
+++ b/core/src/net/sf/openrocket/util/TestRockets.java
@@ -1662,19 +1662,6 @@ public class TestRockets {
 		TrapezoidFinSet trapezoidfinset = new TrapezoidFinSet(3, 0.051, 0.025, 0.038, 0.044);
 		bodytube.addChild(trapezoidfinset);
 
-		// This is how we can dump a test rocket so we can look at it in OR to better
-		// visualize it
-		//
-		// OpenRocketDocument doc = OpenRocketDocumentFactory.createDocumentFromRocket(rocket);
-		// OpenRocketSaver saver = new OpenRocketSaver();
-		// try {
-		//     FileOutputStream str = new FileOutputStream("3fnc.ork");
-		//	   saver.save(str, doc, null);
-		// }
-		// catch (Exception e) {
-		//     System.err.println("exception " + e);
-		// }
-
 		return rocket;
 	}
 
@@ -1710,8 +1697,23 @@ public class TestRockets {
 				podBody.addChild(fins);
 			}
 		}
-		
+
 		return rocket;
 	}
 	
+	/**
+	 * dump a test rocket to a file, so we can open it in OR
+	 */
+	static void dumpRocket(Rocket rocket, String filename) {
+
+		OpenRocketDocument doc = OpenRocketDocumentFactory.createDocumentFromRocket(rocket);
+		OpenRocketSaver saver = new OpenRocketSaver();
+		try {
+			FileOutputStream str = new FileOutputStream(filename);
+			saver.save(str, doc, null);
+		}
+		catch (Exception e) {
+			System.err.println("exception " + e);
+		}
+	}
 }

--- a/core/src/net/sf/openrocket/util/TestRockets.java
+++ b/core/src/net/sf/openrocket/util/TestRockets.java
@@ -1668,8 +1668,8 @@ public class TestRockets {
 	// second model used to test with/without pods.  In order to
 	// maintain consistency between the models, we'll create the
 	// no-pods first, and then modify it to make the with-pods version
-	public static final Rocket make3FNCWithPods() {
-		Rocket rocket = TestRockets.make3FNCNoPods();
+	public static final Rocket makeEstesAlphaIIIWithPods() {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
 
 		// find the body and fins
 		final InstanceMap imap = rocket.getSelectedConfiguration().getActiveInstances();

--- a/core/src/net/sf/openrocket/util/TestRockets.java
+++ b/core/src/net/sf/openrocket/util/TestRockets.java
@@ -1635,39 +1635,7 @@ public class TestRockets {
 		return rocketDoc;
 	}
 
-	// the following two models are used in testing
-	// otherwise-identical rockets, one created in the obvious way
-	// using a single finset and the other creating three pods, each
-	// with a single fin.
-	public static final Rocket make3FNCNoPods()  {
-
-		Rocket rocket = new Rocket();
-
-		rocket.enableEvents();
-
-		AxialStage stage = new AxialStage();
-		stage.setName("Sustainer");
-		rocket.addChild(stage);
-
-		// shape, length, radius
-		NoseCone nosecone = new NoseCone(Transition.Shape.OGIVE, 0.102, 0.0125);
-		stage.addChild(nosecone);
-
-		// length, outer radius, thickness
-		BodyTube bodytube = new BodyTube(0.305, 0.0125, 0.001);
-		bodytube.setName("Main Body");
-		stage.addChild(bodytube);
-
-		// number of fins, root chord, tip chord, sweep, height
-		TrapezoidFinSet trapezoidfinset = new TrapezoidFinSet(3, 0.051, 0.025, 0.038, 0.044);
-		bodytube.addChild(trapezoidfinset);
-
-		return rocket;
-	}
-
-	// second model used to test with/without pods.  In order to
-	// maintain consistency between the models, we'll create the
-	// no-pods first, and then modify it to make the with-pods version
+	// Alpha III modified to put fins on "phantom" pods
 	public static final Rocket makeEstesAlphaIIIWithPods() {
 		Rocket rocket = TestRockets.makeEstesAlphaIII();
 

--- a/core/src/net/sf/openrocket/util/TestRockets.java
+++ b/core/src/net/sf/openrocket/util/TestRockets.java
@@ -1,7 +1,7 @@
 package net.sf.openrocket.util;
 
 import java.util.ArrayList;
-// import java.io.FileOutputStream;
+import java.io.FileOutputStream;
 import java.util.Map;
 import java.util.Random;
 

--- a/core/src/net/sf/openrocket/util/TestRockets.java
+++ b/core/src/net/sf/openrocket/util/TestRockets.java
@@ -1,7 +1,7 @@
 package net.sf.openrocket.util;
 
 import java.util.ArrayList;
-import java.io.FileOutputStream;
+// import java.io.FileOutputStream;
 import java.util.Map;
 import java.util.Random;
 

--- a/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java
+++ b/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java
@@ -234,12 +234,12 @@ public class BarrowmanCalculatorTest {
 
 	@Test
 	public void testPhantomTubes() {
-		Rocket rocketNoPods = TestRockets.make3FNCNoPods();
+		Rocket rocketNoPods = TestRockets.makeEstesAlphaIII();
 		FlightConfiguration configNoPods = rocketNoPods.getSelectedConfiguration();
 		FlightConditions conditionsNoPods = new FlightConditions(configNoPods);
 		WarningSet warningsNoPods = new WarningSet();
 		
-		Rocket rocketWithPods = TestRockets.make3FNCWithPods();
+		Rocket rocketWithPods = TestRockets.makeEstesAlphaIIIWithPods();
 		FlightConfiguration configPods = rocketWithPods.getSelectedConfiguration();
 		FlightConditions conditionsPods = new FlightConditions(configPods);
 		WarningSet warningsPods = new WarningSet();
@@ -248,7 +248,7 @@ public class BarrowmanCalculatorTest {
 
 		final AerodynamicForces forcesNoPods = calcPods.getAerodynamicForces(configNoPods, conditionsNoPods, warningsNoPods);
 		final AerodynamicForces forcesPods = calcPods.getAerodynamicForces(configPods, conditionsPods, warningsPods);
-		assertEquals(" 3FNC With Pods rocket CD value is incorrect:", forcesPods.getCD(), forcesNoPods.getCD(), EPSILON);
+		assertEquals(" Estes Alpha III With Pods rocket CD value is incorrect:", forcesPods.getCD(), forcesNoPods.getCD(), EPSILON);
 
 		// The "with pods" version has no way of seeing the fins are
 		// on the actual body tube rather than the phantom tubes,
@@ -265,16 +265,16 @@ public class BarrowmanCalculatorTest {
 		// will be off-axis (one of the fins is taken as having an
 		// angle of 0 to the airstream, so it has no contribution).
 		// This doesn't turn out to cause a problem in an actual
-		// simulation, so we are just not testing for it.  Test with
-		// correction if we want some time is here but commented out
+		// simulation.
 		
 		final Coordinate cpNoPods = calcNoPods.getCP(configNoPods, conditionsNoPods, warningsNoPods);
 		final Coordinate cpPods = calcPods.getCP(configPods, conditionsPods, warningsPods);
-		
-		assertEquals(" 3FNC With Pods rocket cp x value is incorrect:", cpPods.x, cpNoPods.x - 0.00672, EPSILON);
-		// assertEquals(" 3FNC With Pods rocket cp y value is incorrect:", cpPods.y, cpNoPods.y - 0.00548, EPSILON);
-		// assertEquals(" 3FNC With Pods rocket cp z value is incorrect:", cpPods.z, cpNoPods.z, EPSILON);
-		assertEquals(" 3FNC With Pods rocket CNa value is incorrect:", cpPods.weight, cpNoPods.weight - 3.14271, EPSILON);
+		System.out.printf("with pods %s\n", cpPods.toString());
+		System.out.printf("without pods %s\n", cpNoPods.toString());
+		assertEquals(" Alpha III With Pods rocket cp x value is incorrect:", cpNoPods.x - 0.002788761352, cpPods.x, EPSILON);
+		assertEquals(" Alpha III With Pods rocket cp y value is incorrect:", cpNoPods.y - 0.005460218430206499, cpPods.y, EPSILON);
+		assertEquals(" Alpha III With Pods rocket cp z value is incorrect:", cpNoPods.z, cpPods.z, EPSILON);
+		assertEquals(" Alpha III With Pods rocket CNa value is incorrect:", cpPods.weight, cpNoPods.weight - 3.91572, EPSILON);
 	}
 			
 }


### PR DESCRIPTION
Fixes #568 by iterating through all instances of rocket components when calculating drag.
Adds unit test for fins on pods as in bug report.

Jar file is at https://www.dropbox.com/s/rnzs2i0xp9e5l0z/OpenRocket-PR603.jar?dl=0 if anyone would like to take it for a spin.


