### PR TITLE
[fixes #651] Fix shine wrong init value

### DIFF
--- a/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
@@ -389,6 +389,9 @@ public class AppearancePanel extends JPanel {
 			add(new JLabel(trans.get("AppearanceCfg.lbl.shine")));
 			DoubleModel shineModel = new DoubleModel(ab, "Shine",
 					UnitGroup.UNITS_RELATIVE);
+			// Set the initial value to the reset state, not the shine value of the default appearance of this component
+			if (mDefault.getValue() && previousUserSelectedAppearance != null)
+				shineModel.setValue(previousUserSelectedAppearance.getShine());
 			JSpinner spin = new JSpinner(shineModel.getSpinnerModel());
 			spin.setEditor(new SpinnerEditor(spin));
 			JSlider slide = new JSlider(shineModel.getSliderModel(0, 1));


### PR DESCRIPTION
This PR fixes #651 where the shine value would have the wrong initial value.

The problem was that the shineModel takes in the value of ab. However, ab's appearance is first set to the default appearance for that component. For example, the body tube's default appearance has a shine value of 30%, thus the spinner will be set to 30. When unchecking the default value, ab now has a new (non-default) appearance, with init value 0. The spinner is still at 30% at this time, but the shineModel value is already at 0. So when you change the slider or use the spinner up/down button, you suddenly jump from the 30%-value to the 0%-value.

So at the initialization of shineModel, I set its value equal to the reset value 0, found in resetToDefaults of AppearanceBuilder.

Here is the [jar file](https://www.dropbox.com/s/rxfcksfxkh4qi47/OpenRocket-651.jar?dl=0) for testing.