### PR TITLE
[fixes #640] Dialogs should now close with the [x] button 

### DIFF
--- a/swing/src/net/sf/openrocket/gui/configdialog/ComponentConfigDialog.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/ComponentConfigDialog.java
@@ -52,7 +52,6 @@ public class ComponentConfigDialog extends JDialog implements ComponentChangeLis
 		GUIUtil.rememberWindowPosition(this);
 
 		// overrides common defaults in 'GUIUTIL.setDisposableDialogOptions', above
-		setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
 		addWindowListener(new WindowAdapter() {
 			/**
 			 *  Triggered by the 'Close' Button on the ConfigDialogs.  AND Esc. AND the [x] button (on Windows)


### PR DESCRIPTION
I botched this upgrade in the other commit, so here's the tweak that makes it work.