### PR TITLE
Use simulation options (addresses 

### DIFF
--- a/core/src/net/sf/openrocket/simulation/SimulationOptions.java
+++ b/core/src/net/sf/openrocket/simulation/SimulationOptions.java
@@ -574,5 +574,28 @@ public class SimulationOptions implements ChangeSource, Cloneable {
 		
 		return conditions;
 	}
+
+	public String toString() {
+		return "SimulationOptions [\n"
+			.concat("    AtmosphericModel: " + getAtmosphericModel().toString() + "\n")
+			.concat(String.format("    launchRodLength:  %f\n", launchRodLength))
+			.concat(String.format("    launchIntoWind: %b\n", launchIntoWind))
+			.concat(String.format("    launchRodAngle:  %f\n", launchRodAngle))
+			.concat(String.format("    windDirection:  %f\n", windDirection))
+			.concat(String.format("    launchRodDirection:  %f\n", launchRodDirection))
+			.concat(String.format("    windAverage:  %f\n", windAverage))
+			.concat(String.format("    windTurbulence:  %f\n", windTurbulence))
+			.concat(String.format("    launchAltitude:  %f\n", launchAltitude))
+			.concat(String.format("    launchLatitude:  %f\n", launchLatitude))
+			.concat(String.format("    launchLongitude:  %f\n", launchLongitude))
+			.concat("    geodeticComputation:  " + geodeticComputation.toString() + "\n")
+			.concat(String.format("    useISA:  %b\n", useISA))
+			.concat(String.format("    launchTemperature:  %f\n", launchTemperature))
+			.concat(String.format("    launchPressure:  %f\n", launchPressure))
+			.concat(String.format("    timeStep:  %f\n", timeStep))
+			.concat(String.format("    maximumAngle:  %f\n", maximumAngle))
+			.concat(String.format("    calculateExtras:  %b\n", calculateExtras))
+			.concat("]\n");
+	}
 	
 }

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -682,9 +682,27 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 			extraText.setCalculatingData(true);
 
 			Rocket duplicate = (Rocket) document.getRocket().copy();
-			Simulation simulation = ((SwingPreferences) Application.getPreferences()).getBackgroundSimulation(duplicate);
-			simulation.setFlightConfigurationId( document.getSelectedConfiguration().getId());
 
+			// find a Simulation based on the current flight configuration
+			FlightConfigurationId curID = curConfig.getFlightConfigurationID();
+			Simulation simulation = null;
+			for (Simulation sim : document.getSimulations()) {
+				if (sim.getFlightConfigurationId().compareTo(curID) == 0) {
+					simulation = sim;
+					break;
+				}
+			}
+
+			// I *think* every FlightConfiguration has at least one associated simulation; just in case I'm wrong,
+			// if there isn't one we'll create a new simulation to update the statistics in the panel using the
+			// default simulation conditions
+			if (simulation == null) {
+				System.out.println("creating new simulation");
+				simulation = ((SwingPreferences) Application.getPreferences()).getBackgroundSimulation(duplicate);
+				simulation.setFlightConfigurationId( document.getSelectedConfiguration().getId());
+			} else
+				System.out.println("using pre-existing simulation");
+			
 			backgroundSimulationWorker = new BackgroundSimulationWorker(document, simulation);
 			backgroundSimulationExecutor.execute(backgroundSimulationWorker);
 		}


### PR DESCRIPTION
This PR addresses #671 (data in RocketPanel doesn't match simulation results) by searching for a Simulation associated with the current FlightConfiguration.  Two things I'd like input on before proceeding:

(1) Yes, I said "a" simulation, not "the" simulation.  It is possible to have multiple Simulations associated with a single FlightConfiguration; this PR simply chooses one of them so there is no guarantee it'll pick the one the user prefers.  A change that would get around this would be to directly choose a current Simulation in the current "Flight configuration:" dropdown; we could either just put the Simulation names in the dropdown, or we have plenty of room to use something like
Simulation 1 [J381-8;J150-0]
concatenating the Simulation name with the FlightConfiguration name

(2) When the simulation is run to generate the statistics in the RocketPanel, it only runs to apogee of each stage.  If the user proceeds to go up and plot the simulation without rerunning it, the graph is disconcerting to say the least!  I wonder if I need to mark the Simulation as needing to be rerun before plotting?

