### PR TITLE
Fix rocket scaling in 3D views

### DIFF
--- a/swing/src/net/sf/openrocket/gui/figure3d/RocketFigure3d.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/RocketFigure3d.java
@@ -496,7 +496,7 @@ public class RocketFigure3d extends JPanel implements GLEventListener {
 		// Add 10% for space around it.
 		final double dX = (b.span().x * 1.2 / 2.0)
 				/ Math.tan(Math.toRadians(fovX / 2.0));
-		final double dY = (b.span().y * 2.0 * 1.2 / 2.0)
+		final double dY = (b.span().y * 1.2 / 2.0)
 				/ Math.tan(Math.toRadians(fovY / 2.0));
 		
 		// Move back the greater of the 2 distances


### PR DESCRIPTION
When setting up the view for 3D figures, the Y span is doubled
incorrectly. This appears to be legacy behavior and the BoundingBox
itself accounts for the full span. Removing the 2x scaling resolves the
rocket scaling appropriately.

Fixes #788

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>