### PR TITLE
Avoid considering cp with 0 weight when calculating worst-case CP for display in RocketInfo

### DIFF
--- a/core/src/net/sf/openrocket/aerodynamics/AbstractAerodynamicCalculator.java
+++ b/core/src/net/sf/openrocket/aerodynamics/AbstractAerodynamicCalculator.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import net.sf.openrocket.rocketcomponent.FlightConfiguration;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
+import net.sf.openrocket.util.MathUtil;
 import net.sf.openrocket.util.Coordinate;
 
 
@@ -62,7 +63,7 @@ public abstract class AbstractAerodynamicCalculator implements AerodynamicCalcul
 		for (int i = 0; i < DIVISIONS; i++) {
 			cond.setTheta(2 * Math.PI * i / DIVISIONS);
 			cp = getCP(configuration, cond, warnings);
-			if (cp.x < worst.x) {
+			if ((cp.weight > MathUtil.EPSILON) && (cp.x < worst.x)) {
 				worst = cp;
 				theta = cond.getTheta();
 			}

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -592,7 +592,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 
 		cg = MassCalculator.calculateLaunch( curConfig).getCM();
 
-		if (cp.weight > MassCalculator.MIN_MASS){
+		if (cp.weight > MathUtil.EPSILON){
 			cpx = cp.x;
 		}else{
 			cpx = Double.NaN;


### PR DESCRIPTION
This fixes #648 (errrors in CP calculation).  The fins in the first example design in the issue are extremely small, and at some angles of attack can result in a CP weight so small as to be meaningless.  This PR only considers CP's with a non-zero weight in finding the worst case for display in the RocketInfo panel.

Also, in RocketPanel, a comparison was being made between CP weight at worst case and rocket minimum mass.  These have nothing obvious to do with each other, so this PR changes the test to be against MathUtil.EPSILON to avoid confusion in the future (this doesn't change behavior, as MIN_MASS is set to EPSILON in the MassCalculator class).

This doesn't address the off-center rendering of CG in some cases (#641), which is referenced in #648 but appears to be unrelated.