### PR TITLE
Don't create new SimulationStatus on landing.

### DIFF
--- a/core/src/net/sf/openrocket/simulation/GroundStepper.java
+++ b/core/src/net/sf/openrocket/simulation/GroundStepper.java
@@ -12,10 +12,8 @@ public class GroundStepper extends AbstractSimulationStepper {
 	private static final Logger log = LoggerFactory.getLogger(GroundStepper.class);
 	
 	@Override
-	public SimulationStatus initialize(SimulationStatus original) {
+	public SimulationStatus initialize(SimulationStatus status) {
 		log.trace("initializing GroundStepper");
-		SimulationStatus status = new SimulationStatus(original);
-
 		return status;
 	}
 


### PR DESCRIPTION
Makes consistent with BasicLandingStepper; more generally, if you don't need a more specialized status derived from SimulationStatus (as is the case with RK4SimulationStepper), you don't need to create a new SimulationStatus when entering a new flight phase.
Fixes #725 (creating a new SimulationStatus doesn't automatically copy warnings, so existing warnings were being forgotten on landing)