### PR TITLE
Set the glViewport size on reshape

### DIFF
--- a/swing/src/net/sf/openrocket/gui/figure3d/RocketFigure3d.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/RocketFigure3d.java
@@ -459,6 +459,8 @@ public class RocketFigure3d extends JPanel implements GLEventListener {
 		final double ratio = (double) w / (double) h;
 		fovX = fovY * ratio;
 		
+		// Make sure to set the viewport size to cover the full size
+		gl.glViewport(0, 0, w, h);
 		gl.glMatrixMode(GLMatrixFunc.GL_PROJECTION);
 		gl.glLoadIdentity();
 		glu.gluPerspective(fovY, ratio, 0.1f, 50f);


### PR DESCRIPTION
Explicitly set the glViewport size on reshape in order to ensure it is
rendered at the full scale of the viewport. Not doing so causes the
display to render very small.

Fixes #790

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>