### PR TITLE
Fix offset locations of mass components

### DIFF
--- a/swing/src/net/sf/openrocket/gui/rocketfigure/MassComponentShapes.java
+++ b/swing/src/net/sf/openrocket/gui/rocketfigure/MassComponentShapes.java
@@ -33,7 +33,7 @@ public class MassComponentShapes extends RocketComponentShape {
 														radialDistance * Math.sin(radialAngleRadians));
 		final Coordinate renderPosition = transformation.transform(localPosition);
 		
-		Shape[] s = {new RoundRectangle2D.Double(renderPosition.x - radius, renderPosition.y - radius, length, 2*radius, arc, arc)};
+		Shape[] s = {new RoundRectangle2D.Double(renderPosition.x, renderPosition.y - radius, length, 2*radius, arc, arc)};
 		
 		final MassComponent.MassComponentType type = ((MassComponent)component).getMassComponentType();
 		switch (type) {

--- a/swing/src/net/sf/openrocket/gui/rocketfigure/ParachuteShapes.java
+++ b/swing/src/net/sf/openrocket/gui/rocketfigure/ParachuteShapes.java
@@ -29,7 +29,7 @@ public class ParachuteShapes extends RocketComponentShape {
 														radialDistance * Math.sin(radialAngleRadians));
 		final Coordinate renderPosition = transformation.transform(localPosition);
 		
-		Shape[] s = {new RoundRectangle2D.Double(renderPosition.x - radius, renderPosition.y - radius, length, 2*radius, arc, arc)};
+		Shape[] s = {new RoundRectangle2D.Double(renderPosition.x, renderPosition.y - radius, length, 2*radius, arc, arc)};
 		
 		return RocketComponentShape.toArray( addSymbol(s), component);
 	}

--- a/swing/src/net/sf/openrocket/gui/rocketfigure/StreamerShapes.java
+++ b/swing/src/net/sf/openrocket/gui/rocketfigure/StreamerShapes.java
@@ -28,7 +28,7 @@ public class StreamerShapes extends RocketComponentShape {
 														radialDistance * Math.sin(radialAngleRadians));
 		final Coordinate renderPosition = transformation.transform(localPosition);
 		
-		Shape[] s = {new RoundRectangle2D.Double(renderPosition.x - radius, renderPosition.y - radius, length, 2*radius, arc, arc)};
+		Shape[] s = {new RoundRectangle2D.Double(renderPosition.x, renderPosition.y - radius, length, 2*radius, arc, arc)};
 		
 		return RocketComponentShape.toArray(addSymbol(s), component);
 	}


### PR DESCRIPTION
2D side view renderings of mass components within body tubes
were adjusted forward based off the radius of the object. This
change corrects the X position adjustement and makes it consistent
with 15.03 and 3D renderings.

Closes #785
Closes #828

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>