### PR TITLE
Don't revalidate/repaint component in Ruler.updateSize()

### DIFF
--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -260,6 +260,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		figureHolder.add(scrollPane, BorderLayout.CENTER);
 		rotationSlider.setEnabled(true);
 		scaleSelector.setEnabled(true);
+		scrollPane.revalidate();
 		revalidate();
 		figureHolder.revalidate();
 		figure.repaint();

--- a/swing/src/net/sf/openrocket/gui/scalefigure/ScaleScrollPane.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/ScaleScrollPane.java
@@ -258,7 +258,7 @@ public class ScaleScrollPane extends JScrollPane
 	////////////////  The view port rulers  ////////////////
 	
 	
-	private class Ruler extends JComponent {
+	private class Ruler extends JComponent implements ChangeListener {
 		public static final int HORIZONTAL = 0;
 		public static final int VERTICAL = 1;
 		
@@ -266,26 +266,23 @@ public class ScaleScrollPane extends JScrollPane
 		
 		public Ruler(int orientation) {
 			this.orientation = orientation;
-			
-			rulerUnit.addChangeListener(new ChangeListener() {
-				@Override
-				public void stateChanged(ChangeEvent e) {
-				    updateSize();
-					Ruler.this.repaint();
-				}
-			});
+			rulerUnit.addChangeListener(this);
+		}
+		
+		@Override
+		public void stateChanged(ChangeEvent e) {
+			updateSize();
+			repaint();
 		}
 		
 		private void updateSize() {
 			if (orientation == HORIZONTAL) {
-			    Ruler.this.setMinimumSize(new Dimension(component.getWidth() + 10, RULER_SIZE));
-			    Ruler.this.setPreferredSize(new Dimension(component.getWidth() + 10, RULER_SIZE));
+			    setMinimumSize(new Dimension(component.getWidth() + 10, RULER_SIZE));
+			    setPreferredSize(new Dimension(component.getWidth() + 10, RULER_SIZE));
 			} else {
-			    Ruler.this.setMinimumSize(new Dimension(RULER_SIZE, component.getHeight() + 10));
-			    Ruler.this.setPreferredSize(new Dimension(RULER_SIZE, component.getHeight() + 10));
+			    setMinimumSize(new Dimension(RULER_SIZE, component.getHeight() + 10));
+			    setPreferredSize(new Dimension(RULER_SIZE, component.getHeight() + 10));
 			}
-			revalidate();
-			repaint();
 		}
 		
         private double fromPx(final int px) {


### PR DESCRIPTION
Analysis from Justin Hanney indicates that the CPU is constantly
processing paint events in the ScaleScrollPane.Ruler. Change the
updateSize method to not revalidate and repaint since the
paintComponent method also invokes the updateSize to ensure it is
drawing components of the right size.

This change also refactors the ChangeListener implementation to
have the RulerClass implement the method instead of using an
anonymous class for event handling when ruler units change.

Additionally, this change adds a revalidate call to the scrollPane
to fix an issue where the ruler is not repainted when switching views
from 3D to 2D.

Fixes #615

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>