### PR TITLE
[fixes #608] save all instance counts, even if equal to 1 

### DIFF
--- a/core/src/net/sf/openrocket/file/openrocket/savers/RocketComponentSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/savers/RocketComponentSaver.java
@@ -90,8 +90,8 @@ public class RocketComponentSaver {
 			
 			if( c instanceof Clusterable ){
 				; // no-op.  Instance counts are set via named cluster configurations
-			}else if( 1 < instanceCount ) {
-				emitInteger( elements, "instancecount", c.getInstanceCount() );
+			}else {
+				emitInteger(elements, "instancecount", c.getInstanceCount());
 			}
 			
 			if( c instanceof LineInstanceable ){


### PR DESCRIPTION
(because different components have different default instance counts