### PR TITLE
Update UI appropriately when FinSet::setTabOffsetMethod() is called

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/ComponentAssembly.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/ComponentAssembly.java
@@ -158,7 +158,7 @@ public abstract class ComponentAssembly extends RocketComponent implements Axial
 		}else{
 			throw new BugException("Unrecognized subclass of Component Assembly.  Please update this method.");
 		}
-		fireComponentChangeEvent(ComponentChangeEvent.AERODYNAMIC_CHANGE);
+		fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 	}
 	
 	@Override

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -317,6 +317,7 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 	public void setTabOffsetMethod(final AxialMethod newPositionMethod) {
 		this.tabOffsetMethod = newPositionMethod;
 		this.tabOffset = tabOffsetMethod.getAsOffset( tabPosition, tabLength, length);
+		fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 	}
 	
 	/**

--- a/core/src/net/sf/openrocket/rocketcomponent/InternalComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/InternalComponent.java
@@ -22,7 +22,7 @@ public abstract class InternalComponent extends RocketComponent implements Axial
 	@Override
 	public void setAxialMethod(final AxialMethod newAxialMethod) {
 		super.setAxialMethod(newAxialMethod);
-		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
+		fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 	}
 	
 

--- a/core/src/net/sf/openrocket/rocketcomponent/ParallelStage.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/ParallelStage.java
@@ -181,7 +181,7 @@ public class ParallelStage extends AxialStage implements FlightConfigurableCompo
 		
 		super.setAxialMethod(_newPosition);
 		
-		fireComponentChangeEvent(ComponentChangeEvent.AERODYNAMIC_CHANGE);
+		fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 	}
 	
 	@Override

--- a/core/src/net/sf/openrocket/rocketcomponent/PodSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/PodSet.java
@@ -119,7 +119,7 @@ public class PodSet extends ComponentAssembly implements RingInstanceable {
 	@Override
 	public void setAxialMethod( final AxialMethod newMethod ) {
 		super.setAxialMethod( newMethod );
-		fireComponentChangeEvent( ComponentChangeEvent.BOTH_CHANGE );
+		fireComponentChangeEvent( ComponentChangeEvent.NONFUNCTIONAL_CHANGE );
 	}
 	
 	@Override

--- a/core/src/net/sf/openrocket/rocketcomponent/RailButton.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RailButton.java
@@ -208,7 +208,7 @@ public class RailButton extends ExternalComponent implements AnglePositionable, 
 	@Override
 	public void setAxialMethod( AxialMethod position) {
 		super.setAxialMethod(position);
-		fireComponentChangeEvent(ComponentChangeEvent.AERODYNAMIC_CHANGE);
+		fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 	}
 	
 	public BoundingBox getInstanceBoundingBox(){

--- a/core/src/net/sf/openrocket/rocketcomponent/TubeFinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/TubeFinSet.java
@@ -225,7 +225,7 @@ public class TubeFinSet extends ExternalComponent implements AxialPositionable, 
 	@Override
 	public void setAxialMethod(AxialMethod position) {
 		super.setAxialMethod(position);
-		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
+		fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 	}
 	
 	@Override


### PR DESCRIPTION
Fixes #834.

Also, while tracking it down, I noticed there are several implementations of setAxialMethod() that call fireComponentChangeEvent() with parameter vales other than ComponentChangeEvent.NONFUNCTIONAL_CHANGE.  Since the method is documented as only changing external views of the component position, it's a NONFUNCTIONAL_CHANGE. Calling it with some other value can cause unnecessary computation.