### PR TITLE
[fixes #868] Fin tabs correctly adjust their location when the fin tab _length_ is changed.

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/EllipticalFinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/EllipticalFinSet.java
@@ -71,7 +71,7 @@ public class EllipticalFinSet extends FinSet {
 		if (MathUtil.equals(this.length, length))
 			return;
 		this.length = length;
-		validateFinTab();
+		validateFinTabLength();
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 	

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -274,7 +274,7 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 		}
 		
 		tabHeight = newTabHeight;
-
+		validateFinTabHeight();
 		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
 	}
 	
@@ -293,7 +293,13 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 		
 		tabLength = lengthRequest;
 		
+		setTabPosition();
+		
 		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
+	}
+	
+	protected void setTabPosition(){
+		this.tabPosition = this.tabOffsetMethod.getAsPosition(tabOffset, tabLength, length);
 	}
 	
 	/** 
@@ -303,7 +309,7 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 	 */
 	public void setTabOffset( final double offsetRequest) {
 		tabOffset = offsetRequest;
-		tabPosition = tabOffsetMethod.getAsPosition( tabOffset, tabLength, length);
+		setTabPosition();
 		
 		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
 	}
@@ -318,7 +324,8 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
      */
 	public void setTabOffsetMethod(final AxialMethod newPositionMethod) {
 		this.tabOffsetMethod = newPositionMethod;
-		this.tabOffset = tabOffsetMethod.getAsOffset( tabPosition, tabLength, length);
+		this.tabOffset = this.tabOffsetMethod.getAsOffset(tabPosition, tabLength, length);
+		
 		fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 	}
 	
@@ -340,25 +347,32 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 		return tabPosition + tabLength;
 	}
 	
-	public void validateFinTab(){
-		this.tabPosition = this.tabOffsetMethod.getAsPosition(tabOffset, tabLength, length);
-
+	public void validateFinTabPosition() {
 		//check front bounds:
-		if( tabPosition < 0){
+		if (tabPosition < 0) {
 			this.tabPosition = 0;
 		}
 
 		//check tail bounds:
-		if (this.length < tabPosition ) {
+		if (this.length < tabPosition) {
 			this.tabPosition = length;
 		}
+	}
+	
+	public void validateFinTabLength() {
+		//System.err.println(String.format("    >> Fin Tab Length: %.6f @ %.6f", tabLength, tabOffset));
+		
 		final double xTabBack = getTabTrailingEdge();
-		if( this.length < xTabBack ){
+		if (this.length < xTabBack) {
 			this.tabLength -= (xTabBack - this.length);
 		}
-
+		
 		tabLength = Math.max(0, tabLength);
-
+		
+		//System.err.println(String.format("    << Fin Tab Length: %.6f @ %.6f", tabLength, tabOffset));
+	}
+	
+	public void validateFinTabHeight(){
 		// check tab height 
 		if( null != getParent() ){
 			// pulls the parent-body radius at the fin-tab reference point.
@@ -792,7 +806,6 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 			this.centerOfMass = Coordinate.NaN;
 			this.totalVolume = Double.NaN;
 			this.cantRotation = null;
-			validateFinTab();
 		}
 		
 		super.componentChanged(e);

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -792,7 +792,9 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 			this.centerOfMass = Coordinate.NaN;
 			this.totalVolume = Double.NaN;
 			this.cantRotation = null;
+			validateFinTab();
 		}
+		
 		super.componentChanged(e);
 	}
 	

--- a/core/src/net/sf/openrocket/rocketcomponent/FreeformFinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FreeformFinSet.java
@@ -319,7 +319,7 @@ public class FreeformFinSet extends FinSet {
 			clampLastPoint();
 
 			if (oldLength != this.length)
-				validateFinTab();
+				validateFinTabLength();
 		}
 	}
 

--- a/core/src/net/sf/openrocket/rocketcomponent/TrapezoidFinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/TrapezoidFinSet.java
@@ -77,8 +77,9 @@ public class TrapezoidFinSet extends FinSet {
 		if (length == r)
 			return;
 		length = Math.max(r, 0);
-		validateFinTab();
-		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
+		setTabPosition();
+		
+		fireComponentChangeEvent(ComponentChangeEvent.AEROMASS_CHANGE);
 	}
 	
 	public double getTipChord() {

--- a/core/test/net/sf/openrocket/rocketcomponent/FinSetTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/FinSetTest.java
@@ -3,6 +3,7 @@ package net.sf.openrocket.rocketcomponent;
 import static org.junit.Assert.assertEquals;
 
 import net.sf.openrocket.material.Material;
+import net.sf.openrocket.util.TestRockets;
 import org.junit.Test;
 
 import net.sf.openrocket.rocketcomponent.position.*;
@@ -98,32 +99,64 @@ public class FinSetTest extends BaseTestCase {
 	}
 
     @Test
-    public void testTabGetAs(){
+    public void testTabGetAs() {
 		final FinSet fins = FinSetTest.createSimpleFin();
 		assertEquals("incorrect fin length:", 0.06, fins.getLength(), EPSILON);
 		assertEquals("incorrect fin tab length:", 0.02, fins.getTabLength(), EPSILON);
-
-		// TOP -> native(TOP)
-		fins.setTabOffsetMethod(AxialMethod.TOP);
-		fins.setTabOffset(0.0);
-
-		assertEquals("Setting by TOP method failed!", 0.0, fins.getTabFrontEdge(), EPSILON);
-		assertEquals("Setting by TOP method failed!", 0.0, fins.getTabOffset(), EPSILON);
-
-		// MIDDLE -> native
-		fins.setTabOffsetMethod(AxialMethod.MIDDLE);
-		fins.setTabOffset(0.0);
-		assertEquals("Setting by TOP method failed!", 0.02, fins.getTabFrontEdge(), EPSILON);
-		assertEquals("Setting by TOP method failed!", 0.0, fins.getTabOffset(), EPSILON);
-
-		// BOTTOM -> native
-		fins.setTabOffsetMethod(AxialMethod.BOTTOM);
-		fins.setTabOffset(0.0);
-
-		assertEquals("Setting by TOP method failed!", 0.04, fins.getTabFrontEdge(), EPSILON);
-		assertEquals("Setting by TOP method failed!", 0.0, fins.getTabOffset(), EPSILON);
+	
+		{   // TOP -> native(TOP)
+			fins.setTabOffsetMethod(AxialMethod.TOP);
+			fins.setTabOffset(0.0);
+		
+			assertEquals("Setting by TOP method failed!", 0.0, fins.getTabFrontEdge(), EPSILON);
+			assertEquals("Setting by TOP method failed!", 0.0, fins.getTabOffset(), EPSILON);
+			assertEquals("Setting by TOP method failed!", 0.02, fins.getTabLength(), EPSILON);
+		}
+		{   // MIDDLE -> native
+			fins.setTabOffsetMethod(AxialMethod.MIDDLE);
+			fins.setTabOffset(0.0);
+			assertEquals("Setting by MIDDLE method failed!", 0.02, fins.getTabFrontEdge(), EPSILON);
+			assertEquals("Setting by MIDDLE method failed!", 0.0, fins.getTabOffset(), EPSILON);
+			assertEquals("Setting by MIDDLE method failed!", 0.02, fins.getTabLength(), EPSILON);
+		}
+		{// BOTTOM -> native
+			fins.setTabOffsetMethod(AxialMethod.BOTTOM);
+			fins.setTabOffset(0.0);
+			
+			assertEquals("Setting by BOTTOM method failed!", 0.04, fins.getTabFrontEdge(), EPSILON);
+			assertEquals("Setting by BOTTOM method failed!", 0.0, fins.getTabOffset(), EPSILON);
+			assertEquals("Setting by BOTTOM method failed!", 0.02, fins.getTabLength(), EPSILON);
+		}
 	}
+	
+	
+	@Test
+	public void testTabSetLength() {
+		final Rocket rocket = TestRockets.makeEstesAlphaIII();
 
+		final BodyTube body = (BodyTube)rocket.getChild(0).getChild(1);
+		assertEquals("incorrect body tube length:", 0.20, body.getLength(), EPSILON);
+
+		final FinSet fins = (FinSet)body.getChild(0);
+		fins.setTabHeight(0.01);
+		fins.setTabLength(0.02);
+		assertEquals("incorrect fin length:", 0.05, fins.getLength(), EPSILON);
+		assertEquals("incorrect fin tab height:", 0.01, fins.getTabHeight(), EPSILON);
+		assertEquals("incorrect fin tab length:", 0.02, fins.getTabLength(), EPSILON);
+		assertEquals("incorrect fin location", 0.015, fins.getTabFrontEdge(), EPSILON);
+		
+		{   // MIDDLE -> native
+			fins.setTabOffsetMethod(AxialMethod.MIDDLE);
+			fins.setTabOffset(0.0);
+			fins.setTabHeight(0.02);
+			fins.setTabLength(0.04);
+			
+			assertEquals("Setting by MIDDLE method failed!", 0.005, fins.getTabFrontEdge(), EPSILON);
+			assertEquals("Setting by MIDDLE method failed!", 0.0, fins.getTabOffset(), EPSILON);
+			assertEquals("Setting by MIDDLE method failed!", 0.04, fins.getTabLength(), EPSILON);
+		}
+	}
+	
 	@Test
 	public void testTabLocationUpdate() {
 		final FinSet fins = FinSetTest.createSimpleFin();

--- a/core/test/net/sf/openrocket/rocketcomponent/FinSetTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/FinSetTest.java
@@ -93,7 +93,7 @@ public class FinSetTest extends BaseTestCase {
 			fins.setTabOffsetMethod( methods[caseIndex]);
 
 			//query
-			double actShift = fins.getTabOffset();
+			final double actShift = fins.getTabOffset();
 			assertEquals(String.format("Offset doesn't match for: %s \n", methods[caseIndex].name()), expShift[caseIndex], actShift, EPSILON);
 		}
 	}
@@ -148,7 +148,11 @@ public class FinSetTest extends BaseTestCase {
 		{   // MIDDLE -> native
 			fins.setTabOffsetMethod(AxialMethod.MIDDLE);
 			fins.setTabOffset(0.0);
-			fins.setTabHeight(0.02);
+			
+			assertEquals("Setting by MIDDLE method failed!", 0.015, fins.getTabFrontEdge(), EPSILON);
+			assertEquals("Setting by MIDDLE method failed!", 0.0, fins.getTabOffset(), EPSILON);
+			assertEquals("Setting by MIDDLE method failed!", 0.02, fins.getTabLength(), EPSILON);
+			
 			fins.setTabLength(0.04);
 			
 			assertEquals("Setting by MIDDLE method failed!", 0.005, fins.getTabFrontEdge(), EPSILON);
@@ -171,9 +175,9 @@ public class FinSetTest extends BaseTestCase {
 		assertEquals("Setting by TOP method failed!", 0.02, fins.getTabFrontEdge(), EPSILON);
 
 		((TrapezoidFinSet)fins).setRootChord(0.08);
-
-		assertEquals("Front edge doesn't match after adjusting root chord...", 0.03, fins.getTabFrontEdge(), EPSILON);
+		
 		assertEquals("Offset doesn't match after adjusting root chord....", 0.0, fins.getTabOffset(), EPSILON);
+		assertEquals("Front edge doesn't match after adjusting root chord...", 0.03, fins.getTabFrontEdge(), EPSILON);
 	}
 
 	@Test


### PR DESCRIPTION
This fix addresses Issue #868, and may help with #865.

Basically, the update function in fin set wasn't checking the fin-tab properties, so I inserted a call to `validateFinTab()`.   It appears to work, now, according to the description / images in #868.    Thanks to @hcraigmiller for the high-quality bug report 👍 

@JoePfeiffer I got you fam.