### PR TITLE
Fix TrapezoidFinSetTest

### DIFF
--- a/core/test/net/sf/openrocket/rocketcomponent/TrapezoidFinSetTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/TrapezoidFinSetTest.java
@@ -55,7 +55,7 @@ public class TrapezoidFinSetTest extends BaseTestCase {
 	@Test
 	public void testMultiplicity() {
 		final TrapezoidFinSet trapFins = new TrapezoidFinSet();
-		assertEquals(1, trapFins.getFinCount());
+		assertEquals(3, trapFins.getFinCount());
 	}
 
 	@Test


### PR DESCRIPTION
Commit 312e90 updated finset count and tests for FinSets but not
the TrapezoidFinSetTest.testMultiplicity()

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>