### PR TITLE
Pin CP to axis (Fix 654)

### DIFF
--- a/core/src/net/sf/openrocket/aerodynamics/AerodynamicForces.java
+++ b/core/src/net/sf/openrocket/aerodynamics/AerodynamicForces.java
@@ -407,24 +407,4 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 		return this;
 	}
 	
-	public AerodynamicForces multiplex(final int instanceCount) {
-		
-		this.cp = cp.setWeight(cp.weight*instanceCount);
-		if(1 < instanceCount) {
-			this.cp = cp.setY(0f).setZ(0f);
-		}
-		this.CNa = CNa*instanceCount;
-		this.CN = CN*instanceCount;
-		this.Cm = Cm*instanceCount;
-		this.Cside = Cside*instanceCount;
-		this.Cyaw = Cyaw*instanceCount;
-		this.Croll = Croll*instanceCount;
-		this.CrollDamp = CrollDamp*instanceCount;
-		this.CrollForce = CrollForce*instanceCount;
-	
-		modID++;
-		
-		return this;
-	}
-	
 }

--- a/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
+++ b/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
@@ -204,8 +204,7 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 					
 					Coordinate cp_inst = instanceForces.getCP();
 					Coordinate cp_abs = context.transform.transform(cp_inst);
-					if ((comp instanceof FinSet) && (((FinSet)comp).getFinCount() > 2))
-						cp_abs = cp_abs.setY(0.0).setZ(0.0);
+					cp_abs = cp_abs.setY(0.0).setZ(0.0);
 					
 //					if( 1e-6 < cp_inst.weight) {
 //						System.err.println("_________ cp:inst: (rel): " + cp_inst.toString());

--- a/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java
+++ b/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java
@@ -338,20 +338,13 @@ public class BarrowmanCalculatorTest {
 		// results with and without it
 		// cpNoPods (0.34125,0.00000,0.00000,w=16.20502) -- interference disabled
 		// cpNoPods (0.34797,0.00000,0.00000,w=19.34773) -- interference enabled
-
-		// another note:  the fact that this is seen as three one-fin
-		// FinSets instead of a single three-fin FinSet means the CP
-		// will be off-axis (one of the fins is taken as having an
-		// angle of 0 to the airstream, so it has no contribution).
-		// This doesn't turn out to cause a problem in an actual
-		// simulation.
 		
 		final Coordinate cpNoPods = calcNoPods.getCP(configNoPods, conditionsNoPods, warningsNoPods);
 		final Coordinate cpPods = calcPods.getCP(configPods, conditionsPods, warningsPods);
 		System.out.printf("with pods %s\n", cpPods.toString());
 		System.out.printf("without pods %s\n", cpNoPods.toString());
 		assertEquals(" Alpha III With Pods rocket cp x value is incorrect:", cpNoPods.x - 0.002788761352, cpPods.x, EPSILON);
-		assertEquals(" Alpha III With Pods rocket cp y value is incorrect:", cpNoPods.y - 0.005460218430206499, cpPods.y, EPSILON);
+		assertEquals(" Alpha III With Pods rocket cp y value is incorrect:", cpNoPods.y, cpPods.y, EPSILON);
 		assertEquals(" Alpha III With Pods rocket cp z value is incorrect:", cpNoPods.z, cpPods.z, EPSILON);
 		assertEquals(" Alpha III With Pods rocket CNa value is incorrect:", cpPods.weight, cpNoPods.weight - 3.91572, EPSILON);
 	}


### PR DESCRIPTION
My test for three or more fins in BarrowmanCalculator.calculatedNonAxialForces() turns out to be the only place in the code where it's possible to set the CP off-axis.  Everywhere else, CP is pinned to the axis; the code would be clearer if CP were just a Double instead of a Coordinate (but that's a bigger change than I want to make right now).

So anyway, this pins CP to the axis in this one case as well by removing the "if" statement.  In essence, the code now assumes radial symmetry; even if we're only looking at a single fin we assume there is a matching fin somewhere.

We may want to investigate whether the CP should be allowed to be off-center (say, modeling a glider) in the future, but not right now.