### PR TITLE
Resolves #666 -- fix the "Exception loading stream" error while loading certain rockets.

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -299,7 +299,7 @@ public abstract class FinSet extends ExternalComponent implements RingInstanceab
 	/** 
 	 * internally, set the internal offset and optionally validate tab
 	 * 
-	 * @param offsetRequest new requested tob offset
+	 * @param offsetRequest new requested tab offset
 	 */
 	public void setTabOffset( final double offsetRequest) {
 		tabOffset = offsetRequest;

--- a/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
@@ -608,21 +608,21 @@ public abstract class SymmetricComponent extends BodyComponent implements Radial
 			return null;
 		}
 
+		final ComponentAssembly assembly = this.getAssembly();
 		// might be: (a) Rocket -- for centerline stages
 		//           (b) BodyTube -- for Parallel Stages
-		final AxialStage stage = this.getStage();
-		final RocketComponent stageParent = stage.getParent();
+		final RocketComponent assemblyParent = assembly.getParent();
 
 		// note:  this is not guaranteed to _contain_ a stage... but that we're _searching_ for one.
-		int stageIndex = stageParent.getChildPosition(stage);
+		int assemblyIndex = assemblyParent.getChildPosition(assembly);
 		int symmetricIndex = this.parent.getChildPosition(this) + 1;
 
-		while(stageIndex < stageParent.getChildCount()) {
-			final RocketComponent nextStage = stageParent.getChild(stageIndex);
+		while(assemblyIndex < assemblyParent.getChildCount()) {
+			final RocketComponent searchAssembly = assemblyParent.getChild(assemblyIndex);
 
-			if(nextStage instanceof AxialStage){
-				while (symmetricIndex < nextStage.getChildCount()) {
-					final RocketComponent nextSymmetric = nextStage.getChild(symmetricIndex);
+			if(searchAssembly instanceof ComponentAssembly){
+				while (symmetricIndex < searchAssembly.getChildCount()) {
+					final RocketComponent nextSymmetric = searchAssembly.getChild(symmetricIndex);
 
 					if (nextSymmetric instanceof SymmetricComponent) {
 						return (SymmetricComponent) nextSymmetric;
@@ -630,8 +630,8 @@ public abstract class SymmetricComponent extends BodyComponent implements Radial
 					++symmetricIndex;
 				}
 			}
-			++stageIndex;
-			symmetricIndex = nextStage.getChildCount() - 1;
+			++assemblyIndex;
+			symmetricIndex = searchAssembly.getChildCount() - 1;
 		}
 		return null;
 	}

--- a/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
@@ -570,21 +570,21 @@ public abstract class SymmetricComponent extends BodyComponent implements Radial
 			return null;
 		}
 
-		// might be: (a) Rocket -- for centerline stages
-		//           (b) BodyTube -- for Parallel Stages
-		final AxialStage stage = this.getStage();
-		final RocketComponent stageParent = stage.getParent();
+		final ComponentAssembly assembly = this.getAssembly();
+		// might be: (a) Rocket -- for Centerline/Axial stages
+		//           (b) BodyTube -- for Parallel Stages & PodSets
+		final RocketComponent assemblyParent = assembly.getParent();
 
 		// note:  this is not guaranteed to _contain_ a stage... but that we're _searching_ for one.
-		int stageIndex = stageParent.getChildPosition(stage);
-		int symmetricIndex = this.parent.getChildPosition(this)-1;
+		int assemblyIndex = assemblyParent.getChildPosition(assembly);       // position of stage w/in parent
+		int symmetricIndex = this.parent.getChildPosition(this)-1;  // guess at index of previous stage
 
-		while( 0 <= stageIndex ) {
-			final RocketComponent prevStage = stageParent.getChild(stageIndex);
+		while( 0 <= assemblyIndex ) {
+			final RocketComponent searchAssembly = assemblyParent.getChild(assemblyIndex);
 
-			if(prevStage instanceof AxialStage){
+			if(searchAssembly instanceof ComponentAssembly){
 				while (0 <= symmetricIndex) {
-					final RocketComponent previousSymmetric = prevStage.getChild(symmetricIndex);
+					final RocketComponent previousSymmetric = searchAssembly.getChild(symmetricIndex);
 
 					if (previousSymmetric instanceof SymmetricComponent) {
 						return (SymmetricComponent) previousSymmetric;
@@ -592,8 +592,8 @@ public abstract class SymmetricComponent extends BodyComponent implements Radial
 					--symmetricIndex;
 				}
 			}
-			--stageIndex;
-			symmetricIndex = prevStage.getChildCount() - 1;
+			--assemblyIndex;
+			symmetricIndex = searchAssembly.getChildCount() - 1;
 		}
 		return null;
 	}


### PR DESCRIPTION
The culprit was treating PodSets like stages in the `SymmetricComponent.getPreviousSymmetricComponent` and ``SymmetricComponent.getNextSymmetricComponent` methods.

[Testable Jar file: Openrocket-fix666.jar](https://drive.google.com/open?id=1YDi1j6dKpxm5zCRofQRmLnqPFpyntrKL)