### PR TITLE
[Fixes #723] Fix scaling crashes in some circumstances

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/RingComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RingComponent.java
@@ -179,8 +179,7 @@ public abstract class RingComponent extends StructuralComponent implements Coaxi
 		if (1 == instanceCount ) {
 			cg = new Coordinate( length/2, 0, 0, instanceMass );
 		}else{
-			Coordinate offsets[] = getInstanceOffsets();
-			for( Coordinate c : offsets) {
+			for( Coordinate c : getInstanceOffsets() ) {
 				c = c.setWeight( instanceMass );
 				cg = cg.average(c); 
 			}

--- a/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
@@ -1930,7 +1930,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 	
 	protected static final double ringMass(double outerRadius, double innerRadius,
 			double length, double density) {
-		return Math.PI * (MathUtil.pow2(outerRadius) - MathUtil.pow2(innerRadius)) *
+		return Math.PI * Math.max(MathUtil.pow2(outerRadius) - MathUtil.pow2(innerRadius),0) *
 				length * density;
 	}
 	

--- a/swing/src/net/sf/openrocket/gui/dialogs/ScaleDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/ScaleDialog.java
@@ -392,7 +392,11 @@ public class ScaleDialog extends JDialog {
 		scale.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
+
+				final Rocket rocket = document.getRocket();
+				rocket.enableEvents(false);
 				doScale();
+				rocket.enableEvents(true);
 
 				ScaleDialog.this.document.getRocket().fireComponentChangeEvent( ComponentChangeEvent.AEROMASS_CHANGE);
 

--- a/swing/src/net/sf/openrocket/gui/scalefigure/AbstractScaleFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/AbstractScaleFigure.java
@@ -185,7 +185,7 @@ public abstract class AbstractScaleFigure extends JPanel {
      * Updates the figure shapes and figure size.
      */
     public void updateFigure() {
-        log.trace(String.format("____ Updating %s to: %g user scale, %g overall scale", this.getClass().getSimpleName(), this.getAbsoluteScale(), this.scale));
+        log.trace(String.format("____ Updating %s to: %g user scale, %g overall scale", this.getClass().getSimpleName(), this.userScale, this.scale));
         
         updateSubjectDimensions();
         updateCanvasSize();


### PR DESCRIPTION
The root cause was that scaling progresses through Component properties 1-by-1, and this may cause an inconsistent, physically impossible state.   (in this case, an inner diameter > outer diameter).

Fixes:
1. `RocketComponent.ringMass` : clamp the thickness (== outer diameter - inner diameter)  to be >= 0.
2. Disable events during rocket scaling.   This has a side effect of greatly speeding the scaling process ^^

@hcraigmiller
