### PR TITLE
Resolves #742 - Crash on rocket-load

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
@@ -585,7 +585,6 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 		//           (b) BodyTube -- for Parallel Stages & PodSets
 		final RocketComponent grandParent = this.parent.getParent();
 
-		// note:  this is not guaranteed to _contain_ a stage... but that we're _searching_ for one.
 		int searchParentIndex = grandParent.getChildPosition(this.parent);       // position of stage w/in parent
 		int searchSiblingIndex = this.parent.getChildPosition(this)-1;  // guess at index of previous stage
 
@@ -595,7 +594,6 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 			if(searchParent instanceof ComponentAssembly){
 				while (0 <= searchSiblingIndex) {
 					final RocketComponent searchSibling = searchParent.getChild(searchSiblingIndex);
-
 					if (searchSibling instanceof SymmetricComponent) {
 						return (SymmetricComponent) searchSibling;
 					}
@@ -603,7 +601,9 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 				}
 			}
 			--searchParentIndex;
-			searchSiblingIndex = searchParent.getChildCount() - 1;
+			if( 0 <= searchParentIndex){
+				searchSiblingIndex = grandParent.getChild(searchParentIndex).getChildCount() - 1;
+			}
 		}
 		return null;
 	}
@@ -640,7 +640,7 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 				}
 			}
 			++searchParentIndex;
-			searchSiblingIndex = searchParent.getChildCount() - 1;
+			searchSiblingIndex = 0;
 		}
 		return null;
 	}

--- a/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
@@ -577,17 +577,16 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 	 * @return	the previous SymmetricComponent, or null.
 	 */
 	public final SymmetricComponent getPreviousSymmetricComponent() {
-		if(null == this.parent) {
+		if((null == this.parent) || (null == this.parent.getParent())){
 			return null;
 		}
 
-		final ComponentAssembly assembly = this.getAssembly();
 		// might be: (a) Rocket -- for Centerline/Axial stages
 		//           (b) BodyTube -- for Parallel Stages & PodSets
-		final RocketComponent grandParent = assembly.getParent();
+		final RocketComponent grandParent = this.parent.getParent();
 
 		// note:  this is not guaranteed to _contain_ a stage... but that we're _searching_ for one.
-		int searchParentIndex = grandParent.getChildPosition(assembly);       // position of stage w/in parent
+		int searchParentIndex = grandParent.getChildPosition(this.parent);       // position of stage w/in parent
 		int searchSiblingIndex = this.parent.getChildPosition(this)-1;  // guess at index of previous stage
 
 		while( 0 <= searchParentIndex ) {
@@ -615,17 +614,16 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 	 * @return	the next SymmetricComponent, or null.
 	 */
 	public final SymmetricComponent getNextSymmetricComponent() {
-		if(null == this.parent) {
+		if((null == this.parent) || (null == this.parent.getParent())){
 			return null;
 		}
 
-		final ComponentAssembly assembly = this.getAssembly();
 		// might be: (a) Rocket -- for centerline stages
 		//           (b) BodyTube -- for Parallel Stages
-		final RocketComponent grandParent = assembly.getParent();
+		final RocketComponent grandParent = this.parent.getParent();
 
 		// note:  this is not guaranteed to _contain_ a stage... but that we're _searching_ for one.
-		int searchParentIndex = grandParent.getChildPosition(assembly);
+		int searchParentIndex = grandParent.getChildPosition(this.parent);
 		int searchSiblingIndex = this.parent.getChildPosition(this) + 1;
 
 		while(searchParentIndex < grandParent.getChildCount()) {

--- a/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
@@ -584,27 +584,27 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 		final ComponentAssembly assembly = this.getAssembly();
 		// might be: (a) Rocket -- for Centerline/Axial stages
 		//           (b) BodyTube -- for Parallel Stages & PodSets
-		final RocketComponent assemblyParent = assembly.getParent();
+		final RocketComponent grandParent = assembly.getParent();
 
 		// note:  this is not guaranteed to _contain_ a stage... but that we're _searching_ for one.
-		int assemblyIndex = assemblyParent.getChildPosition(assembly);       // position of stage w/in parent
-		int symmetricIndex = this.parent.getChildPosition(this)-1;  // guess at index of previous stage
+		int searchParentIndex = grandParent.getChildPosition(assembly);       // position of stage w/in parent
+		int searchSiblingIndex = this.parent.getChildPosition(this)-1;  // guess at index of previous stage
 
-		while( 0 <= assemblyIndex ) {
-			final RocketComponent searchAssembly = assemblyParent.getChild(assemblyIndex);
+		while( 0 <= searchParentIndex ) {
+			final RocketComponent searchParent = grandParent.getChild(searchParentIndex);
 
-			if(searchAssembly instanceof ComponentAssembly){
-				while (0 <= symmetricIndex) {
-					final RocketComponent previousSymmetric = searchAssembly.getChild(symmetricIndex);
+			if(searchParent instanceof ComponentAssembly){
+				while (0 <= searchSiblingIndex) {
+					final RocketComponent searchSibling = searchParent.getChild(searchSiblingIndex);
 
-					if (previousSymmetric instanceof SymmetricComponent) {
-						return (SymmetricComponent) previousSymmetric;
+					if (searchSibling instanceof SymmetricComponent) {
+						return (SymmetricComponent) searchSibling;
 					}
-					--symmetricIndex;
+					--searchSiblingIndex;
 				}
 			}
-			--assemblyIndex;
-			symmetricIndex = searchAssembly.getChildCount() - 1;
+			--searchParentIndex;
+			searchSiblingIndex = searchParent.getChildCount() - 1;
 		}
 		return null;
 	}
@@ -622,27 +622,27 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 		final ComponentAssembly assembly = this.getAssembly();
 		// might be: (a) Rocket -- for centerline stages
 		//           (b) BodyTube -- for Parallel Stages
-		final RocketComponent assemblyParent = assembly.getParent();
+		final RocketComponent grandParent = assembly.getParent();
 
 		// note:  this is not guaranteed to _contain_ a stage... but that we're _searching_ for one.
-		int assemblyIndex = assemblyParent.getChildPosition(assembly);
-		int symmetricIndex = this.parent.getChildPosition(this) + 1;
+		int searchParentIndex = grandParent.getChildPosition(assembly);
+		int searchSiblingIndex = this.parent.getChildPosition(this) + 1;
 
-		while(assemblyIndex < assemblyParent.getChildCount()) {
-			final RocketComponent searchAssembly = assemblyParent.getChild(assemblyIndex);
+		while(searchParentIndex < grandParent.getChildCount()) {
+			final RocketComponent searchParent = grandParent.getChild(searchParentIndex);
 
-			if(searchAssembly instanceof ComponentAssembly){
-				while (symmetricIndex < searchAssembly.getChildCount()) {
-					final RocketComponent nextSymmetric = searchAssembly.getChild(symmetricIndex);
+			if(searchParent instanceof ComponentAssembly){
+				while (searchSiblingIndex < searchParent.getChildCount()) {
+					final RocketComponent searchSibling = searchParent.getChild(searchSiblingIndex);
 
-					if (nextSymmetric instanceof SymmetricComponent) {
-						return (SymmetricComponent) nextSymmetric;
+					if (searchSibling instanceof SymmetricComponent) {
+						return (SymmetricComponent) searchSibling;
 					}
-					++symmetricIndex;
+					++searchSiblingIndex;
 				}
 			}
-			++assemblyIndex;
-			symmetricIndex = searchAssembly.getChildCount() - 1;
+			++searchParentIndex;
+			searchSiblingIndex = searchParent.getChildCount() - 1;
 		}
 		return null;
 	}

--- a/core/test/net/sf/openrocket/rocketcomponent/RocketTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/RocketTest.java
@@ -245,7 +245,7 @@ public class RocketTest extends BaseTestCase {
 			body.setOuterRadiusAutomatic(true);
 			assertEquals(" radius match: ", expRadius, body.getOuterRadius(), EPSILON);
 		}
-		{ // test auto-radius within a stage: body tube -> trailing transition
+		{ // test auto-radius within a stage: tail cone -> body tube
 			final BodyTube body = (BodyTube) booster.getChild(0);
 			assertEquals(" radius match: ", expRadius, body.getOuterRadius(), EPSILON);
 			final Transition tailCone = (Transition)booster.getChild(1);


### PR DESCRIPTION
I tracked this down to a logic error in `SymmetricComponent.getPreviousSymmetricComponent`.

And fixed the error, obviously.  (+ some minor cleanup).