### PR TITLE
Only validate freeform fin tab when fin length changes

### DIFF
--- a/core/src/net/sf/openrocket/file/openrocket/importt/FinTabPositionSetter.java
+++ b/core/src/net/sf/openrocket/file/openrocket/importt/FinTabPositionSetter.java
@@ -2,6 +2,9 @@ package net.sf.openrocket.file.openrocket.importt;
 
 import java.util.HashMap;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.rocketcomponent.FinSet;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
@@ -9,6 +12,7 @@ import net.sf.openrocket.rocketcomponent.position.*;
 import net.sf.openrocket.util.Reflection;
 
 class FinTabPositionSetter extends DoubleSetter {
+	private static final Logger log = LoggerFactory.getLogger(FinTabPositionSetter.class);
 	
 	public FinTabPositionSetter() {
 		super(Reflection.findMethod(FinSet.class, "setTabOffset", double.class));

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -6,6 +6,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.material.Material;
 
@@ -23,6 +27,7 @@ import net.sf.openrocket.util.MathUtil;
 import net.sf.openrocket.util.Transformation;
 
 public abstract class FinSet extends ExternalComponent implements AxialPositionable, BoxBounded, RingInstanceable {
+	private static final Logger log = LoggerFactory.getLogger(FinSet.class);
 	private static final Translator trans = Application.getTranslator();
 
 	/**

--- a/core/src/net/sf/openrocket/rocketcomponent/FreeformFinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FreeformFinSet.java
@@ -305,6 +305,7 @@ public class FreeformFinSet extends FinSet {
 
 	@Override
 	public void update() {
+		final double oldLength = this.length;
 		this.length = points.get(points.size() -1).x - points.get(0).x;
 		this.setAxialOffset(this.axialMethod, this.axialOffset);
 
@@ -317,7 +318,8 @@ public class FreeformFinSet extends FinSet {
 			
 			clampLastPoint();
 
-			validateFinTab();
+			if (oldLength != this.length)
+				validateFinTab();
 		}
 	}
 


### PR DESCRIPTION
This is a partial fix for #794 (Freeform fin set tab length is different when opened than when saved).  This turns out to be a new manifestation of #527 (fin tabs loaded incorrectly), which was fixed for trapezoidal and ellipsoidal finsets in #530.  There was quite a bit of discussion as to why this is the right approach in the comments on that PR.

In the case of freeform fins, changing the fin tab length (which happens as part of loading the file) causes a call to a general update() method, which validates the fin tab.  This PR modifies the call to update() so it only validates the tab when the length of the fin has changed, bringing it into line with the other finset types.

Submitting this PR now, as the symptoms in the reported issue appear to be an unrelated UI bug.
