### PR TITLE
[Fixes #645] fix auto radius calculation on Symmetric Components

### DIFF
--- a/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
+++ b/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
@@ -629,9 +629,9 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 					}
 				}
 				
-				// if I'm the last componenet, set my base CD
-				// note I can't depend on the iterator serving up components in order,
-				// so I can't just do this after the last iteration.
+				// if I'm the last component, set my base CD
+				// note:  the iterator *should* serve up the next component.... buuuut ....
+				//        this code has is tested, and there's no compelling reason to change. 
 				if (s.getNextSymmetricComponent() == null) {
 					double area = Math.PI * pow2(s.getAftRadius());
 					double cd = base * area / conditions.getRefArea();

--- a/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
@@ -1630,9 +1630,26 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 		}
 		return null;
 	}
-	
-	
-	// TODO: Move these methods elsewhere (used only in SymmetricComponent)
+
+	public final RocketComponent getNextComponent() {
+		checkState();
+		if (getChildCount() > 0)
+			return getChild(0);
+
+		RocketComponent current = this;
+		RocketComponent nextParent = this.parent;
+
+		while (nextParent != null) {
+			int pos = nextParent.getChildPosition(current);
+			if (pos < nextParent.getChildCount() - 1)
+				return nextParent.getChild(pos + 1);
+
+			current = nextParent;
+			nextParent = current.parent;
+		}
+		return null;
+	}
+
 	public final RocketComponent getPreviousComponent() {
 		checkState();
 		this.checkComponentStructure();
@@ -1662,28 +1679,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 			c = c.getChild(c.getChildCount() - 1);
 		return c;
 	}
-	
-	// TODO: Move these methods elsewhere (used only in SymmetricComponent)
-	public final RocketComponent getNextComponent() {
-		checkState();
-		if (getChildCount() > 0)
-			return getChild(0);
-		
-		RocketComponent current = this;
-		RocketComponent nextParent = this.parent;
-		
-		while (nextParent != null) {
-			int pos = nextParent.getChildPosition(current);
-			if (pos < nextParent.getChildCount() - 1)
-				return nextParent.getChild(pos + 1);
-			
-			current = nextParent;
-			nextParent = current.parent;
-		}
-		return null;
-	}
-	
-	
+
 	///////////  Event handling  //////////
 	//
 	// Listener lists are provided by the root Rocket component,

--- a/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
@@ -2179,7 +2179,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 			
 			for (int instanceNumber = 0; instanceNumber < this.getInstanceCount(); instanceNumber++) {
 				final String instancePrefix = String.format("%s    [%2d/%2d]", indent, instanceNumber+1, getInstanceCount());
-				buffer.append(String.format("%-40s|  %5.3f; %24s; %24s;\n", instancePrefix, getLength(), this.axialOffset, getLocations()[0]));
+				buffer.append(String.format("%-40s|  %5.3f; %24s; %24s;\n", instancePrefix, getLength(), this.axialOffset, getLocations()[instanceNumber]));
 			}
 		}else{
 			throw new IllegalStateException("This is a developer error! If you implement an instanced class, please subclass the Instanceable interface.");

--- a/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
@@ -566,17 +566,17 @@ public abstract class SymmetricComponent extends BodyComponent implements Radial
 	 * @return	the previous SymmetricComponent, or null.
 	 */
 	public final SymmetricComponent getPreviousSymmetricComponent() {
-		RocketComponent c;
-		for (c = this.getPreviousComponent(); c != null; c = c.getPreviousComponent()) {
-			if (c instanceof PodSet) {
-				return null;
-			}
-			if (c instanceof SymmetricComponent) {
-				return (SymmetricComponent) c;
-			}
-			if (!(c instanceof AxialStage) &&
-				(c.axialMethod == AxialMethod.AFTER)) {
-				return null; // Bad component type as "parent"
+		if(null == this.parent) {
+			return null;
+		}
+
+		int pos = parent.getChildPosition(this);
+		while( 0 < pos ) {
+			--pos;
+			final RocketComponent comp = parent.getChild(pos);
+
+			if (comp instanceof SymmetricComponent) {
+				return (SymmetricComponent) comp;
 			}
 		}
 		return null;
@@ -588,17 +588,19 @@ public abstract class SymmetricComponent extends BodyComponent implements Radial
 	 * @return	the next SymmetricComponent, or null.
 	 */
 	public final SymmetricComponent getNextSymmetricComponent() {
-		RocketComponent c;
-		for (c = this.getNextComponent(); c != null; c = c.getNextComponent()) {
-			if (c instanceof PodSet) {
-				return null;
+		if(null == this.parent) {
+			return null;
+		}
+		
+		int pos = parent.getChildPosition(this);
+		++pos;
+		while( pos < parent.getChildCount() ) {
+			final RocketComponent comp = parent.getChild(pos);
+			++pos;
+
+			if (comp instanceof SymmetricComponent) {
+				return (SymmetricComponent) comp;
 			}
-			if (c instanceof SymmetricComponent) {
-				return (SymmetricComponent) c;
-			}
-			if (!(c instanceof AxialStage) &&
-					(c.axialMethod == AxialMethod.AFTER))
-				return null; // Bad component type as "parent"
 		}
 		return null;
 	}

--- a/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
@@ -570,14 +570,30 @@ public abstract class SymmetricComponent extends BodyComponent implements Radial
 			return null;
 		}
 
-		int pos = parent.getChildPosition(this);
-		while( 0 < pos ) {
-			--pos;
-			final RocketComponent comp = parent.getChild(pos);
+		// might be: (a) Rocket -- for centerline stages
+		//           (b) BodyTube -- for Parallel Stages
+		final AxialStage stage = this.getStage();
+		final RocketComponent stageParent = stage.getParent();
 
-			if (comp instanceof SymmetricComponent) {
-				return (SymmetricComponent) comp;
+		// note:  this is not guaranteed to _contain_ a stage... but that we're _searching_ for one.
+		int stageIndex = stageParent.getChildPosition(stage);
+		int symmetricIndex = this.parent.getChildPosition(this)-1;
+
+		while( 0 <= stageIndex ) {
+			final RocketComponent prevStage = stageParent.getChild(stageIndex);
+
+			if(prevStage instanceof AxialStage){
+				while (0 <= symmetricIndex) {
+					final RocketComponent previousSymmetric = prevStage.getChild(symmetricIndex);
+
+					if (previousSymmetric instanceof SymmetricComponent) {
+						return (SymmetricComponent) previousSymmetric;
+					}
+					--symmetricIndex;
+				}
 			}
+			--stageIndex;
+			symmetricIndex = prevStage.getChildCount() - 1;
 		}
 		return null;
 	}
@@ -591,16 +607,31 @@ public abstract class SymmetricComponent extends BodyComponent implements Radial
 		if(null == this.parent) {
 			return null;
 		}
-		
-		int pos = parent.getChildPosition(this);
-		++pos;
-		while( pos < parent.getChildCount() ) {
-			final RocketComponent comp = parent.getChild(pos);
-			++pos;
 
-			if (comp instanceof SymmetricComponent) {
-				return (SymmetricComponent) comp;
+		// might be: (a) Rocket -- for centerline stages
+		//           (b) BodyTube -- for Parallel Stages
+		final AxialStage stage = this.getStage();
+		final RocketComponent stageParent = stage.getParent();
+
+		// note:  this is not guaranteed to _contain_ a stage... but that we're _searching_ for one.
+		int stageIndex = stageParent.getChildPosition(stage);
+		int symmetricIndex = this.parent.getChildPosition(this) + 1;
+
+		while(stageIndex < stageParent.getChildCount()) {
+			final RocketComponent nextStage = stageParent.getChild(stageIndex);
+
+			if(nextStage instanceof AxialStage){
+				while (symmetricIndex < nextStage.getChildCount()) {
+					final RocketComponent nextSymmetric = nextStage.getChild(symmetricIndex);
+
+					if (nextSymmetric instanceof SymmetricComponent) {
+						return (SymmetricComponent) nextSymmetric;
+					}
+					++symmetricIndex;
+				}
 			}
+			++stageIndex;
+			symmetricIndex = nextStage.getChildCount() - 1;
 		}
 		return null;
 	}

--- a/core/src/net/sf/openrocket/util/TestRockets.java
+++ b/core/src/net/sf/openrocket/util/TestRockets.java
@@ -551,7 +551,7 @@ public class TestRockets {
 		}
 	}
 
-	// This is an extra stage tacked onto the end of an Estes Alpha III 
+	// This is an extra stage tacked onto the end of an Estes Alpha III
 	// http://www.rocketreviews.com/alpha-iii---estes-221256.html
 	// 
 	// This function is used for unit, integration tests, DO NOT CHANGE WITHOUT UPDATING TESTS
@@ -586,7 +586,7 @@ public class TestRockets {
 				double finRootChord = .05;
 				double finTipChord = .03;
 				double finSweep = 0.02;
-				double finHeight = 0.05;
+				double finHeight = 0.03;
 				FinSet finset = new TrapezoidFinSet(finCount, finRootChord, finTipChord, finSweep, finHeight);
 				finset.setName("Booster Fins");
 				finset.setThickness( 0.0032);
@@ -611,6 +611,14 @@ public class TestRockets {
 				}
 				boosterBody.addChild(boosterMMT);
 			}
+
+			// Tail Cone
+			Transition boosterTail = new Transition();
+			boosterTail.setForeRadius(0.012);
+			boosterTail.setAftRadius(0.01);
+			boosterTail.setLength(0.005);
+			boosterTail.setName("Booster Tail Cone");
+			boosterStage.addChild( boosterTail);
 		}
 
 		rocket.setSelectedConfiguration( TEST_FCID_1 );

--- a/core/test/net/sf/openrocket/rocketcomponent/FlightConfigurationTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/FlightConfigurationTest.java
@@ -462,9 +462,9 @@ public class FlightConfigurationTest extends BaseTestCase {
 					assertThat((Class<TrapezoidFinSet>) boosterFinContext0.component.getClass(), equalTo(TrapezoidFinSet.class));
 					assertThat(boosterFinContext0.instanceNumber, equalTo(0));
 					final Coordinate boosterFin0Location = boosterFinContext0.getLocation();
-					assertEquals(boosterFin0Location.x,  1.044, EPSILON);
-					assertEquals(boosterFin0Location.y, -0.104223611, EPSILON);
-					assertEquals(boosterFin0Location.z, -0.027223611, EPSILON);
+					assertEquals(1.044, boosterFin0Location.x, EPSILON);
+					assertEquals( -0.104223611, boosterFin0Location.y, EPSILON);
+					assertEquals( -0.027223611, boosterFin0Location.z, EPSILON);
 
 					final InstanceContext boosterFinContext1 = finContextList.get(4);
 					assertThat((Class<TrapezoidFinSet>) boosterFinContext1.component.getClass(), equalTo(TrapezoidFinSet.class));

--- a/core/test/net/sf/openrocket/rocketcomponent/FreeformFinSetTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/FreeformFinSetTest.java
@@ -1207,7 +1207,7 @@ public class FreeformFinSetTest extends BaseTestCase {
 		assertEquals(0.03423168, coords.x, EPSILON);
 		assertEquals(0.01427544, coords.y, EPSILON);
 		
-		BodyTube bt = new BodyTube();
+		BodyTube bt = new BodyTube(0.1, 0.1);
 		bt.addChild(fins);
 		FinSetCalc calc = new FinSetCalc(fins);
 		FlightConditions conditions = new FlightConditions(null);

--- a/core/test/net/sf/openrocket/rocketcomponent/RocketTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/RocketTest.java
@@ -56,6 +56,29 @@ public class RocketTest extends BaseTestCase {
 	}
 
 	@Test
+	public void testAutoAlphaIII() {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+
+		AxialStage stage = (AxialStage) rocket.getChild(0);
+
+		BodyTube body = (BodyTube)stage.getChild(1);
+		final double expRadius = 0.012;
+		double actRadius = body.getOuterRadius();
+		assertEquals(" radius match: ", expRadius, actRadius, EPSILON);
+
+		body.setOuterRadiusAutomatic(true);
+		actRadius = body.getOuterRadius();
+		assertEquals(" radius match: ", expRadius, actRadius, EPSILON);
+
+		final Transition transition = new Transition();
+		stage.addChild(transition);
+
+		transition.setForeRadiusAutomatic(true);
+		actRadius = transition.getForeRadius();
+		assertEquals(" trailing transition match: ", expRadius, actRadius, EPSILON);
+	}
+
+	@Test
 	public void testEstesAlphaIII(){
 		Rocket rocket = TestRockets.makeEstesAlphaIII();
 			

--- a/core/test/net/sf/openrocket/rocketcomponent/TransitionTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/TransitionTest.java
@@ -56,27 +56,25 @@ public class TransitionTest extends BaseTestCase {
 
 	@Test
 	public void testVerifyBackwardConicTransition(){
-		Transition nose = new Transition();
-		nose.setType( Transition.Shape.CONICAL);
-		nose.setForeRadius( 1.0);
-		nose.setAftRadius( 0.5);
-		nose.setLength( 5.0);
-		
-		assertEquals("nose cone length is wrong ", 5.0, nose.getLength(), EPSILON );
-		assertEquals("nose cone fore radius is wrong ", 1.0, nose.getForeRadius(), EPSILON );
-		assertEquals("nose cone aft radius is wrong ", 0.5, nose.getAftRadius(), EPSILON );
-		assertThat("nose cone shape type is wrong ", Transition.Shape.CONICAL, equalTo(nose.getType()));
-		assertEquals("nose cone shape parameter is wrong ", 0.0, nose.getShapeParameter(), EPSILON );
-		
-		assertEquals("bad shape - conical forward transition", 1.0, nose.getRadius(0.0), EPSILON );
-		assertEquals("bad shape - conical forward transition", 0.9, nose.getRadius(1.0), EPSILON );
-		assertEquals("bad shape - conical forward transition", 0.8, nose.getRadius(2.0), EPSILON );
-		assertEquals("bad shape - conical forward transition", 0.7, nose.getRadius(3.0), EPSILON );
-		assertEquals("bad shape - conical forward transition", 0.6, nose.getRadius(4.0), EPSILON );
-		assertEquals("bad shape - conical forward transition", 0.5, nose.getRadius(5.0), EPSILON );
-		
-	}
+		Transition tail = new Transition();
+		tail.setType( Transition.Shape.CONICAL);
+		tail.setForeRadius( 1.0);
+		tail.setAftRadius( 0.5);
+		tail.setLength( 5.0);
 
+		assertEquals("nose cone length is wrong ", 5.0, tail.getLength(), EPSILON );
+		assertEquals("nose cone fore radius is wrong ", 1.0, tail.getForeRadius(), EPSILON );
+		assertEquals("nose cone aft radius is wrong ", 0.5, tail.getAftRadius(), EPSILON );
+		assertThat("nose cone shape type is wrong ", Transition.Shape.CONICAL, equalTo(tail.getType()));
+		assertEquals("nose cone shape parameter is wrong ", 0.0, tail.getShapeParameter(), EPSILON );
+
+		assertEquals("bad shape - conical forward transition", 1.0, tail.getRadius(0.0), EPSILON );
+		assertEquals("bad shape - conical forward transition", 0.9, tail.getRadius(1.0), EPSILON );
+		assertEquals("bad shape - conical forward transition", 0.8, tail.getRadius(2.0), EPSILON );
+		assertEquals("bad shape - conical forward transition", 0.7, tail.getRadius(3.0), EPSILON );
+		assertEquals("bad shape - conical forward transition", 0.6, tail.getRadius(4.0), EPSILON );
+		assertEquals("bad shape - conical forward transition", 0.5, tail.getRadius(5.0), EPSILON );
+	}
 
 	@Test
 	public void testVerifyOgiveNoseCone(){
@@ -85,7 +83,7 @@ public class TransitionTest extends BaseTestCase {
 		nose.setForeRadius( 0.0);
 		nose.setAftRadius( 1.0);
 		nose.setLength( 8.0);
-		
+
 		assertEquals("nose cone length is wrong ", 8.0, nose.getLength(), EPSILON );
 		assertEquals("nose cone fore radius is wrong ", 0.0, nose.getForeRadius(), EPSILON );
 		assertEquals("nose cone aft radius is wrong ", 1.0, nose.getAftRadius(), EPSILON );
@@ -101,73 +99,67 @@ public class TransitionTest extends BaseTestCase {
 		assertEquals("bad shape - conical forward transition", 0.93840316661, nose.getRadius(6.0), EPSILON );
 		assertEquals("bad shape - conical forward transition", 0.98461174156, nose.getRadius(7.0), EPSILON );
 		assertEquals("bad shape - conical forward transition", 1.0, nose.getRadius(8.0), EPSILON );
-		
 	}
 
 	@Test
 	public void testVerifyForwardOgiveTransition(){
-		Transition nose = new Transition();
-		nose.setType( Transition.Shape.OGIVE);
-		nose.setForeRadius( 0.44135);
-		nose.setAftRadius( 1.0);
-		nose.setLength( 6.0);
-		
-		assertEquals("nose cone length is wrong ", 6.0, nose.getLength(), EPSILON );
-		assertEquals("nose cone fore radius is wrong ", 0.44135, nose.getForeRadius(), EPSILON );
-		assertEquals("nose cone aft radius is wrong ", 1.0, nose.getAftRadius(), EPSILON );
-		assertThat("nose cone shape type is wrong ", Transition.Shape.OGIVE, equalTo(nose.getType()));
-		assertEquals("nose cone shape parameter is wrong ", 1.0, nose.getShapeParameter(), EPSILON );
-		
-		assertEquals("bad shape - conical forward transition", 0.44135250736, nose.getRadius(0.0), EPSILON );
-		assertEquals("bad shape - conical forward transition", 0.61308144666, nose.getRadius(1.0), EPSILON );
-		assertEquals("bad shape - conical forward transition", 0.75290684574, nose.getRadius(2.0), EPSILON );
-		assertEquals("bad shape - conical forward transition", 0.86124225056, nose.getRadius(3.0), EPSILON );
-		assertEquals("bad shape - conical forward transition", 0.93840316661, nose.getRadius(4.0), EPSILON );
-		assertEquals("bad shape - conical forward transition", 0.98461174156, nose.getRadius(5.0), EPSILON );
-		assertEquals("bad shape - conical forward transition", 1.0, nose.getRadius(6.0), EPSILON );
-		
+		Transition transition = new Transition();
+		transition.setType( Transition.Shape.OGIVE);
+		transition.setForeRadius( 0.44135);
+		transition.setAftRadius( 1.0);
+		transition.setLength( 6.0);
+
+		assertEquals("nose cone length is wrong ", 6.0, transition.getLength(), EPSILON );
+		assertEquals("nose cone fore radius is wrong ", 0.44135, transition.getForeRadius(), EPSILON );
+		assertEquals("nose cone aft radius is wrong ", 1.0, transition.getAftRadius(), EPSILON );
+		assertThat("nose cone shape type is wrong ", Transition.Shape.OGIVE, equalTo(transition.getType()));
+		assertEquals("nose cone shape parameter is wrong ", 1.0, transition.getShapeParameter(), EPSILON );
+
+		assertEquals("bad shape - conical forward transition", 0.44135250736, transition.getRadius(0.0), EPSILON );
+		assertEquals("bad shape - conical forward transition", 0.61308144666, transition.getRadius(1.0), EPSILON );
+		assertEquals("bad shape - conical forward transition", 0.75290684574, transition.getRadius(2.0), EPSILON );
+		assertEquals("bad shape - conical forward transition", 0.86124225056, transition.getRadius(3.0), EPSILON );
+		assertEquals("bad shape - conical forward transition", 0.93840316661, transition.getRadius(4.0), EPSILON );
+		assertEquals("bad shape - conical forward transition", 0.98461174156, transition.getRadius(5.0), EPSILON );
+		assertEquals("bad shape - conical forward transition", 1.0, transition.getRadius(6.0), EPSILON );
 	}
-	
+
 	@Test
 	public void testVerifyBackwardOgiveTransition(){
-		Transition nose = new Transition();
-		nose.setType( Transition.Shape.OGIVE);
-		nose.setForeRadius( 1.0);
-		nose.setAftRadius( 0.44135);
-		nose.setLength( 6.0);
-		
-		assertEquals("nose cone length is wrong ", 6.0, nose.getLength(), EPSILON );
-		assertEquals("nose cone fore radius is wrong ", 1.0, nose.getForeRadius(), EPSILON );
-		assertEquals("nose cone aft radius is wrong ", 0.44135, nose.getAftRadius(), EPSILON );
-		assertThat("nose cone shape type is wrong ", Transition.Shape.OGIVE, equalTo(nose.getType()));
-		assertEquals("nose cone shape parameter is wrong ",1.0, nose.getShapeParameter(), EPSILON );
-		
-		assertEquals("bad shape - conical forward transition", 1.0, nose.getRadius(0.0), EPSILON );
-		assertEquals("bad shape - conical forward transition", 0.98461174156, nose.getRadius(1.0), EPSILON );
-		assertEquals("bad shape - conical forward transition", 0.93840316661, nose.getRadius(2.0), EPSILON );
-		assertEquals("bad shape - conical forward transition", 0.86124225056, nose.getRadius(3.0), EPSILON );
-		assertEquals("bad shape - conical forward transition", 0.75290684574, nose.getRadius(4.0), EPSILON );
-		assertEquals("bad shape - conical forward transition", 0.61308144666, nose.getRadius(5.0), EPSILON );
-		assertEquals("bad shape - conical forward transition", 0.44135250736, nose.getRadius(6.0), EPSILON );
-		
-	
-	
+		Transition transition = new Transition();
+		transition.setType( Transition.Shape.OGIVE);
+		transition.setForeRadius( 1.0);
+		transition.setAftRadius( 0.44135);
+		transition.setLength( 6.0);
+
+		assertEquals("nose cone length is wrong ", 6.0, transition.getLength(), EPSILON );
+		assertEquals("nose cone fore radius is wrong ", 1.0, transition.getForeRadius(), EPSILON );
+		assertEquals("nose cone aft radius is wrong ", 0.44135, transition.getAftRadius(), EPSILON );
+		assertThat("nose cone shape type is wrong ", Transition.Shape.OGIVE, equalTo(transition.getType()));
+		assertEquals("nose cone shape parameter is wrong ",1.0, transition.getShapeParameter(), EPSILON );
+
+		assertEquals("bad shape - conical forward transition", 1.0, transition.getRadius(0.0), EPSILON );
+		assertEquals("bad shape - conical forward transition", 0.98461174156, transition.getRadius(1.0), EPSILON );
+		assertEquals("bad shape - conical forward transition", 0.93840316661, transition.getRadius(2.0), EPSILON );
+		assertEquals("bad shape - conical forward transition", 0.86124225056, transition.getRadius(3.0), EPSILON );
+		assertEquals("bad shape - conical forward transition", 0.75290684574, transition.getRadius(4.0), EPSILON );
+		assertEquals("bad shape - conical forward transition", 0.61308144666, transition.getRadius(5.0), EPSILON );
+		assertEquals("bad shape - conical forward transition", 0.44135250736, transition.getRadius(6.0), EPSILON );
 	}
-	
+
 	@Test
 	public void testStockIntegration(){
 		Rocket rocket = TestRockets.makeEstesAlphaIII();
 		NoseCone nose = (NoseCone)rocket.getChild(0).getChild(0);
-		
+
 		assertEquals("Alpha3 nose cone length is wrong ", 0.07, nose.getLength(), EPSILON );
 		assertEquals("Alpha3 nose cone fore radius is wrong ", 0.00, nose.getForeRadius(), EPSILON );
 		assertEquals("Alpha3 nose cone aft radius is wrong ", 0.012, nose.getAftRadius(), EPSILON );
 		assertThat("Alpha3 nose cone shape type is wrong ", Transition.Shape.OGIVE, equalTo(nose.getType()));
 		assertEquals("Alpha3 nose cone shape parameter is wrong ", 1.0, nose.getShapeParameter(), EPSILON );
-	
+
 		assertEquals("Alpha3 nose cone aft shoulder length is wrong ", 0.02, nose.getAftShoulderLength(), EPSILON );
 		assertEquals("Alpha3 nose cone aft shoulder radius is wrong ", 0.011, nose.getAftShoulderRadius(), EPSILON );
-		
 	}
 	
 }

--- a/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
@@ -172,8 +172,6 @@ public class ComponentPresetChooserDialog extends JDialog {
 	
 	
 	private JPanel getFilterCheckboxes() {
-		SymmetricComponent sc;
-		
 		JPanel panel = new JPanel(new MigLayout("ins 0"));
 		
 		/*
@@ -197,37 +195,40 @@ public class ComponentPresetChooserDialog extends JDialog {
 				}
 			});
 		}
-		
-		/*
-		 * Add filter by fore diameter
-		 */
-		foreDiameterFilterCheckBox = new JCheckBox(trans.get("ComponentPresetChooserDialog.checkbox.filterForeDiameter"));
-		sc = getPreviousSymmetricComponent();
-		if (sc != null && foreDiameterColumnIndex >= 0) {
-			foreDiameterFilter = new ComponentPresetRowFilter(sc.getAftRadius() * 2.0, foreDiameterColumnIndex);
-			panel.add(foreDiameterFilterCheckBox, "wrap");
-			foreDiameterFilterCheckBox.addItemListener(new ItemListener() {
-				@Override
-				public void itemStateChanged(ItemEvent e) {
-					updateFilters();
-				}
-			});
-		}
-		
-		/*
-		 * Add filter by aft diameter
-		 */
-		aftDiameterFilterCheckBox = new JCheckBox(trans.get("ComponentPresetChooserDialog.checkbox.filterAftDiameter"));
-		sc = getNextSymmetricComponent();
-		if (sc != null && aftDiameterColumnIndex >= 0) {
-			aftDiameterFilter = new ComponentPresetRowFilter(sc.getForeRadius() * 2.0, aftDiameterColumnIndex);
-			panel.add(aftDiameterFilterCheckBox, "wrap");
-			aftDiameterFilterCheckBox.addItemListener(new ItemListener() {
-				@Override
-				public void itemStateChanged(ItemEvent e) {
-					updateFilters();
-				}
-			});
+
+		if(component instanceof SymmetricComponent) {
+			final SymmetricComponent curSym = (SymmetricComponent) component;
+			/*
+			 * Add filter by fore diameter
+			 */
+			foreDiameterFilterCheckBox = new JCheckBox(trans.get("ComponentPresetChooserDialog.checkbox.filterForeDiameter"));
+			final SymmetricComponent prevSym = curSym.getPreviousSymmetricComponent();
+			if (prevSym != null && foreDiameterColumnIndex >= 0) {
+				foreDiameterFilter = new ComponentPresetRowFilter(prevSym.getAftRadius() * 2.0, foreDiameterColumnIndex);
+				panel.add(foreDiameterFilterCheckBox, "wrap");
+				foreDiameterFilterCheckBox.addItemListener(new ItemListener() {
+					@Override
+					public void itemStateChanged(ItemEvent e) {
+						updateFilters();
+					}
+				});
+			}
+
+			/*
+			 * Add filter by aft diameter
+			 */
+			aftDiameterFilterCheckBox = new JCheckBox(trans.get("ComponentPresetChooserDialog.checkbox.filterAftDiameter"));
+			final SymmetricComponent nextSym = curSym.getNextSymmetricComponent();
+			if (nextSym != null && aftDiameterColumnIndex >= 0) {
+				aftDiameterFilter = new ComponentPresetRowFilter(nextSym.getForeRadius() * 2.0, aftDiameterColumnIndex);
+				panel.add(aftDiameterFilterCheckBox, "wrap");
+				aftDiameterFilterCheckBox.addItemListener(new ItemListener() {
+					@Override
+					public void itemStateChanged(ItemEvent e) {
+						updateFilters();
+					}
+				});
+			}
 		}
 		
 		return panel;
@@ -274,29 +275,5 @@ public class ComponentPresetChooserDialog extends JDialog {
 		}
 		
 		componentSelectionTable.setRowFilter(RowFilter.andFilter(filters));
-	}
-	
-	
-	private SymmetricComponent getPreviousSymmetricComponent() {
-		RocketComponent c = component;
-		while (c != null) {
-			c = c.getPreviousComponent();
-			if (c instanceof SymmetricComponent) {
-				return (SymmetricComponent) c;
-			}
-		}
-		return null;
-	}
-	
-	
-	private SymmetricComponent getNextSymmetricComponent() {
-		RocketComponent c = component;
-		while (c != null) {
-			c = c.getNextComponent();
-			if (c instanceof SymmetricComponent) {
-				return (SymmetricComponent) c;
-			}
-		}
-		return null;
 	}
 }


### PR DESCRIPTION
Fixes the "auto" calculation on Symmetric Components (to include transitions and bodies) when pods are present (and previously would interfere)

Addresses: #645 
See that issue for more details, and example file.

## Todo   
- [x] 1. Auto-sizing within a stage
- [x] 2. Auto-sizing across multiple "AxialStage" instances, within the same rocket
    - [x] Add unit test
    - [x] Adjust behavior
- [x] 3. Unit Tests pass
- [x] 4. 'getNextSymmetricComponent' Usages:
  - [x] a. BarrowmanCalculator.java:635 -- desired behavior
  - [x] `swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java`
- [x] 5. 'getPreviousSymmetricComponent' Usages:
  - [x] a. BarrowmanCalculator.java:557 -- desired behavior
  - [x] b. BarrowmanCalculator.java:618 -- desired behavior
  - [x] `swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java`


