### PR TITLE
Fix 761

### DIFF
--- a/core/src/net/sf/openrocket/database/motor/MotorDatabase.java
+++ b/core/src/net/sf/openrocket/database/motor/MotorDatabase.java
@@ -17,10 +17,7 @@ public interface MotorDatabase {
 	 * @param length		the length, or NaN.
 	 * @return				a list of all the matching motors.
 	 */
-	public List<? extends Motor> findMotors(Motor.Type type,
+	public List<? extends Motor> findMotors(String digest, Motor.Type type,
 			String manufacturer, String designation, double diameter,
 			double length);
-			
-	public Motor findMotor(String digest);
-	
 }

--- a/core/src/net/sf/openrocket/file/DatabaseMotorFinder.java
+++ b/core/src/net/sf/openrocket/file/DatabaseMotorFinder.java
@@ -3,6 +3,9 @@ package net.sf.openrocket.file;
 import java.util.Collections;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import net.sf.openrocket.aerodynamics.Warning;
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.motor.Motor;
@@ -16,6 +19,7 @@ import net.sf.openrocket.startup.Application;
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
 public class DatabaseMotorFinder implements MotorFinder {
+	private static final Logger log = LoggerFactory.getLogger(DatabaseMotorFinder.class);
 	
 	/**
 	 * Do something when a missing motor is found.
@@ -40,6 +44,8 @@ public class DatabaseMotorFinder implements MotorFinder {
 	
 	@Override
 	public Motor findMotor(Type type, String manufacturer, String designation, double diameter, double length, String digest, WarningSet warnings) {
+
+		log.debug("type " + type + ", manufacturer " + manufacturer + ", designation " + designation + ", diameter " +  diameter + ", length " + length + ", digest " +  digest + ", warnings " +  warnings);
 		
 		if (designation == null) {
 			warnings.add(Warning.fromString("No motor specified, ignoring."));
@@ -65,6 +71,9 @@ public class DatabaseMotorFinder implements MotorFinder {
 		// One motor
 		if (motors.size() == 1) {
 			Motor m = motors.get(0);
+			
+			log.debug("motor is " + m.getDesignation());
+
 			if (digest != null && !digest.equals(m.getDigest())) {
 				String str = "Motor with designation '" + designation + "'";
 				if (manufacturer != null)

--- a/core/src/net/sf/openrocket/file/DatabaseMotorFinder.java
+++ b/core/src/net/sf/openrocket/file/DatabaseMotorFinder.java
@@ -54,14 +54,7 @@ public class DatabaseMotorFinder implements MotorFinder {
 		
 		List<? extends Motor> motors;
 		
-		{
-			Motor m = Application.getMotorSetDatabase().findMotor(digest);
-			if (m != null) {
-				motors = Collections.<Motor> singletonList(m);
-			} else {
-				motors = Application.getMotorSetDatabase().findMotors(type, manufacturer, designation, diameter, length);
-			}
-		}
+		motors = Application.getMotorSetDatabase().findMotors(digest, type, manufacturer, designation, diameter, length);
 		
 		// No motors
 		if (motors.size() == 0) {


### PR DESCRIPTION
Issue #761 was caused by what amounted to a hash collision between the two motors' digests.  This PR combines the old findMotor() and findMotors() methods, allowing the use of any motor description elements provided as a key to resolve the collision.