### PR TITLE
[fixes #551] [UI] removed 'add stage' text button; reordered remaining buttons

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -346,9 +346,6 @@ public class BasicFrame extends JFrame {
 		button = new JButton(actions.getEditAction());
 		panel.add(button, "sizegroup buttons");
 
-		button = new JButton(actions.getNewStageAction());
-		panel.add(button, "sizegroup buttons");
-
 		button = new JButton(actions.getDeleteAction());
 		button.setIcon(null);
 		button.setMnemonic(0);


### PR DESCRIPTION
Addresses the duplicate "add stage" buttons. 

It contains the changes: 

1. Removes the 'add stage button
~~2. Reorders the buttons to "move up ", "edit", "move down", .... (space)  "delete"~~
~~3. add some spacing.~~

Edit: no consensus on button ordering or icons was reached, so I just left them as they were.