### PR TITLE
Fix scaling on high dpi monitors

### DIFF
--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -264,6 +264,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		rotationSlider.setEnabled(true);
 		scaleSelector.setEnabled(true);
 		scrollPane.revalidate();
+		scrollPane.repaint();
 		revalidate();
 		figureHolder.revalidate();
 		figure.repaint();


### PR DESCRIPTION
GLJPanel handles display scaling better than the GLCanvas does natively.
Change to use the GLJPanel always when rendering in 3D mode. FBO
(offscreen rendering) will be set on the GLJPanel via the
GLCapabilities.

Also, ensure when creating a Graphics2D object from a GLOverlay to set
the current transform to the default transform for the component. The
default transform of the swing components will take into account the
scaling of the screen that it is rendered on. By setting the transform
of the overlay, we can be sure that it gets the scaling information as
well.

Fixes #854

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>