### PR TITLE
Check to see if column index is valid

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurableTableModel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurableTableModel.java
@@ -89,7 +89,12 @@ public class FlightConfigurableTableModel<T extends FlightConfigurableComponent>
 	}
 
 	public int getColumnIndex(FlightConfigurableComponent comp) {
-		return components.indexOf(comp);
+		int index = components.indexOf(comp);
+		if (index >= 0) {
+			// Increment the index to account for the fcid column.
+			index += 1;
+		}
+		return index;
 	}
 
 	@Override

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
@@ -83,14 +83,14 @@ public class RecoveryConfigurationPanel extends FlightConfigurablePanel<Recovery
 			final RocketComponent source = cce.getSource();
 			if(source instanceof FlightConfigurableComponent) {
 				final int index = recoveryTableModel.getColumnIndex((FlightConfigurableComponent) source);
-				recoveryTable.getColumnModel().getColumn(index).setHeaderValue(source.getName());
-
+				if (index >= 0) {
+					recoveryTable.getColumnModel().getColumn(index).setHeaderValue(source.getName());
+				}
 				// you would think this would be enough by itself, but it requires an nudge from the above lines to
 				// actually update.
 				recoveryTable.getTableHeader().resizeAndRepaint();
 			}
 		});
-//		recoveryTable.setColumnModel(recoveryTableModel);
 		recoveryTable.setDefaultRenderer(Object.class, new RecoveryTableCellRenderer());
 
 		return recoveryTable;


### PR DESCRIPTION
Check to see if column index returned from the FlightConfigurationTable
model is referencing a valid column before getting the column data.
Additionally, the FlightConfigurationTableModel was not adequately
accounting for the FCID table column when returning the column.

Fixes #677

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>