### PR TITLE
Force a .rkt extension rather than .ork on export

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -1369,7 +1369,7 @@ public class BasicFrame extends JFrame {
 
 		((SwingPreferences) Application.getPreferences()).setDefaultDirectory(chooser.getCurrentDirectory());
 
-		file = FileHelper.forceExtension(file, "ork");
+		file = FileHelper.forceExtension(file, "rkt");
 		if (FileHelper.confirmWrite(file, this) ) {
 			return saveAsRocksim(file);
 		}


### PR DESCRIPTION
Exporting the rocket to a rocksim format should use the extension .rkt
rather than .ork. However, refactoring the code between save as and
export in commit 4924773 in correctly used the .ork extension in the
exportAsAction.

Fixes #872

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>