### PR TITLE
[fixes #950] Photo Studio sky image empty option

### DIFF
--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettingsConfig.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettingsConfig.java
@@ -23,6 +23,7 @@ import javax.swing.colorchooser.ColorSelectionModel;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
+import com.jogamp.opengl.GL2;
 import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.gui.adaptors.BooleanModel;
 import net.sf.openrocket.gui.adaptors.DoubleModel;
@@ -31,6 +32,7 @@ import net.sf.openrocket.gui.components.EditableSpinner;
 import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.components.StyledLabel.Style;
 import net.sf.openrocket.gui.components.UnitSelector;
+import net.sf.openrocket.gui.figure3d.TextureCache;
 import net.sf.openrocket.gui.figure3d.photo.sky.Sky;
 import net.sf.openrocket.gui.figure3d.photo.sky.Sky.Credit;
 import net.sf.openrocket.gui.figure3d.photo.sky.builtin.Lake;
@@ -236,7 +238,16 @@ public class PhotoSettingsConfig extends JTabbedPane {
 
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.skyImage")));
 
-				add(new JComboBox<Sky>(new DefaultComboBoxModel<Sky>(new Sky[] { null, Mountains.instance, Meadow.instance,
+				Sky noSky = new Sky() {		// Dummy sky for 'none' selection option
+					@Override
+					public void draw(GL2 gl, TextureCache cache) { }
+
+					@Override
+					public String toString() {
+						return trans.get("DecalModel.lbl.select");
+					}
+				};
+				add(new JComboBox<Sky>(new DefaultComboBoxModel<Sky>(new Sky[] { noSky, Mountains.instance, Meadow.instance,
 						Storm.instance, Lake.instance, Orbit.instance, Miramar.instance }) {
 				}) {
 					{
@@ -245,10 +256,10 @@ public class PhotoSettingsConfig extends JTabbedPane {
 							public void actionPerformed(ActionEvent e) {
 								@SuppressWarnings("unchecked")
 								Object s = ((JComboBox<Sky>) e.getSource()).getSelectedItem();
-								if (s instanceof Sky) {
+								if (s instanceof Sky && s != noSky) {
 									p.setSky((Sky) s);
 									skyColorButton.setEnabled(false);
-								} else if (s == null) {
+								} else if (s == noSky) {
 									p.setSky(null);
 									skyColorButton.setEnabled(true);
 								}


### PR DESCRIPTION
This PR fixes #950 where in PhotoStudio the sky image option would just have an empty option to use the sky color instead of an image.

In line with how the appearance in a component config is implemented, I made it so that the empty option now displays a "< none >"-message. This is done by adding a dummy sky object with as string value the "< none >"-message.

![None option](https://user-images.githubusercontent.com/11031519/123692828-91837d00-d857-11eb-83bd-b8d350a38307.png)

@hcraigmiller suggested to also leave out the 'Sky'-terms out of 'Sky color' and 'Sky image' because it is already present as the bold 'Sky'-label. I decided not to change this because to be honest I don't really look at those title labels, plus it reduces having to continuously look at different locations to understand what's going on.

Here is a [jar file](https://www.dropbox.com/s/4ckavcgf78h73o2/OpenRocket-950.jar?dl=0) for testing.