### PR TITLE
[fixes #948] Fix bad appearance of active tabs on Mac

### DIFF
--- a/swing/src/net/sf/openrocket/gui/util/GUIUtil.java
+++ b/swing/src/net/sf/openrocket/gui/util/GUIUtil.java
@@ -250,7 +250,6 @@ public class GUIUtil {
 		try {
 			// Set system L&F
 			UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-			UIManager.put("TabbedPane.foreground", Color.black);
 			
 			// Check whether we have an ugly L&F
 			LookAndFeel laf = UIManager.getLookAndFeel();

--- a/swing/src/net/sf/openrocket/gui/util/GUIUtil.java
+++ b/swing/src/net/sf/openrocket/gui/util/GUIUtil.java
@@ -1,14 +1,6 @@
 package net.sf.openrocket.gui.util;
 
-import java.awt.Component;
-import java.awt.Container;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.Image;
-import java.awt.KeyboardFocusManager;
-import java.awt.Point;
-import java.awt.Toolkit;
-import java.awt.Window;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ComponentAdapter;
@@ -258,6 +250,7 @@ public class GUIUtil {
 		try {
 			// Set system L&F
 			UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+			UIManager.put("TabbedPane.foreground", Color.black);
 			
 			// Check whether we have an ugly L&F
 			LookAndFeel laf = UIManager.getLookAndFeel();

--- a/swing/src/net/sf/openrocket/startup/OSXSetup.java
+++ b/swing/src/net/sf/openrocket/startup/OSXSetup.java
@@ -1,9 +1,6 @@
 package net.sf.openrocket.startup;
 
-import java.awt.Desktop;
-import java.awt.Image;
-import java.awt.Taskbar;
-import java.awt.Toolkit;
+import java.awt.*;
 import java.awt.desktop.AboutHandler;
 import java.awt.desktop.PreferencesHandler;
 import java.awt.desktop.QuitHandler;
@@ -16,6 +13,8 @@ import net.sf.openrocket.arch.SystemInfo.Platform;
 import net.sf.openrocket.gui.dialogs.AboutDialog;
 import net.sf.openrocket.gui.dialogs.preferences.PreferencesDialog;
 import net.sf.openrocket.gui.main.BasicFrame;
+
+import javax.swing.*;
 
 /**
  * Static code for initialization of OSX UI Elements: Menu, Icon, Name and
@@ -90,6 +89,9 @@ final class OSXSetup {
 					SwingStartup.class.getResource(ICON_RSRC));
 			final Taskbar osxTaskbar = Taskbar.getTaskbar();
 			osxTaskbar.setIconImage(dockIcon);
+
+			// Set the foreground of active tabs to black; there was a bug where you had a white background and white foreground
+			UIManager.put("TabbedPane.foreground", Color.black);
 
 		} catch (final Throwable t) {
 			// None of the preceding is critical to the app,


### PR DESCRIPTION
This PR fixes #948 where the foreground of active tabbed panes was white on OSX machines, making it very much unreadable. All credits for the solution go to @wolsen .

Here is a [jar file](https://www.dropbox.com/s/rtv7vj30nwfgr67/OpenRocket-948.jar?dl=0) for testing.