### PR TITLE
Use the open -a prefix to commands on OSX

### DIFF
--- a/swing/src/net/sf/openrocket/gui/util/EditDecalHelper.java
+++ b/swing/src/net/sf/openrocket/gui/util/EditDecalHelper.java
@@ -8,6 +8,8 @@ import java.text.MessageFormat;
 
 import net.sf.openrocket.appearance.AppearanceBuilder;
 import net.sf.openrocket.appearance.DecalImage;
+import net.sf.openrocket.arch.SystemInfo;
+import net.sf.openrocket.arch.SystemInfo.Platform;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.gui.dialogs.EditDecalDialog;
 import net.sf.openrocket.gui.watcher.FileWatcher;
@@ -177,6 +179,15 @@ public class EditDecalHelper {
 				command = commandTemplate.replace("%%", filename);
 			} else {
 				command = commandTemplate + " " + filename;
+			}
+			
+			/* On OSX, the program needs to be opened using the command
+			 * open -a to tell it which application to use to open the 
+			 * program. Check to see if the command starts with it or not
+			 * and pre-pend it as necessary. See issue #619.
+			 */
+			if (SystemInfo.getPlatform() == Platform.MAC_OS && !command.startsWith("open -a")) {
+				command = "open -a " + command;
 			}
 			
 			try {


### PR DESCRIPTION
On the OSX platform, the command editor needs to open the program
with using the 'open' command.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>