### PR TITLE
[Documentation] Linking project overview dashboard to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 OpenRocket
 ==========
-
-Build Status - [ ![Build Status](https://travis-ci.org/openrocket/openrocket.png) ](https://travis-ci.org/openrocket/openrocket)
-------------
+[![Build Status](https://travis-ci.org/openrocket/openrocket.png) ](https://travis-ci.org/openrocket/openrocket)
+[![SourceSpy Dashboard](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/openrocketopenrocket/)
 
 Overview
 --------
@@ -38,8 +37,6 @@ OpenRocket is an Open Source project licensed under the [GNU GPL](https://www.gn
 
 Contributing
 ------------
-[![SourceSpy Dashboard](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/openrocketopenrocket/)
-
 OpenRocket needs help to become even better. Implementing features, writing documentation and creating example designs are just a few ways of helping. If you are interested in helping make OpenRocket the best rocket simulator out there, please [click here for information on how to get involved!](http://openrocket.sourceforge.net/getinvolved.html)
 
 **Contributors**

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ OpenRocket is an Open Source project licensed under the [GNU GPL](https://www.gn
 
 Contributing
 ------------
+[![SourceSpy Dashboard](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/openrocketopenrocket/)
 
 OpenRocket needs help to become even better. Implementing features, writing documentation and creating example designs are just a few ways of helping. If you are interested in helping make OpenRocket the best rocket simulator out there, please [click here for information on how to get involved!](http://openrocket.sourceforge.net/getinvolved.html)
 


### PR DESCRIPTION
Adding a link to the README header. The linked dashboard describes overall repository structure. The goal is to help new developers explore project and understand architecture/dependencies. Direct link: https://sourcespy.com/github/openrocketopenrocket/