### PR TITLE
Fix #881, #907 issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ openrocket.log
 
 *.snap
 prime/*
+swing/resources/datafiles/presets/system.ser

--- a/core/src/net/sf/openrocket/rocketcomponent/position/AxialMethod.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/position/AxialMethod.java
@@ -3,7 +3,7 @@ package net.sf.openrocket.rocketcomponent.position;
 import net.sf.openrocket.startup.Application;
 
 public enum AxialMethod implements DistanceMethod {
-	// subject component is simply located absolutely, from the origin (tip-of-rocket) 
+	// subject component is simply located absolutely, from the origin (tip-of-rocket)
 	ABSOLUTE (Application.getTranslator().get("RocketComponent.Position.Method.Axial.ABSOLUTE")){
 		@Override
 		public boolean clampToZero() { return false; }
@@ -18,8 +18,8 @@ public enum AxialMethod implements DistanceMethod {
 			return position;
 		}
 	},
-		
-	// subject component will trail the target component, in the increasing coordinate direction 
+
+	// subject component will trail the target component, in the increasing coordinate direction
 	AFTER (Application.getTranslator().get("RocketComponent.Position.Method.Axial.AFTER")){
 		@Override
 		public boolean clampToZero() { return false; }
@@ -51,7 +51,7 @@ public enum AxialMethod implements DistanceMethod {
 			return position;
 		}
 	},
-	
+
 	// This coordinate is measured from the middle of the parent component to the middle of this component
 	MIDDLE (Application.getTranslator().get("RocketComponent.Position.Method.Axial.MIDDLE")) {
 		@Override
@@ -70,7 +70,7 @@ public enum AxialMethod implements DistanceMethod {
 			return position + (innerLength - outerLength) / 2;
 		}
 	},
-	
+
 	// This coordinate is measured from the bottom of the parent component to the bottom of this component
 	BOTTOM (Application.getTranslator().get("RocketComponent.Position.Method.Axial.BOTTOM")){
 		@Override
@@ -94,15 +94,15 @@ public enum AxialMethod implements DistanceMethod {
 
 	// just as a reminder:
 	// public T[] getEnumConstants()
-	
-	public static final AxialMethod[] axialOffsetMethods = { TOP, MIDDLE, BOTTOM };
-	
+
+	public static final AxialMethod[] axialOffsetMethods = { ABSOLUTE, TOP, MIDDLE, BOTTOM };
+
 	public final String description;
-	
+
 	AxialMethod( final String newDescription ) {
 		this.description=newDescription;
 	}
-	
+
 	public abstract boolean clampToZero();
 
 	public abstract double getAsOffset(double position, double innerLength, double outerLength);
@@ -113,5 +113,5 @@ public enum AxialMethod implements DistanceMethod {
 	public String toString() {
 		return description;
 	}
-	
+
 }


### PR DESCRIPTION
I apologize for the (again) whitespace changes... I can't seem to figure out how to make VSCode not change them. I've tried several user setting overrides, but it keeps changing correcting the whitespace even when I think I'm telling it not to.

I believe this fixes #881. I thought about (_and tried_) changing the `RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH` constant with a negative sign, but I soon realized that only the relative position field was bungled, and changing this constant screwed up other parts of the import. I tested it on my own RockSim model, the [OEM-provided PublicMissiles Spitfire kit file.](https://publicmissiles.com/images/spitfire.zip) The issue wasn't present for me in the official 15.03 `.jar` app, but I did replicate the issue easily with the current unstable branch.

As Craig pointed out, the fins were positioned wrong on import:
![image](https://user-images.githubusercontent.com/3847882/118069317-d2333f80-b358-11eb-86e5-3874681e79be.png)

But this patch corrects it for me:
![image](https://user-images.githubusercontent.com/3847882/118068816-de6acd00-b357-11eb-8084-22e4c1fa4f84.png)

**EDIT:**
This PR now also fixes #907 by re-adding the ABSOLUTE axial offset enum type to the AxialMethod[] axialOffsetMethods array that every component config references.

As far as I can tell, all of the functionality was still built into the code. The option appears to have been removed by just taking away the reference to the enum type option.