### PR TITLE
Selection of deployment configuration for one motor on recovery tab opens the config menu for a different motor

### DIFF
--- a/.idea/ant.xml
+++ b/.idea/ant.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AntConfiguration">
+    <buildFile url="file://$PROJECT_DIR$/build.xml" />
+  </component>
+</project>

--- a/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/DeploymentSelectionDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/DeploymentSelectionDialog.java
@@ -45,11 +45,16 @@ public class DeploymentSelectionDialog extends JDialog {
 	private final JSpinner altSpinner;
 	private final UnitSelector altUnit;
 	private final JSlider altSlider;
-	
-	public DeploymentSelectionDialog(Window parent, final Rocket rocket, final RecoveryDevice component) {
+
+	/**
+	 * Dialog for configuring the parachute deployment
+	 * @param parent: window from which the dialog window is called
+	 * @param rocket: current rocket
+	 * @param component: current recovery device
+	 * @param id: flight configuration id of the currently selected item in the recovery table
+	 */
+	public DeploymentSelectionDialog(Window parent, final Rocket rocket, final RecoveryDevice component, FlightConfigurationId id) {
 		super(parent, trans.get("edtmotorconfdlg.title.Selectdeploymentconf"), Dialog.ModalityType.APPLICATION_MODAL);
-		
-		final FlightConfigurationId id = rocket.getSelectedConfiguration().getFlightConfigurationID();
 		
 		newConfiguration = component.getDeploymentConfigurations().get(id).clone();
 		

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
@@ -67,18 +67,18 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 		FlightConfigurationId defaultFCID = rocket.getSelectedConfiguration().getFlightConfigurationID();
 		FlightConfigurationId selectedFCID = getSelectedConfigurationId();
 		
-		if ( selectedFCID == null ) {
-			// need to unselect
+		if (selectedFCID == null) {
+			// Need to unselect
 			table.clearSelection();
-		} else if ( !defaultFCID.equals(selectedFCID)){			
+		} else if (!defaultFCID.equals(selectedFCID)){
 			// Need to change selection
 			// We'll select the correct row, in the currently selected column.
 			int col = table.getSelectedColumn();
-			if ( col < 0 ) {
+			if (col < 0) {
 				col = (table.getColumnCount() > 1) ? 1 : 0;
 			}
 			
-			for( int rowNum = 0; rowNum < table.getRowCount(); rowNum++ ) {
+			for (int rowNum = 0; rowNum < table.getRowCount(); rowNum++) {
 				FlightConfigurationId rowFCID = rocket.getId(rowNum );
 				if ( rowFCID.equals(selectedFCID) ) {
 					table.changeSelection(rowNum, col, true, false);
@@ -88,12 +88,12 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 		}
 	}
 
-	protected void restoreSelection( int row, int col ) {
-		if ( row <= 0 || col <= 0 ) {
+	protected void restoreSelection(int row, int col) {
+		if (row <= 0 || col <= 0) {
 			synchronizeConfigurationSelection();
 			return;
 		}
-		if ( row >= table.getRowCount() || col >= table.getColumnCount() ) {
+		if (row >= table.getRowCount() || col >= table.getColumnCount()) {
 			synchronizeConfigurationSelection();
 			return;
 		}
@@ -105,9 +105,8 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 
 			@Override
 			public void valueChanged(ListSelectionEvent e) {
-				if ( e.getValueIsAdjusting() ) {
-					return;
-				}
+				if (e.getValueIsAdjusting()) return;
+
 //				int firstrow = e.getFirstIndex();
 //				int lastrow = e.getLastIndex();
 //				ListSelectionModel model = (ListSelectionModel) e.getSource();
@@ -134,9 +133,8 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 
 		int col = table.convertColumnIndexToModel(table.getSelectedColumn());
 		int row = table.convertRowIndexToModel(table.getSelectedRow());
-		if ( row < 0 || col < 0 ) {
-			return null;
-		}
+		if (row < 0 || col < 0) return null;
+
 		Object tableValue = table.getModel().getValueAt(row, col);
 		if ( tableValue instanceof Pair ) {
 			@SuppressWarnings("unchecked")
@@ -146,19 +144,18 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 		return null;
 	}
 
-	protected FlightConfigurationId  getSelectedConfigurationId() {
+	protected FlightConfigurationId getSelectedConfigurationId() {
 		int col = table.convertColumnIndexToModel(table.getSelectedColumn());
 		int row = table.convertRowIndexToModel(table.getSelectedRow());
-		if ( row < 0 || col < 0 || row >= table.getRowCount() || col >= table.getColumnCount() ) {
-			return null;
-		}
+		if (row < 0 || col < 0 || row >= table.getRowCount() || col >= table.getColumnCount()) return null;
+
 		Object tableValue = table.getModel().getValueAt(row, col);
-		if ( tableValue instanceof Pair ) {
+		if (tableValue instanceof Pair) {
 			@SuppressWarnings("unchecked")
 			Pair<FlightConfigurationId,T> selectedComponent = (Pair<FlightConfigurationId,T>) tableValue;
 			FlightConfigurationId fcid = selectedComponent.getU();
 			return fcid;
-		} else if ( tableValue instanceof FlightConfigurationId ){
+		} else if (tableValue instanceof FlightConfigurationId) {
 			return (FlightConfigurationId) tableValue;
 		}
 		return FlightConfigurationId.ERROR_FCID;
@@ -191,7 +188,7 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 				@SuppressWarnings("unchecked")
 				Pair<FlightConfigurationId, T> v = (Pair<FlightConfigurationId, T>) oldValue;
 				
-				if(v!=null){
+				if (v!=null){
 					FlightConfigurationId fcid = v.getU();
 					T component = v.getV();
 					label = format(component, fcid, label );
@@ -204,13 +201,13 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 
 		private final void setSelected( JComponent c, JTable table, boolean isSelected, boolean hasFocus ) {
 			c.setOpaque(true);
-			if ( isSelected) {
+			if (isSelected) {
 				c.setBackground(table.getSelectionBackground());
 			} else {
 				c.setBackground(table.getBackground());
 			}
 			Border b = null;
-			if ( hasFocus ) {
+			if (hasFocus) {
 				if (isSelected) {
 					b = UIManager.getBorder("Table.focusSelectedCellHighlightBorder");
 				} else {

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
@@ -98,19 +98,18 @@ public class RecoveryConfigurationPanel extends FlightConfigurablePanel<Recovery
 
 	private void selectDeployment() {
 		RecoveryDevice c = getSelectedComponent();
-		if (c == null) {
-			return;
-		}
-		JDialog d = new DeploymentSelectionDialog(SwingUtilities.getWindowAncestor(this), rocket, c);
+		FlightConfigurationId id = getSelectedConfigurationId();
+		if ((c == null) || (id == null) || (id == FlightConfigurationId.ERROR_FCID)) return;
+
+		JDialog d = new DeploymentSelectionDialog(SwingUtilities.getWindowAncestor(this), rocket, c, id);
 		d.setVisible(true);
 		fireTableDataChanged();
 	}
 
 	private void resetDeployment() {
 		RecoveryDevice c = getSelectedComponent();
-		if (c == null) {
-			return;
-		}
+		if (c == null) return;
+
 		FlightConfigurationId id = rocket.getSelectedConfiguration().getFlightConfigurationID();
 		c.getDeploymentConfigurations().reset(id);
 		fireTableDataChanged();


### PR DESCRIPTION
Fixed the issue of wrong configuration selection when trying to edit the Deployment Configuration of the configuration selected in the Recovery tab of the motors.

The issue was that the Deployment Configuration was based on the flight configuration that was selected for the rocket, not the one that was selected in the recovery tab. Fixed this by fetching the flight configuration ID in selectDeployment in RecoveryConfigurationPanel and passing this ID to the DeploymentSelectionDialog (also added an extra parameter in its constructor for this).

Fixes [#763](https://github.com/openrocket/openrocket/issues/763)

Here is the [jar file](https://www.dropbox.com/s/85ebgbdn72uopi2/OpenRocket.jar?dl=0) for testing.