### PR TITLE
Only draw carets in 3d when length > 0

### DIFF
--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -616,9 +616,6 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 			cgy = cg.y * Math.cos(rotation) + cg.z*Math.sin(rotation);
 		}
 
-		figure3d.setCG(cg);
-		figure3d.setCP(cp);
-
 		double length = curConfig.getLength();
 		
 		double diameter = Double.NaN;
@@ -640,6 +637,14 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		extraText.setMassWithoutMotors( emptyInfo.getMass() );
 		extraText.setWarnings(warnings);
 
+		if (length > 0) {
+			figure3d.setCG(cg);
+			figure3d.setCP(cp);
+		} else {
+			figure3d.setCG(new Coordinate(Double.NaN, Double.NaN));
+			figure3d.setCP(new Coordinate(Double.NaN, Double.NaN));
+		}
+		
 		if (figure.getType() == RocketPanel.VIEW_TYPE.SideView && length > 0) {
 			extraCP.setPosition(cpx, cpy);
 			extraCG.setPosition(cgx, cgy);


### PR DESCRIPTION
Only set the CG and CP for the 3D renderings when the length
is greater than 0. This makes the 3D rendering behavior consistent
with the 2D side view

Fixes #776

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>