### PR TITLE
Rename user preference interface to include openrocket

### DIFF
--- a/snap/local/launcher
+++ b/snap/local/launcher
@@ -8,7 +8,7 @@ export XDG_CURRENT_DESKTOP=GNOME
 
 JAVA_OPTS="-Dsun.java2d.xrender=true -Dprism.useFontConfig=false -Dawt.useSystemAAFontSettings=on -Dswing.aatext=true -Dswing.defaultlaf=com.sun.java.swing.plaf.gtk.GTKLookAndFeel -Dswing.crossplatformlaf=com.sun.java.swing.plaf.gtk.GTKLookAndFeel -Djava.io.tmpdir=$SNAP_USER_COMMON"
 
-if ! snapctl is-connected dot-java-user-prefs; then
+if ! snapctl is-connected dot-java-user-prefs-openrocket; then
     JAVA_OPTS="$JAVA_OPTS -Djava.util.prefs.userRoot=$SNAP_USER_COMMON/"
 fi
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,7 +21,7 @@ grade: stable
 confinement: strict
 
 plugs:
-  dot-java-user-prefs:
+  dot-java-user-prefs-openrocket:
     interface: personal-files
     read:
       - $HOME/.java/.userPrefs/OpenRocket
@@ -44,7 +44,7 @@ apps:
       - network
       - cups-control
       - opengl
-      - dot-java-user-prefs
+      - dot-java-user-prefs-openrocket
       - dot-openrocket-db
     environment:
       JAVA_HOME: "$SNAP/usr/lib/jvm/java-11-openjdk-amd64"


### PR DESCRIPTION
Initial feedback from the Snapcraft store suggests to further refine
the dot-java-user-prefs interface name to include OpenRocket so its
clear to a user which files are being accessed. This changes the
interface name to accommodate that feedback.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>