### PR TITLE
Allow automatic calculation of fin tabs on transitions

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -333,7 +333,7 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 	/**
 	 * Return the tab trailing edge position *from the front of the fin*.
 	 */
-	private double getTabTrailingEdge() {
+	public double getTabTrailingEdge() {
 		return tabPosition + tabLength;
 	}
 	

--- a/swing/src/net/sf/openrocket/gui/configdialog/FinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/FinSetConfig.java
@@ -228,31 +228,29 @@ public abstract class FinSetConfig extends RocketComponentConfig {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				log.info(Markers.USER_MARKER, "Computing " + component.getComponentName() + " tab height.");
-				
+
+				double inRad = 0.0;
 				RocketComponent parent = component.getParent();
 				if (parent instanceof Coaxial) {
 					try {
 						document.startUndo("Compute fin tabs");
 						
 						List<CenteringRing> rings = new ArrayList<>();
-                        //Do deep recursive iteration
+                        // Do deep recursive iteration to find centering rings and determine
+						// radius of inner tube
                         Iterator<RocketComponent> iter = parent.iterator(false);
                         while (iter.hasNext()) {
                             RocketComponent rocketComponent =  iter.next();
 							if (rocketComponent instanceof InnerTube) {
 								InnerTube it = (InnerTube) rocketComponent;
 								if (it.isMotorMount()) {
-									double depth = ((Coaxial) parent).getOuterRadius() - it.getOuterRadius();
-									//Set fin tab depth
-									if (depth >= 0.0d) {
-										tabHeightModel.setValue(depth);
-										tabHeightModel.setCurrentUnit(UnitGroup.UNITS_LENGTH.getDefaultUnit());
-									}
+									inRad = it.getOuterRadius();
 								}
 							} else if (rocketComponent instanceof CenteringRing) {
 								rings.add((CenteringRing) rocketComponent);
 							}
 						}
+						
 						//Figure out position and length of the fin tab
 						if (!rings.isEmpty()) {
 						    AxialMethod temp = (AxialMethod) em.getSelectedItem();
@@ -263,7 +261,14 @@ public abstract class FinSetConfig extends RocketComponentConfig {
 							//Be nice to the user and set the tab relative position enum back the way they had it.
 							em.setSelectedItem(temp);
 						}
-						
+
+						// compute tab height
+						double height = ((Coaxial) parent).getOuterRadius() - inRad;
+						//Set fin tab height
+						if (height >= 0.0d) {
+							tabHeightModel.setValue(height);
+							tabHeightModel.setCurrentUnit(UnitGroup.UNITS_LENGTH.getDefaultUnit());
+						}
 					} finally {
 						document.stopUndo();
 					}

--- a/swing/src/net/sf/openrocket/gui/configdialog/FinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/FinSetConfig.java
@@ -35,9 +35,12 @@ import net.sf.openrocket.rocketcomponent.FinSet;
 import net.sf.openrocket.rocketcomponent.FreeformFinSet;
 import net.sf.openrocket.rocketcomponent.InnerTube;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
+import net.sf.openrocket.rocketcomponent.SymmetricComponent;
+import net.sf.openrocket.rocketcomponent.Transition;
 import net.sf.openrocket.rocketcomponent.position.AxialMethod;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
+import net.sf.openrocket.util.MathUtil;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -231,7 +234,7 @@ public abstract class FinSetConfig extends RocketComponentConfig {
 
 				double inRad = 0.0;
 				RocketComponent parent = component.getParent();
-				if (parent instanceof Coaxial) {
+				if (parent instanceof SymmetricComponent){
 					try {
 						document.startUndo("Compute fin tabs");
 						
@@ -263,7 +266,9 @@ public abstract class FinSetConfig extends RocketComponentConfig {
 						}
 
 						// compute tab height
-						double height = ((Coaxial) parent).getOuterRadius() - inRad;
+						double height = MathUtil.min(((SymmetricComponent)parent).getRadius(((FinSet) component).getTabFrontEdge()),
+													 ((SymmetricComponent)parent).getRadius(((FinSet) component).getTabTrailingEdge())) - inRad;
+						// double height = ((Coaxial) parent).getOuterRadius() - inRad;
 						//Set fin tab height
 						if (height >= 0.0d) {
 							tabHeightModel.setValue(height);


### PR DESCRIPTION
Fixes #833 

Two commits: first restructures the fintab calculation a bit without changing anything, second changes calculation assuming Coaxial to more general calculation with SymmetricComponent.