### PR TITLE
Center rocket in side-view 2d renderings

### DIFF
--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketFigure.java
@@ -1,7 +1,14 @@
 package net.sf.openrocket.gui.scalefigure;
 
 
-import java.awt.*;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.Shape;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.NoninvertibleTransformException;
@@ -443,17 +450,17 @@ public class RocketFigure extends AbstractScaleFigure {
 	 */
 	@Override
 	protected void updateCanvasOrigin() {
-	    final int subjectFront = (int)(subjectBounds_m.getMinX()*scale);
-	    final int subjectWidth = (int)(subjectBounds_m.getWidth()*scale);
+		final int subjectWidth = (int)(subjectBounds_m.getWidth()*scale);
 	    final int subjectHeight = (int)(subjectBounds_m.getHeight()*scale);
+	    final int mid_x = (Math.max(getWidth(), subjectWidth) / 2);
 	    
 	    if (currentViewType == RocketPanel.VIEW_TYPE.BackView){
-	        final int newOriginX = borderThickness_px.width + Math.max(getWidth(), subjectWidth + 2*borderThickness_px.width)/ 2;	        
+	        final int newOriginX = mid_x;
 	        final int newOriginY = borderThickness_px.height + getHeight() / 2;
 
 	        originLocation_px = new Point(newOriginX, newOriginY);
     	}else if (currentViewType == RocketPanel.VIEW_TYPE.SideView){
-            final int newOriginX = borderThickness_px.width - subjectFront;
+    		final int newOriginX = mid_x - (int) ((subjectBounds_m.getWidth() * scale) / 2);
     	    final int newOriginY = Math.max(getHeight(), subjectHeight + 2*borderThickness_px.height )/ 2;
     	    originLocation_px = new Point(newOriginX, newOriginY);
     	}

--- a/swing/src/net/sf/openrocket/gui/scalefigure/ScaleScrollPane.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/ScaleScrollPane.java
@@ -14,13 +14,10 @@ import java.awt.event.ComponentEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
-import java.awt.geom.Rectangle2D;
-import java.util.EventObject;
 
 import javax.swing.BorderFactory;
 import javax.swing.JComponent;
 import javax.swing.JScrollPane;
-import javax.swing.ScrollPaneConstants;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
@@ -29,9 +26,7 @@ import net.sf.openrocket.gui.components.UnitSelector;
 import net.sf.openrocket.unit.Tick;
 import net.sf.openrocket.unit.Unit;
 import net.sf.openrocket.unit.UnitGroup;
-import net.sf.openrocket.util.BugException;
 import net.sf.openrocket.util.MathUtil;
-import net.sf.openrocket.util.StateChangeListener;
 
 
 


### PR DESCRIPTION
Center the rocket within the side-view 2d renderings. This is similar to
how the side-view is rendered in 15.03 version.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>