### PR TITLE
Restore 15.03 selection behavior for flight config

### DIFF
--- a/swing/src/net/sf/openrocket/gui/components/ConfigurationComboBox.java
+++ b/swing/src/net/sf/openrocket/gui/components/ConfigurationComboBox.java
@@ -1,14 +1,17 @@
 package net.sf.openrocket.gui.components;
 
+import java.util.EventObject;
+
 import javax.swing.JComboBox;
 import javax.swing.MutableComboBoxModel;
-import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.ListDataListener;
+import javax.swing.event.PopupMenuEvent;
 import javax.swing.event.PopupMenuListener;
 
-import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.rocketcomponent.FlightConfiguration;
 import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
+import net.sf.openrocket.rocketcomponent.Rocket;
+import net.sf.openrocket.util.StateChangeListener;
 
 // combobox for flight configurations
 // this is insane -- it appears the only way to reconstruct a
@@ -17,7 +20,7 @@ import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
 // to the combobox or to its model) is to reconstruct the model.  This
 // is done quickly enough I might as well just do it every time the
 // combobox is opened, rather than trying to watch and see if it's needed.
-public class ConfigurationComboBox extends JComboBox<FlightConfiguration> {
+public class ConfigurationComboBox extends JComboBox<FlightConfiguration> implements StateChangeListener {
     public class ConfigurationModel implements MutableComboBoxModel<FlightConfiguration> {
 		
 		private final Rocket rkt;
@@ -77,20 +80,25 @@ public class ConfigurationComboBox extends JComboBox<FlightConfiguration> {
     private final Rocket rkt;
 
     public ConfigurationComboBox(Rocket _rkt) {
-	rkt = _rkt;
-	setModel(new ConfigurationModel(rkt));
-
-	addPopupMenuListener(new PopupMenuListener()
-	    {
-		public void popupMenuCanceled(PopupMenuEvent e) {}
-		public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {}
-		
-		public void popupMenuWillBecomeVisible(PopupMenuEvent e)
-		{
-		    setModel(new ConfigurationModel(rkt));		    
-		}
-		
-	    });
+		rkt = _rkt;
+		setModel(new ConfigurationModel(rkt));
+		rkt.addChangeListener(this);
 	
+		addPopupMenuListener(new PopupMenuListener() {
+			public void popupMenuCanceled(PopupMenuEvent e) {}
+			public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {}
+			
+			public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
+			    setModel(new ConfigurationModel(rkt));		    
+			}
+			
+		});
+	
+    }
+    
+    @Override
+    public void stateChanged(EventObject e) {
+    	this.repaint();
+    	this.revalidate();
     }
 }

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurationPanel.java
@@ -44,11 +44,6 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 	private final static int RECOVERY_TAB_INDEX = 1;
 	private final static int SEPARATION_TAB_INDEX = 2;
 
-	@Override
-	public void stateChanged(EventObject e) {
-		updateButtonState();
-	}
-
 	public FlightConfigurationPanel(OpenRocketDocument doc) {
 		super(new MigLayout("fill","[grow][][][][][grow]"));
 		
@@ -77,7 +72,12 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 		newConfButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
+				
 				addOrCopyConfiguration(false);
+				int lastRow = motorConfigurationPanel.table.getRowCount() - 1;
+				int lastCol = motorConfigurationPanel.table.getColumnCount() - 1;
+				motorConfigurationPanel.table.setRowSelectionInterval(lastRow, lastRow);
+				motorConfigurationPanel.table.setColumnSelectionInterval(lastCol, lastCol);
 				configurationChanged();
 			}
 			
@@ -146,7 +146,7 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 			newConfig = new FlightConfiguration(rocket, null);
 			newId = newConfig.getId();
 		}
-
+		
 		// associate configuration with Id and select it
 		rocket.setFlightConfiguration(newId, newConfig);
 		rocket.setSelectedConfiguration(newId);
@@ -216,4 +216,11 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 
 	}
 	
+	@Override
+	public void stateChanged(EventObject e) {
+		updateButtonState();
+		motorConfigurationPanel.synchronizeConfigurationSelection();
+		recoveryConfigurationPanel.synchronizeConfigurationSelection();
+		separationConfigurationPanel.synchronizeConfigurationSelection();
+	}
 }


### PR DESCRIPTION
Restore the behavior from the 15.03 version of the flight configuration
panel. Selected flight configuration is synchronized with the rocket
panel where the design is being done and vice versa.

Fixes #916

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>