### PR TITLE
Avoid trying to cast an array type

### DIFF
--- a/core/src/net/sf/openrocket/database/ComponentPresetDatabase.java
+++ b/core/src/net/sf/openrocket/database/ComponentPresetDatabase.java
@@ -99,7 +99,7 @@ public class ComponentPresetDatabase extends Database<ComponentPreset> implement
 
 	@Override
 	public List<ComponentPreset> listForTypes( List<ComponentPreset.Type> types ) {
-		return listForTypes( (ComponentPreset.Type[]) types.toArray() );
+		return listForTypes( types.toArray(new ComponentPreset.Type[0]) );
 	}
 
 	@Override


### PR DESCRIPTION
ComponentPresetDatabase:listForTypes() tried to cast an array, which  failed at runtime.  Create the array with the right type in the first place.

Fixes #650.