### PR TITLE
[fixes 771] Fix simulation not running after motor configuration change + fix simulation table not updating

### DIFF
--- a/core/src/net/sf/openrocket/document/OpenRocketDocument.java
+++ b/core/src/net/sf/openrocket/document/OpenRocketDocument.java
@@ -791,7 +791,7 @@ public class OpenRocketDocument implements ComponentChangeListener {
 		listeners.remove(listener);
 	}
 	
-	protected void fireDocumentChangeEvent(DocumentChangeEvent event) {
+	public void fireDocumentChangeEvent(DocumentChangeEvent event) {
 		DocumentChangeListener[] array = listeners.toArray(new DocumentChangeListener[0]);
 		for (DocumentChangeListener l : array) {
 			l.documentChanged(event);

--- a/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
+++ b/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
@@ -259,7 +259,7 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 	private boolean handleEvents() throws SimulationException {
 		boolean ret = true;
 		FlightEvent event;
-		
+
 		log.trace("HandleEvents: current branch = " + currentStatus.getFlightData().getBranchName());
 		for (event = nextEvent(); event != null; event = nextEvent()) {
 			log.trace("Obtained event from queue:  " + event.toString());
@@ -300,7 +300,7 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 			// Ignore events for components that are no longer attached to the rocket
 			if (event.getSource() != null && event.getSource().getParent() != null &&
 					!currentStatus.getConfiguration().isComponentActive(event.getSource())) {
-				log.trace("Ignoring event from unattached componenent");
+				log.trace("Ignoring event from unattached component");
 				continue;
 			}
 			
@@ -332,6 +332,7 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 			
 			
 			// Check for recovery device deployment, add events to queue
+			// TODO: LOW: check if deprecated function getActiveComponents needs to be replaced
 			for (RocketComponent c : currentStatus.getConfiguration().getActiveComponents()) {
 				if (!(c instanceof RecoveryDevice))
 					continue;

--- a/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
+++ b/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
@@ -533,7 +533,8 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 			}
 			
 		}
-		
+
+		// TODO : FUTURE : do not hard code the 1200 (maybe even make it configurable by the user)
 		if( 1200 < currentStatus.getSimulationTime() ){
 			ret = false;
 			log.error("Simulation hit max time (1200s): aborting.");

--- a/core/src/net/sf/openrocket/simulation/FlightData.java
+++ b/core/src/net/sf/openrocket/simulation/FlightData.java
@@ -220,7 +220,7 @@ public class FlightData {
 			timeToApogee = Double.NaN;
 		
 
-		// Launch rod velocity
+		// Launch rod velocity + deployment velocity + ground hit velocity
 		for (FlightEvent event : branch.getEvents()) {
 			if (event.getType() == FlightEvent.Type.LAUNCHROD) {
 				double t = event.getTime();

--- a/core/src/net/sf/openrocket/simulation/listeners/system/GroundHitListener.java
+++ b/core/src/net/sf/openrocket/simulation/listeners/system/GroundHitListener.java
@@ -1,0 +1,29 @@
+package net.sf.openrocket.simulation.listeners.system;
+
+import net.sf.openrocket.simulation.FlightEvent;
+import net.sf.openrocket.simulation.SimulationStatus;
+import net.sf.openrocket.simulation.listeners.AbstractSimulationListener;
+
+
+/**
+ * A simulation listeners that ends the simulation when the ground is hit.
+ * 
+ * @author Sibo Van Gool <sibo.vangool@hotmail.com>
+ */
+public class GroundHitListener extends AbstractSimulationListener {
+	
+	public static final GroundHitListener INSTANCE = new GroundHitListener();
+	
+	@Override
+	public boolean handleFlightEvent(SimulationStatus status, FlightEvent event) {
+		if (event.getType() == FlightEvent.Type.GROUND_HIT) {
+			status.getEventQueue().add(new FlightEvent(FlightEvent.Type.SIMULATION_END, status.getSimulationTime()));
+		}
+		return true;
+	}
+	
+	@Override
+	public boolean isSystemListener() {
+		return true;
+	}
+}

--- a/swing/src/net/sf/openrocket/gui/main/SimulationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/SimulationPanel.java
@@ -575,7 +575,7 @@ public class SimulationPanel extends JPanel {
 			public void documentChanged(DocumentChangeEvent event) {
 				if (!(event instanceof SimulationChangeEvent))
 					return;
-				simulationTableModel.fireTableDataChanged();
+				fireMaintainSelection();
 			}
 		});
 

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -66,7 +66,7 @@ import net.sf.openrocket.simulation.FlightData;
 import net.sf.openrocket.simulation.customexpression.CustomExpression;
 import net.sf.openrocket.simulation.customexpression.CustomExpressionSimulationListener;
 import net.sf.openrocket.simulation.listeners.SimulationListener;
-import net.sf.openrocket.simulation.listeners.system.ApogeeEndListener;
+import net.sf.openrocket.simulation.listeners.system.GroundHitListener;
 import net.sf.openrocket.simulation.listeners.system.InterruptListener;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
@@ -770,7 +770,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		protected SimulationListener[] getExtraListeners() {
 			return new SimulationListener[] {
 					InterruptListener.INSTANCE,
-					ApogeeEndListener.INSTANCE,
+					GroundHitListener.INSTANCE,
 					exprListener };
 
 		}

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -38,6 +38,7 @@ import net.sf.openrocket.aerodynamics.FlightConditions;
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.document.Simulation;
+import net.sf.openrocket.document.events.SimulationChangeEvent;
 import net.sf.openrocket.gui.adaptors.DoubleModel;
 import net.sf.openrocket.gui.components.BasicSlider;
 import net.sf.openrocket.gui.components.ConfigurationComboBox;
@@ -216,6 +217,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		rkt.addComponentChangeListener(new ComponentChangeListener() {
 			@Override
 			public void componentChanged(ComponentChangeEvent e) {
+				updateExtras();
 				if (is3d) {
 					if (e.isTextureChange()) {
 						figure3d.flushTextureCaches();
@@ -557,7 +559,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 
 	/**
 	 * Updates the extra data included in the figure.  Currently this includes
-	 * the CP and CG carets.
+	 * the CP and CG carets. Also start the background simulator.
 	 */
 	private WarningSet warnings = new WarningSet();
 
@@ -708,7 +710,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 				simulation.setFlightConfigurationId( document.getSelectedConfiguration().getId());
 			} else
 				System.out.println("using pre-existing simulation");
-			
+
 			backgroundSimulationWorker = new BackgroundSimulationWorker(document, simulation);
 			backgroundSimulationExecutor.execute(backgroundSimulationWorker);
 		}
@@ -758,12 +760,12 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 			// Do nothing if cancelled
 			if (isCancelled() || backgroundSimulationWorker != this)
 				return;
-
 			backgroundSimulationWorker = null;
 			extraText.setFlightData(simulation.getSimulatedData());
 			extraText.setCalculatingData(false);
 			figure.repaint();
 			figure3d.repaint();
+			document.fireDocumentChangeEvent(new SimulationChangeEvent(simulation));
 		}
 
 		@Override


### PR DESCRIPTION
This pull fixes the simulation not updating after having selected a different motor configuration. I just added updateExtras method to the rocket componentChangeListener in RocketPanel.

There was an additional problem that the simulation table would not update its state. So if the simulation was done, this would not update the simulation table. Only if you selected the row in the simulation table that should have updated, that row would update its information. I fixed this by adding a fireDocumentChangeEvent to the BackgroundSimulationWorker in RocketPanel once the simulation was done.

Here is a [jar](https://www.dropbox.com/s/63s84ubhjk7fej4/OpenRocket-771.jar?dl=0) file for testing.