### PR TITLE
More improvements for Bug #954

### DIFF
--- a/core/src/net/sf/openrocket/document/OpenRocketDocument.java
+++ b/core/src/net/sf/openrocket/document/OpenRocketDocument.java
@@ -594,6 +594,7 @@ public class OpenRocketDocument implements ComponentChangeListener {
 		}
 		
 		fireUndoRedoChangeEvent();
+		fireDocumentChangeEvent(new DocumentChangeEvent(e.getSource()));
 	}
 
 	/**

--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoFrame.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoFrame.java
@@ -9,6 +9,8 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -72,6 +74,17 @@ public class PhotoFrame extends JFrame {
 		setJMenuBar(getMenu(app));
 		setContentPane(photoPanel);
 
+		if (!app)
+			setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+		
+		addWindowListener(new WindowAdapter() {
+			@Override
+			public void windowClosing(WindowEvent e) {
+				closeAction();
+			}
+		});
+
+		
 		GUIUtil.rememberWindowSize(this);
 		this.setLocationByPlatform(true);
 		GUIUtil.rememberWindowPosition(this);
@@ -305,6 +318,11 @@ public class PhotoFrame extends JFrame {
 
 	}
 
+	private boolean closeAction() {
+		photoPanel.clearDoc();
+		return true;
+	}
+	
 	public static void main(String args[]) throws Exception {
 
 		LoggingSystemSetup.setupLoggingAppender();

--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoPanel.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoPanel.java
@@ -46,6 +46,7 @@ import net.sf.openrocket.gui.figure3d.photo.exhaust.FlameRenderer;
 import net.sf.openrocket.gui.main.Splash;
 import net.sf.openrocket.motor.Motor;
 import net.sf.openrocket.motor.MotorConfiguration;
+import net.sf.openrocket.rocketcomponent.AxialStage;
 import net.sf.openrocket.rocketcomponent.FlightConfiguration;
 import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
 import net.sf.openrocket.rocketcomponent.MotorMount;
@@ -417,7 +418,11 @@ public class PhotoPanel extends JPanel implements GLEventListener {
 		rr.render(drawable, configuration, new HashSet<RocketComponent>());
 		
 		//Figure out the lowest stage shown
-		final int bottomStageNumber = configuration.getBottomStage().getStageNumber();
+
+		AxialStage bottomStage = configuration.getBottomStage();
+		int bottomStageNumber = 0;
+		if (bottomStage != null)
+			bottomStage.getStageNumber();
 		//final int currentStageNumber = configuration.getActiveStages()[configuration.getActiveStages().length-1];
 		//final AxialStage currentStage = (AxialStage)configuration.getRocket().getChild( bottomStageNumber);
 		


### PR DESCRIPTION
If Photo Studio window and the main design window are visible at the same time, many changes made to the design don't immediately show up in the photo studio, but will show up when the photo view is dragged or changed.
This PR makes the updates immediate by routing all change events to the top level document change event.

Also fixes a couple of tangentially related problems:
1. every time the Photo Studio is opened a new copy of everything including the OpenGL context, the window data, and the event listeners is created.  These are never destroyed, so the event listener list fills up with old copies of the photo studio, which leaks resources and slows everything down.  Added a listener to the window close event, and made sure the window is disposed on close.
2. If all stages have been turned invisible, the photo studio crashes trying to figure out where to draw engines.  Added some checks to handle this case.
