### PR TITLE
[fixes #971] Fix default appearance unchecking

### DIFF
--- a/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
@@ -315,6 +315,7 @@ public class AppearancePanel extends JPanel {
 						previousUserSelectedAppearance = (ab == null) ? null
 								: ab.getAppearance();
 						ab.setAppearance(defaultAppearance);
+						c.setAppearance(null);
 					} else {
 						ab.setAppearance(previousUserSelectedAppearance);
 					}


### PR DESCRIPTION
This PR fixes #971 where the 'default appearance' would uncheck itself after first unchecking the checkbox, then checking it again, closing the Appearance Panel and then reopening the panel.

The problem was that when the Appearance Panel opens, it checks the appearance of the component to know whether it should check or uncheck the default appearance. If the component's appearance is null, the default appearance checkbox will be checked and the default appearance is used. Else, the Appearance Panel will use the appearance of the component and thus uncheck the default appearance checkbox, since the component already has a custom appearance.

The problem is however that if you first uncheck the checkbox, then check it again, the component will be assigned the default appearance, but this is a not-null appearance. Hence, if you close the Appearance panel and open it again, it will once again check 'Is the appearance of this component null?'. Well, no, now you have applied the default appearance to the component, so the Appearance thinks 'Okay, I will continue with the appearance that the component has and I don't have to check the default appearance, because the component already has a custom appearance'. Even though this "custom" appearance is in fact the default appearance, the Appearance Panel doesn't know this.

So, the fix: I set it so that when you check the default appearance, you also set the appearance of that component to null. This essentially means that that component doesn't have a custom appearance, but the default one.

Here is a [jar file](https://www.dropbox.com/s/5i0da5ak61zku9m/OpenRocket-971.jar?dl=0) for testing.