### PR TITLE
Remove openrocket.log from tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,5 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
+
+openrocket.log

--- a/openrocket.log
+++ b/openrocket.log
@@ -1,1 +1,0 @@
-Error: Unable to access jarfile OpenRocket.jar


### PR DESCRIPTION
Remove the openrocket.log file that is errantly in the tree.
Update .gitignore to not include openrocket.log in the future.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>