### PR TITLE
Adjustments to snap stuff

### DIFF
--- a/snap/local/launcher
+++ b/snap/local/launcher
@@ -8,11 +8,11 @@ export XDG_CURRENT_DESKTOP=GNOME
 
 JAVA_OPTS="-Dsun.java2d.xrender=true -Dprism.useFontConfig=false -Dawt.useSystemAAFontSettings=on -Dswing.aatext=true -Dswing.defaultlaf=com.sun.java.swing.plaf.gtk.GTKLookAndFeel -Dswing.crossplatformlaf=com.sun.java.swing.plaf.gtk.GTKLookAndFeel -Djava.io.tmpdir=$SNAP_USER_COMMON"
 
-if ! snapctl is-connected preferences; then
+if ! snapctl is-connected dot-java-user-prefs; then
     JAVA_OPTS="$JAVA_OPTS -Djava.util.prefs.userRoot=$SNAP_USER_COMMON/"
 fi
 
-if ! snapctl is-connected openrocket-db; then
+if ! snapctl is-connected dot-openrocket-db; then
     JAVA_OPTS="$JAVA_OPTS -Duser.home=$SNAP_USER_COMMON/"
 fi
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,13 +21,13 @@ grade: stable
 confinement: strict
 
 plugs:
-  preferences:
+  dot-java-user-prefs:
     interface: personal-files
     read:
-      - $HOME/.java
+      - $HOME/.java/.userPrefs/OpenRocket
     write:
-      - $HOME/.java
-  openrocket-db:
+      - $HOME/.java/.userPrefs/OpenRocket
+  dot-openrocket-db:
     interface: personal-files
     read:
       - $HOME/.openrocket
@@ -44,8 +44,8 @@ apps:
       - network
       - cups-control
       - opengl
-      - preferences
-      - openrocket-db
+      - dot-java-user-prefs
+      - dot-openrocket-db
     environment:
       JAVA_HOME: "$SNAP/usr/lib/jvm/java-11-openjdk-amd64"
 
@@ -75,9 +75,6 @@ parts:
     override-build: |
       snapcraftctl build
       mv swing/build/jar/OpenRocket.jar $SNAPCRAFT_PART_INSTALL/OpenRocket.jar
-    build-packages:
-      # Add gcc as a build package due to bug https://bugs.launchpad.net/snapcraft/+bug/1883392
-      - gcc
     stage-packages:
       - openjdk-11-jre
       - ca-certificates


### PR DESCRIPTION
Drop gcc as a build-dependency as LP#1883392 was fixed and delivered.
Additionally, change personal-files interfaces to be more explicit which
should allow for the snap store assertions which will possibly allow the
auto-connecting of the interfaces upon install for the OpenRocket app.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>