### PR TITLE
Fix TubeFinSet 2D rendering

### DIFF
--- a/core/src/net/sf/openrocket/file/openrocket/importt/DocumentConfig.java
+++ b/core/src/net/sf/openrocket/file/openrocket/importt/DocumentConfig.java
@@ -294,6 +294,10 @@ class DocumentConfig {
 				Reflection.findMethod(TubeFinSet.class, "setOuterRadius", double.class),
 				"auto",
 				Reflection.findMethod(TubeFinSet.class, "setOuterRadiusAutomatic", boolean.class)));
+		setters.put("TubeFinSet:instancecount", new IntSetter(
+				Reflection.findMethod(TubeFinSet.class,  "setInstanceCount", int.class)));
+		setters.put("TubeFinSet:angleoffset", new AnglePositionSetter() );
+		setters.put("TubeFinSet:radiusoffset", new RadiusPositionSetter() );
 		
 		// InternalComponent - nothing
 		

--- a/core/src/net/sf/openrocket/rocketcomponent/TubeFinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/TubeFinSet.java
@@ -12,11 +12,12 @@ import net.sf.openrocket.rocketcomponent.position.AxialMethod;
 import net.sf.openrocket.rocketcomponent.position.AxialPositionable;
 import net.sf.openrocket.rocketcomponent.position.RadiusMethod;
 import net.sf.openrocket.startup.Application;
+import net.sf.openrocket.util.BoundingBox;
 import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.MathUtil;
 import net.sf.openrocket.util.Transformation;
 
-public class TubeFinSet extends ExternalComponent implements RingInstanceable, AxialPositionable {
+public class TubeFinSet extends ExternalComponent implements AxialPositionable, BoxBounded, RingInstanceable {
 	private static final Translator trans = Application.getTranslator();
 	
 	private final static double DEFAULT_RADIUS = 0.025;
@@ -312,6 +313,14 @@ public class TubeFinSet extends ExternalComponent implements RingInstanceable, A
 		addBound(bounds, length, 2 * (r + outerRadius));
 		
 		return bounds;
+	}
+	
+	@Override
+	public BoundingBox getInstanceBoundingBox() {
+		BoundingBox box = new BoundingBox();
+		box.update(new Coordinate(0, -outerRadius, -outerRadius));
+		box.update(new Coordinate(length, outerRadius, outerRadius));
+		return box;
 	}
 	
 	/**

--- a/core/src/net/sf/openrocket/rocketcomponent/TubeFinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/TubeFinSet.java
@@ -68,7 +68,7 @@ public class TubeFinSet extends ExternalComponent implements RingInstanceable, A
 	}
 	
 	/**
-	 * Return the outer radius of the body tube.
+	 * Return the outer radius of the tube-fin
 	 *
 	 * @return  the outside radius of the tube
 	 */
@@ -104,7 +104,7 @@ public class TubeFinSet extends ExternalComponent implements RingInstanceable, A
 	}
 	
 	/**
-	 * Set the outer radius of the body tube.  If the radius is less than the wall thickness,
+	 * Set the outer radius of the tube-fin.  If the radius is less than the wall thickness,
 	 * the wall thickness is decreased accordingly of the value of the radius.
 	 * This method sets the automatic radius off.
 	 *

--- a/swing/src/net/sf/openrocket/gui/figure3d/geometry/ComponentRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/geometry/ComponentRenderer.java
@@ -317,7 +317,6 @@ public class ComponentRenderer {
 	private void renderTubeFins(GL2 gl, TubeFinSet fs, Surface which) {
 		gl.glPushMatrix();
 		gl.glMatrixMode(GLMatrixFunc.GL_MODELVIEW);
-		System.out.println(fs.getBaseRotation());
 		gl.glRotated(fs.getBaseRotation() * (180.0 / Math.PI), 1, 0, 0);
 		for( int i = 0; i< fs.getFinCount(); i++ ) {
 			gl.glPushMatrix();

--- a/swing/src/net/sf/openrocket/gui/figure3d/geometry/ComponentRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/geometry/ComponentRenderer.java
@@ -318,13 +318,8 @@ public class ComponentRenderer {
 		gl.glPushMatrix();
 		gl.glMatrixMode(GLMatrixFunc.GL_MODELVIEW);
 		gl.glRotated(fs.getBaseRotation() * (180.0 / Math.PI), 1, 0, 0);
-		for( int i = 0; i< fs.getFinCount(); i++ ) {
-			gl.glPushMatrix();
-			gl.glTranslated(0, fs.getOuterRadius() + fs.getBodyRadius(), 0);
-			renderTube(gl, which, fs.getOuterRadius(), fs.getInnerRadius(), fs.getLength());
-			gl.glPopMatrix();
-			gl.glRotated(360.0 / fs.getFinCount(), 1, 0, 0);
-		}
+		gl.glTranslated(0, fs.getOuterRadius(), 0);
+		renderTube(gl, which, fs.getOuterRadius(), fs.getInnerRadius(), fs.getLength());
 		gl.glPopMatrix();
 	}
 

--- a/swing/src/net/sf/openrocket/gui/figure3d/geometry/ComponentRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/geometry/ComponentRenderer.java
@@ -317,7 +317,6 @@ public class ComponentRenderer {
 	private void renderTubeFins(GL2 gl, TubeFinSet fs, Surface which) {
 		gl.glPushMatrix();
 		gl.glMatrixMode(GLMatrixFunc.GL_MODELVIEW);
-		gl.glRotated(fs.getBaseRotation() * (180.0 / Math.PI), 1, 0, 0);
 		gl.glTranslated(0, fs.getOuterRadius(), 0);
 		renderTube(gl, which, fs.getOuterRadius(), fs.getInnerRadius(), fs.getLength());
 		gl.glPopMatrix();

--- a/swing/src/net/sf/openrocket/gui/rocketfigure/TubeFinSetShapes.java
+++ b/swing/src/net/sf/openrocket/gui/rocketfigure/TubeFinSetShapes.java
@@ -35,13 +35,10 @@ public class TubeFinSetShapes extends RocketComponentShape {
 		final double outerRadius = finSet.getOuterRadius();
 		final double length = finSet.getLength();
 		Coordinate[] locations = transformLocations(finSet, transformation);
-		Transformation finRotation = finSet.getFinRotationTransformation();
 
-		Shape[] shapes = new Shape[finSet.getFinCount()];
-		for (int i=0; i < shapes.length; i++) {
-			shapes[i] = new Rectangle2D.Double(locations[0].x, (locations[0].y-outerRadius), length, 2*outerRadius);
-			locations = finRotation.transform(locations);
-		}
+		Shape[] shapes = new Shape[] {
+				new Rectangle2D.Double(locations[0].x, (locations[0].y-outerRadius), length, 2*outerRadius)
+			};
 		
 		return RocketComponentShape.toArray(shapes, component);
 	}
@@ -62,13 +59,10 @@ public class TubeFinSetShapes extends RocketComponentShape {
 		
 		final double outerRadius = finSet.getOuterRadius();
 		Coordinate[] locations = transformLocations(finSet, transformation);
-		Transformation finRotation = finSet.getFinRotationTransformation();
 
-		Shape[] shapes = new Shape[finSet.getFinCount()];
-		for (int i=0; i < shapes.length; i++) {
-			shapes[i] = new Ellipse2D.Double((locations[0].z - outerRadius), (locations[0].y - outerRadius), (2 * outerRadius), (2 * outerRadius));
-			locations = finRotation.transform(locations);
-		}
+		Shape[] shapes = new Shape[] {
+				new Ellipse2D.Double((locations[0].z - outerRadius), (locations[0].y - outerRadius), (2 * outerRadius), (2 * outerRadius))
+			};
 		
 		return RocketComponentShape.toArray(shapes, component);
 	}
@@ -95,13 +89,12 @@ public class TubeFinSetShapes extends RocketComponentShape {
 	private static Coordinate[] transformLocations(final TubeFinSet finSet, final Transformation transformation) {
 		final double outerRadius = finSet.getOuterRadius();
 		final double bodyRadius = finSet.getBodyRadius();
-        Coordinate[] locations = finSet.getComponentLocations();
-		Transformation baseRotation = finSet.getBaseRotationTransformation();
+		Coordinate[] locations = finSet.getInstanceLocations();
 		
 		for (int i=0; i < locations.length; i++) {
-			Coordinate c = locations[i].add(0, (bodyRadius + outerRadius), 0);
-			c = transformation.linearTransform(c);
-			c = baseRotation.transform(c);
+			Coordinate c = locations[i].setX(0.);
+			c = c.sub(0, (bodyRadius - outerRadius), 0);
+			c = transformation.transform(c);
 			locations[i] = c;
 		}
 		

--- a/swing/src/net/sf/openrocket/gui/rocketfigure/TubeFinSetShapes.java
+++ b/swing/src/net/sf/openrocket/gui/rocketfigure/TubeFinSetShapes.java
@@ -25,19 +25,16 @@ public class TubeFinSetShapes extends RocketComponentShape {
 	 * 
 	 * @param component the TubeFinSet to get the shapes for
 	 * @param transformation the transformation to apply to the shapes
-	 * @return an array of RocketComponentShapes that are used to draw the
-	 *         TubeFinSet from the side.
+	 * @return an array of RocketComponentShapes that are used to draw the TubeFinSet from the side.
 	 */
 	public static RocketComponentShape[] getShapesSide( final RocketComponent component, final Transformation transformation) {
-
-		TubeFinSet finSet = (TubeFinSet) component;
-
+		final TubeFinSet finSet = (TubeFinSet) component;
 		final double outerRadius = finSet.getOuterRadius();
 		final double length = finSet.getLength();
-		Coordinate[] locations = transformLocations(finSet, transformation);
+		final Coordinate location = transformation.transform(new Coordinate(0, outerRadius, 0));
 
-		Shape[] shapes = new Shape[] {
-				new Rectangle2D.Double(locations[0].x, (locations[0].y-outerRadius), length, 2*outerRadius)
+		final Shape[] shapes = new Shape[] {
+				new Rectangle2D.Double(location.x, (location.y-outerRadius), length, 2*outerRadius)
 			};
 		
 		return RocketComponentShape.toArray(shapes, component);
@@ -54,51 +51,14 @@ public class TubeFinSetShapes extends RocketComponentShape {
 	 *         TubeFinSet from the back
 	 */
 	public static RocketComponentShape[] getShapesBack( final RocketComponent component, final Transformation transformation) {
-			
-		TubeFinSet finSet = (TubeFinSet) component;
-		
+		final TubeFinSet finSet = (TubeFinSet) component;
 		final double outerRadius = finSet.getOuterRadius();
-		Coordinate[] locations = transformLocations(finSet, transformation);
+		final Coordinate location = transformation.transform(new Coordinate(0, outerRadius, 0));
 
-		Shape[] shapes = new Shape[] {
-				new Ellipse2D.Double((locations[0].z - outerRadius), (locations[0].y - outerRadius), (2 * outerRadius), (2 * outerRadius))
+		final Shape[] shapes = new Shape[] {
+				new Ellipse2D.Double((location.z - outerRadius), (location.y - outerRadius), (2 * outerRadius), (2 * outerRadius))
 			};
 		
 		return RocketComponentShape.toArray(shapes, component);
 	}
-	
-	/**
-	 * Translates and rotates the coordinates as follows:
-	 * 
-	 * 1. Ensure the coordinate accounts for the body and outer radius. This
-	 *    adjusts the Y value of the coordinate to place it in the correct
-	 *    position relative to the body tube.
-	 * 
-	 * 2. Perform a linear transformation of the coordinate using the supplied
-	 *    transform. Using the linear transform ensures the coordinate is
-	 *    rotated per the view, but avoids applying an offset translation
-	 *    since that is already applied in the locations retrieved from the
-	 *    TubeFinSet.
-	 * 
-	 * 3. Apply the base rotational transform described by the TubeFinSet
-	 *    component itself.
-	 *    
-	 * @param finSet the TubeFinSet to apply the transformation to
-	 * @param transformation the Transformation to apply to the TubeFinSet
-	 */
-	private static Coordinate[] transformLocations(final TubeFinSet finSet, final Transformation transformation) {
-		final double outerRadius = finSet.getOuterRadius();
-		final double bodyRadius = finSet.getBodyRadius();
-		Coordinate[] locations = finSet.getInstanceLocations();
-		
-		for (int i=0; i < locations.length; i++) {
-			Coordinate c = locations[i].setX(0.);
-			c = c.sub(0, (bodyRadius - outerRadius), 0);
-			c = transformation.transform(c);
-			locations[i] = c;
-		}
-		
-		return locations;
-	}
-	
 }


### PR DESCRIPTION
The TubeFinSetShapes were applying the supplied transform too many
times, resulting in the the shapes being offset off the viewing area.
The offset transform is already applied to the component instance
that is provided to the TubeFinSetShapes methods, so applying the
transform resulted in the offset being moved to the right.

This change removes the transform being applied to the component
locations when retrieved and only applies a linear transformation
to the component locations when applying the base rotational
transform. Using the linear transform avoids applying the offset
in addition to the rest of the transform.

The problem existed in both the side view and the back view, however
the back view was not as obvious due to the nature of the view. The
common code between both functions applying the transform is
refactored into a common location to reduce the amount of code.
Additionally, documentation was added explaining the transform process
that is being applied to the component locations for the final shapes.

Fixes #605

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>