### PR TITLE
Restore default fin count to 3 for TrapezoidFinSet

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/TrapezoidFinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/TrapezoidFinSet.java
@@ -39,7 +39,7 @@ public class TrapezoidFinSet extends FinSet {
 	
 	
 	public TrapezoidFinSet() {
-		this(1, 0.05, 0.05, 0.025, 0.03);
+		this(3, 0.05, 0.05, 0.025, 0.03);
 	}
 	
 	// TODO: HIGH:  height=0 -> CP = NaN

--- a/core/test/net/sf/openrocket/rocketcomponent/FinSetTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/FinSetTest.java
@@ -17,6 +17,12 @@ public class FinSetTest extends BaseTestCase {
 	public void testMultiplicity() {
 		final EllipticalFinSet fins = new EllipticalFinSet();
 		assertEquals(3, fins.getFinCount());
+		
+		final FreeformFinSet freeFins = new FreeformFinSet();
+		assertEquals(3, freeFins.getFinCount());
+		
+		final TrapezoidFinSet trapFins = new TrapezoidFinSet();
+		assertEquals(3, trapFins.getFinCount());
 	}
 
     /**


### PR DESCRIPTION
TrapezoidFinSet fin count was reduced to 1 in previous commits in order
to fix a bug. The actual problem was that the instancecount was not
persisted in the ork file. This change restores the default to 3.

Fixes #850

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>