### PR TITLE
[fixes #502] Refactors Bounds Calculation

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/AxialStage.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/AxialStage.java
@@ -54,25 +54,7 @@ public class AxialStage extends ComponentAssembly implements FlightConfigurableC
 	public void reset( final FlightConfigurationId fcid){
 		separations.reset(fcid);
 	}
-	
-	/**
-	 * {@inheritDoc}
-	 * not strictly accurate, but this should provide an acceptable estimate for total vehicle size 
-	 */
-	@Override
-	public Collection<Coordinate> getComponentBounds() {
-		Collection<Coordinate> bounds = new ArrayList<Coordinate>(8);
-		Coordinate[] instanceLocations = this.getInstanceLocations();
-		double x_min = instanceLocations[0].x;
-		double x_max = x_min + this.length;
-		double r_max = 0;
-		
-		addBound(bounds, x_min, r_max);
-		addBound(bounds, x_max, r_max);
-		
-		return bounds;
-	}
-	
+
 	/**
 	 * Check whether the given type can be added to this component.  A Stage allows
 	 * only BodyComponents to be added.

--- a/core/src/net/sf/openrocket/rocketcomponent/BodyTube.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/BodyTube.java
@@ -10,6 +10,7 @@ import net.sf.openrocket.motor.MotorConfiguration;
 import net.sf.openrocket.motor.MotorConfigurationSet;
 import net.sf.openrocket.preset.ComponentPreset;
 import net.sf.openrocket.startup.Application;
+import net.sf.openrocket.util.BoundingBox;
 import net.sf.openrocket.util.BugException;
 import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.MathUtil;
@@ -21,7 +22,7 @@ import net.sf.openrocket.util.MathUtil;
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
 
-public class BodyTube extends SymmetricComponent implements MotorMount, Coaxial {
+public class BodyTube extends SymmetricComponent implements BoxBounded, MotorMount, Coaxial {
 	private static final Translator trans = Application.getTranslator();
 	
 	private double outerRadius = 0;
@@ -296,52 +297,19 @@ public class BodyTube extends SymmetricComponent implements MotorMount, Coaxial 
 	private static double getFilledVolume(double r, double l) {
 		return Math.PI * r * r * l;
 	}
-	
-	
-	/**
-	 * Adds bounding coordinates to the given set.  The body tube will fit within the
-	 * convex hull of the points.
-	 *
-	 * Currently the points are simply a rectangular box around the body tube.
-	 */
-	@Override
-	public Collection<Coordinate> getComponentBounds() {
-		Collection<Coordinate> bounds = new ArrayList<Coordinate>(8);
-		double x_min_shape = 0;
-		double x_max_shape = this.length;
-		double r_max_shape = getOuterRadius();
-		
-		Coordinate[] locs = this.getLocations();
-		// not strictly accurate, but this should provide an acceptable estimate for total vehicle size
-		double x_min_inst = Double.MAX_VALUE;
-		double x_max_inst = Double.MIN_VALUE;
-		double r_max_inst = 0.0;
-		
-		// refactor: get component inherent bounds
-		for (Coordinate cur : locs) {
-			double x_cur = cur.x;
-			double r_cur = MathUtil.hypot(cur.y, cur.z);
-			if (x_min_inst > x_cur) {
-				x_min_inst = x_cur;
-			}
-			if (x_max_inst < x_cur) {
-				x_max_inst = x_cur;
-			}
-			if (r_cur > r_max_inst) {
-				r_max_inst = r_cur;
-			}
-		}
-		
-		// combine the position bounds with the inherent shape bounds
-		double x_min = x_min_shape + x_min_inst;
-		double x_max = x_max_shape + x_max_inst;
-		double r_max = r_max_shape + r_max_inst;
-		
-		addBoundingBox(bounds, x_min, x_max, r_max);
-		return bounds;
+
+	public BoundingBox getInstanceBoundingBox(){
+		BoundingBox instanceBounds = new BoundingBox();
+
+		instanceBounds.update(new Coordinate(this.getLength(), 0,0));
+
+		final double r = getOuterRadius();
+		instanceBounds.update(new Coordinate(0,r,r));
+		instanceBounds.update(new Coordinate(0,-r,-r));
+
+		return instanceBounds;
 	}
-	
-	
+
 	/**
 	 * Check whether the given type can be added to this component.  BodyTubes allow any
 	 * InternalComponents or ExternalComponents, excluding BodyComponents, to be added.

--- a/core/src/net/sf/openrocket/rocketcomponent/BoxBounded.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/BoxBounded.java
@@ -1,0 +1,15 @@
+package net.sf.openrocket.rocketcomponent;
+
+import net.sf.openrocket.util.BoundingBox;
+
+public interface BoxBounded {
+
+    /**
+     * Get a bounding box for a single instance of this component, from its own reference point.
+     * This is expected to be compbined with a InstanceContext for bounds in the global / rocket frame.
+     *
+     * @return BoundingBox from the instance's reference point.
+     */
+    BoundingBox getInstanceBoundingBox();
+
+}

--- a/core/src/net/sf/openrocket/rocketcomponent/ComponentAssembly.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/ComponentAssembly.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 
+import net.sf.openrocket.util.BoundingBox;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,7 +23,7 @@ import net.sf.openrocket.util.Coordinate;
  * 
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
-public abstract class ComponentAssembly extends RocketComponent implements  AxialPositionable {
+public abstract class ComponentAssembly extends RocketComponent implements AxialPositionable, BoxBounded {
 	private static final Logger log = LoggerFactory.getLogger(ComponentAssembly.class);
 	
 	/**
@@ -54,7 +55,7 @@ public abstract class ComponentAssembly extends RocketComponent implements  Axia
 	public Collection<Coordinate> getComponentBounds() {
 		return Collections.emptyList();
 	}
-	
+
 	/**
 	 * Null method (ComponentAssembly has no mass of itself).
 	 */
@@ -70,7 +71,9 @@ public abstract class ComponentAssembly extends RocketComponent implements  Axia
 	public double getComponentMass() {
 		return 0;
 	}
-	
+
+	public BoundingBox getInstanceBoundingBox (){ return new BoundingBox(); }
+
 	/**
 	 * Null method (ComponentAssembly has no mass of itself).
 	 */

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -710,37 +710,14 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 	
 
 	public BoundingBox getInstanceBoundingBox(){
-		BoundingBox singleFinBounds= new BoundingBox().update(getFinPoints());
-		final double finLength = singleFinBounds.max.x;
-		final double finHeight = singleFinBounds.max.y;
-		
-		Coordinate[] locations = getInstanceLocations();
-		double[] angles = getInstanceAngles();
+		final BoundingBox singleFinBounds = new BoundingBox();
 
-		BoundingBox finSetBox = new BoundingBox();
-		
-		/*
-		 * The fins themselves will be offset by the location itself to match
-		 * the outside radius of a body tube. The bounds encapsulate the outer
-		 * portion of all the tips of the fins.
-		 * 
-		 * The height of each fin along the Y axis can be determined by:
-		 * yHeight = cos(angle) * finHeight
-		 * 
-		 * The height (depth?) of each fin along the Z axis can be determined by:
-		 * zHeight = sin(angle) * finHeight
-		 * 
-		 * The boundingBox should be that box which is the smallest box where
-		 * a convex hull will contain all Coordinates.
-		 */
-		for (int i = 0; i < locations.length; i++) {
-			double y = Math.cos(angles[i]) * finHeight;
-			double z = Math.sin(angles[i]) * finHeight;
-			finSetBox.update(locations[i].add(0, y, z));
-			finSetBox.update(locations[i].add(finLength, y, z));
-		}
-		
-		return finSetBox;
+		singleFinBounds.update(getFinPoints());
+
+		singleFinBounds.update(new Coordinate( 0, 0, -this.thickness/2));
+		singleFinBounds.update(new Coordinate( 0, 0,  this.thickness/2));
+
+		return singleFinBounds;
 	}
 	
 	/**
@@ -751,7 +728,7 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 	 */
 	@Override
 	public Collection<Coordinate> getComponentBounds() {
-		Collection<Coordinate> bounds = new ArrayList<Coordinate>(8);
+		Collection<Coordinate> bounds = new ArrayList<>(8);
 		
 		// should simply return this component's bounds in this component's body frame.
 		

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -25,12 +25,8 @@ import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.MathUtil;
 import net.sf.openrocket.util.Transformation;
 
-public abstract class FinSet extends ExternalComponent implements RingInstanceable, AxialPositionable {
+public abstract class FinSet extends ExternalComponent implements AxialPositionable, BoxBounded, RingInstanceable {
 	private static final Translator trans = Application.getTranslator();
-	
-	@SuppressWarnings("unused")
-	private static final Logger log = LoggerFactory.getLogger(FinSet.class);
-	
 
 	/**
 	 * Maximum allowed cant of fins.
@@ -713,13 +709,14 @@ public abstract class FinSet extends ExternalComponent implements RingInstanceab
 	}
 	
 
-	public BoundingBox getBoundingBox() {
+	public BoundingBox getInstanceBoundingBox(){
 		BoundingBox singleFinBounds= new BoundingBox().update(getFinPoints());
 		final double finLength = singleFinBounds.max.x;
 		final double finHeight = singleFinBounds.max.y;
 		
 		Coordinate[] locations = getInstanceLocations();
 		double[] angles = getInstanceAngles();
+
 		BoundingBox finSetBox = new BoundingBox();
 		
 		/*

--- a/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
@@ -588,7 +588,7 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 					}
 					componentBounds = instanceBounds.transform(context.transform);
 				}
-			}else if ((component instanceof AxialStage) || (component instanceof BodyTube) || (component instanceof PodSet)) {
+			}else if (component instanceof BodyTube) {
 				// Legacy Case #1:
 				// These components do not need the transform performed in
 				// order to provide the proper coordinates for length calculation.
@@ -600,7 +600,6 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 				// Legacy Case #2:
 				// These components do not implement
 				Collection<Coordinate> instanceCoordinates = component.getComponentBounds();
-
 				for (InstanceContext context : contexts) {
 					/*
 					 * If the instance is not active in the current context, then

--- a/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
@@ -557,59 +557,77 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 	 * in the current configuration.
 	 */
 	private void calculateBounds(){
-		BoundingBox bounds = new BoundingBox();
+		BoundingBox rocketBounds = new BoundingBox();
 
 		InstanceMap map = getActiveInstances();
 		for (Map.Entry<RocketComponent, java.util.ArrayList<InstanceContext>>  entry : map.entrySet()) {
 			RocketComponent component = entry.getKey();
+			BoundingBox componentBounds = new BoundingBox();
 			List<InstanceContext> contexts = entry.getValue();
-						
-			Collection<Coordinate> coordinates = new ArrayList<Coordinate>();
+
 			/* FinSets already provide a bounding box, so let's use that.
 			 */
-			if (component instanceof FinSet) {
-				bounds.update(((FinSet) component).getBoundingBox());
-				continue;
-			} else {
-				coordinates.addAll(component.getComponentBounds());
-			}
-			BoundingBox componentBox = new BoundingBox();
-			List<Coordinate> transformedCoords = new ArrayList<Coordinate>();
-			for (InstanceContext ctxt : contexts) {
-				/*
-				 * If the instance is not active in the current context, then
-				 * skip the bound calculations. This is mildly confusing since
-				 * getActiveInstances() implies that it will only return the
-				 * instances that are active, but it returns all instances and
-				 * the context indicates if it is active or not.
-				 */
-				if (!ctxt.active) {
-					continue;
-				}
-				for (Coordinate c : coordinates) {
-					Coordinate tc = null;
-					/* These components do not need the transform performed in
-					 * order to provide the proper coordinates for length calculation.
-					 * The transformation will cause the values to be calculated
-					 * incorrectly. This should be fixed in the appropriate places
-					 * not handled as one-offs in here.
+			if (component instanceof BoxBounded) {
+				for (InstanceContext context : contexts) {
+					/*
+					 * If the instance is not active in the current context, then
+					 * skip the bound calculations. This is mildly confusing since
+					 * getActiveInstances() implies that it will only return the
+					 * instances that are active, but it returns all instances and
+					 * the context indicates if it is active or not.
 					 */
-					if ((component instanceof AxialStage) || (component instanceof BodyTube) ||
-						(component instanceof PodSet)) {
-						tc = c;
-					} else {
-						tc = ctxt.transform.transform(c);
+					if (!context.active) {
+						continue;
 					}
-					componentBox.update(tc);
-					transformedCoords.add(tc);
+
+					BoundingBox instanceBounds = ((BoxBounded) component).getInstanceBoundingBox();
+					if(instanceBounds.isEmpty()) {
+						// this component is probably non-physical (like an assembly) or has invalid bounds.  Skip.
+						// i.e. 'break' out of the per-instance-context loop, and let the per-component loop continue
+						break;
+					}
+					componentBounds = instanceBounds.transform(context.transform);
+				}
+			}else if ((component instanceof AxialStage) || (component instanceof BodyTube) || (component instanceof PodSet)) {
+				// Legacy Case #1:
+				// These components do not need the transform performed in
+				// order to provide the proper coordinates for length calculation.
+				// The transformation will cause the values to be calculated
+				// incorrectly. This should be fixed in the appropriate places
+				// not handled as one-offs in here.
+				componentBounds.update(component.getComponentBounds());
+			} else {
+				// Legacy Case #2:
+				// These components do not implement
+				Collection<Coordinate> instanceCoordinates = component.getComponentBounds();
+
+				for (InstanceContext context : contexts) {
+					/*
+					 * If the instance is not active in the current context, then
+					 * skip the bound calculations. This is mildly confusing since
+					 * getActiveInstances() implies that it will only return the
+					 * instances that are active, but it returns all instances and
+					 * the context indicates if it is active or not.
+					 */
+					if (!context.active) {
+						continue;
+					}
+
+					Collection<Coordinate> transformedCoords = new ArrayList<>(instanceCoordinates);
+					// mutating.  Transforms coordinates in place.
+					context.transform.transform(instanceCoordinates);
+
+					for (Coordinate tc : transformedCoords) {
+						componentBounds.update(tc);
+					}
 				}
 			}
-			
-			bounds.update(componentBox);
+
+			rocketBounds.update(componentBounds);
 		}
 		
 		boundsModID = rocket.getModID();
-		cachedLength = bounds.span().x;
+		cachedLength = rocketBounds.span().x;
 		/* Special case for the scenario that all of the stages are removed and are
 		 * inactive. Its possible that this shouldn't be allowed, but it is currently
 		 * so we'll just adjust the length here.  
@@ -617,7 +635,7 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 		if (getActiveStages().isEmpty()) {
 			cachedLength = 0;
 		}
-		cachedBounds.update( bounds );
+		cachedBounds.update( rocketBounds );
 	}
 	
 	/**

--- a/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
@@ -588,17 +588,8 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 					}
 					componentBounds = instanceBounds.transform(context.transform);
 				}
-			}else if (component instanceof BodyTube) {
-				// Legacy Case #1:
-				// These components do not need the transform performed in
-				// order to provide the proper coordinates for length calculation.
-				// The transformation will cause the values to be calculated
-				// incorrectly. This should be fixed in the appropriate places
-				// not handled as one-offs in here.
-				componentBounds.update(component.getComponentBounds());
 			} else {
-				// Legacy Case #2:
-				// These components do not implement
+				// Legacy Case: These components do not implement the BoxBounded Interface.
 				Collection<Coordinate> instanceCoordinates = component.getComponentBounds();
 				for (InstanceContext context : contexts) {
 					/*

--- a/core/src/net/sf/openrocket/rocketcomponent/FreeformFinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FreeformFinSet.java
@@ -203,7 +203,7 @@ public class FreeformFinSet extends FinSet {
 	 * @param yRequest the y-coordinate.
 	 */
 	public void setPoint(final int index, final double xRequest, final double yRequest) {
-
+		final Coordinate revertPoint = points.get(index);
 		if(null != this.getParent()) {
 			final Coordinate prior =  points.get(index);
 			points.set(index, new Coordinate(xRequest, yRequest));
@@ -215,11 +215,9 @@ public class FreeformFinSet extends FinSet {
 
 		update();
 
-		// this maps the last index and the next-to-last-index to the same 'testIndex'
-		int testIndex = Math.min(index, (points.size() - 2));
-		if (intersects(testIndex)) {
+		if (intersects()) {
 			// intersection found!  log error and abort!
-			log.error(String.format("ERROR: found an intersection while setting fin point #%d to [%6.4g, %6.4g] <body frame> : ABORTING setPoint(..) !! ", index, xRequest, yRequest));
+			points.set(index, revertPoint);
 			return;
 		}
 
@@ -395,7 +393,8 @@ public class FreeformFinSet extends FinSet {
 	 */
 	private boolean intersects(final int targetIndex) {
 		if ((points.size() - 2) < targetIndex) {
-			throw new IndexOutOfBoundsException("request validate of non-existent fin edge segment: " + targetIndex + "/" + points.size());
+			log.error("request validation of non-existent fin edge segment: " + targetIndex + "/" + points.size());
+			// throw new IndexOutOfBoundsException("request validate of non-existent fin edge segment: " + targetIndex + "/" + points.size());
 		}
 
 		// (pre-check the indices above.)
@@ -419,9 +418,9 @@ public class FreeformFinSet extends FinSet {
 			
 			final Line2D.Double comparisonLine = new Line2D.Double(pc1, pc2);
 			if (targetLine.intersectsLine(comparisonLine)) {
-				log.error(String.format("Found intersection at %d-%d and %d-%d", targetIndex, targetIndex+1, comparisonIndex, comparisonIndex+1)); 
-				log.error(String.format("                   between (%g, %g) => (%g, %g)", pt1.x, pt1.y, pt2.x, pt2.y)); 
-				log.error(String.format("                       and (%g, %g) => (%g, %g)", pc1.x, pc1.y, pc2.x, pc2.y));
+				log.warn(String.format("Found intersection at %d-%d and %d-%d", targetIndex, targetIndex+1, comparisonIndex, comparisonIndex+1));
+				log.warn(String.format("                   between (%g, %g) => (%g, %g)", pt1.x, pt1.y, pt2.x, pt2.y));
+				log.warn(String.format("                       and (%g, %g) => (%g, %g)", pc1.x, pc1.y, pc2.x, pc2.y));
 				return true;
 			}
 		}

--- a/core/src/net/sf/openrocket/rocketcomponent/PodSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/PodSet.java
@@ -3,11 +3,13 @@ package net.sf.openrocket.rocketcomponent;
 import java.util.ArrayList;
 import java.util.Collection;
 
+import jdk.jshell.spi.ExecutionControl;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.rocketcomponent.position.AngleMethod;
 import net.sf.openrocket.rocketcomponent.position.AxialMethod;
 import net.sf.openrocket.rocketcomponent.position.RadiusMethod;
 import net.sf.openrocket.startup.Application;
+import net.sf.openrocket.util.BoundingBox;
 import net.sf.openrocket.util.BugException;
 import net.sf.openrocket.util.Coordinate;
 
@@ -43,35 +45,7 @@ public class PodSet extends ComponentAssembly implements RingInstanceable {
 		//// Stage
 		return trans.get("PodSet.PodSet");
 	}
-	
-	
-	// not strictly accurate, but this should provide an acceptable estimate for total vehicle size 
-	@Override
-	public Collection<Coordinate> getComponentBounds() {
-		Collection<Coordinate> bounds = new ArrayList<Coordinate>(8);
-		double x_min = Double.MAX_VALUE;
-		double x_max = Double.MIN_VALUE;
-		double r_max = 0;
-		
-		Coordinate[] instanceLocations = this.getComponentLocations();
-		
-		for (Coordinate currentInstanceLocation : instanceLocations) {
-			if (x_min > (currentInstanceLocation.x)) {
-				x_min = currentInstanceLocation.x;
-			}
-			if (x_max < (currentInstanceLocation.x + this.length)) {
-				x_max = currentInstanceLocation.x + this.length;
-			}
-			if (r_max < (this.getRadiusOffset())) {
-				r_max = this.getRadiusOffset();
-			}
-		}
-		addBound(bounds, x_min, r_max);
-		addBound(bounds, x_max, r_max);
-		
-		return bounds;
-	}
-	
+
 	/**
 	 * Check whether the given type can be added to this component.  A Stage allows
 	 * only BodyComponents to be added.
@@ -85,7 +59,6 @@ public class PodSet extends ComponentAssembly implements RingInstanceable {
 		return BodyComponent.class.isAssignableFrom(type);
 	}
 
-		
 	@Override
 	public double getInstanceAngleIncrement(){
 		return angleSeparation;

--- a/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
@@ -2,17 +2,14 @@ package net.sf.openrocket.rocketcomponent;
 
 import java.util.*;
 
+import net.sf.openrocket.util.*;
+import net.sf.openrocket.util.ArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.rocketcomponent.position.AxialMethod;
 import net.sf.openrocket.startup.Application;
-import net.sf.openrocket.util.ArrayList;
-import net.sf.openrocket.util.Coordinate;
-import net.sf.openrocket.util.MathUtil;
-import net.sf.openrocket.util.StateChangeListener;
-import net.sf.openrocket.util.UniqueID;
 
 
 /**
@@ -83,7 +80,16 @@ public class Rocket extends ComponentAssembly {
 		configSet = new FlightConfigurableParameterSet<>( defaultConfig );
 		this.selectedConfiguration = defaultConfig;
 	}
-	
+
+	/**
+	 * Return a bounding box enveloping the rocket.  By definition, the bounding box is a convex hull.
+	 *
+	 * Note: this function gets the bounding box for the entire rocket.
+	 *
+	 * @return    Return a bounding box enveloping the rocket
+	 */
+	public BoundingBox getBoundingBox (){ return selectedConfiguration.getBoundingBox(); }
+
 	public String getDesigner() {
 		checkState();
 		return designer;

--- a/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
@@ -9,6 +9,7 @@ import java.util.List;
 import net.sf.openrocket.preset.ComponentPreset;
 import net.sf.openrocket.rocketcomponent.PodSet;
 import net.sf.openrocket.rocketcomponent.position.AxialMethod;
+import net.sf.openrocket.util.BoundingBox;
 import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.MathUtil;
 
@@ -20,7 +21,7 @@ import net.sf.openrocket.util.MathUtil;
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
 
-public abstract class SymmetricComponent extends BodyComponent implements RadialParent {
+public abstract class SymmetricComponent extends BodyComponent implements BoxBounded, RadialParent {
 	public static final double DEFAULT_RADIUS = 0.025;
 	public static final double DEFAULT_THICKNESS = 0.002;
 	
@@ -40,13 +41,23 @@ public abstract class SymmetricComponent extends BodyComponent implements Radial
 	private double rotationalInertia = -1;
 	private Coordinate cg = null;
 	
-	
 
 	public SymmetricComponent() {
 		super();
 	}
-	
-	
+
+	public BoundingBox getInstanceBoundingBox(){
+		BoundingBox instanceBounds = new BoundingBox();
+
+		instanceBounds.update(new Coordinate(this.getLength(), 0,0));
+
+		final double r = Math.max(getForeRadius(), getAftRadius());
+		instanceBounds.update(new Coordinate(0,r,r));
+		instanceBounds.update(new Coordinate(0,-r,-r));
+
+		return instanceBounds;
+	}
+
 	/**
 	 * Return the component radius at position x.
 	 * @param x Position on x-axis.

--- a/core/src/net/sf/openrocket/util/BoundingBox.java
+++ b/core/src/net/sf/openrocket/util/BoundingBox.java
@@ -39,11 +39,22 @@ public class BoundingBox {
 	}
 
 	/**
-	 * return a copy of this bounding box, transformed by the given transformation matrix
- 	 * @return
+	 * Generate a new bounding box, transformed by the given transformation matrix
+	 *
+	 * Note: This implementation is not _exact_!  Do not use this for Aerodynamic, Mass or Simulation calculations....
+	 *       But it will be sufficiently close for UI purposes.
+	 *
+ 	 * @return a new box, transform by the given transform
 	 */
 	public BoundingBox transform(Transformation transform){
-		return new BoundingBox(transform.transform(this.min), transform.transform(this.max));
+		final Coordinate p1 = transform.transform(this.min);
+		final Coordinate p2 = transform.transform(this.max);
+
+		final BoundingBox newBox = new BoundingBox();
+		newBox.update(p1);
+		newBox.update(p2);
+
+		return newBox;
 	}
 
 	private void update_x_min( final double xVal) {
@@ -92,7 +103,7 @@ public class BoundingBox {
 		update_x_min(c.x);
 		update_y_min(c.y);
 		update_z_min(c.z);
-		
+
 		update_x_max(c.x);
 		update_y_max(c.y);
 		update_z_max(c.z);
@@ -126,7 +137,7 @@ public class BoundingBox {
 		}
 		update_x_min(other.min.x);
 		update_y_min(other.min.y);
-		update_z_min(other.min.y);
+		update_z_min(other.min.z);
 		
 		update_x_max(other.max.x);
 		update_y_max(other.max.y);

--- a/core/src/net/sf/openrocket/util/BoundingBox.java
+++ b/core/src/net/sf/openrocket/util/BoundingBox.java
@@ -7,7 +7,7 @@ import java.util.Collection;
 public class BoundingBox {
 	public Coordinate min;
 	public Coordinate max;
-	
+
 	public BoundingBox() {
 	    clear();
 	}
@@ -27,8 +27,25 @@ public class BoundingBox {
 	public BoundingBox clone() {
 		return new BoundingBox( this.min, this.max );
 	}
-	
-	
+
+	public boolean isEmpty(){
+		if( (min.x > max.x) ||
+			(min.y > max.y) ||
+			(min.z > max.z)){
+			return true;
+		}else{
+			return false;
+		}
+	}
+
+	/**
+	 * return a copy of this bounding box, transformed by the given transformation matrix
+ 	 * @return
+	 */
+	public BoundingBox transform(Transformation transform){
+		return new BoundingBox(transform.transform(this.min), transform.transform(this.max));
+	}
+
 	private void update_x_min( final double xVal) {
 		if( min.x > xVal)
 			min = min.setX( xVal );
@@ -104,6 +121,9 @@ public class BoundingBox {
     }
 	
 	public BoundingBox update( BoundingBox other ) {
+		if(other.isEmpty()){
+			return this;
+		}
 		update_x_min(other.min.x);
 		update_y_min(other.min.y);
 		update_z_min(other.min.y);
@@ -121,7 +141,7 @@ public class BoundingBox {
 	}
 	
 	public Collection<Coordinate> toCollection(){
-		Collection<Coordinate> toReturn = new ArrayList<Coordinate>();
+		Collection<Coordinate> toReturn = new ArrayList<>();
 		toReturn.add( this.max);
 		toReturn.add( this.min);
 		return toReturn;

--- a/core/src/net/sf/openrocket/util/Coordinate.java
+++ b/core/src/net/sf/openrocket/util/Coordinate.java
@@ -62,8 +62,8 @@ public final class Coordinate implements Cloneable, Serializable {
 	public static final Coordinate ZERO = new Coordinate(0, 0, 0, 0);
 	public static final Coordinate NUL = new Coordinate(0, 0, 0, 0);
 	public static final Coordinate NaN = new Coordinate(Double.NaN, Double.NaN,Double.NaN, Double.NaN);
-	public static final Coordinate MAX = new Coordinate(Double.MAX_VALUE,Double.MAX_VALUE,Double.MAX_VALUE,Double.MAX_VALUE);
-	public static final Coordinate MIN = new Coordinate(Double.MIN_VALUE,Double.MIN_VALUE,Double.MIN_VALUE,Double.MIN_VALUE);
+	public static final Coordinate MAX = new Coordinate( Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE,Double.MAX_VALUE);
+	public static final Coordinate MIN = new Coordinate(-Double.MAX_VALUE,-Double.MAX_VALUE,-Double.MAX_VALUE,0.0);
 
 	public static final Coordinate X_UNIT = new Coordinate(1, 0, 0);
 	public static final Coordinate Y_UNIT = new Coordinate(0, 1, 0);

--- a/core/src/net/sf/openrocket/util/TestRockets.java
+++ b/core/src/net/sf/openrocket/util/TestRockets.java
@@ -1038,12 +1038,11 @@ public class TestRockets {
 						boosterBody.addChild(boosterFins);
 						boosterFins.setName("Booster Fins");
 						boosterFins.setFinCount(3);
-						boosterFins.setAngleOffset( Math.PI / 4);
 						boosterFins.setThickness(0.003);
 						boosterFins.setCrossSection(CrossSection.ROUNDED);
 						boosterFins.setRootChord(0.32);
 						boosterFins.setTipChord(0.12);
-						boosterFins.setHeight(0.12);
+						boosterFins.setHeight(0.10);
 						boosterFins.setSweep(0.18);
 						boosterFins.setAxialMethod(AxialMethod.BOTTOM);
 						boosterFins.setAxialOffset(0.0);

--- a/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java
+++ b/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java
@@ -123,22 +123,23 @@ public class BarrowmanCalculatorTest {
 		{
 			boosterFins.setFinCount(3);
 			final Coordinate cp_3fin = calc.getCP(config, conditions, warnings);
-			assertEquals(" Falcon 9 Heavy CNa value is incorrect:", 21.5111598, cp_3fin.weight, EPSILON);
-			assertEquals(" Falcon 9 Heavy CP x value is incorrect:", 1.04662388, cp_3fin.x, EPSILON);
+			assertEquals(" Falcon 9 Heavy CNa value is incorrect:", 16.51651439, cp_3fin.weight, EPSILON);
+			assertEquals(" Falcon 9 Heavy CP x value is incorrect:", 1.00667319, cp_3fin.x, EPSILON);
 			assertEquals(" Falcon 9 Heavy CP y value is incorrect:", 0.0, cp_3fin.y, EPSILON);
 			assertEquals(" Falcon 9 Heavy CP z value is incorrect:", 0.0, cp_3fin.z, EPSILON);
 		}{
 			boosterFins.setFinCount(2);
+			boosterFins.setAngleOffset(Math.PI/4);
 			final Coordinate cp_2fin = calc.getCP(config, conditions, warnings);
-			assertEquals(" Falcon 9 Heavy CNa value is incorrect:", 15.43711196967902, cp_2fin.weight, EPSILON);
-			assertEquals(" Falcon 9 Heavy CP x value is incorrect:", 0.9946423753010524, cp_2fin.x, EPSILON);
+			assertEquals(" Falcon 9 Heavy CNa value is incorrect:", 12.1073483560, cp_2fin.weight, EPSILON);
+			assertEquals(" Falcon 9 Heavy CP x value is incorrect:", 0.9440139181, cp_2fin.x, EPSILON);
 			assertEquals(" Falcon 9 Heavy CP y value is incorrect:", 0.0, cp_2fin.y, EPSILON);
 			assertEquals(" Falcon 9 Heavy CP z value is incorrect:", 0.0, cp_2fin.z, EPSILON);
 		}{
 			boosterFins.setFinCount(1);
 			final Coordinate cp_1fin = calc.getCP(config, conditions, warnings);
-			assertEquals(" Falcon 9 Heavy CNa value is incorrect:", 9.36306412, cp_1fin.weight, EPSILON);
-			assertEquals(" Falcon 9 Heavy CP x value is incorrect:", 0.87521867, cp_1fin.x, EPSILON);
+			assertEquals(" Falcon 9 Heavy CNa value is incorrect:",  7.6981823141, cp_1fin.weight, EPSILON);
+			assertEquals(" Falcon 9 Heavy CP x value is incorrect:", 0.8095779106, cp_1fin.x, EPSILON);
 			assertEquals(" Falcon 9 Heavy CP y value is incorrect:", 0f, cp_1fin.y, EPSILON);
 			assertEquals(" Falcon 9 Heavy CP z value is incorrect:", 0f, cp_1fin.z, EPSILON);
 		}

--- a/core/test/net/sf/openrocket/masscalc/MassCalculatorTest.java
+++ b/core/test/net/sf/openrocket/masscalc/MassCalculatorTest.java
@@ -240,7 +240,7 @@ public class MassCalculatorTest extends BaseTestCase {
 			compMass = mmt.getComponentMass();
 			assertEquals(mmt.getName() + " mass calculated incorrectly: ", expMass, compMass, EPSILON);
 
-			expMass = 0.15995232;
+			expMass = 0.13329359999999998;
 			final FinSet boosterFins = (FinSet) boosters.getChild(1).getChild(1);
 			compMass = boosterFins.getComponentMass();
 			assertEquals(boosterFins.getName() + " mass calculated incorrectly: ", expMass, compMass, EPSILON);
@@ -442,10 +442,10 @@ public class MassCalculatorTest extends BaseTestCase {
 			assertEquals(cc.getName() + " Longitudinal MOI calculated incorrectly: ", expInertia, compInertia, EPSILON);
 
 			final FinSet boosterFins = (FinSet) boosters.getChild(1).getChild(1);
-			expInertia = 0.00413298;
+			expInertia = 0.0027856368437246307;
 			compInertia = boosterFins.getRotationalInertia();
 			assertEquals(boosterFins.getName() + " Rotational MOI calculated incorrectly: ", expInertia, compInertia, EPSILON);
-			expInertia = 0.01215133;
+			expInertia = 0.00835546;
 			compInertia = boosterFins.getLongitudinalInertia();
 			assertEquals(boosterFins.getName() + " Longitudinal MOI calculated incorrectly: ", expInertia, compInertia, EPSILON);
 
@@ -558,8 +558,8 @@ public class MassCalculatorTest extends BaseTestCase {
 		final RigidBody actualData = MassCalculator.calculateStructure(config);
 		final Coordinate actualCM = actualData.getCM();
 
-		double expMass = 0.66198084;
-		double expCMx = 1.08642949;
+		double expMass = 0.608663395;
+		double expCMx = 1.073157592;
 		assertEquals("Heavy Booster Mass is incorrect: ", expMass, actualCM.weight, EPSILON);
 
 		assertEquals("Heavy Booster CM.x is incorrect: ", expCMx, actualCM.x, EPSILON);
@@ -578,11 +578,11 @@ public class MassCalculatorTest extends BaseTestCase {
 		RigidBody actualBoosterLaunchData = MassCalculator.calculateLaunch(config);
 
 		double actualMass = actualBoosterLaunchData.getMass();
-		double expectedMass = 1.64598084;
+		double expectedMass = 1.592663395;
 		assertEquals(" Booster Launch Mass is incorrect: ", expectedMass, actualMass, EPSILON);
 
 		final Coordinate actualCM = actualBoosterLaunchData.getCM();
-		double expectedCMx = 1.22267891;
+		double expectedCMx = 1.22216804;
 		Coordinate expCM = new Coordinate(expectedCMx, 0, 0, expectedMass);
 		assertEquals(" Booster Launch CM.x is incorrect: ", expCM.x, actualCM.x, EPSILON);
 		assertEquals(" Booster Launch CM.y is incorrect: ", expCM.y, actualCM.y, EPSILON);
@@ -602,8 +602,8 @@ public class MassCalculatorTest extends BaseTestCase {
 		RigidBody spentData = MassCalculator.calculateBurnout(config);
 		Coordinate spentCM = spentData.getCM();
 
-		double expSpentMass = 1.17398084;
-		double expSpentCMx = 1.18582650;
+		double expSpentMass = 1.12066339;
+		double expSpentCMx = 1.18334714;
 		Coordinate expLaunchCM = new Coordinate(expSpentCMx, 0, 0, expSpentMass);
 		assertEquals(" Booster Launch Mass is incorrect: ", expLaunchCM.weight, spentCM.weight, EPSILON);
 		assertEquals(" Booster Launch CM.x is incorrect: ", expLaunchCM.x, spentCM.x, EPSILON);
@@ -668,11 +668,11 @@ public class MassCalculatorTest extends BaseTestCase {
 
 		RigidBody spent = MassCalculator.calculateBurnout(config);
 
-		double expMOIRotational = 0.01593066;
+		double expMOIRotational = 0.01291984;
 		double boosterMOIRotational = spent.getRotationalInertia();
 		assertEquals(" Booster x-axis MOI is incorrect: ", expMOIRotational, boosterMOIRotational, EPSILON);
 
-		double expMOI_tr = 0.08018692435877221;
+		double expMOI_tr = 0.0724434964;
 		double boosterMOI_tr = spent.getLongitudinalInertia();
 		assertEquals(" Booster transverse MOI is incorrect: ", expMOI_tr, boosterMOI_tr, EPSILON);
 	}
@@ -688,9 +688,9 @@ public class MassCalculatorTest extends BaseTestCase {
 
 		RigidBody launchData = MassCalculator.calculateLaunch(config);
 
-		final double expIxx = 0.01899116;
+		final double expIxx = 0.01598035;
 		final double actIxx = launchData.getRotationalInertia();
-		final double expIyy = 0.08637653;
+		final double expIyy = 0.07877196;
 		final double actIyy = launchData.getLongitudinalInertia();
 
 		assertEquals(" Booster x-axis MOI is incorrect: ", expIxx, actIxx, EPSILON);
@@ -731,11 +731,11 @@ public class MassCalculatorTest extends BaseTestCase {
 		assertEquals(" Booster Launch CM is incorrect: ", expCM, boosterSetCM);
 
 		// Validate MOI
-		double expMOI_axial = 0.01261079;
+		double expMOI_axial = 0.009599975;
 		double boosterMOI_xx = burnout.getRotationalInertia();
 		assertEquals(" Booster x-axis MOI is incorrect: ", expMOI_axial, boosterMOI_xx, EPSILON);
 
-		double expMOI_tr = 16.046826943504207;
+		double expMOI_tr = 14.83014382;
 		double boosterMOI_tr = burnout.getLongitudinalInertia();
 		assertEquals(" Booster transverse MOI is incorrect: ", expMOI_tr, boosterMOI_tr, EPSILON);
 	}
@@ -774,10 +774,10 @@ public class MassCalculatorTest extends BaseTestCase {
 		Coordinate boosterCM = boosterData.getCM();
 		// cm= 3.409905g@[0.853614,-0.000000,0.000000]
 
-		double expTotalMass = 3.40990464;
+		double expTotalMass = 3.3565872;
 		assertEquals(" Booster Launch Mass is incorrect: ", expTotalMass, boosterData.getMass(), EPSILON);
 
-		double expCMx = 0.85361377;
+		double expCMx = 0.847508988;
 		Coordinate expCM = new Coordinate(expCMx, 0, 0, expTotalMass);
 		assertEquals(" Booster Launch CM.x is incorrect: ", expCM.x, boosterCM.x, EPSILON);
 		assertEquals(" Booster Launch CM.y is incorrect: ", expCM.y, boosterCM.y, EPSILON);
@@ -785,11 +785,11 @@ public class MassCalculatorTest extends BaseTestCase {
 		assertEquals(" Booster Launch CM is incorrect: ", expCM, boosterCM);
 
 		// Validate MOI
-		double expMOI_axial = 0.031538609;
+		double expMOI_axial = 0.028527795;
 		double boosterMOI_xx = boosterData.getRotationalInertia();
 		assertEquals(" Booster x-axis MOI is incorrect: ", expMOI_axial, boosterMOI_xx, EPSILON);
 
-		double expMOI_tr = 0.37548843;
+		double expMOI_tr = 0.35989628;
 		double boosterMOI_tr = boosterData.getLongitudinalInertia();
 		assertEquals(" Booster transverse MOI is incorrect: ", expMOI_tr, boosterMOI_tr, EPSILON);
 	}
@@ -820,11 +820,11 @@ public class MassCalculatorTest extends BaseTestCase {
 
 		RigidBody structure = MassCalculator.calculateStructure(config);
 
-		final double expMass = 0.66198084;
+		final double expMass = 0.6086633952494;
 		double calcTotalMass = structure.getMass();
 		assertEquals(" Booster Launch Mass is incorrect: ", expMass, calcTotalMass, EPSILON);
 
-		final double expCMx = 1.12869951;
+		final double expCMx = 1.1191303646;
 		Coordinate expCM = new Coordinate(expCMx, 0, 0, expMass);
 		assertEquals(" Booster Launch CM.x is incorrect: ", expCM.x, structure.getCM().x, EPSILON);
 		assertEquals(" Booster Launch CM.y is incorrect: ", expCM.y, structure.getCM().y, EPSILON);
@@ -832,11 +832,11 @@ public class MassCalculatorTest extends BaseTestCase {
 		assertEquals(" Booster Launch CM is incorrect: ", expCM, structure.getCM());
 
 		// Validate MOI
-		final double expMOI_axial = 0.012610790;
+		final double expMOI_axial = 0.009599975;
 		double boosterMOI_xx = structure.getRotationalInertia();
 		assertEquals(" Booster x-axis MOI is incorrect: ", expMOI_axial, boosterMOI_xx, EPSILON);
 
-		final double expMOI_tr = 0.063491225;
+		final double expMOI_tr = 0.05520749289;
 		double boosterMOI_tr = structure.getLongitudinalInertia();
 		assertEquals(" Booster transverse MOI is incorrect: ", expMOI_tr, boosterMOI_tr, EPSILON);
 	}

--- a/core/test/net/sf/openrocket/rocketcomponent/FlightConfigurationTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/FlightConfigurationTest.java
@@ -463,25 +463,24 @@ public class FlightConfigurationTest extends BaseTestCase {
 					assertThat(boosterFinContext0.instanceNumber, equalTo(0));
 					final Coordinate boosterFin0Location = boosterFinContext0.getLocation();
 					assertEquals(1.044, boosterFin0Location.x, EPSILON);
-					assertEquals( -0.104223611, boosterFin0Location.y, EPSILON);
-					assertEquals( -0.027223611, boosterFin0Location.z, EPSILON);
+					assertEquals( -0.1155, boosterFin0Location.y, EPSILON);
+					assertEquals( 0.0, boosterFin0Location.z, EPSILON);
 
 					final InstanceContext boosterFinContext1 = finContextList.get(4);
 					assertThat((Class<TrapezoidFinSet>) boosterFinContext1.component.getClass(), equalTo(TrapezoidFinSet.class));
 					assertThat(boosterFinContext1.instanceNumber, equalTo(1));
 					final Coordinate boosterFin1Location = boosterFinContext1.getLocation();
-					assertEquals(boosterFin1Location.x,  1.044, EPSILON);
-					assertEquals(boosterFin1Location.y, -0.03981186, EPSILON);
-					assertEquals(boosterFin1Location.z, -0.00996453, EPSILON);
+					assertEquals( 1.044, boosterFin1Location.x, EPSILON);
+					assertEquals(-0.05775, boosterFin1Location.y, EPSILON);
+					assertEquals(-0.033341978, boosterFin1Location.z, EPSILON);
 
 					final InstanceContext boosterFinContext2 = finContextList.get(5);
 					assertThat((Class<TrapezoidFinSet>) boosterFinContext2.component.getClass(), equalTo(TrapezoidFinSet.class));
 					assertThat(boosterFinContext2.instanceNumber, equalTo(2));
 					final Coordinate boosterFin2Location = boosterFinContext2.getLocation();
-					assertEquals(boosterFin2Location.x,  1.044, EPSILON);
-					assertEquals(boosterFin2Location.y, -0.08696453, EPSILON);
-					assertEquals(boosterFin2Location.z,  0.03718814, EPSILON);
-
+					assertEquals(1.044, boosterFin2Location.x, EPSILON);
+					assertEquals(-0.05775, boosterFin2Location.y, EPSILON);
+					assertEquals( 0.03334, boosterFin2Location.z,  EPSILON);
 				}
 
 			}

--- a/core/test/net/sf/openrocket/rocketcomponent/RocketTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/RocketTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import net.sf.openrocket.rocketcomponent.position.AxialMethod;
+import net.sf.openrocket.util.BoundingBox;
 import org.junit.Test;
 
 import net.sf.openrocket.rocketcomponent.position.AngleMethod;
@@ -58,10 +59,10 @@ public class RocketTest extends BaseTestCase {
 
 	@Test
 	public void testEstesAlphaIII(){
-		Rocket rocket = TestRockets.makeEstesAlphaIII();
-			
-		AxialStage stage= (AxialStage)rocket.getChild(0);
-		
+		final Rocket rocket = TestRockets.makeEstesAlphaIII();
+
+		final AxialStage stage= (AxialStage)rocket.getChild(0);
+
 		Coordinate expLoc;
 		Coordinate actLoc;
 		{
@@ -136,6 +137,15 @@ public class RocketTest extends BaseTestCase {
 			}
 			
 		}
+
+		final BoundingBox bounds = rocket.getBoundingBox();
+		assertEquals(bounds.min.x, 0.0,  EPSILON);
+		assertEquals(bounds.max.x, 0.27, EPSILON);
+
+		assertEquals( -0.032385640, bounds.min.y, EPSILON);
+		assertEquals( -0.054493575, bounds.min.z, EPSILON);
+		assertEquals(  0.062000000,  bounds.max.y, EPSILON);
+		assertEquals(  0.052893575, bounds.max.z, EPSILON);
 	}
 	
 	@Test 
@@ -270,6 +280,15 @@ public class RocketTest extends BaseTestCase {
 				assertThat(mmt.getName()+" not positioned correctly: ", actLoc, equalTo( expLoc ));
 			}
 		}
+
+		final BoundingBox bounds = rocket.getBoundingBox();
+		assertEquals( bounds.min.x, 0.0,  EPSILON);
+		assertEquals( bounds.max.x, 0.335, EPSILON);
+
+		assertEquals( -0.032385640, bounds.min.y, EPSILON);
+		assertEquals( -0.054493575, bounds.min.z, EPSILON);
+		assertEquals(  0.062000000,  bounds.max.y, EPSILON);
+		assertEquals(  0.052893575, bounds.max.z, EPSILON);
 	}
 	
 	@Test
@@ -389,8 +408,20 @@ public class RocketTest extends BaseTestCase {
 					assertEquals(coreFins.getName()+" location is incorrect: ", 1.044, loc.x, EPSILON);
 				}
 			}
-			
 		}
+
+		// DEBUG
+		System.err.println(rocket.toDebugTree());
+
+		final BoundingBox bounds = rocket.getBoundingBox();
+		assertEquals( 0.0,   bounds.min.x,  EPSILON);
+		assertEquals( 1.364, bounds.max.x, EPSILON);
+
+		assertEquals( -0.215500, bounds.min.y, EPSILON);
+		assertEquals(  0.215500, bounds.max.y, EPSILON);
+
+		assertEquals( -0.12069451, bounds.min.z, EPSILON);
+		assertEquals(  0.12069451, bounds.max.z, EPSILON);
 	}
 
 }

--- a/swing/src/net/sf/openrocket/gui/figure3d/geometry/FinRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/geometry/FinRenderer.java
@@ -19,7 +19,7 @@ public class FinRenderer {
 	
 	public void renderFinSet(final GL2 gl, FinSet finSet ) {
 		
-	    BoundingBox bounds = finSet.getBoundingBox();
+	    BoundingBox bounds = finSet.getInstanceBoundingBox();
 		gl.glMatrixMode(GL.GL_TEXTURE);
 		gl.glPushMatrix();
 		gl.glScaled(1 / (bounds.max.x - bounds.min.x), 1 / (bounds.max.y - bounds.min.y), 0);

--- a/swing/src/net/sf/openrocket/gui/scalefigure/AbstractScaleFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/AbstractScaleFigure.java
@@ -45,30 +45,30 @@ public abstract class AbstractScaleFigure extends JPanel {
 	// size of the visible region
 	protected Dimension visibleBounds_px = new Dimension(0,0);
 	
-    // ======= whatever this figure is drawing, in real-space coordinates:  meters
-    protected Rectangle2D subjectBounds_m = null;
-    
-    // combines the translation and scale in one place: 
-    // which frames does this transform between ?  
-    protected AffineTransform projection = null;
+	// ======= whatever this figure is drawing, in real-space coordinates:  meters
+	protected Rectangle2D subjectBounds_m = null;
+
+	// combines the translation and scale in one place:
+	// which frames does this transform between ?
+	protected AffineTransform projection = null;
 
 	protected final List<EventListener> listeners = new LinkedList<EventListener>();
 	
 	
 	public AbstractScaleFigure() {
-	    // produces a pixels-per-meter scale factor 
-	    //
-	    // dots     dots     inch
-	    // ----  = ------ * -----
-	    // meter    inch    meter
-	    //
-        this.baseScale = GUIUtil.getDPI() * INCHES_PER_METER;
-        this.userScale = 1.0;
-        this.scale = baseScale * userScale;
- 
-        this.setPreferredSize(new Dimension(100,100));
-        setSize(100,100);
-        
+		// produces a pixels-per-meter scale factor
+		//
+		// dots     dots     inch
+		// ----  = ------ * -----
+		// meter    inch    meter
+		//
+		this.baseScale = GUIUtil.getDPI() * INCHES_PER_METER;
+		this.userScale = 1.0;
+		this.scale = baseScale * userScale;
+
+		this.setPreferredSize(new Dimension(100,100));
+		setSize(100,100);
+
 		setBackground(Color.WHITE);
 		setOpaque(true);
 	}
@@ -77,28 +77,28 @@ public abstract class AbstractScaleFigure extends JPanel {
 		return userScale;
 	}
 	
-    public double getAbsoluteScale() {
-       return scale;
-    }
+	public double getAbsoluteScale() {
+		return scale;
+	}
 
-    public Dimension getSubjectOrigin() {
+	public Dimension getSubjectOrigin() {
         return originLocation_px;
     }
-    
+
 	/**
 	 * Set the scale level of the figure.  A scale value of 1.0 is equivalent to 100 % scale.
 	 * Smaller scales display the subject smaller.
 	 *
 	 *  If the figure would be smaller than the 'visibleBounds', then the figure is grown to match,
 	 *  and the figures internal contents are centered according to the figure's origin.
-	 * 
+	 *
 	 * @param newScaleRequest the scale level
 	 * @param visibleBounds the visible bounds upon the Figure
 	 */
 	public void scaleTo(final double newScaleRequest, final Dimension visibleBounds) {
 		if (MathUtil.equals(this.userScale, newScaleRequest, 0.01)){
 			return;}
-		if (Double.isInfinite(newScaleRequest) || Double.isNaN(newScaleRequest)) {
+		if (Double.isInfinite(newScaleRequest) || Double.isNaN(newScaleRequest) || 0 > newScaleRequest) {
 			return;}
 
 		this.userScale = MathUtil.clamp( newScaleRequest, MINIMUM_ZOOM, MAXIMUM_ZOOM);
@@ -115,21 +115,21 @@ public abstract class AbstractScaleFigure extends JPanel {
      * @param visibleBounds the visible bounds to scale this figure to.  
      */
 	public void scaleTo(Dimension visibleBounds) {
-	    if( 0 == visibleBounds.getWidth() || 0 == visibleBounds.getHeight())
-	        return;
-	    
-	    updateSubjectDimensions();
-	    
-	    // dimensions within the viewable area, which are available to draw
+		if( 0 == visibleBounds.getWidth() || 0 == visibleBounds.getHeight())
+			return;
+
+		updateSubjectDimensions();
+
+		// dimensions within the viewable area, which are available to draw
 		final int drawable_width_px = visibleBounds.width - 2 * borderThickness_px.width;
 		final int drawable_height_px = visibleBounds.height - 2 * borderThickness_px.height;
 
-        if(( 0 < drawable_width_px ) && ( 0 < drawable_height_px)) {
-		    final double width_scale = (drawable_width_px) / ( subjectBounds_m.getWidth() * baseScale);
-    		final double height_scale = (drawable_height_px) / ( subjectBounds_m.getHeight() * baseScale);
-    		final double minScale = Math.min(height_scale, width_scale);
-    		
-    		scaleTo(minScale, visibleBounds);
+		if(( 0 < drawable_width_px ) && ( 0 < drawable_height_px)) {
+			final double width_scale = (drawable_width_px) / ( subjectBounds_m.getWidth() * baseScale);
+			final double height_scale = (drawable_height_px) / ( subjectBounds_m.getHeight() * baseScale);
+			final double minScale = Math.min(height_scale, width_scale);
+
+			scaleTo(minScale, visibleBounds);
 		}
 	}
 	

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketFigure.java
@@ -407,32 +407,35 @@ public class RocketFigure extends AbstractScaleFigure {
 	}
 	
 
-    /**
-     * Gets the bounds of the drawn subject in Model-Space
-     * 
-     *  i.e. the maximum extents in the selected dimensions.
-     * The bounds are stored in the variables minX, maxX and maxR.
-     * 
-     * @return
-     */
-    @Override
-    protected void updateSubjectDimensions() {
-        // calculate bounds, and store in class variables
-        final BoundingBox bounds = rocket.getSelectedConfiguration().getBoundingBox();
-        final double maxR = Math.max(Math.hypot(bounds.min.y, bounds.min.z),
-                                     Math.hypot(bounds.max.y, bounds.max.z));
-        
-        switch (currentViewType) {
-        case SideView:
-            subjectBounds_m = new Rectangle2D.Double(bounds.min.x, -maxR, bounds.span().x, 2 * maxR);
-            break;
-        case BackView:
-            subjectBounds_m = new Rectangle2D.Double(-maxR, -maxR, 2 * maxR, 2 * maxR);
-            break;
-        default:
-            throw new BugException("Illegal figure type = " + currentViewType);
-        }
-    }
+	/**
+	 * Gets the bounds of the drawn subject in Model-Space
+	 *
+	 *  i.e. the maximum extents in the selected dimensions.
+	 * The bounds are stored in the variables minX, maxX and maxR.
+	 *
+	 * @return
+	 */
+	@Override
+	protected void updateSubjectDimensions() {
+		// calculate bounds, and store in class variables
+		BoundingBox newBounds = rocket.getSelectedConfiguration().getBoundingBox();
+		if(newBounds.isEmpty())
+			newBounds = new BoundingBox(Coordinate.ZERO,Coordinate.X_UNIT);
+
+		final double maxR = Math.max(Math.hypot(newBounds.min.y, newBounds.min.z),
+				Math.hypot(newBounds.max.y, newBounds.max.z));
+
+		switch (currentViewType) {
+			case SideView:
+				subjectBounds_m = new Rectangle2D.Double(newBounds.min.x, -maxR, newBounds.span().x, 2 * maxR);
+				break;
+			case BackView:
+				subjectBounds_m = new Rectangle2D.Double(-maxR, -maxR, 2 * maxR, 2 * maxR);
+				break;
+			default:
+				throw new BugException("Illegal figure type = " + currentViewType);
+		}
+	}
     
 	/**
 	 * Calculates the necessary size of the figure and set the PreferredSize 


### PR DESCRIPTION
1. Simplifies code in FlightConfiguration
2. Adds Interface to indicate implementation of `getInstanceBoundingBox` function
3. Adjusts test to ensure that refactoring still behaves as desired
4. Adds a fix to the Intersection testing code in `FreeformFinSet.setPoint`
