### PR TITLE
Simplify plugs per snap store review feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ fabric.properties
 openrocket.log
 
 *.snap
+prime/*

--- a/snap/local/launcher
+++ b/snap/local/launcher
@@ -8,11 +8,33 @@ export XDG_CURRENT_DESKTOP=GNOME
 
 JAVA_OPTS="-Dsun.java2d.xrender=true -Dprism.useFontConfig=false -Dawt.useSystemAAFontSettings=on -Dswing.aatext=true -Dswing.defaultlaf=com.sun.java.swing.plaf.gtk.GTKLookAndFeel -Dswing.crossplatformlaf=com.sun.java.swing.plaf.gtk.GTKLookAndFeel -Djava.io.tmpdir=$SNAP_USER_COMMON"
 
-if ! snapctl is-connected dot-java-user-prefs-openrocket; then
-    JAVA_OPTS="$JAVA_OPTS -Djava.util.prefs.userRoot=$SNAP_USER_COMMON/"
+#
+# Determine if we need to migrate user preferences from a previous
+# installation or not. This will be determined if the dot-java-user-prefs
+# interface is connected (should be autoconnected via the installation)
+# and the user's $HOME/.java/.userPrefs/OpenRocket directory exists.
+# Note, $HOME is remapped within a snap so it is necessary to use
+# SNAP_REAL_HOME instead.
+#
+if snapctl is-connected dot-java-user-prefs-openrocket; then
+    SRC_PREFS=$SNAP_REAL_HOME/.java/.userPrefs/OpenRocket
+    TGT_PREFS=$SNAP_USER_COMMON/.java/.userPrefs/
+    if [[ -d $SRC_PREFS && ! -d "$TGT_PREFS" ]]; then
+        echo "Migrating user preferences from $SRC_PREFS to $TGT_PREFS"
+        mkdir -p $TGT_PREFS
+        cp -r "$SRC_PREFS" "$TGT_PREFS"
+    fi
 fi
 
-if ! snapctl is-connected dot-openrocket-db; then
+# Configure the preferences to use $SNAP_USER_COMMON
+# rather than the standard $HOME/.java/.userPrefs directory
+# For security reasons, the Snap store team will not grant
+# write access generically to the java user preferences storage
+# as it would allow the app to read any data stored in the java
+# user prefs dir. So we'll force it to use the snap.
+JAVA_OPTS="$JAVA_OPTS -Djava.util.prefs.userRoot=$SNAP_USER_COMMON/"
+
+if ! snapctl is-connected dot-openrocket; then
     JAVA_OPTS="$JAVA_OPTS -Duser.home=$SNAP_USER_COMMON/"
 fi
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: openrocket
 adopt-info: openrocket
-grade: stable
+grade: devel
 summary: A free, fully featured model rocket simulator.
 description: |
   OpenRocket is a free, fully featured model rocket simulator that allows you
@@ -16,8 +16,6 @@ description: |
     * Read more about it on the OpenRocket.info.
 license: GPL-3.0
 base: core18
-
-grade: stable
 confinement: strict
 
 plugs:
@@ -25,12 +23,8 @@ plugs:
     interface: personal-files
     read:
       - $HOME/.java/.userPrefs/OpenRocket
-    write:
-      - $HOME/.java/.userPrefs/OpenRocket
-  dot-openrocket-db:
+  dot-openrocket:
     interface: personal-files
-    read:
-      - $HOME/.openrocket
     write:
       - $HOME/.openrocket
 
@@ -45,7 +39,7 @@ apps:
       - cups-control
       - opengl
       - dot-java-user-prefs-openrocket
-      - dot-openrocket-db
+      - dot-openrocket
     environment:
       JAVA_HOME: "$SNAP/usr/lib/jvm/java-11-openjdk-amd64"
 


### PR DESCRIPTION
The snap store review team has approved auto-connecting the plugs
for OpenRocket to allow the application to access the .openrocket
and .java/.userPrefs/OpenRocket directories on Linux without being
prompted by the user.

This patch adjusts the snapcraft.yaml definition per the feedback at
https://forum.snapcraft.io/t/request-for-personal-files-for-openrocket/20579/5

Once this is updated, we can start automatically building and publishing
snap packages for the unstable branch to the snapstore.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>