### PR TITLE
Fix FinSetTest.testTabLocation

### DIFF
--- a/core/test/net/sf/openrocket/rocketcomponent/FinSetTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/FinSetTest.java
@@ -83,7 +83,7 @@ public class FinSetTest extends BaseTestCase {
 
 		final double expFront = 0.02;
 		final AxialMethod[] methods = AxialMethod.axialOffsetMethods;
-		final double[] expShift = {0.02, 0.0, -0.02};
+		final double[] expShift = {0.02, 0.02, 0.0, -0.02};
 		for( int caseIndex=0; caseIndex < methods.length; ++caseIndex ){
 			double actFront = fins.getTabFrontEdge();
 			assertEquals(" Front edge doesn't match!", expFront, actFront, EPSILON);


### PR DESCRIPTION
Commit 936333a2 re-introduced the AxialMethod.ABSOLUTE as an offset
method but did not update the corresponding unit test. Add in the
expected offset value for AxialMethod.ABSOLUTE.

Fixes #931

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>