### PR TITLE
Lug & rail default rotation 180°

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/LaunchLug.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/LaunchLug.java
@@ -21,7 +21,7 @@ public class LaunchLug extends ExternalComponent implements AnglePositionable, B
 	private double radius;
 	private double thickness;
 	
-	private double angleOffsetRadians = 0;
+	private double angleOffsetRadians = Math.PI;
 	private double radialOffset = 0;
 	
 	private int instanceCount = 1;

--- a/core/src/net/sf/openrocket/rocketcomponent/RailButton.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RailButton.java
@@ -56,7 +56,7 @@ public class RailButton extends ExternalComponent implements AnglePositionable, 
 
 	private double radialDistance_m=0;
 	protected static final AngleMethod angleMethod = AngleMethod.RELATIVE;
-	private double angle_rad = 0;
+	private double angle_rad = Math.PI;
 	private int instanceCount = 1;
 	private double instanceSeparation = 0; // front-front along the positive rocket axis. i.e. [1,0,0];
 	

--- a/core/test/net/sf/openrocket/rocketcomponent/LaunchLugTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/LaunchLugTest.java
@@ -22,7 +22,7 @@ public class LaunchLugTest extends BaseTestCase {
 		lug.setInstanceCount(2);
 		
 		double expX = 0.111 + body.getLocations()[0].x;
-		double expR = body.getOuterRadius()+lug.getOuterRadius();
+		double expR = -(body.getOuterRadius()+lug.getOuterRadius());
 		Coordinate expPos = new Coordinate( expX, expR, 0, 0);
 		Coordinate actPos[] = lug.getLocations();
 		assertEquals(" LaunchLug has the wrong x value: ", expPos.x, actPos[0].x, EPSILON);

--- a/core/test/net/sf/openrocket/rocketcomponent/RocketTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/RocketTest.java
@@ -89,7 +89,7 @@ public class RocketTest extends BaseTestCase {
 				}
 
 				LaunchLug lugs = (LaunchLug)body.getChild(1);
-				expLoc = new Coordinate(0.181, 0.015, 0);
+				expLoc = new Coordinate(0.181, -0.015, 0);
 				assertThat(lugs.getName()+" have incorrect count: ", lugs.getInstanceCount(), equalTo(1));
 				actLocs = lugs.getComponentLocations();
 				{ // singular instance:


### PR DESCRIPTION
Changed the default launch lug & rail button rotation to 180°, as per suggestion on #940 .

[Java file](https://www.dropbox.com/s/anonqe9iu7m1ye9/OpenRocket-940.jar?dl=0) for testing.

(also changed the layout of the smokeShader, not needed for this issue, but it ended up in this commit, sorry)

