### PR TITLE
[fixes #681] Fires an change event from InnerTube `setMotorMount(...)`

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/InnerTube.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/InnerTube.java
@@ -306,6 +306,7 @@ public class InnerTube extends ThicknessRingComponent implements AxialPositionab
     	if (this.isActingMount == _active)
     		return;
     	this.isActingMount = _active;
+		fireComponentChangeEvent(ComponentChangeEvent.MOTOR_CHANGE);
     }
 
 	@Override


### PR DESCRIPTION
basically, if an innertube is enabled or disabled, fire an event, so UI components can update.