### PR TITLE
save RK4SimulationStepper simulation step data after step, not before it

### DIFF
--- a/core/src/net/sf/openrocket/simulation/RK4SimulationStepper.java
+++ b/core/src/net/sf/openrocket/simulation/RK4SimulationStepper.java
@@ -204,10 +204,6 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 			}
 		}
 		
-		// Store data
-		// TODO: MEDIUM: Store acceleration etc of entire RK4 step, store should be cloned or something...
-		storeData(status, store);
-		
 
 		//// Second position, k2 = f(t + h/2, y + k1*h/2)
 		
@@ -269,6 +265,10 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 		status.setSimulationTime(status.getSimulationTime() + store.timestep);
 		
 		status.setPreviousTimeStep(store.timestep);
+		
+		// Store data
+		// TODO: MEDIUM: Store acceleration etc of entire RK4 step, store should be cloned or something...
+		storeData(status, store);
 		
 		// Verify that values don't run out of range
 		if (status.getRocketVelocity().length2() > 1e18 ||


### PR DESCRIPTION
This fixes Issue #890.

Note that it trades losing the last simulation data point with losing the first.  However, the data for all points prior to liftoff is pretty much nonsense anyway: until the motor thrust exceeds the force of gravity, the rocket sinks into the ground in the RK4SimulationStepper, and then its location is patched in BasicEventSimulationEngine.  This actually doesn't end up affecting the simulation in any observable way, so it isn't a real problem.