### PR TITLE
Don't switch to use GLJPanel always

### DIFF
--- a/swing/src/net/sf/openrocket/gui/figure3d/RocketFigure3d.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/RocketFigure3d.java
@@ -158,14 +158,12 @@ public class RocketFigure3d extends JPanel implements GLEventListener {
 			}
 			
 			if (Application.getPreferences().getBoolean(Preferences.OPENGL_USE_FBO, false)) {
-				log.trace("GL - enabling FBO");
-				caps.setFBO(true);
+				log.trace("GL - Creating GLJPanel");
+				canvas = new GLJPanel(caps);
 			} else {
-				log.trace("GL - disabling FBO");
-				caps.setFBO(false);
+				log.trace("GL - Creating GLCanvas");
+				canvas = new GLCanvas(caps);
 			}
-			log.trace("GL - Creating GLJPanel");
-			canvas = new GLJPanel(caps);
 			
 			log.trace("GL - Registering as GLEventListener on canvas");
 			((GLAutoDrawable) canvas).addGLEventListener(this);


### PR DESCRIPTION
Relying primarily on the FBO option for capabilities passed to the
GLJPanel interferes with the part picking algorithm. Revert that
piece of the fix.

Fixes #937

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>