### PR TITLE
[fixes #927 & #771] Fix auto-run simulation NA values

### DIFF
--- a/core/src/net/sf/openrocket/document/OpenRocketDocument.java
+++ b/core/src/net/sf/openrocket/document/OpenRocketDocument.java
@@ -810,7 +810,7 @@ public class OpenRocketDocument implements ComponentChangeListener {
 		listeners.remove(listener);
 	}
 	
-	protected void fireDocumentChangeEvent(DocumentChangeEvent event) {
+	public void fireDocumentChangeEvent(DocumentChangeEvent event) {
 		DocumentChangeListener[] array = listeners.toArray(new DocumentChangeListener[0]);
 		for (DocumentChangeListener l : array) {
 			l.documentChanged(event);

--- a/core/src/net/sf/openrocket/models/atmosphere/InterpolatingAtmosphericModel.java
+++ b/core/src/net/sf/openrocket/models/atmosphere/InterpolatingAtmosphericModel.java
@@ -18,10 +18,20 @@ public abstract class InterpolatingAtmosphericModel implements AtmosphericModel 
 		if (levels == null)
 			computeLayers();
 		
-		if (altitude <= 0)
+		if (altitude <= 0) {
+			// TODO: LOW: levels[0] returned null in some cases, see GitHub issue #952 for more information
+			if (levels[0] == null) {
+				computeLayers();
+			}
 			return levels[0];
-		if (altitude >= DELTA * (levels.length - 1))
+		}
+		if (altitude >= DELTA * (levels.length - 1)) {
+			// TODO: LOW: levels[levels.length - 1] returned null in some cases, see GitHub issue #952 for more information
+			if (levels[levels.length - 1] == null) {
+				computeLayers();
+			}
 			return levels[levels.length - 1];
+		}
 		
 		int n = (int) (altitude / DELTA);
 		double d = (altitude - n * DELTA) / DELTA;

--- a/core/src/net/sf/openrocket/motor/MotorConfiguration.java
+++ b/core/src/net/sf/openrocket/motor/MotorConfiguration.java
@@ -115,6 +115,8 @@ public class MotorConfiguration implements FlightConfigurableParameter<MotorConf
 	
 	public void useDefaultIgnition() {
 		this.ignitionOveride = false;
+		setIgnitionDelay(0);
+		setIgnitionEvent(IgnitionEvent.AUTOMATIC);
 	}
 	
 	public double getIgnitionDelay() {

--- a/core/src/net/sf/openrocket/rocketcomponent/DeploymentConfiguration.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/DeploymentConfiguration.java
@@ -8,6 +8,8 @@ import net.sf.openrocket.unit.UnitGroup;
 import net.sf.openrocket.util.MathUtil;
 import net.sf.openrocket.util.Pair;
 
+import java.util.Objects;
+
 public class DeploymentConfiguration implements FlightConfigurableParameter<DeploymentConfiguration> {
 	
 	
@@ -154,5 +156,17 @@ public class DeploymentConfiguration implements FlightConfigurableParameter<Depl
 	@Override
 	public void update(){
 	}
-	
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		DeploymentConfiguration that = (DeploymentConfiguration) o;
+		return Double.compare(that.deployAltitude, deployAltitude) == 0 && Double.compare(that.deployDelay, deployDelay) == 0 && deployEvent == that.deployEvent;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(deployEvent, deployAltitude, deployDelay);
+	}
 }

--- a/core/src/net/sf/openrocket/rocketcomponent/StageSeparationConfiguration.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/StageSeparationConfiguration.java
@@ -5,6 +5,8 @@ import net.sf.openrocket.simulation.FlightEvent;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.MathUtil;
 
+import java.util.Objects;
+
 public class StageSeparationConfiguration implements FlightConfigurableParameter<StageSeparationConfiguration> {
 	
 	public static enum SeparationEvent {
@@ -144,8 +146,20 @@ public class StageSeparationConfiguration implements FlightConfigurableParameter
 		clone.separationDelay = this.separationDelay;
 		return clone;
 	}
-	
-	
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		StageSeparationConfiguration that = (StageSeparationConfiguration) o;
+		return Double.compare(that.separationDelay, separationDelay) == 0 && separationEvent == that.separationEvent;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(separationEvent, separationDelay);
+	}
+
 	private void fireChangeEvent() {
 
 	}

--- a/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
+++ b/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
@@ -259,7 +259,7 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 	private boolean handleEvents() throws SimulationException {
 		boolean ret = true;
 		FlightEvent event;
-		
+
 		log.trace("HandleEvents: current branch = " + currentStatus.getFlightData().getBranchName());
 		for (event = nextEvent(); event != null; event = nextEvent()) {
 			log.trace("Obtained event from queue:  " + event.toString());
@@ -300,7 +300,7 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 			// Ignore events for components that are no longer attached to the rocket
 			if (event.getSource() != null && event.getSource().getParent() != null &&
 					!currentStatus.getConfiguration().isComponentActive(event.getSource())) {
-				log.trace("Ignoring event from unattached componenent");
+				log.trace("Ignoring event from unattached component");
 				continue;
 			}
 			
@@ -332,6 +332,7 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 			
 			
 			// Check for recovery device deployment, add events to queue
+			// TODO: LOW: check if deprecated function getActiveComponents needs to be replaced
 			for (RocketComponent c : currentStatus.getConfiguration().getActiveComponents()) {
 				if (!(c instanceof RecoveryDevice))
 					continue;

--- a/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
+++ b/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
@@ -533,7 +533,8 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 			}
 			
 		}
-		
+
+		// TODO : FUTURE : do not hard code the 1200 (maybe even make it configurable by the user)
 		if( 1200 < currentStatus.getSimulationTime() ){
 			ret = false;
 			log.error("Simulation hit max time (1200s): aborting.");

--- a/core/src/net/sf/openrocket/simulation/FlightData.java
+++ b/core/src/net/sf/openrocket/simulation/FlightData.java
@@ -220,7 +220,7 @@ public class FlightData {
 			timeToApogee = Double.NaN;
 		
 
-		// Launch rod velocity
+		// Launch rod velocity + deployment velocity + ground hit velocity
 		for (FlightEvent event : branch.getEvents()) {
 			if (event.getType() == FlightEvent.Type.LAUNCHROD) {
 				double t = event.getTime();

--- a/core/src/net/sf/openrocket/simulation/listeners/system/GroundHitListener.java
+++ b/core/src/net/sf/openrocket/simulation/listeners/system/GroundHitListener.java
@@ -1,0 +1,29 @@
+package net.sf.openrocket.simulation.listeners.system;
+
+import net.sf.openrocket.simulation.FlightEvent;
+import net.sf.openrocket.simulation.SimulationStatus;
+import net.sf.openrocket.simulation.listeners.AbstractSimulationListener;
+
+
+/**
+ * A simulation listeners that ends the simulation when the ground is hit.
+ * 
+ * @author Sibo Van Gool <sibo.vangool@hotmail.com>
+ */
+public class GroundHitListener extends AbstractSimulationListener {
+	
+	public static final GroundHitListener INSTANCE = new GroundHitListener();
+	
+	@Override
+	public boolean handleFlightEvent(SimulationStatus status, FlightEvent event) {
+		if (event.getType() == FlightEvent.Type.GROUND_HIT) {
+			status.getEventQueue().add(new FlightEvent(FlightEvent.Type.SIMULATION_END, status.getSimulationTime()));
+		}
+		return true;
+	}
+	
+	@Override
+	public boolean isSystemListener() {
+		return true;
+	}
+}

--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -221,7 +221,7 @@ public class BasicFrame extends JFrame {
 
 		//  Bottom segment, rocket figure
 
-		rocketpanel = new RocketPanel(document);
+		rocketpanel = new RocketPanel(document, this);
 		vertical.setBottomComponent(rocketpanel);
 
 		rocketpanel.setSelectionModel(tree.getSelectionModel());
@@ -1099,6 +1099,9 @@ public class BasicFrame extends JFrame {
 		tabbedPane.setSelectedIndex(tab);
 	}
 
+	public int getSelectedTab() {
+		return tabbedPane.getSelectedIndex();
+	}
 
 
 	private void openAction() {

--- a/swing/src/net/sf/openrocket/gui/main/SimulationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/SimulationPanel.java
@@ -576,7 +576,7 @@ public class SimulationPanel extends JPanel {
 			public void documentChanged(DocumentChangeEvent event) {
 				if (!(event instanceof SimulationChangeEvent))
 					return;
-				simulationTableModel.fireTableDataChanged();
+				fireMaintainSelection();
 			}
 		});
 

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
@@ -54,10 +54,14 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 		synchronizeConfigurationSelection();
 	}
 
-	public void fireTableDataChanged() {
+	/**
+	 * Update the data in the table, with component change event type {cce}
+	 * @param cce index of the ComponentChangeEvent to use (e.g. ComponentChangeEvent.NONFUNCTIONAL_CHANGE)
+	 */
+	public void fireTableDataChanged(int cce) {
 		int selectedRow = table.getSelectedRow();
 		int selectedColumn = table.getSelectedColumn();
-		this.rocket.fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
+		this.rocket.fireComponentChangeEvent(cce);
 		((AbstractTableModel)table.getModel()).fireTableDataChanged();
 		restoreSelection(selectedRow,selectedColumn);
 		updateButtonState();

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurationPanel.java
@@ -15,6 +15,7 @@ import net.sf.openrocket.document.Simulation;
 import net.sf.openrocket.gui.dialogs.flightconfiguration.RenameConfigDialog;
 import net.sf.openrocket.gui.main.BasicFrame;
 import net.sf.openrocket.l10n.Translator;
+import net.sf.openrocket.rocketcomponent.ComponentChangeEvent;
 import net.sf.openrocket.rocketcomponent.FlightConfigurableComponent;
 import net.sf.openrocket.rocketcomponent.FlightConfiguration;
 import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
@@ -79,7 +80,7 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 				int lastCol = motorConfigurationPanel.table.getColumnCount() - 1;
 				motorConfigurationPanel.table.setRowSelectionInterval(lastRow, lastRow);
 				motorConfigurationPanel.table.setColumnSelectionInterval(lastCol, lastCol);
-				configurationChanged();
+				configurationChanged(ComponentChangeEvent.MOTOR_CHANGE);
 			}
 			
 		});
@@ -91,7 +92,7 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				renameConfiguration();
-				configurationChanged();
+				configurationChanged(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 			}
 		});
 		this.add(renameConfButton,"gapright para");
@@ -101,7 +102,7 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				removeConfiguration();
-				configurationChanged();
+				configurationChanged(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 			}
 		});
 		this.add(removeConfButton,"gapright para");
@@ -111,7 +112,7 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				addOrCopyConfiguration(true);
-				configurationChanged();
+				configurationChanged(ComponentChangeEvent.MOTOR_CHANGE);
 			}
 		});
 		this.add(copyConfButton, "wrap");
@@ -172,13 +173,13 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 		if (currentId == null)
 			return;
 		document.removeFlightConfigurationAndSimulations(currentId);
-		configurationChanged();
+		configurationChanged(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 	}
 	
-	private void configurationChanged() {
-		motorConfigurationPanel.fireTableDataChanged();
-		recoveryConfigurationPanel.fireTableDataChanged();
-		separationConfigurationPanel.fireTableDataChanged();
+	private void configurationChanged(int cce) {
+		motorConfigurationPanel.fireTableDataChanged(cce);
+		recoveryConfigurationPanel.fireTableDataChanged(cce);
+		separationConfigurationPanel.fireTableDataChanged(cce);
 	}
 	
 	private void updateButtonState() {

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
@@ -203,13 +203,15 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
         	throw new IllegalStateException("Attempting to set a motor on the default FCID.");
         }
 
+        double initDelay = curMount.getMotorConfig(fcid).getEjectionDelay();
+
 		motorChooserDialog.setMotorMountAndConfig( fcid, curMount );
 		motorChooserDialog.setVisible(true);
 
         Motor mtr = motorChooserDialog.getSelectedMotor();
 		double d = motorChooserDialog.getSelectedDelay();
 		if (mtr != null) {
-			if (mtr == curMount.getMotorConfig(fcid).getMotor()) {
+			if (mtr == curMount.getMotorConfig(fcid).getMotor() && d == initDelay) {
 				return;
 			}
 	        final MotorConfiguration templateConfig = curMount.getMotorConfig(fcid);

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
@@ -29,10 +29,12 @@ import net.sf.openrocket.gui.widgets.SelectColorButton;
 import net.sf.openrocket.motor.IgnitionEvent;
 import net.sf.openrocket.motor.Motor;
 import net.sf.openrocket.motor.MotorConfiguration;
+import net.sf.openrocket.rocketcomponent.ComponentChangeEvent;
 import net.sf.openrocket.rocketcomponent.FlightConfiguration;
 import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
 import net.sf.openrocket.rocketcomponent.MotorMount;
 import net.sf.openrocket.rocketcomponent.Rocket;
+import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
 import net.sf.openrocket.util.Chars;
 
@@ -207,14 +209,17 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
         Motor mtr = motorChooserDialog.getSelectedMotor();
 		double d = motorChooserDialog.getSelectedDelay();
 		if (mtr != null) {
+			if (mtr == curMount.getMotorConfig(fcid).getMotor()) {
+				return;
+			}
 	        final MotorConfiguration templateConfig = curMount.getMotorConfig(fcid);
 	        final MotorConfiguration newConfig = new MotorConfiguration( curMount, fcid, templateConfig);
 	        newConfig.setMotor(mtr);
 			newConfig.setEjectionDelay(d);
 			curMount.setMotorConfig( newConfig, fcid);
-		}
 
-		fireTableDataChanged();
+			fireTableDataChanged(ComponentChangeEvent.MOTOR_CHANGE);
+		}
 	}
 
 	private void removeMotor() {
@@ -226,24 +231,30 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
         
         curMount.setMotorConfig( null, fcid); 
 		
-		fireTableDataChanged();
+		fireTableDataChanged(ComponentChangeEvent.MOTOR_CHANGE);
 	}
 
 	private void selectIgnition() {
-		MotorMount curMount = getSelectedComponent();		
-		FlightConfigurationId fcid= getSelectedConfigurationId();
-        if ( (null == fcid )||( null == curMount )){
-            return;
-        }
-        
+		MotorMount curMount = getSelectedComponent();
+		FlightConfigurationId fcid = getSelectedConfigurationId();
+		if ((null == fcid) || (null == curMount)) {
+			return;
+		}
+
+		MotorConfiguration curInstance = curMount.getMotorConfig(fcid);
+		IgnitionEvent initialIgnitionEvent = curInstance.getIgnitionEvent();
+		double initialIgnitionDelay = curInstance.getIgnitionDelay();
+
 		// this call also performs the update changes
 		IgnitionSelectionDialog ignitionDialog = new IgnitionSelectionDialog(
 				SwingUtilities.getWindowAncestor(this.flightConfigurationPanel),
 				fcid,
 				curMount);
 		ignitionDialog.setVisible(true);
-				
-		fireTableDataChanged();
+
+		if (!initialIgnitionEvent.equals(curInstance.getIgnitionEvent()) || (initialIgnitionDelay != curInstance.getIgnitionDelay())) {
+			fireTableDataChanged(ComponentChangeEvent.MOTOR_CHANGE);
+		}
 	}
 
 
@@ -254,10 +265,14 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
             return;
         }
         MotorConfiguration curInstance = curMount.getMotorConfig(fcid);
+		IgnitionEvent initialIgnitionEvent = curInstance.getIgnitionEvent();
+		double initialIgnitionDelay = curInstance.getIgnitionDelay();
 		
         curInstance.useDefaultIgnition();
 
-		fireTableDataChanged();
+		if (!initialIgnitionEvent.equals(curInstance.getIgnitionEvent()) || (initialIgnitionDelay != curInstance.getIgnitionDelay())) {
+			fireTableDataChanged(ComponentChangeEvent.MOTOR_CHANGE);
+		}
 	}
 
 

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
@@ -99,22 +99,31 @@ public class RecoveryConfigurationPanel extends FlightConfigurablePanel<Recovery
 
 	private void selectDeployment() {
 		RecoveryDevice c = getSelectedComponent();
-		if (c == null) {
+		FlightConfigurationId fcid = getSelectedConfigurationId();
+		if ((c == null) || (fcid == null)) {
 			return;
 		}
+		DeploymentConfiguration initialConfig = c.getDeploymentConfigurations().get(fcid).copy(fcid);
 		JDialog d = new DeploymentSelectionDialog(SwingUtilities.getWindowAncestor(this), rocket, c);
 		d.setVisible(true);
-		fireTableDataChanged();
+		if (!initialConfig.equals(c.getDeploymentConfigurations().get(fcid))) {
+			fireTableDataChanged(ComponentChangeEvent.AERODYNAMIC_CHANGE);
+		}
+
 	}
 
 	private void resetDeployment() {
 		RecoveryDevice c = getSelectedComponent();
-		if (c == null) {
+		FlightConfigurationId fcid = getSelectedConfigurationId();
+		if ((c == null) || (fcid == null)) {
 			return;
 		}
+		DeploymentConfiguration initialConfig = c.getDeploymentConfigurations().get(fcid).copy(fcid);
 		FlightConfigurationId id = rocket.getSelectedConfiguration().getFlightConfigurationID();
 		c.getDeploymentConfigurations().reset(id);
-		fireTableDataChanged();
+		if (!initialConfig.equals(c.getDeploymentConfigurations().get(fcid))) {
+			fireTableDataChanged(ComponentChangeEvent.AERODYNAMIC_CHANGE);
+		}
 	}
 
 	public void updateButtonState() {

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
@@ -17,6 +17,7 @@ import net.sf.openrocket.formatting.RocketDescriptor;
 import net.sf.openrocket.gui.dialogs.flightconfiguration.SeparationSelectionDialog;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.rocketcomponent.AxialStage;
+import net.sf.openrocket.rocketcomponent.ComponentChangeEvent;
 import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
 import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.rocketcomponent.StageSeparationConfiguration;
@@ -46,7 +47,7 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialS
 		selectSeparationButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				selectDeployment();
+				selectSeparation();
 			}
 		});
 		this.add(selectSeparationButton, "split, align right, sizegroup button");
@@ -57,7 +58,7 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialS
 		resetDeploymentButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				resetDeployment();
+				resetSeparation();
 			}
 		});
 		this.add(resetDeploymentButton, "sizegroup button, wrap");
@@ -86,7 +87,7 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialS
 				updateButtonState();
 				if (e.getClickCount() == 2) {
 					// Double-click edits 
-					selectDeployment();
+					selectSeparation();
 				}
 			}
 		});
@@ -95,27 +96,35 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialS
 		return separationTable;
 	}
 
-	private void selectDeployment() {
+	private void selectSeparation() {
 		AxialStage stage = getSelectedComponent();
-		if (stage == null) {
+		FlightConfigurationId fcid = getSelectedConfigurationId();
+		if ((stage == null) || (fcid == null)) {
 			return;
 		}
+		StageSeparationConfiguration initialConfig = stage.getSeparationConfigurations().get(fcid).copy(fcid);
 		JDialog d = new SeparationSelectionDialog(SwingUtilities.getWindowAncestor(this), rocket, stage);
 		d.setVisible(true);
-		fireTableDataChanged();
+		if (!initialConfig.equals(stage.getSeparationConfigurations().get(fcid))) {
+			fireTableDataChanged(ComponentChangeEvent.AEROMASS_CHANGE);
+		}
 	}
 	
-	private void resetDeployment() {
+	private void resetSeparation() {
 		AxialStage stage = getSelectedComponent();
-		if (stage == null) {
+		FlightConfigurationId fcid = getSelectedConfigurationId();
+		if ((stage == null) || (fcid == null)) {
 			return;
 		}
-		
+
+		StageSeparationConfiguration initialConfig = stage.getSeparationConfigurations().get(fcid).copy(fcid);
 		// why? 
 		FlightConfigurationId id = rocket.getSelectedConfiguration().getFlightConfigurationID();
 		stage.getSeparationConfigurations().reset(id);
-		
-		fireTableDataChanged();
+
+		if (!initialConfig.equals(stage.getSeparationConfigurations().get(fcid))) {
+			fireTableDataChanged(ComponentChangeEvent.AEROMASS_CHANGE);
+		}
 	}
 	public void updateButtonState() {
 		boolean componentSelected = getSelectedComponent() != null;

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -718,6 +718,9 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		// Re-run the present simulation(s)
 		List<Simulation> sims = new LinkedList<>();
 		for (Simulation sim : document.getSimulations()) {
+			if (sim.getStatus() == Simulation.Status.UPTODATE || sim.getStatus() == Simulation.Status.LOADED)
+				continue;
+
 			// Find a Simulation based on the current flight configuration
 			if (!updateAllSims) {
 				if (sim.getFlightConfigurationId().compareTo(curID) == 0) {
@@ -740,6 +743,18 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 	 * @param rkt rocket for which the simulations are run
 	 */
 	private void runBackgroundSimulations(List<Simulation> sims, Rocket rkt) {
+		if (sims.size() == 0) {
+			FlightConfigurationId curID = document.getSelectedConfiguration().getFlightConfigurationID();
+			for (Simulation sim : document.getSimulations()) {
+				if (sim.getFlightConfigurationId().compareTo(curID) == 0) {
+					extraText.setFlightData(sim.getSimulatedData());
+					break;
+				}
+			}
+			extraText.setCalculatingData(false);
+			return;
+		}
+
 		// I *think* every FlightConfiguration has at least one associated simulation; just in case I'm wrong,
 		// if there isn't one we'll create a new simulation to update the statistics in the panel using the
 		// default simulation conditions

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -66,7 +66,7 @@ import net.sf.openrocket.simulation.FlightData;
 import net.sf.openrocket.simulation.customexpression.CustomExpression;
 import net.sf.openrocket.simulation.customexpression.CustomExpressionSimulationListener;
 import net.sf.openrocket.simulation.listeners.SimulationListener;
-import net.sf.openrocket.simulation.listeners.system.ApogeeEndListener;
+import net.sf.openrocket.simulation.listeners.system.GroundHitListener;
 import net.sf.openrocket.simulation.listeners.system.InterruptListener;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
@@ -770,7 +770,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		protected SimulationListener[] getExtraListeners() {
 			return new SimulationListener[] {
 					InterruptListener.INSTANCE,
-					ApogeeEndListener.INSTANCE,
+					GroundHitListener.INSTANCE,
 					exprListener };
 
 		}

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -38,6 +38,7 @@ import net.sf.openrocket.aerodynamics.FlightConditions;
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.document.Simulation;
+import net.sf.openrocket.document.events.SimulationChangeEvent;
 import net.sf.openrocket.gui.adaptors.DoubleModel;
 import net.sf.openrocket.gui.components.BasicSlider;
 import net.sf.openrocket.gui.components.ConfigurationComboBox;
@@ -216,6 +217,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		rkt.addComponentChangeListener(new ComponentChangeListener() {
 			@Override
 			public void componentChanged(ComponentChangeEvent e) {
+				updateExtras();
 				if (is3d) {
 					if (e.isTextureChange()) {
 						figure3d.flushTextureCaches();
@@ -557,7 +559,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 
 	/**
 	 * Updates the extra data included in the figure.  Currently this includes
-	 * the CP and CG carets.
+	 * the CP and CG carets. Also start the background simulator.
 	 */
 	private WarningSet warnings = new WarningSet();
 
@@ -708,7 +710,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 				simulation.setFlightConfigurationId( document.getSelectedConfiguration().getId());
 			} else
 				System.out.println("using pre-existing simulation");
-			
+
 			backgroundSimulationWorker = new BackgroundSimulationWorker(document, simulation);
 			backgroundSimulationExecutor.execute(backgroundSimulationWorker);
 		}
@@ -758,12 +760,12 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 			// Do nothing if cancelled
 			if (isCancelled() || backgroundSimulationWorker != this)
 				return;
-
 			backgroundSimulationWorker = null;
 			extraText.setFlightData(simulation.getSimulatedData());
 			extraText.setCalculatingData(false);
 			figure.repaint();
 			figure3d.repaint();
+			document.fireDocumentChangeEvent(new SimulationChangeEvent(simulation));
 		}
 
 		@Override

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -745,15 +745,15 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 	 */
 	private void runBackgroundSimulations(List<Simulation> sims, Rocket rkt) {
 		if (sims.size() == 0) {
+			extraText.setCalculatingData(false);
 			FlightConfigurationId curID = document.getSelectedConfiguration().getFlightConfigurationID();
 			for (Simulation sim : document.getSimulations()) {
 				if (sim.getFlightConfigurationId().compareTo(curID) == 0) {
 					extraText.setFlightData(sim.getSimulatedData());
-					break;
+					return;
 				}
 			}
-			extraText.setCalculatingData(false);
-			return;
+			extraText.setFlightData(FlightData.NaN_DATA);
 		}
 
 		// I *think* every FlightConfiguration has at least one associated simulation; just in case I'm wrong,
@@ -820,7 +820,12 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 			if (isCancelled() || backgroundSimulationWorker != this)
 				return;
 			backgroundSimulationWorker = null;
-			extraText.setFlightData(simulation.getSimulatedData());
+
+			// Only set the flight data information of the current flight configuration
+			FlightConfigurationId curID = document.getSelectedConfiguration().getFlightConfigurationID();
+			if (simulation.getFlightConfigurationId().compareTo(curID) == 0) {
+				extraText.setFlightData(simulation.getSimulatedData());
+			}
 			extraText.setCalculatingData(false);
 			figure.repaint();
 			figure3d.repaint();

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -718,7 +718,8 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		// Re-run the present simulation(s)
 		List<Simulation> sims = new LinkedList<>();
 		for (Simulation sim : document.getSimulations()) {
-			if (sim.getStatus() == Simulation.Status.UPTODATE || sim.getStatus() == Simulation.Status.LOADED)
+			if (sim.getStatus() == Simulation.Status.UPTODATE || sim.getStatus() == Simulation.Status.LOADED
+					|| !document.getRocket().getFlightConfiguration(sim.getFlightConfigurationId()).hasMotors())
 				continue;
 
 			// Find a Simulation based on the current flight configuration


### PR DESCRIPTION
Okay, so this was a pretty deep problem to solve.

I noticed that the problem only occurred on velocity at deployment, ground hit velocity and optimum delay. After a bit of searching, I found that the simulation events of recovery device hit and ground hit in BasicSimulationEngine weren't getting triggered. To see what happens, I printed some log info about the simulation events when the problem arose and this was the output. The following shows in chronological order the different simulation events that occur after I have changed a parameter of a rocket component (event of altitude change not included, because there were a lot of them):
    Event - Launch
    Event - Motor ignition
    Event - Lift-off
    Event - Launch rod clearance
    Event - Motor burnout
    Event - Ejection charge
    Event - Apogee
    Event - Simulation end

For reference, this is the desired event log, from a normal simulation run:
    Event - Launch
    Event - Motor ignition
    Event - Lift-off
    Event - Launch rod clearance
    Event - Motor burnout
    Event - Ejection charge
    Event - Apogee
    Event - Simulation end
    Event - Recovery device deployment
    Event - Recovery device deployment
    Event - Ground hit
    Event - Simulation end

You can see that the simulation just ends after apogee. The culprit for this was the handleFlightEvent method in ApogeeEndListener. The ApogeeEndListener is instantiated in getExtraListeners in RocketPanel in the SimulationListener interface. This basically makes it so that when you change a parameter of the rocket and a simulation is auto run, when that simulation hits apogee, the next event of the simulation will be SIMULATION_END, as can be seen in ApogeeEndListener. This is not what we want, we want the simulation to stop after ground hit.

Therefor, I created a new listener, GroundHitListener, which will end the simulation after ground hit. This solves the issue.

I have to admit that I am not sure why the choice was made to stop the simulation after apogee in the first place, but I believe that ground hit should be the right way to end your simulation?



On top of that, I found a secondary problem. When you just changed a component value and change a value again, whilst the simulation is still calculating the first change (you can see it in the rocket preview window on the bottom left 'Calculating…'), then it also triggers a simulation end after apogee. This is a log of the events of first changing a component value and then doing it again during calculation. Note the 'simulation end' after apogee.
using pre-existing simulation
    Event - Launch
    Event - Motor ignition
    Event - Lift-off
    Event - Launch rod clearance
    using pre-existing simulation
    Event - Launch
    Event - Motor ignition
    Event - Lift-off
    Event - Launch rod clearance
    Event - Motor burnout
    Event - Ejection charge
    Event - Apogee
    Event - Simulation end
    Event - Recovery device deployment
    Event - Recovery device deployment
    Event - Ground hit
    Event - Simulation end

I will leave this last problem for a different pull request however, since it is not closely related to the concerning current issue.

I also still have to fix the issue that the simulation status remains in the red (out-of-date) state, even when the simulation is updated; it goes to the green (up-to-date) state once I close the dialog of the component configuration.

Here is a [jar](https://www.dropbox.com/s/x9jfi7krslp6vy7/OpenRocket-927.jar?dl=0) for testing.

Fixes #927 (and possibly also #771 ?)