### PR TITLE
[fixes #843] Added radial positioning for the shock cord component

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -1066,6 +1066,11 @@ ShockCordCfg.lbl.Posrelativeto = Position relative to:
 ShockCordCfg.lbl.plus = plus
 ShockCordCfg.lbl.Packedlength = Packed length:
 ShockCordCfg.lbl.Packeddiam = Packed diameter:
+ShockCordCfg.tab.Radialpos = Radial position
+ShockCordCfg.tab.ttip.Radialpos = Radial position configuration
+ShockCordCfg.lbl.Radialdistance = Radial distance:
+ShockCordCfg.lbl.Radialdirection = Radial direction:
+ShockCordCfg.but.Reset = Reset
 ShockCordCfg.tab.General = General
 ShockCordCfg.tab.ttip.General = General properties
 

--- a/swing/src/net/sf/openrocket/gui/configdialog/ShockCordConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/ShockCordConfig.java
@@ -1,10 +1,7 @@
 package net.sf.openrocket.gui.configdialog;
 
 
-import javax.swing.JComboBox;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JSpinner;
+import javax.swing.*;
 
 import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.document.OpenRocketDocument;
@@ -15,10 +12,15 @@ import net.sf.openrocket.gui.components.BasicSlider;
 import net.sf.openrocket.gui.components.UnitSelector;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.material.Material;
+import net.sf.openrocket.rocketcomponent.MassComponent;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
+import net.sf.openrocket.rocketcomponent.ShockCord;
 import net.sf.openrocket.rocketcomponent.position.AxialMethod;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
 @SuppressWarnings("serial")
 public class ShockCordConfig extends RocketComponentConfig {
@@ -114,11 +116,56 @@ public class ShockCordConfig extends RocketComponentConfig {
 
 
 		//// General and General properties
-		tabbedPane.insertTab(trans.get("ShockCordCfg.tab.General"), null, panel, trans.get("ShockCordCfg.tab.ttip.General"), 0);
-		//		tabbedPane.insertTab("Radial position", null, positionTab(), 
-		//				"Radial position configuration", 1);
+		tabbedPane.insertTab(trans.get("ShockCordCfg.tab.General"), null, panel,
+				trans.get("ShockCordCfg.tab.ttip.General"), 0);
+		//// Radial position and Radial position configuration
+		tabbedPane.insertTab(trans.get("ShockCordCfg.tab.Radialpos"), null, positionTab(),
+				trans.get("ShockCordCfg.tab.ttip.Radialpos"), 1);
 		tabbedPane.setSelectedIndex(0);
 	}
-	
 
+	// TODO: LOW: there is a lot of duplicate code here with other mass components... (e.g. in MassComponentConfig or ParachuteConfig)
+	protected JPanel positionTab() {
+		JPanel panel = new JPanel(new MigLayout("gap rel unrel", "[][65lp::][30lp::]", ""));
+
+		////  Radial position
+		//// Radial distance:
+		panel.add(new JLabel(trans.get("ShockCordCfg.lbl.Radialdistance")));
+
+		DoubleModel m = new DoubleModel(component, "RadialPosition", UnitGroup.UNITS_LENGTH, 0);
+
+		JSpinner spin = new JSpinner(m.getSpinnerModel());
+		spin.setEditor(new SpinnerEditor(spin));
+		panel.add(spin, "growx");
+
+		panel.add(new UnitSelector(m), "growx");
+		panel.add(new BasicSlider(m.getSliderModel(0, 0.1, 1.0)), "w 100lp, wrap");
+
+
+		//// Radial direction:
+		panel.add(new JLabel(trans.get("ShockCordCfg.lbl.Radialdirection")));
+
+		m = new DoubleModel(component, "RadialDirection", UnitGroup.UNITS_ANGLE);
+
+		spin = new JSpinner(m.getSpinnerModel());
+		spin.setEditor(new SpinnerEditor(spin));
+		panel.add(spin, "growx");
+
+		panel.add(new UnitSelector(m), "growx");
+		panel.add(new BasicSlider(m.getSliderModel(-Math.PI, Math.PI)), "w 100lp, wrap");
+
+
+		//// Reset button
+		JButton button = new JButton(trans.get("ShockCordCfg.but.Reset"));
+		button.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				((ShockCord) component).setRadialDirection(0.0);
+				((ShockCord) component).setRadialPosition(0.0);
+			}
+		});
+		panel.add(button, "spanx, right");
+
+		return panel;
+	}
 }

--- a/swing/src/net/sf/openrocket/gui/rocketfigure/ShockCordShapes.java
+++ b/swing/src/net/sf/openrocket/gui/rocketfigure/ShockCordShapes.java
@@ -1,6 +1,9 @@
 package net.sf.openrocket.gui.rocketfigure;
 
+import net.sf.openrocket.rocketcomponent.MassComponent;
+import net.sf.openrocket.rocketcomponent.MassObject;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
+import net.sf.openrocket.rocketcomponent.ShockCord;
 import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.Transformation;
 
@@ -13,33 +16,41 @@ import java.awt.geom.RoundRectangle2D;
 public class ShockCordShapes extends RocketComponentShape {
 
 	public static RocketComponentShape[] getShapesSide( final RocketComponent component, final Transformation transformation) {
-
-
-		net.sf.openrocket.rocketcomponent.MassObject massObj = (net.sf.openrocket.rocketcomponent.MassObject)component;
+		final ShockCord massObj = (ShockCord)component;
 		
 		double length = massObj.getLength();
 		double radius = massObj.getRadius();
 		double arc = Math.min(length, 2*radius) * 0.7;
-		
-		Coordinate start = transformation.transform(Coordinate.ZERO);
+		final double radialDistance = massObj.getRadialPosition();
+		final double radialAngleRadians = massObj.getRadialDirection();
+
+		final Coordinate localPosition = new Coordinate(0,
+				radialDistance * Math.cos(radialAngleRadians),
+				radialDistance * Math.sin(radialAngleRadians));
+		final Coordinate renderPosition = transformation.transform(localPosition);
 		Shape[] s = new Shape[1];
-		s[0] = new RoundRectangle2D.Double(start.x,(start.y-radius),
+		s[0] = new RoundRectangle2D.Double(renderPosition.x,(renderPosition.y-radius),
 					length,2*radius,arc,arc);
 		
-		return RocketComponentShape.toArray( addSymbol(s), component);
+		return RocketComponentShape.toArray(addSymbol(s), component);
 	}
 	
 
 	public static RocketComponentShape[] getShapesBack( final RocketComponent component, final Transformation transformation) {
-
-		net.sf.openrocket.rocketcomponent.MassObject tube = (net.sf.openrocket.rocketcomponent.MassObject)component;
+		final ShockCord massObj = (ShockCord)component;
 		
-		double or = tube.getRadius();
+		double or = massObj.getRadius();
+		final double radialDistance = massObj.getRadialPosition();
+		final double radialAngleRadians = massObj.getRadialDirection();
+
+		final Coordinate localPosition = new Coordinate(0,
+				radialDistance * Math.cos(radialAngleRadians),
+				radialDistance * Math.sin(radialAngleRadians));
+		final Coordinate renderPosition = transformation.transform(localPosition);
 		
 		Shape[] s = new Shape[1];
-		Coordinate start = transformation.transform(Coordinate.ZERO);
 		
-		s[0] = new Ellipse2D.Double((start.z-or),(start.y-or),2*or,2*or);
+		s[0] = new Ellipse2D.Double((renderPosition.z-or),(renderPosition.y-or),2*or,2*or);
 		
 //		Coordinate[] start = transformation.transform(tube.toAbsolute(instanceOffset));
 //


### PR DESCRIPTION
This pull fixes #843, where you could not change the radial position of the shock cord component.

The fix was to first add the radial position tab to the shock cord configuration panel into ShockCordConfig. These settings were taken from the MassComponentConfig, which does have radial positioning. I also had to add new translations for the shock cord radial positioning in message.properties.

Next, the changes in radial position settings of the shock cord had to be applied to the 2D figure of the shock cord component. This was done by porting some settings from the MassComponentShapes to the ShockCordShapes.

! Be aware, for the radial positioning of the shock cord to work in the 3D view, #957 first needs to be merged. I already included these changes for the jar file, so that you can still test the radial positioning in the 3D view, but left it out of the commit.

Here is the [jar file](https://www.dropbox.com/s/xpmgcntp53uzvxb/OpenRocket-843.jar?dl=0) for testing.