### PR TITLE
[Fixes 637] Update print dialog to allow simulation control

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -115,6 +115,7 @@ AboutDialog.lbl.translatorIcon =
 PrintDialog.title = Print or export
 PrintDialog.but.previewAndPrint = Preview & Print
 PrintDialog.checkbox.showByStage = Show by stage
+PrintDialog.checkbox.updateSimulations = Update simulation data
 PrintDialog.lbl.selectElements = Select elements to include:
 printdlg.but.saveaspdf = Save as PDF
 printdlg.but.preview = Preview

--- a/swing/src/net/sf/openrocket/gui/dialogs/PrintDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/PrintDialog.java
@@ -50,6 +50,8 @@ import net.sf.openrocket.startup.Application;
  */
 public class PrintDialog extends JDialog implements TreeSelectionListener {
 	
+	private static final long serialVersionUID = 1L;
+	
 	private static final Logger log = LoggerFactory.getLogger(PrintDialog.class);
 	private static final Translator trans = Application.getTranslator();
 	
@@ -65,6 +67,8 @@ public class PrintDialog extends JDialog implements TreeSelectionListener {
 	private JButton cancel;
 
     private double rotation = 0d;
+    
+    private boolean updateSimulations = true;
 	
 	private final static SwingPreferences prefs = (SwingPreferences) Application.getPreferences();
 	
@@ -122,6 +126,19 @@ public class PrintDialog extends JDialog implements TreeSelectionListener {
 		
 
 		// Checkboxes and buttons
+		final JPanel optionsPanel = new JPanel(new MigLayout());
+		
+		final JCheckBox updateSimulationsCheckbox = new JCheckBox(trans.get("checkbox.updateSimulations"));
+		updateSimulationsCheckbox.setEnabled(true);
+		updateSimulationsCheckbox.setSelected(this.updateSimulations);
+		updateSimulationsCheckbox.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				updateSimulations = updateSimulationsCheckbox.isSelected();
+			}
+		});
+		optionsPanel.add(updateSimulationsCheckbox, "pad 0, grow, wrap");
+		
 		final JCheckBox sortByStage = new JCheckBox(trans.get("checkbox.showByStage"));
 		sortByStage.setEnabled(stages > 1);
 		sortByStage.setSelected(stages > 1);
@@ -142,10 +159,10 @@ public class PrintDialog extends JDialog implements TreeSelectionListener {
 				}
 			}
 		});
-		panel.add(sortByStage, "aligny top, split");
+		optionsPanel.add(sortByStage);
+		panel.add(optionsPanel, "pad 0, aligny top, split");
 		
-
-		panel.add(new JPanel(), "growx");
+		panel.add(new JPanel(), "pad 0, aligny top, growx");
 		
 
 		JButton settingsButton = new JButton(trans.get("printdlg.but.settings"));
@@ -159,8 +176,8 @@ public class PrintDialog extends JDialog implements TreeSelectionListener {
 				setPrintSettings(settings);
 			}
 		});
-		panel.add(settingsButton, "wrap para");
-		
+		panel.add(settingsButton, "aligny top, wrap para");
+				
 
 		previewButton = new JButton(trans.get("but.previewAndPrint"));
 		previewButton.addActionListener(new ActionListener() {
@@ -286,7 +303,10 @@ public class PrintDialog extends JDialog implements TreeSelectionListener {
 	 */
 	private File generateReport(File f, PrintSettings settings) throws IOException {
 		Iterator<PrintableContext> toBePrinted = currentTree.getToBePrinted();
-		new PrintController().print(document, toBePrinted, new FileOutputStream(f), settings, rotation);
+		PrintController controller = new PrintController();
+		controller.setWindow(this.getOwner());
+		controller.print(document, toBePrinted, new FileOutputStream(f),
+		                 settings, rotation, updateSimulations);
 		return f;
 	}
 	

--- a/swing/src/net/sf/openrocket/gui/print/PrintController.java
+++ b/swing/src/net/sf/openrocket/gui/print/PrintController.java
@@ -20,6 +20,7 @@ import net.sf.openrocket.gui.print.visitor.PageFitPrintStrategy;
 import net.sf.openrocket.gui.print.visitor.PartsDetailVisitorStrategy;
 import net.sf.openrocket.gui.print.visitor.TransitionStrategy;
 
+import java.awt.Window;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Iterator;
@@ -30,6 +31,33 @@ import java.util.Set;
  * file.
  */
 public class PrintController {
+	
+	/**
+	 * Used for displaying progress information when the Window
+	 * is not null.
+	 */
+	private Window window = null;
+	
+	/**
+	 * Sets the reference Window for displaying progress information
+	 * for long running print operations.
+	 * 
+	 * @param window the reference window
+	 */
+	public void setWindow(final Window window) {
+		this.window = window;
+	}
+	
+	/**
+	 * Returns the reference Window for displaying progress information
+	 * for long running print operations.
+	 * 
+	 * @return the reference Window for displaying progress. May be null
+	 *         if no reference Window has been set.
+	 */
+	public Window getWindow() {
+		return this.window;
+	}
 
     /**
      * Print the selected components to a PDF document.
@@ -39,9 +67,10 @@ public class PrintController {
      * @param outputFile  the file being written to
      * @param settings    the print settings
      * @param rotation    the angle the rocket figure is rotated
+     * @param runSims     determines whether to re-run out of date simulations or not
      */
     public void print(OpenRocketDocument doc, Iterator<PrintableContext> toBePrinted, OutputStream outputFile,
-                      PrintSettings settings, double rotation) {
+                      PrintSettings settings, double rotation, boolean runSims) {
 
         Document idoc = new Document(getSize(settings));
         PdfWriter writer = null;
@@ -51,12 +80,7 @@ public class PrintController {
 
             writer.addViewerPreference(PdfName.PRINTSCALING, PdfName.NONE);
             writer.addViewerPreference(PdfName.PICKTRAYBYPDFSIZE, PdfBoolean.PDFTRUE);
-            try {
-                idoc.open();
-                Thread.sleep(1000);
-            }
-            catch (InterruptedException e) {
-            }
+            idoc.open();
 
             // Used to combine multiple components onto fewer sheets of paper
             PageFitPrintStrategy pageFitPrint = new PageFitPrintStrategy(idoc, writer);
@@ -70,7 +94,7 @@ public class PrintController {
 
                 switch (printableContext.getPrintable()) {
                     case DESIGN_REPORT:
-                        DesignReport dp = new DesignReport(doc, idoc, rotation);
+                        DesignReport dp = new DesignReport(doc, idoc, rotation, runSims, true, this.window);
                         dp.writeToDocument(writer);
                         idoc.newPage();
                         break;


### PR DESCRIPTION
Updates the print dialog to allow for simulations to be re-run
or not. Selecting the "Update simulation data" checkbox will
re-run any out of date simulations prior to generating the
design report.

Fixes #637

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>