### PR TITLE
[fixes #928] Fix launch lug reference

### DIFF
--- a/swing/src/net/sf/openrocket/gui/configdialog/LaunchLugConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/LaunchLugConfig.java
@@ -20,6 +20,9 @@ import net.sf.openrocket.rocketcomponent.position.AxialMethod;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
 
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
 @SuppressWarnings("serial")
 public class LaunchLugConfig extends RocketComponentConfig {
 	
@@ -108,28 +111,33 @@ public class LaunchLugConfig extends RocketComponentConfig {
 		
 		// create a new panel for the right column
 		panel = new JPanel(new MigLayout("gap rel unrel", "[][65lp::][30lp::][]", ""));
-		
+
 		//// Position relative to:
 		panel.add(new JLabel(trans.get("LaunchLugCfg.lbl.Posrelativeto")));		
 		EnumModel<AxialMethod> positionModel = new EnumModel<AxialMethod>(component, "AxialMethod", AxialMethod.axialOffsetMethods );
 		JComboBox<AxialMethod> positionCombo = new JComboBox<AxialMethod>( positionModel );
-		panel.add( positionCombo, "spanx, growx, wrap");
+		panel.add(positionCombo, "spanx, growx, wrap");
 		
 		//// plus
+		final DoubleModel mAxOff = new DoubleModel(component, "AxialOffset", UnitGroup.UNITS_LENGTH);
 		panel.add(new JLabel(trans.get("LaunchLugCfg.lbl.plus")), "right");
-		
-		m = new DoubleModel(component, "AxialOffset", UnitGroup.UNITS_LENGTH);
-		spin = new JSpinner(m.getSpinnerModel());
+		spin = new JSpinner(mAxOff.getSpinnerModel());				// Plus quantity input
 		spin.setEditor(new SpinnerEditor(spin));
 		panel.add(spin, "growx");
 		
-		panel.add(new UnitSelector(m), "growx");
-		panel.add(new BasicSlider(m.getSliderModel(
+		panel.add(new UnitSelector(mAxOff), "growx");		// Unity selection
+		panel.add(new BasicSlider(mAxOff.getSliderModel(			// Plus quantity slider
 				new DoubleModel(component.getParent(), "Length", -1.0, UnitGroup.UNITS_NONE),
 				new DoubleModel(component.getParent(), "Length"))),
 				"w 100lp, wrap para");
-		
-		
+
+		// Add an action listener to update the plus quantity, based on the selected reference point
+		positionCombo.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				mAxOff.stateChanged(e);
+			}
+		});
 		
 		//// Material
 		panel.add(materialPanel( Material.Type.BULK), "span, wrap");


### PR DESCRIPTION
Fixed the issue of the lug distance spinner not updating after another reference point was set. Was fixed by trigger a stateChange on the DoubleModel of the AxialOffset of the lug after an item was selected in the reference JComboBox.

Fixes #928 

Here is the [jar](https://www.dropbox.com/s/zdelttkrufxp3nb/OpenRocket-928.jar?dl=0) for testing.