### PR TITLE
[fixes #904] Fix inside color tube different color from outside

### DIFF
--- a/swing/src/net/sf/openrocket/gui/figure3d/RealisticRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/RealisticRenderer.java
@@ -91,12 +91,7 @@ public class RealisticRenderer extends RocketRenderer {
 	@Override
 	public void renderComponent(final GL2 gl, Geometry geom, final float alpha) {
 	    Appearance app = getAppearance( geom.getComponent() );
-	    if (app.getPaint().getAlpha()<255){
-			// if transparent, draw inside the same as the outside so we dont get a cardboard interior on a clear payload bay
-			render(gl, geom, Surface.INSIDE, app, true, alpha);
-		}else{
-			render(gl, geom, Surface.INSIDE, DefaultAppearance.getDefaultAppearance(geom.getComponent()), true, 1.0f);
-		}
+		render(gl, geom, Surface.INSIDE, app, true, alpha);
 		render(gl, geom, Surface.OUTSIDE, app, true, alpha);
 		render(gl, geom, Surface.EDGES, app, false, alpha);
 	}


### PR DESCRIPTION
This pull fixes issue #904 where the inside of a tube did not match the color of the outside. The previous implementation was deliberately programmed to have the default appearance (e.g. cardboard appearance) for the inside (unless you set the alpha of the appearance to a value lower than 255). 

As mentioned on the [forum](https://www.rocketryforum.com/threads/painting-the-inside-of-a-body-tube-with-openrocket.165220/#post-2114880), this might have be done to reflect the reality of not painting the inside, but only the outside of e.g. the body tube. Because of this, I will work on #905 which gives the user the control for different inside and outside colors.

Here is the [jar file](https://www.dropbox.com/s/5ty1uvgi266l5yv/OpenRocket-904.jar?dl=0) for testing.