### PR TITLE
[fixes #977] Fix Storm sky image going blank

### DIFF
--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/sky/SkyBoxCross.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/sky/SkyBoxCross.java
@@ -17,6 +17,7 @@ import com.jogamp.opengl.util.texture.awt.AWTTextureIO;
 public class SkyBoxCross extends Sky {
 	
 	private final URL imageURL;
+	private GL2 previousGL = null;	// GL that the textures were previously bound to
 	Texture north, east, south, west, up, down;
 	
 	public SkyBoxCross(final URL imageURL) {
@@ -40,6 +41,7 @@ public class SkyBoxCross extends Sky {
 			south = AWTTextureIO.newTexture(GLProfile.getDefault(), fixBug(i.getSubimage(dx * 3, dy, dx, dy)), true);
 			up = AWTTextureIO.newTexture(GLProfile.getDefault(), fixBug(i.getSubimage(dx, 0, dx, dy)), true);
 			down = AWTTextureIO.newTexture(GLProfile.getDefault(), fixBug(i.getSubimage(dx, 2 * dy, dx, dy)), true);
+			previousGL = gl;
 		} catch (IOException e) {
 			throw new Error(e);
 		}
@@ -47,7 +49,7 @@ public class SkyBoxCross extends Sky {
 	
 	@Override
 	public void draw(GL2 gl, final TextureCache cache) {
-		if (north == null) {
+		if (north == null || gl != previousGL) {
 			loadTextures(gl);
 		}
 		


### PR DESCRIPTION
This PR fixes #977 where the sky image for Stormy Days would go blank after selecting it, closing Photo Studio, reopening Photo Studio and trying Stormy Days again.

The problem was that the north, east, west... textures inside SkyBoxCross were being saved/loaded in the Storm singleton class, but the textures get somewhat bound to the gl. So, I added a variable to check what the previous gl was. If it does not equal the current gl, then reload the textures.

Here is a [jar file](https://www.dropbox.com/s/ir2qorsesc31vrq/OpenRocket-977.jar?dl=0) for testing.