### PR TITLE
Don't set a warning if recovery device is deployed while motor is coasting

### DIFF
--- a/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
+++ b/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
@@ -466,7 +466,7 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 					
 					// Check whether any motor in the active stages is active anymore
 					for (MotorClusterState state : currentStatus.getActiveMotors() ) {
-						if ( state.isSpent() ) {
+						if (state.isDelaying() || state.isSpent()) {
 							continue;
 						}
 						currentStatus.getWarnings().add(Warning.RECOVERY_DEPLOYMENT_WHILE_BURNING);

--- a/core/src/net/sf/openrocket/simulation/MotorClusterState.java
+++ b/core/src/net/sf/openrocket/simulation/MotorClusterState.java
@@ -162,6 +162,10 @@ public class MotorClusterState {
 		return ! isPlugged();
 	}
 
+	public boolean isDelaying() {
+		return currentState == ThrustState.DELAYING;
+	}
+
 	public boolean isSpent(){
 		return currentState == ThrustState.SPENT;
 	}

--- a/core/src/net/sf/openrocket/simulation/SimulationStatus.java
+++ b/core/src/net/sf/openrocket/simulation/SimulationStatus.java
@@ -229,7 +229,7 @@ public class SimulationStatus implements Monitorable {
 	public Collection<MotorClusterState> getActiveMotors() {
 		List<MotorClusterState> activeList = new ArrayList<MotorClusterState>();
 		for( MotorClusterState state: this.motorStateList ){
-			if (this.configuration.isComponentActive( state.getMount() {
+			if (this.configuration.isComponentActive( state.getMount())) {
 				activeList.add( state );
 			}
 		}

--- a/core/src/net/sf/openrocket/simulation/SimulationStatus.java
+++ b/core/src/net/sf/openrocket/simulation/SimulationStatus.java
@@ -229,7 +229,7 @@ public class SimulationStatus implements Monitorable {
 	public Collection<MotorClusterState> getActiveMotors() {
 		List<MotorClusterState> activeList = new ArrayList<MotorClusterState>();
 		for( MotorClusterState state: this.motorStateList ){
-			if(( ! state.isSpent()) && (this.configuration.isComponentActive( state.getMount()))){
+			if (this.configuration.isComponentActive( state.getMount() {
 				activeList.add( state );
 			}
 		}


### PR DESCRIPTION
Fixes #762 

Background:  a motor that has burned out can be in one of two states:  DELAYING (the delay charge has not yet fired) or SPENT (either the delay charge, if any, has fired or there was no delay charge).

The existing SimulationStatus:getActiveMotors() method returned a list of motors that were active for the stage, and which were not SPENT.  The test for the warning redundantly tested for a SPENT motor, still didn't test for a DELAYING motor, and consequently set the warning.

This PR
(1) adds a boolean MotorClusterStatus:isDelaying() method, analogous to the existing state test methods

(2) modifies SimulationStatus.java:getActiveMotors() to return all the motors, not just the ones that aren't SPENT.  This is to improve consistency with FlightConfiguration:getActiveMotors(), and to make for a more consistent usage between the two calls to the method.

(3) adds !isDelaying() to the test for the warning.