### PR TITLE
Invalidate MotorInformationPanel when updating (fixes #885)

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/MotorInformationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/MotorInformationPanel.java
@@ -273,7 +273,7 @@ class MotorInformationPanel extends JPanel {
 				selectedMotor.getBurnoutMass()));
 		caseInfoLabel.setText(selectedMotor.getCaseInfo());
 		propInfoLabel.setText(selectedMotor.getPropellantInfo());
-		compatibleCasesLabel.setText( StringUtils.join(",",selectedMotor.getCompatibleCases()));
+		compatibleCasesLabel.setText("<html>" + StringUtils.join(", ",selectedMotor.getCompatibleCases()) + "<html>");
 		dataPointsLabel.setText("" + (selectedMotor.getTimePoints().length - 1));
 
 		if (digestLabel != null) {
@@ -308,6 +308,7 @@ class MotorInformationPanel extends JPanel {
 
 		plot.setDataset(dataset);
 
+		invalidate();
 	}
 	
 	private void setComment(String s) {


### PR DESCRIPTION
Calls invalidate() as the last action inside MotorInformationPanel.updateData(), forcing a redraw of the panel.  This makes sure the panel is large enough to display all of its contents

Also, clean up display of the compatible cases a little bit by adding a space between cases, and wrapping in <html></html> tags to allow line breaks.