### PR TITLE
[fixes #968] Fix bad highlight colors

### DIFF
--- a/swing/src/net/sf/openrocket/gui/components/ColorChooser.java
+++ b/swing/src/net/sf/openrocket/gui/components/ColorChooser.java
@@ -17,6 +17,8 @@ import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
+import net.sf.openrocket.gui.widgets.SelectColorButton;
+
 /**
  * A panel implementation of a color chooser.  The panel has a label and a textfield.  The label identifies 
  * what the color is to be used for (the purpose), and the textfield is uneditable but has its background set
@@ -58,7 +60,7 @@ public class ColorChooser extends JPanel {
         field.setBackground(curColor);
         parent.add(field, "width 50:100:100");
 
-        final JButton button = new JButton(COLOR_CHOOSER_BUTTON_LABEL);
+        final JButton button = new SelectColorButton(COLOR_CHOOSER_BUTTON_LABEL);
 
         ActionListener actionListener = new ActionListener() {
             @Override

--- a/swing/src/net/sf/openrocket/gui/components/SimulationExportPanel.java
+++ b/swing/src/net/sf/openrocket/gui/components/SimulationExportPanel.java
@@ -32,6 +32,7 @@ import net.sf.openrocket.simulation.FlightDataType;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.Unit;
 import net.sf.openrocket.unit.UnitGroup;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 @SuppressWarnings("serial")
 public class SimulationExportPanel extends JPanel {
@@ -135,7 +136,7 @@ public class SimulationExportPanel extends JPanel {
 		panel.add(new JScrollPane(table), "wmin 300lp, width 300lp, height 1, grow 100, wrap");
 		
 		// Select all/none buttons
-		button = new JButton(trans.get("SimExpPan.but.Selectall"));
+		button = new SelectColorButton(trans.get("SimExpPan.but.Selectall"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -144,7 +145,7 @@ public class SimulationExportPanel extends JPanel {
 		});
 		panel.add(button, "split 2, growx 1, sizegroup selectbutton");
 		
-		button = new JButton(trans.get("SimExpPan.but.Selectnone"));
+		button = new SelectColorButton(trans.get("SimExpPan.but.Selectnone"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -179,7 +180,7 @@ public class SimulationExportPanel extends JPanel {
 		
 
 		// Export button
-		button = new JButton(trans.get("SimExpPan.but.Exporttofile"));
+		button = new SelectColorButton(trans.get("SimExpPan.but.Exporttofile"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/components/StageSelector.java
+++ b/swing/src/net/sf/openrocket/gui/components/StageSelector.java
@@ -10,6 +10,7 @@ import javax.swing.JPanel;
 import javax.swing.JToggleButton;
 
 import net.miginfocom.swing.MigLayout;
+import net.sf.openrocket.gui.widgets.SelectColorToggleButton;
 import net.sf.openrocket.rocketcomponent.AxialStage;
 import net.sf.openrocket.rocketcomponent.ComponentChangeEvent;
 import net.sf.openrocket.rocketcomponent.FlightConfiguration;
@@ -36,7 +37,7 @@ public class StageSelector extends JPanel implements StateChangeListener {
 		buttons.clear();
 		this.removeAll();
 		for(AxialStage stage : configuration.getRocket().getStageList()){
-			JToggleButton button = new JToggleButton(new StageAction(stage));
+			JToggleButton button = new SelectColorToggleButton(new StageAction(stage));
 			button.setSelected(configuration.isStageActive(stage.getStageNumber()));
 			this.add(button);
 			buttons.add(button);

--- a/swing/src/net/sf/openrocket/gui/components/compass/CompassSelectionButton.java
+++ b/swing/src/net/sf/openrocket/gui/components/compass/CompassSelectionButton.java
@@ -23,6 +23,7 @@ import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.Chars;
 import net.sf.openrocket.util.MathUtil;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 
 /**
@@ -146,7 +147,7 @@ public class CompassSelectionButton extends FlatButton implements Resettable {
 			
 			panel.add(new JLabel("" + Chars.DEGREE), "wrap para");
 			
-			JButton close = new JButton("OK");
+			JButton close = new SelectColorButton("OK");
 			close.addActionListener(new ActionListener() {
 				@Override
 				public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
@@ -43,6 +43,7 @@ import net.sf.openrocket.unit.Unit;
 import net.sf.openrocket.unit.UnitGroup;
 import net.sf.openrocket.util.LineStyle;
 import net.sf.openrocket.util.StateChangeListener;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 public class AppearancePanel extends JPanel {
 	private static final long serialVersionUID = 2709187552673202019L;
@@ -204,7 +205,7 @@ public class AppearancePanel extends JPanel {
 			figureColor = Application.getPreferences().getDefaultColor(
 					c.getClass());
 		}
-		final JButton figureColorButton = new JButton(
+		final JButton figureColorButton = new SelectColorButton(
 				new ColorIcon(figureColor));
 
 		ab.addChangeListener(new StateChangeListener() {
@@ -252,7 +253,7 @@ public class AppearancePanel extends JPanel {
 					Style.BOLD));
 			add(colorDefault);
 
-			JButton button = new JButton(
+			JButton button = new SelectColorButton(
 					trans.get("RocketCompCfg.but.Saveasdefstyle"));
 			button.addActionListener(new ActionListener() {
 				@Override
@@ -359,7 +360,7 @@ public class AppearancePanel extends JPanel {
 		DecalModel decalModel = new DecalModel(panel, document, builder);
 		JComboBox<DecalImage> textureDropDown = new JComboBox<DecalImage>(decalModel);
 
-		JButton colorButton = new JButton(new ColorIcon(builder.getPaint()));
+		JButton colorButton = new SelectColorButton(new ColorIcon(builder.getPaint()));
 
 		builder.addChangeListener(new StateChangeListener() {
 			@Override
@@ -429,7 +430,7 @@ public class AppearancePanel extends JPanel {
 		mDefault.addEnableComponent(textureDropDown, false);
 		p.add(textureDropDown, "grow");
 		panel.add(p, "span 3, growx, wrap");
-		JButton editBtn = new JButton(
+		JButton editBtn = new SelectColorButton(
 				trans.get("AppearanceCfg.but.edit"));
 		editBtn.setEnabled(builder.getImage() != null);
 		// Enable the editBtn only when the appearance builder has an Image

--- a/swing/src/net/sf/openrocket/gui/configdialog/FinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/FinSetConfig.java
@@ -41,6 +41,7 @@ import net.sf.openrocket.rocketcomponent.position.AxialMethod;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
 import net.sf.openrocket.util.MathUtil;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,7 +69,7 @@ public abstract class FinSetConfig extends RocketComponentConfig {
 		//// Convert buttons
 		if (!(component instanceof FreeformFinSet)) {
 			//// Convert to freeform
-			convert = new JButton(trans.get("FinSetConfig.but.Converttofreeform"));
+			convert = new SelectColorButton(trans.get("FinSetConfig.but.Converttofreeform"));
 			//// Convert this fin set into a freeform fin set
 			convert.setToolTipText(trans.get("FinSetConfig.but.Converttofreeform.ttip"));
 			convert.addActionListener(new ActionListener() {
@@ -94,7 +95,7 @@ public abstract class FinSetConfig extends RocketComponentConfig {
 		}
 		
 		//// Split fins
-		split = new JButton(trans.get("FinSetConfig.but.Splitfins"));
+		split = new SelectColorButton(trans.get("FinSetConfig.but.Splitfins"));
 		//// Split the fin set into separate fins
 		split.setToolTipText(trans.get("FinSetConfig.but.Splitfins.ttip"));
 		split.addActionListener(new ActionListener() {
@@ -225,7 +226,7 @@ public abstract class FinSetConfig extends RocketComponentConfig {
 		panel.add( enumCombo, "spanx 3, growx, wrap para");
 
 		// Calculate fin tab height, length, and position
-		autoCalc = new JButton(trans.get("FinSetConfig.but.AutoCalc"));
+		autoCalc = new SelectColorButton(trans.get("FinSetConfig.but.AutoCalc"));
 		
 		autoCalc.addActionListener(new ActionListener() {
 			@Override

--- a/swing/src/net/sf/openrocket/gui/configdialog/FreeformFinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/FreeformFinSetConfig.java
@@ -67,6 +67,7 @@ import net.sf.openrocket.rocketcomponent.position.AxialMethod;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
 import net.sf.openrocket.util.Coordinate;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 @SuppressWarnings("serial")
 public class FreeformFinSetConfig extends FinSetConfig {
@@ -238,7 +239,7 @@ public class FreeformFinSetConfig extends FinSetConfig {
 		});
 		JScrollPane tablePane = new JScrollPane(table);
 		
-		JButton scaleButton = new JButton(trans.get("FreeformFinSetConfig.lbl.scaleFin"));
+		JButton scaleButton = new SelectColorButton(trans.get("FreeformFinSetConfig.lbl.scaleFin"));
 		scaleButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -252,7 +253,7 @@ public class FreeformFinSetConfig extends FinSetConfig {
 		//		panel.add(new JLabel("Coordinates:"), "aligny bottom, alignx 50%");
 		//		panel.add(new JLabel("    View:"), "wrap, aligny bottom");
 		
-		JButton exportCsvButton = new JButton("Export CSV");
+		JButton exportCsvButton = new SelectColorButton("Export CSV");
 		exportCsvButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -268,7 +269,7 @@ public class FreeformFinSetConfig extends FinSetConfig {
 				}
 			}
 		});
-        JButton importButton = new JButton(trans.get("CustomFinImport.button.label"));
+        JButton importButton = new SelectColorButton(trans.get("CustomFinImport.button.label"));
             importButton.addActionListener(new ActionListener() {
                 @Override
                 public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/configdialog/InnerTubeConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/InnerTubeConfig.java
@@ -35,6 +35,7 @@ import net.sf.openrocket.gui.adaptors.EnumModel;
 import net.sf.openrocket.gui.components.BasicSlider;
 import net.sf.openrocket.gui.components.DescriptionArea;
 import net.sf.openrocket.gui.components.UnitSelector;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.material.Material;
 import net.sf.openrocket.rocketcomponent.ClusterConfiguration;
@@ -230,7 +231,7 @@ public class InnerTubeConfig extends RocketComponentConfig {
 
 
 		//// Reset button
-		JButton button = new JButton(trans.get("ringcompcfg.but.Reset"));
+		JButton button = new SelectColorButton(trans.get("ringcompcfg.but.Reset"));
 		//// Reset the component to the rocket centerline
 		button.setToolTipText(trans.get("ringcompcfg.but.Resetcomponant"));
 		button.addActionListener(new ActionListener() {
@@ -314,7 +315,7 @@ public class InnerTubeConfig extends RocketComponentConfig {
 
 		// Split button
 		//// Split cluster
-		JButton split = new JButton(trans.get("InnerTubeCfg.but.Splitcluster"));
+		JButton split = new SelectColorButton(trans.get("InnerTubeCfg.but.Splitcluster"));
 		//// <html>Split the cluster into separate components.<br>
 		//// This also duplicates all components attached to this inner tube.
 		split.setToolTipText(trans.get("InnerTubeCfg.lbl.longA1") +
@@ -357,7 +358,7 @@ public class InnerTubeConfig extends RocketComponentConfig {
 
 		// Reset button
 		///// Reset settings
-		JButton reset = new JButton(trans.get("InnerTubeCfg.but.Resetsettings"));
+		JButton reset = new SelectColorButton(trans.get("InnerTubeCfg.but.Resetsettings"));
 		//// Reset the separation and rotation to the default values
 		reset.setToolTipText(trans.get("InnerTubeCfg.but.ttip.Resetsettings"));
 		reset.addActionListener(new ActionListener() {

--- a/swing/src/net/sf/openrocket/gui/configdialog/MassComponentConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/MassComponentConfig.java
@@ -22,6 +22,7 @@ import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.rocketcomponent.position.AxialMethod;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 
 @SuppressWarnings("serial")
@@ -169,7 +170,7 @@ public class MassComponentConfig extends RocketComponentConfig {
 		
 		
 		//// Reset button
-		JButton button = new JButton(trans.get("MassComponentCfg.but.Reset"));
+		JButton button = new SelectColorButton(trans.get("MassComponentCfg.but.Reset"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/configdialog/ParachuteConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/ParachuteConfig.java
@@ -23,6 +23,7 @@ import net.sf.openrocket.gui.components.HtmlLabel;
 import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.components.StyledLabel.Style;
 import net.sf.openrocket.gui.components.UnitSelector;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.material.Material;
 import net.sf.openrocket.rocketcomponent.DeploymentConfiguration;
@@ -77,7 +78,7 @@ public class ParachuteConfig extends RecoveryDeviceConfig {
 		panel.add(spin, "growx");
 		
 		//// Reset button
-		JButton button = new JButton(trans.get("ParachuteCfg.but.Reset"));
+		JButton button = new SelectColorButton(trans.get("ParachuteCfg.but.Reset"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -279,7 +280,7 @@ public class ParachuteConfig extends RecoveryDeviceConfig {
 		
 		
 		//// Reset button
-		JButton button = new JButton(trans.get("ParachuteCfg.but.Reset"));
+		JButton button = new SelectColorButton(trans.get("ParachuteCfg.but.Reset"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
@@ -36,6 +36,7 @@ import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.components.StyledLabel.Style;
 import net.sf.openrocket.gui.components.UnitSelector;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.material.Material;
 import net.sf.openrocket.preset.ComponentPreset;
@@ -138,7 +139,7 @@ public class RocketComponentConfig extends JPanel {
 		}
 		
 		//// Close button
-		JButton closeButton = new JButton(trans.get("dlg.but.close"));
+		JButton closeButton = new SelectColorButton(trans.get("dlg.but.close"));
 		closeButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent arg0) {
@@ -242,7 +243,7 @@ public class RocketComponentConfig extends JPanel {
 			subPanel.add( finishCombo, "spanx 4, growx, split");
 			
 			//// Set for all
-			JButton button = new JButton(trans.get("RocketCompCfg.but.Setforall"));
+			JButton button = new SelectColorButton(trans.get("RocketCompCfg.but.Setforall"));
 			//// Set this finish for all components of the rocket.
 			button.setToolTipText(trans.get("RocketCompCfg.but.ttip.Setforall"));
 			button.addActionListener(new ActionListener() {

--- a/swing/src/net/sf/openrocket/gui/configdialog/ShockCordConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/ShockCordConfig.java
@@ -12,7 +12,7 @@ import net.sf.openrocket.gui.components.BasicSlider;
 import net.sf.openrocket.gui.components.UnitSelector;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.material.Material;
-import net.sf.openrocket.rocketcomponent.MassComponent;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.rocketcomponent.ShockCord;
 import net.sf.openrocket.rocketcomponent.position.AxialMethod;
@@ -156,7 +156,7 @@ public class ShockCordConfig extends RocketComponentConfig {
 
 
 		//// Reset button
-		JButton button = new JButton(trans.get("ShockCordCfg.but.Reset"));
+		JButton button = new SelectColorButton(trans.get("ShockCordCfg.but.Reset"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/configdialog/StreamerConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/StreamerConfig.java
@@ -21,6 +21,7 @@ import net.sf.openrocket.gui.components.BasicSlider;
 import net.sf.openrocket.gui.components.HtmlLabel;
 import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.components.UnitSelector;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.material.Material;
 import net.sf.openrocket.rocketcomponent.DeploymentConfiguration;
@@ -280,7 +281,7 @@ public class StreamerConfig extends RecoveryDeviceConfig {
 		
 		
 		//// Reset button
-		JButton button = new JButton(trans.get("StreamerCfg.but.Reset"));
+		JButton button = new SelectColorButton(trans.get("StreamerCfg.but.Reset"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/customexpression/CustomExpressionPanel.java
+++ b/swing/src/net/sf/openrocket/gui/customexpression/CustomExpressionPanel.java
@@ -31,6 +31,7 @@ import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.logging.Markers;
 import net.sf.openrocket.simulation.customexpression.CustomExpression;
 import net.sf.openrocket.startup.Application;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 @SuppressWarnings("serial")
 public class CustomExpressionPanel extends JPanel {
@@ -62,7 +63,7 @@ public class CustomExpressionPanel extends JPanel {
 		//this.add(desc, "width 1px, growx 1, wrap unrel, wrap");
 		
 		//// New expression
-		JButton button = new JButton(trans.get("customExpressionPanel.but.NewExpression"));
+		JButton button = new SelectColorButton(trans.get("customExpressionPanel.but.NewExpression"));
 		button.setToolTipText(trans.get("customExpressionPanel.but.ttip.NewExpression"));
 		button.addActionListener(new ActionListener() {
 			@Override
@@ -77,7 +78,7 @@ public class CustomExpressionPanel extends JPanel {
 		this.add(button, "split 4, width :100:200");
 		
 		//// Import
-		final JButton importButton = new JButton(trans.get("customExpressionPanel.but.Import"));
+		final JButton importButton = new SelectColorButton(trans.get("customExpressionPanel.but.Import"));
 		importButton.setToolTipText(trans.get("customExpressionPanel.but.ttip.Import"));
 		importButton.addActionListener(new ActionListener() {
 			@Override
@@ -115,7 +116,7 @@ public class CustomExpressionPanel extends JPanel {
 		this.add(importButton, "width :100:200");
 		
 		//// Close button
-		final JButton closeButton = new JButton(trans.get("dlg.but.close"));
+		final JButton closeButton = new SelectColorButton(trans.get("dlg.but.close"));
 		closeButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -196,7 +197,7 @@ public class CustomExpressionPanel extends JPanel {
 			//unitSelector = setLabelStyle(unitSelector);
 			//unitSelector.setBackground(Color.WHITE);
 			
-			JButton editButton = new JButton(Icons.EDIT);
+			JButton editButton = new SelectColorButton(Icons.EDIT);
 			editButton.setToolTipText(trans.get("customExpression.Units.but.ttip.Edit"));
 			editButton.setBorderPainted(false);
 			editButton.addActionListener(new ActionListener() {
@@ -208,7 +209,7 @@ public class CustomExpressionPanel extends JPanel {
 				}
 			});
 			
-			JButton upButton = new JButton(Icons.UP);
+			JButton upButton = new SelectColorButton(Icons.UP);
 			upButton.setToolTipText(trans.get("customExpression.Units.but.ttip.MoveUp"));
 			upButton.setBorderPainted(false);
 			upButton.setVisible(showUp);
@@ -220,7 +221,7 @@ public class CustomExpressionPanel extends JPanel {
 				}
 			});
 			
-			JButton downButton = new JButton(Icons.DOWN);
+			JButton downButton = new SelectColorButton(Icons.DOWN);
 			downButton.setToolTipText(trans.get("customExpression.Units.but.ttip.MoveDown"));
 			downButton.setBorderPainted(false);
 			downButton.setVisible(showDown);
@@ -233,7 +234,7 @@ public class CustomExpressionPanel extends JPanel {
 			});
 			
 			
-			JButton deleteButton = new JButton(Icons.DELETE);
+			JButton deleteButton = new SelectColorButton(Icons.DELETE);
 			//// Remove this expression
 			deleteButton.setToolTipText(trans.get("customExpression.Units.but.ttip.Remove"));
 			deleteButton.setBorderPainted(false);

--- a/swing/src/net/sf/openrocket/gui/customexpression/ExpressionBuilderDialog.java
+++ b/swing/src/net/sf/openrocket/gui/customexpression/ExpressionBuilderDialog.java
@@ -19,6 +19,7 @@ import javax.swing.SwingUtilities;
 import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.gui.util.Icons;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.simulation.customexpression.CustomExpression;
 import net.sf.openrocket.startup.Application;
@@ -52,7 +53,7 @@ public class ExpressionBuilderDialog extends JDialog {
 	private final JLabel nameCheck = new JLabel(RedIcon);
 	private final JLabel expressionCheck = new JLabel(RedIcon);
 	private final JLabel unitCheck = new JLabel(RedIcon);
-	private final JButton okButton = new JButton(trans.get("dlg.but.ok"));
+	private final JButton okButton = new SelectColorButton(trans.get("dlg.but.ok"));
 	private final JTextField expressionField = new JTextField(20);
 	
 	public ExpressionBuilderDialog(Window parent, OpenRocketDocument doc){
@@ -155,7 +156,7 @@ public class ExpressionBuilderDialog extends JDialog {
 		
 		
 		//// Insert variable button
-		final JButton insertVariableButton = new JButton(trans.get("ExpressionBuilderDialog.InsertVariable"));
+		final JButton insertVariableButton = new SelectColorButton(trans.get("ExpressionBuilderDialog.InsertVariable"));
 		insertVariableButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -166,7 +167,7 @@ public class ExpressionBuilderDialog extends JDialog {
 		});
 		
 		//// Insert operator button
-		final JButton insertOperatorButton = new JButton(trans.get("ExpressionBuilderDialog.InsertOperator"));
+		final JButton insertOperatorButton = new SelectColorButton(trans.get("ExpressionBuilderDialog.InsertOperator"));
 		insertOperatorButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -190,7 +191,7 @@ public class ExpressionBuilderDialog extends JDialog {
 		});
 
 		//// Cancel button
-		final JButton cancelButton = new JButton(trans.get("dlg.but.cancel"));
+		final JButton cancelButton = new SelectColorButton(trans.get("dlg.but.cancel"));
 		cancelButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/customexpression/OperatorSelector.java
+++ b/swing/src/net/sf/openrocket/gui/customexpression/OperatorSelector.java
@@ -25,6 +25,7 @@ import javax.swing.event.ListSelectionListener;
 import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +49,7 @@ public class OperatorSelector extends JDialog {
 		this.parentWindow = parent;
 		this.parentBuilder = parentBuilder;
 		
-		final JButton insertButton = new JButton(trans.get("ExpressionBuilderDialog.InsertOperator"));
+		final JButton insertButton = new SelectColorButton(trans.get("ExpressionBuilderDialog.InsertOperator"));
 		
 		JPanel mainPanel = new JPanel(new MigLayout());
 		
@@ -133,7 +134,7 @@ public class OperatorSelector extends JDialog {
 		mainPanel.add(scrollPane, "wrap, push, grow");
 		
 		//// Cancel button
-		final JButton cancelButton = new JButton(trans.get("dlg.but.cancel"));
+		final JButton cancelButton = new SelectColorButton(trans.get("dlg.but.cancel"));
 		cancelButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/customexpression/VariableSelector.java
+++ b/swing/src/net/sf/openrocket/gui/customexpression/VariableSelector.java
@@ -24,6 +24,7 @@ import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +51,7 @@ public class VariableSelector extends JDialog {
 		super(parent, trans.get("CustomVariableSelector.title"), JDialog.ModalityType.DOCUMENT_MODAL);
 
 		this.parentBuilder = parentBuilder;
-		final JButton insertButton = new JButton(trans.get("ExpressionBuilderDialog.InsertVariable"));
+		final JButton insertButton = new SelectColorButton(trans.get("ExpressionBuilderDialog.InsertVariable"));
 
 		JPanel mainPanel = new JPanel(new MigLayout());
 
@@ -114,7 +115,7 @@ public class VariableSelector extends JDialog {
 		mainPanel.add(scrollPane, "wrap, push, grow");
 
 		//// Cancel button
-		final JButton cancelButton = new JButton(trans.get("dlg.but.cancel"));
+		final JButton cancelButton = new SelectColorButton(trans.get("dlg.but.cancel"));
 		cancelButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/AboutDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/AboutDialog.java
@@ -20,6 +20,7 @@ import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.BuildProperties;
 import net.sf.openrocket.util.Chars;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 @SuppressWarnings("serial")
 public class AboutDialog extends JDialog {
@@ -124,7 +125,7 @@ public class AboutDialog extends JDialog {
 		
 		
 		//Close button
-		JButton close = new JButton(trans.get("button.close"));
+		JButton close = new SelectColorButton(trans.get("button.close"));
 		close.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/BugReportDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/BugReportDialog.java
@@ -32,6 +32,7 @@ import net.sf.openrocket.logging.LoggingSystemSetup;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.BuildProperties;
 import net.sf.openrocket.util.JarUtil;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 @SuppressWarnings("serial")
 public class BugReportDialog extends JDialog {
@@ -76,7 +77,7 @@ public class BugReportDialog extends JDialog {
 		panel.add(new StyledLabel(trans.get("bugreport.lbl.Theinformation"), -1), "wrap para");
 		
 		////Close button
-		JButton close = new JButton(trans.get("dlg.but.close"));
+		JButton close = new SelectColorButton(trans.get("dlg.but.close"));
 		close.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
@@ -52,6 +52,7 @@ import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.components.UnitSelector;
 import net.sf.openrocket.gui.scalefigure.RocketPanel;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.widgets.SelectColorToggleButton;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.masscalc.CMAnalysisEntry;
 import net.sf.openrocket.masscalc.MassCalculator;
@@ -124,7 +125,7 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 		BasicSlider slider = new BasicSlider(theta.getSliderModel(0, 2 * Math.PI));
 		panel.add(slider, "growx, split 2");
 		//// Worst button
-		worstToggle = new JToggleButton(trans.get("componentanalysisdlg.ToggleBut.worst"));
+		worstToggle = new SelectColorToggleButton(trans.get("componentanalysisdlg.ToggleBut.worst"));
 		worstToggle.setSelected(true);
 		worstToggle.addActionListener(new ActionListener() {
 			@Override

--- a/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
@@ -64,6 +64,7 @@ import net.sf.openrocket.unit.UnitGroup;
 import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.MathUtil;
 import net.sf.openrocket.util.StateChangeListener;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -462,7 +463,7 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 		JButton button;
 
 		// TODO: LOW: printing
-		//		button = new JButton("Print");
+		//		button = new SelectColorButton("Print");
 		//		button.addActionListener(new ActionListener() {
 		//			public void actionPerformed(ActionEvent e) {
 		//				try {
@@ -476,9 +477,9 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 		//		});
 		//		panel.add(button,"tag ok");
 
-		//button = new JButton("Close");
+		//button = new SelectColorButton("Close");
 		//Close button
-		button = new JButton(trans.get("dlg.but.close"));
+		button = new SelectColorButton(trans.get("dlg.but.close"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/CustomMaterialDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/CustomMaterialDialog.java
@@ -24,6 +24,7 @@ import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.material.Material;
 import net.sf.openrocket.startup.Application;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 @SuppressWarnings("serial")
 public class CustomMaterialDialog extends JDialog {
@@ -110,7 +111,7 @@ public class CustomMaterialDialog extends JDialog {
 		}
 		
 		//// OK button
-		JButton okButton = new JButton(trans.get("dlg.but.ok"));
+		JButton okButton = new SelectColorButton(trans.get("dlg.but.ok"));
 		
 		okButton.addActionListener(new ActionListener() {
 			@Override
@@ -122,7 +123,7 @@ public class CustomMaterialDialog extends JDialog {
 		panel.add(okButton, "span, split, tag ok");
 		
 		////  Cancel
-		JButton closeButton = new JButton(trans.get("dlg.but.cancel"));
+		JButton closeButton = new SelectColorButton(trans.get("dlg.but.cancel"));
 		closeButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/DebugLogDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/DebugLogDialog.java
@@ -58,6 +58,7 @@ import net.sf.openrocket.logging.Markers;
 import net.sf.openrocket.logging.StackTraceWriter;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.NumericComparator;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 @SuppressWarnings("serial")
 public class DebugLogDialog extends JDialog {
@@ -179,7 +180,7 @@ public class DebugLogDialog extends JDialog {
 		topPanel.add(followBox, "skip, gapright para, right");
 		
 		//// Clear button
-		JButton clear = new JButton(trans.get("debuglogdlg.but.clear"));
+		JButton clear = new SelectColorButton(trans.get("debuglogdlg.but.clear"));
 		clear.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -347,7 +348,7 @@ public class DebugLogDialog extends JDialog {
 		
 		
 		//Close button
-		JButton close = new JButton(trans.get("dlg.but.close"));
+		JButton close = new SelectColorButton(trans.get("dlg.but.close"));
 		close.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/EditDecalDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/EditDecalDialog.java
@@ -22,6 +22,7 @@ import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 @SuppressWarnings("serial")
 public class EditDecalDialog extends JDialog {
@@ -64,7 +65,7 @@ public class EditDecalDialog extends JDialog {
 				commandText.setEnabled(false);
 				panel.add(commandText, "growx, wrap");
 				
-				final JButton chooser = new JButton(trans.get("EditDecalDialog.btn.chooser"));
+				final JButton chooser = new SelectColorButton(trans.get("EditDecalDialog.btn.chooser"));
 				chooser.setEnabled(false);
 				chooser.addActionListener(new ActionListener() {
 					
@@ -98,7 +99,7 @@ public class EditDecalDialog extends JDialog {
 				commandText.setEnabled(false);
 				panel.add(commandText, "growx, wrap");
 				
-				final JButton chooser = new JButton(trans.get("EditDecalDialog.btn.chooser"));
+				final JButton chooser = new SelectColorButton(trans.get("EditDecalDialog.btn.chooser"));
 				chooser.setEnabled(false);
 				chooser.addActionListener(new ActionListener() {
 					
@@ -142,7 +143,7 @@ public class EditDecalDialog extends JDialog {
 		}
 		
 		// OK / Cancel buttons
-		JButton okButton = new JButton(trans.get("dlg.but.ok"));
+		JButton okButton = new SelectColorButton(trans.get("dlg.but.ok"));
 		okButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -152,7 +153,7 @@ public class EditDecalDialog extends JDialog {
 		panel.add(okButton, "tag ok, spanx, split");
 		
 		//// Cancel button
-		JButton cancelButton = new JButton(trans.get("dlg.but.cancel"));
+		JButton cancelButton = new SelectColorButton(trans.get("dlg.but.cancel"));
 		cancelButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/LicenseDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/LicenseDialog.java
@@ -19,6 +19,7 @@ import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 public class LicenseDialog extends JDialog {
 	private static final String LICENSE_FILENAME = "LICENSE.TXT";
@@ -64,7 +65,7 @@ public class LicenseDialog extends JDialog {
 		panel.add(new JScrollPane(text),"grow, wrap para");
 		
 		//Close button
-		JButton close = new JButton(trans.get("dlg.but.close"));
+		JButton close = new SelectColorButton(trans.get("dlg.but.close"));
 		close.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/PrintDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/PrintDialog.java
@@ -46,6 +46,7 @@ import net.sf.openrocket.gui.util.SwingPreferences;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.startup.Application;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 /**
  * This class isolates the Swing components used to create a panel that is added to a standard Java print dialog.
@@ -167,7 +168,7 @@ public class PrintDialog extends JDialog implements TreeSelectionListener {
 		panel.add(new JPanel(), "pad 0, aligny top, growx");
 		
 
-		JButton settingsButton = new JButton(trans.get("printdlg.but.settings"));
+		JButton settingsButton = new SelectColorButton(trans.get("printdlg.but.settings"));
 		settingsButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -181,7 +182,7 @@ public class PrintDialog extends JDialog implements TreeSelectionListener {
 		panel.add(settingsButton, "aligny top, wrap para");
 				
 
-		previewButton = new JButton(trans.get("but.previewAndPrint"));
+		previewButton = new SelectColorButton(trans.get("but.previewAndPrint"));
 		previewButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -192,7 +193,7 @@ public class PrintDialog extends JDialog implements TreeSelectionListener {
 		panel.add(previewButton, "split, right, gap para");
 		
 
-		saveAsPDF = new JButton(trans.get("printdlg.but.saveaspdf"));
+		saveAsPDF = new SelectColorButton(trans.get("printdlg.but.saveaspdf"));
 		saveAsPDF.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -204,7 +205,7 @@ public class PrintDialog extends JDialog implements TreeSelectionListener {
 		panel.add(saveAsPDF, "right, gap para");
 		
 
-		cancel = new JButton(trans.get("button.cancel"));
+		cancel = new SelectColorButton(trans.get("button.cancel"));
 		cancel.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/PrintSettingsDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/PrintSettingsDialog.java
@@ -26,6 +26,7 @@ import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.logging.Markers;
 import net.sf.openrocket.startup.Application;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 /**
  * This class is a dialog for displaying advanced settings for printing rocket related info.
@@ -91,7 +92,7 @@ public class PrintSettingsDialog extends JDialog {
 
 
 		//// Reset
-		JButton button = new JButton(trans.get("but.Reset"));
+		JButton button = new SelectColorButton(trans.get("but.Reset"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -105,7 +106,7 @@ public class PrintSettingsDialog extends JDialog {
 		panel.add(button, "spanx, split, right");
 		
 		//// Close
-		JButton closeButton = new JButton(trans.get("but.Close"));
+		JButton closeButton = new SelectColorButton(trans.get("but.Close"));
 		closeButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/ScaleDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/ScaleDialog.java
@@ -39,6 +39,7 @@ import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.MathUtil;
 import net.sf.openrocket.util.Reflection;
 import net.sf.openrocket.util.Reflection.Method;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 /**
  * Dialog that allows scaling the rocket design.
@@ -388,7 +389,7 @@ public class ScaleDialog extends JDialog {
 		
 		
 		// Scale / Accept Buttons
-		JButton scale = new JButton(trans.get("button.scale"));
+		JButton scale = new SelectColorButton(trans.get("button.scale"));
 		scale.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -407,7 +408,7 @@ public class ScaleDialog extends JDialog {
 		panel.add(scale, "span, split, right, gap para");
 
 		// Cancel Button
-		JButton cancel = new JButton(trans.get("button.cancel"));
+		JButton cancel = new SelectColorButton(trans.get("button.cancel"));
 		cancel.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/SwingWorkerDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/SwingWorkerDialog.java
@@ -22,6 +22,7 @@ import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.logging.Markers;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.MathUtil;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 
 /**
@@ -71,7 +72,7 @@ public class SwingWorkerDialog extends JDialog implements PropertyChangeListener
 		panel.add(progressBar, "growx, wrap para");
 		
 		//// Cancel button
-		JButton cancel = new JButton(trans.get("dlg.but.cancel"));
+		JButton cancel = new SelectColorButton(trans.get("dlg.but.cancel"));
 		cancel.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/UpdateInfoDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/UpdateInfoDialog.java
@@ -21,6 +21,7 @@ import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.Chars;
 import net.sf.openrocket.util.ComparablePair;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 public class UpdateInfoDialog extends JDialog {
 	
@@ -73,7 +74,7 @@ public class UpdateInfoDialog extends JDialog {
 		panel.add(remind);
 		
 		//Close button
-		JButton button = new JButton(trans.get("dlg.but.close"));
+		JButton button = new SelectColorButton(trans.get("dlg.but.close"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/DeploymentSelectionDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/DeploymentSelectionDialog.java
@@ -31,6 +31,7 @@ import net.sf.openrocket.rocketcomponent.RecoveryDevice;
 import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 @SuppressWarnings("serial")
 public class DeploymentSelectionDialog extends JDialog {
@@ -121,7 +122,7 @@ public class DeploymentSelectionDialog extends JDialog {
 		
 		panel.add(new JPanel(), "span, split, growx");
 		
-		JButton okButton = new JButton(trans.get("button.ok"));
+		JButton okButton = new SelectColorButton(trans.get("button.ok"));
 		okButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -136,7 +137,7 @@ public class DeploymentSelectionDialog extends JDialog {
 		
 		panel.add(okButton, "sizegroup btn");
 		
-		JButton cancel = new JButton(trans.get("button.cancel"));
+		JButton cancel = new SelectColorButton(trans.get("button.cancel"));
 		cancel.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/IgnitionSelectionDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/IgnitionSelectionDialog.java
@@ -30,6 +30,7 @@ import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 public class IgnitionSelectionDialog extends JDialog {
 	private static final long serialVersionUID = -3399966098520607837L;
@@ -95,7 +96,7 @@ public class IgnitionSelectionDialog extends JDialog {
 		
 		panel.add(new JPanel(), "span, split, growx");
 		
-		JButton okButton = new JButton(trans.get("button.ok"));
+		JButton okButton = new SelectColorButton(trans.get("button.ok"));
 		okButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -133,7 +134,7 @@ public class IgnitionSelectionDialog extends JDialog {
 		panel.add(okButton, "sizegroup btn");
 		
 		
-		JButton cancel = new JButton(trans.get("button.cancel"));
+		JButton cancel = new SelectColorButton(trans.get("button.cancel"));
 		cancel.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/RenameConfigDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/RenameConfigDialog.java
@@ -17,6 +17,7 @@ import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
 import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.startup.Application;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 public class RenameConfigDialog extends JDialog {
 	private static final long serialVersionUID = -5423008694485357248L;
@@ -34,7 +35,7 @@ public class RenameConfigDialog extends JDialog {
 		
 		panel.add(new JPanel(), "growx");
 		
-		JButton okButton = new JButton(trans.get("button.ok"));
+		JButton okButton = new SelectColorButton(trans.get("button.ok"));
 		okButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -45,7 +46,7 @@ public class RenameConfigDialog extends JDialog {
 		});
 		panel.add(okButton);
 		
-		JButton renameToDefaultButton = new JButton(trans.get("RenameConfigDialog.but.reset"));
+		JButton renameToDefaultButton = new SelectColorButton(trans.get("RenameConfigDialog.but.reset"));
 		renameToDefaultButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -55,7 +56,7 @@ public class RenameConfigDialog extends JDialog {
 		});
 		panel.add(renameToDefaultButton);
 		
-		JButton cancel = new JButton(trans.get("button.cancel"));
+		JButton cancel = new SelectColorButton(trans.get("button.cancel"));
 		cancel.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/SeparationSelectionDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/SeparationSelectionDialog.java
@@ -28,6 +28,7 @@ import net.sf.openrocket.rocketcomponent.StageSeparationConfiguration;
 import net.sf.openrocket.rocketcomponent.StageSeparationConfiguration.SeparationEvent;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 @SuppressWarnings("serial")
 public class SeparationSelectionDialog extends JDialog {
@@ -90,7 +91,7 @@ public class SeparationSelectionDialog extends JDialog {
 		
 		panel.add(new JPanel(), "span, split, growx");
 		
-		JButton okButton = new JButton(trans.get("button.ok"));
+		JButton okButton = new SelectColorButton(trans.get("button.ok"));
 		okButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -109,7 +110,7 @@ public class SeparationSelectionDialog extends JDialog {
 		
 		panel.add(okButton, "sizegroup btn");
 		
-		JButton cancel = new JButton(trans.get("button.cancel"));
+		JButton cancel = new SelectColorButton(trans.get("button.cancel"));
 		cancel.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/MotorChooserDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/MotorChooserDialog.java
@@ -20,6 +20,7 @@ import net.sf.openrocket.motor.Motor;
 import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
 import net.sf.openrocket.rocketcomponent.MotorMount;
 import net.sf.openrocket.startup.Application;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 @SuppressWarnings("serial")
 public class MotorChooserDialog extends JDialog implements CloseableDialog {
@@ -48,7 +49,7 @@ public class MotorChooserDialog extends JDialog implements CloseableDialog {
 		
 		
 		// OK / Cancel buttons
-		JButton okButton = new JButton(trans.get("dlg.but.ok"));
+		JButton okButton = new SelectColorButton(trans.get("dlg.but.ok"));
 		okButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -58,7 +59,7 @@ public class MotorChooserDialog extends JDialog implements CloseableDialog {
 		panel.add(okButton, "tag ok, spanx, split");
 		
 		//// Cancel button
-		JButton cancelButton = new JButton(trans.get("dlg.but.cancel"));
+		JButton cancelButton = new SelectColorButton(trans.get("dlg.but.cancel"));
 		cancelButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/MotorFilterPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/MotorFilterPanel.java
@@ -39,6 +39,7 @@ import net.sf.openrocket.rocketcomponent.MotorMount;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 public abstract class MotorFilterPanel extends JPanel {
 	private static final long serialVersionUID = -2068101000195158181L;
@@ -173,7 +174,7 @@ public abstract class MotorFilterPanel extends JPanel {
 
 		sub.add(new JScrollPane(manufacturerCheckList.getList()), "grow,wrap");
 
-		JButton clearMotors = new JButton(trans.get("TCMotorSelPan.btn.checkNone"));
+		JButton clearMotors = new SelectColorButton(trans.get("TCMotorSelPan.btn.checkNone"));
 		clearMotors.addActionListener( new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -184,7 +185,7 @@ public abstract class MotorFilterPanel extends JPanel {
 
 		sub.add(clearMotors,"split 2");
 
-		JButton selectMotors = new JButton(trans.get("TCMotorSelPan.btn.checkAll"));
+		JButton selectMotors = new SelectColorButton(trans.get("TCMotorSelPan.btn.checkAll"));
 		selectMotors.addActionListener( new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorPlotDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorPlotDialog.java
@@ -18,6 +18,7 @@ import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.motor.ThrustCurveMotor;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartPanel;
@@ -106,7 +107,7 @@ public class ThrustCurveMotorPlotDialog extends JDialog {
 		
 
 		// Close button
-		JButton close = new JButton(trans.get("dlg.but.close"));
+		JButton close = new SelectColorButton(trans.get("dlg.but.close"));
 		close.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/optimization/GeneralOptimizationDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/optimization/GeneralOptimizationDialog.java
@@ -100,6 +100,7 @@ import net.sf.openrocket.util.BugException;
 import net.sf.openrocket.util.Chars;
 import net.sf.openrocket.util.Named;
 import net.sf.openrocket.util.TextUtil;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 /**
  * General rocket optimization dialog. 
@@ -259,7 +260,7 @@ public class GeneralOptimizationDialog extends JDialog {
 		// // Add/remove buttons
 		sub = new JPanel(new MigLayout("fill"));
 		
-		addButton = new JButton(Chars.LEFT_ARROW + " " + trans.get("btn.add") + "   ");
+		addButton = new SelectColorButton(Chars.LEFT_ARROW + " " + trans.get("btn.add") + "   ");
 		addButton.setToolTipText(trans.get("btn.add.ttip"));
 		addButton.addActionListener(e -> {
 			SimulationModifier mod = getSelectedAvailableModifier();
@@ -276,7 +277,7 @@ public class GeneralOptimizationDialog extends JDialog {
 		disableComponents.add(addButton);
 		sub.add(addButton, "wrap para, sg button");
 		
-		removeButton = new JButton("   " + trans.get("btn.remove") + " " + Chars.RIGHT_ARROW);
+		removeButton = new SelectColorButton("   " + trans.get("btn.remove") + " " + Chars.RIGHT_ARROW);
 		removeButton.setToolTipText(trans.get("btn.remove.ttip"));
 		removeButton.addActionListener(e -> {
 			SimulationModifier mod = getSelectedModifier();
@@ -295,7 +296,7 @@ public class GeneralOptimizationDialog extends JDialog {
 		disableComponents.add(removeButton);
 		sub.add(removeButton, "wrap para*2, sg button");
 		
-		removeAllButton = new JButton(trans.get("btn.removeAll"));
+		removeAllButton = new SelectColorButton(trans.get("btn.removeAll"));
 		removeAllButton.setToolTipText(trans.get("btn.removeAll.ttip"));
 		removeAllButton.addActionListener(new ActionListener() {
 			@Override
@@ -543,7 +544,7 @@ public class GeneralOptimizationDialog extends JDialog {
 		});
 		sub.add(startButton, "span, growx, wrap para*2");
 		
-		plotButton = new JButton(trans.get("btn.plotPath"));
+		plotButton = new SelectColorButton(trans.get("btn.plotPath"));
 		plotButton.setToolTipText(trans.get("btn.plotPath.ttip"));
 		plotButton.addActionListener(e -> {
 			log.info(Markers.USER_MARKER, "Plotting optimization path, dimensionality=" + selectedModifiers.size());
@@ -559,7 +560,7 @@ public class GeneralOptimizationDialog extends JDialog {
 		disableComponents.add(plotButton);
 		sub.add(plotButton, "span, growx, wrap");
 		
-		saveButton = new JButton(trans.get("btn.save"));
+		saveButton = new SelectColorButton(trans.get("btn.save"));
 		saveButton.setToolTipText(trans.get("btn.save.ttip"));
 		saveButton.addActionListener(e -> {
 			log.info(Markers.USER_MARKER, "User selected save path");
@@ -571,7 +572,7 @@ public class GeneralOptimizationDialog extends JDialog {
 		panel.add(sub, "wrap para*2");
 		
 		// // Bottom buttons
-		final JButton applyButton = new JButton(trans.get("btn.apply"));
+		final JButton applyButton = new SelectColorButton(trans.get("btn.apply"));
 		applyButton.setToolTipText(trans.get("btn.apply.ttip"));
 		applyButton.addActionListener(e -> {
 			log.info(Markers.USER_MARKER, "Applying optimization changes");
@@ -580,7 +581,7 @@ public class GeneralOptimizationDialog extends JDialog {
 		disableComponents.add(applyButton);
 		panel.add(applyButton, "span, split, gapright para, right");
 
-		final JButton resetButton = new JButton(trans.get("btn.reset"));
+		final JButton resetButton = new SelectColorButton(trans.get("btn.reset"));
 		resetButton.setToolTipText(trans.get("btn.reset.ttip"));
 		resetButton.addActionListener(e -> {
 			log.info(Markers.USER_MARKER, "Resetting optimization design");
@@ -589,7 +590,7 @@ public class GeneralOptimizationDialog extends JDialog {
 		disableComponents.add(resetButton);
 		panel.add(resetButton, "gapright para, right");
 
-		final JButton closeButton = new JButton(trans.get("btn.close"));
+		final JButton closeButton = new SelectColorButton(trans.get("btn.close"));
 		closeButton.setToolTipText(trans.get("btn.close.ttip"));
 		closeButton.addActionListener(new ActionListener() {
 			@Override

--- a/swing/src/net/sf/openrocket/gui/dialogs/optimization/GeneralOptimizationDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/optimization/GeneralOptimizationDialog.java
@@ -73,6 +73,7 @@ import net.sf.openrocket.gui.scalefigure.RocketFigure;
 import net.sf.openrocket.gui.scalefigure.ScaleScrollPane;
 import net.sf.openrocket.gui.util.FileHelper;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.widgets.SelectColorToggleButton;
 import net.sf.openrocket.gui.util.SwingPreferences;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.logging.Markers;
@@ -88,7 +89,6 @@ import net.sf.openrocket.optimization.rocketoptimization.goals.MaximizationGoal;
 import net.sf.openrocket.optimization.rocketoptimization.goals.MinimizationGoal;
 import net.sf.openrocket.optimization.rocketoptimization.goals.ValueSeekGoal;
 import net.sf.openrocket.optimization.services.OptimizationServiceHelper;
-import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
 import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.startup.Application;
@@ -527,7 +527,7 @@ public class GeneralOptimizationDialog extends JDialog {
 		
 		// // Start/Stop button
 		
-		startButton = new JToggleButton(START_TEXT);
+		startButton = new SelectColorToggleButton(START_TEXT);
 		startButton.addActionListener(e -> {
 			if (updating) {
 				log.debug("Updating, ignoring event");

--- a/swing/src/net/sf/openrocket/gui/dialogs/optimization/OptimizationPlotDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/optimization/OptimizationPlotDialog.java
@@ -29,6 +29,7 @@ import net.sf.openrocket.unit.UnitGroup;
 import net.sf.openrocket.unit.Value;
 import net.sf.openrocket.util.LinearInterpolator;
 import net.sf.openrocket.util.MathUtil;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartPanel;
@@ -101,7 +102,7 @@ public class OptimizationPlotDialog extends JDialog {
 		panel.add(label, "");
 		
 
-		JButton close = new JButton(trans.get("button.close"));
+		JButton close = new SelectColorButton(trans.get("button.close"));
 		close.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/preferences/GeneralPreferencesPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preferences/GeneralPreferencesPanel.java
@@ -39,6 +39,7 @@ import net.sf.openrocket.startup.Preferences;
 import net.sf.openrocket.util.BuildProperties;
 import net.sf.openrocket.util.Named;
 import net.sf.openrocket.util.Utils;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 @SuppressWarnings("serial")
 public class GeneralPreferencesPanel extends PreferencesPanel {
@@ -123,7 +124,7 @@ public class GeneralPreferencesPanel extends PreferencesPanel {
 		this.add(field, "w 100px, gapright unrel, spanx, growx, split");
 		
 		//// Add button
-		JButton button = new JButton(trans.get("pref.dlg.but.add"));
+		JButton button = new SelectColorButton(trans.get("pref.dlg.but.add"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -166,7 +167,7 @@ public class GeneralPreferencesPanel extends PreferencesPanel {
 		this.add(button, "gapright unrel");
 		
 		//// Reset button
-		button = new JButton(trans.get("pref.dlg.but.reset"));
+		button = new SelectColorButton(trans.get("pref.dlg.but.reset"));
 		
 		button.addActionListener(new ActionListener() {
 			@Override
@@ -199,7 +200,7 @@ public class GeneralPreferencesPanel extends PreferencesPanel {
 		this.add(softwareUpdateBox);
 		
 		//// Check now button
-		button = new JButton(trans.get("pref.dlg.but.checknow"));
+		button = new SelectColorButton(trans.get("pref.dlg.but.checknow"));
 		//// Check for software updates now
 		button.setToolTipText(trans.get("pref.dlg.ttip.Checkupdatesnow"));
 		button.addActionListener(new ActionListener() {
@@ -253,7 +254,7 @@ public class GeneralPreferencesPanel extends PreferencesPanel {
 		panel.add(bar, "growx, wrap para");
 		
 		//// Cancel button
-		JButton cancel = new JButton(trans.get("dlg.but.cancel"));
+		JButton cancel = new SelectColorButton(trans.get("dlg.but.cancel"));
 		cancel.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/preferences/GraphicsPreferencesPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preferences/GraphicsPreferencesPanel.java
@@ -30,6 +30,7 @@ import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.components.StyledLabel.Style;
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.startup.Preferences;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 import com.itextpdf.text.Font;
 
@@ -106,7 +107,7 @@ public class GraphicsPreferencesPanel extends PreferencesPanel {
 				});
 				add(commandText, "growx, wrap");
 				
-				final JButton chooser = new JButton(trans.get("EditDecalDialog.btn.chooser"));
+				final JButton chooser = new SelectColorButton(trans.get("EditDecalDialog.btn.chooser"));
 				chooser.setEnabled(commandLineIsSelected);
 				chooser.addActionListener(new ActionListener() {
 					

--- a/swing/src/net/sf/openrocket/gui/dialogs/preferences/MaterialEditPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preferences/MaterialEditPanel.java
@@ -33,6 +33,7 @@ import net.sf.openrocket.material.Material;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
 import net.sf.openrocket.unit.Value;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 @SuppressWarnings("serial")
 public class MaterialEditPanel extends JPanel {
@@ -118,7 +119,7 @@ public class MaterialEditPanel extends JPanel {
 		
 
 		//// New button
-		addButton = new JButton(trans.get("matedtpan.but.new"));
+		addButton = new SelectColorButton(trans.get("matedtpan.but.new"));
 		//// Add a new material
 		addButton.setToolTipText(trans.get("matedtpan.col.but.ttip.New"));
 		addButton.addActionListener(new ActionListener() {
@@ -140,7 +141,7 @@ public class MaterialEditPanel extends JPanel {
 		this.add(addButton, "gap rel rel para para, w 70lp, split 5, flowy, growx 1, top");
 		
 		//// Edit button
-		editButton = new JButton(trans.get("matedtpan.but.edit"));
+		editButton = new SelectColorButton(trans.get("matedtpan.but.edit"));
 		//// Edit an existing material
 		editButton.setToolTipText(trans.get("matedtpan.but.ttip.edit"));
 		editButton.addActionListener(new ActionListener() {
@@ -183,7 +184,7 @@ public class MaterialEditPanel extends JPanel {
 		this.add(editButton, "gap rel rel para para, growx 1, top");
 		
 		//// Delete button
-		deleteButton = new JButton(trans.get("matedtpan.but.delete"));
+		deleteButton = new SelectColorButton(trans.get("matedtpan.but.delete"));
 		//// Delete a user-defined material
 		deleteButton.setToolTipText(trans.get("matedtpan.but.ttip.delete"));
 		deleteButton.addActionListener(new ActionListener() {
@@ -207,7 +208,7 @@ public class MaterialEditPanel extends JPanel {
 		this.add(new JPanel(), "grow 1");
 		
 		//// Revert all button
-		revertButton = new JButton(trans.get("matedtpan.but.revertall"));
+		revertButton = new SelectColorButton(trans.get("matedtpan.but.revertall"));
 		//// Delete all user-defined materials
 		revertButton.setToolTipText(trans.get("matedtpan.but.ttip.revertall"));
 		revertButton.addActionListener(new ActionListener() {

--- a/swing/src/net/sf/openrocket/gui/dialogs/preferences/PreferencesDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preferences/PreferencesDialog.java
@@ -18,6 +18,7 @@ import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.gui.util.SwingPreferences;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,7 +75,7 @@ public class PreferencesDialog extends JDialog {
 		// new DisplayPreferencesPanel());
 
 		// Close button
-		JButton close = new JButton(trans.get("dlg.but.close"));
+		JButton close = new SelectColorButton(trans.get("dlg.but.close"));
 		close.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent arg0) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/preferences/SimulationPreferencesPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preferences/SimulationPreferencesPanel.java
@@ -19,6 +19,7 @@ import net.sf.openrocket.gui.components.UnitSelector;
 import net.sf.openrocket.simulation.RK4SimulationStepper;
 import net.sf.openrocket.unit.UnitGroup;
 import net.sf.openrocket.util.GeodeticComputationStrategy;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 public class SimulationPreferencesPanel extends PreferencesPanel {
 	private static final long serialVersionUID = 7983195730016979888L;
@@ -151,7 +152,7 @@ public class SimulationPreferencesPanel extends PreferencesPanel {
 		sub.add(subsub, "spanx, wrap para");
 
 		// Reset to default button
-		JButton button = new JButton(trans.get("simedtdlg.but.resettodefault"));
+		JButton button = new SelectColorButton(trans.get("simedtdlg.but.resettodefault"));
 		// Reset the time step to its default value (
 		button.setToolTipText(trans.get("simedtdlg.but.ttip.resettodefault")
 				+ UnitGroup.UNITS_SHORT_TIME

--- a/swing/src/net/sf/openrocket/gui/dialogs/preferences/UnitsPreferencesPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preferences/UnitsPreferencesPanel.java
@@ -13,6 +13,7 @@ import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.components.StyledLabel.Style;
 import net.sf.openrocket.unit.UnitGroup;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 public class UnitsPreferencesPanel extends PreferencesPanel {
 
@@ -136,7 +137,7 @@ public class UnitsPreferencesPanel extends PreferencesPanel {
 		
 		
 		//// Default metric button
-		JButton button = new JButton(trans.get("pref.dlg.but.defaultmetric"));
+		JButton button = new SelectColorButton(trans.get("pref.dlg.but.defaultmetric"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -148,7 +149,7 @@ public class UnitsPreferencesPanel extends PreferencesPanel {
 		this.add(button, "spanx, split 2, grow");
 		
 		//// Default imperial button
-		button = new JButton(trans.get("pref.dlg.but.defaultimperial"));
+		button = new SelectColorButton(trans.get("pref.dlg.but.defaultimperial"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
@@ -33,6 +33,7 @@ import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.rocketcomponent.SymmetricComponent;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.Chars;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 /**
  * Dialog shown for selecting a preset component.
@@ -145,7 +146,7 @@ public class ComponentPresetChooserDialog extends JDialog {
 		
 		
 		// OK / Cancel buttons
-		JButton okButton = new JButton(trans.get("dlg.but.ok"));
+		JButton okButton = new SelectColorButton(trans.get("dlg.but.ok"));
 		okButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -155,7 +156,7 @@ public class ComponentPresetChooserDialog extends JDialog {
 		panel.add(okButton, "tag ok, spanx, split");
 		
 		//// Cancel button
-		JButton cancelButton = new JButton(trans.get("dlg.but.cancel"));
+		JButton cancelButton = new SelectColorButton(trans.get("dlg.but.cancel"));
 		cancelButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettingsConfig.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettingsConfig.java
@@ -46,6 +46,7 @@ import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
 import net.sf.openrocket.util.StateChangeListener;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 @SuppressWarnings("serial")
 public class PhotoSettingsConfig extends JTabbedPane {
@@ -129,16 +130,16 @@ public class PhotoSettingsConfig extends JTabbedPane {
 
 		setPreferredSize(new Dimension(240, 320));
 
-		final JButton sunLightColorButton = new JButton();
+		final JButton sunLightColorButton = new SelectColorButton();
 		sunLightColorButton.setMaximumSize(new Dimension(35, 25));
 
-		final JButton skyColorButton = new JButton();
+		final JButton skyColorButton = new SelectColorButton();
 		skyColorButton.setMaximumSize(new Dimension(35, 25));
 
-		final JButton smokeColorButton = new JButton();
+		final JButton smokeColorButton = new SelectColorButton();
 		smokeColorButton.setMaximumSize(new Dimension(35, 25));
 
-		final JButton flameColorButton = new JButton();
+		final JButton flameColorButton = new SelectColorButton();
 		flameColorButton.setMaximumSize(new Dimension(35, 25));
 
 		p.addChangeListener(new StateChangeListener() {

--- a/swing/src/net/sf/openrocket/gui/help/tours/GuidedTourSelectionDialog.java
+++ b/swing/src/net/sf/openrocket/gui/help/tours/GuidedTourSelectionDialog.java
@@ -28,6 +28,7 @@ import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.Named;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 public class GuidedTourSelectionDialog extends JDialog {
 	private static final long serialVersionUID = -3643116444821710259L;
@@ -90,7 +91,7 @@ public class GuidedTourSelectionDialog extends JDialog {
 		tourLength = new StyledLabel(-1);
 		sub.add(tourLength, "wrap unrel");
 		
-		JButton start = new JButton(trans.get("btn.start"));
+		JButton start = new SelectColorButton(trans.get("btn.start"));
 		start.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -103,7 +104,7 @@ public class GuidedTourSelectionDialog extends JDialog {
 		
 		
 		
-		JButton close = new JButton(trans.get("button.close"));
+		JButton close = new SelectColorButton(trans.get("button.close"));
 		close.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/help/tours/SlideShowDialog.java
+++ b/swing/src/net/sf/openrocket/gui/help/tours/SlideShowDialog.java
@@ -24,6 +24,7 @@ import net.sf.openrocket.logging.Markers;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.BugException;
 import net.sf.openrocket.util.Chars;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 @SuppressWarnings("serial")
 public class SlideShowDialog extends JDialog {
@@ -52,7 +53,7 @@ public class SlideShowDialog extends JDialog {
 		
 		JPanel sub = new JPanel(new MigLayout("ins 0, fill"));
 		
-		prevButton = new JButton(Chars.LEFT_ARROW + " " + trans.get("btn.prev"));
+		prevButton = new SelectColorButton(Chars.LEFT_ARROW + " " + trans.get("btn.prev"));
 		prevButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -64,7 +65,7 @@ public class SlideShowDialog extends JDialog {
 		
 		
 		
-		nextButton = new JButton(trans.get("btn.next") + " " + Chars.RIGHT_ARROW);
+		nextButton = new SelectColorButton(trans.get("btn.next") + " " + Chars.RIGHT_ARROW);
 		nextButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -78,7 +79,7 @@ public class SlideShowDialog extends JDialog {
 		sub.add(new JPanel(), "growx");
 		
 		
-		closeButton = new JButton(trans.get("button.close"));
+		closeButton = new SelectColorButton(trans.get("button.close"));
 		closeButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -60,6 +60,7 @@ import javax.swing.tree.DefaultTreeSelectionModel;
 import javax.swing.tree.TreePath;
 import javax.swing.tree.TreeSelectionModel;
 
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 import net.sf.openrocket.rocketcomponent.AxialStage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -350,16 +351,16 @@ public class BasicFrame extends JFrame {
 
 
 		// Buttons
-		JButton button = new JButton(actions.getMoveUpAction());
+		JButton button = new SelectColorButton(actions.getMoveUpAction());
 		panel.add(button, "sizegroup buttons, aligny 65%");
 
-		button = new JButton(actions.getMoveDownAction());
+		button = new SelectColorButton(actions.getMoveDownAction());
 		panel.add(button, "sizegroup buttons, aligny 0%");
 
-		button = new JButton(actions.getEditAction());
+		button = new SelectColorButton(actions.getEditAction());
 		panel.add(button, "sizegroup buttons");
 
-		button = new JButton(actions.getDeleteAction());
+		button = new SelectColorButton(actions.getDeleteAction());
 		button.setIcon(null);
 		button.setMnemonic(0);
 		panel.add(button, "sizegroup buttons");

--- a/swing/src/net/sf/openrocket/gui/main/SimulationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/SimulationPanel.java
@@ -71,6 +71,7 @@ import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.startup.Preferences;
 import net.sf.openrocket.unit.UnitGroup;
 import net.sf.openrocket.util.AlphanumComparator;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 @SuppressWarnings("serial")
 public class SimulationPanel extends JPanel {
@@ -111,7 +112,7 @@ public class SimulationPanel extends JPanel {
 
 		//// New simulation button
 		{
-			JButton button = new JButton(trans.get("simpanel.but.newsimulation"));
+			JButton button = new SelectColorButton(trans.get("simpanel.but.newsimulation"));
 			//// Add a new simulation
 			button.setToolTipText(trans.get("simpanel.but.ttip.newsimulation"));
 			button.addActionListener(new ActionListener() {
@@ -133,7 +134,7 @@ public class SimulationPanel extends JPanel {
 		}
 
 		//// Edit simulation button
-		editButton = new JButton(trans.get("simpanel.but.editsimulation"));
+		editButton = new SelectColorButton(trans.get("simpanel.but.editsimulation"));
 		//// Edit the selected simulation
 		editButton.setToolTipText(trans.get("simpanel.but.ttip.editsim"));
 		editButton.addActionListener(new ActionListener() {
@@ -155,7 +156,7 @@ public class SimulationPanel extends JPanel {
 		this.add(editButton, "gapright para");
 
 		//// Run simulations
-		runButton = new JButton(trans.get("simpanel.but.runsimulations"));
+		runButton = new SelectColorButton(trans.get("simpanel.but.runsimulations"));
 		//// Re-run the selected simulations
 		runButton.setToolTipText(trans.get("simpanel.but.ttip.runsimu"));
 		runButton.addActionListener(new ActionListener() {
@@ -181,7 +182,7 @@ public class SimulationPanel extends JPanel {
 		this.add(runButton, "gapright para");
 
 		//// Delete simulations button
-		deleteButton = new JButton(trans.get("simpanel.but.deletesimulations"));
+		deleteButton = new SelectColorButton(trans.get("simpanel.but.deletesimulations"));
 		//// Delete the selected simulations
 		deleteButton.setToolTipText(trans.get("simpanel.but.ttip.deletesim"));
 		deleteButton.addActionListener(new ActionListener() {
@@ -236,8 +237,8 @@ public class SimulationPanel extends JPanel {
 		this.add(deleteButton, "gapright para");
 
 		//// Plot / export button
-		plotButton = new JButton(trans.get("simpanel.but.plotexport"));
-		//		button = new JButton("Plot flight");
+		plotButton = new SelectColorButton(trans.get("simpanel.but.plotexport"));
+		//		button = new SelectColorButton("Plot flight");
 		plotButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
@@ -229,6 +229,11 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 					T component = v.getV();
 					label = format(component, fcid, label );
 				}
+				for (Component c : label.getComponents()) {
+					if (c instanceof JLabel) {
+						setSelected((JLabel)c, table, isSelected, hasFocus);
+					}
+				}
 				setSelected(label, table, isSelected, hasFocus);
 				return label;
 			}
@@ -242,7 +247,7 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 				c.setForeground((Color)UIManager.get("Table.selectionForeground"));
 			} else {
 				c.setBackground(table.getBackground());
-				c.setForeground(table.getForeground());
+				c.setForeground(c.getForeground());
 			}
 			Border b = null;
 			if ( hasFocus ) {

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
@@ -211,7 +211,7 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 				log.warn("Detected null newValue to render... (oldValue: "+oldValue+")");
 				newValue = oldValue;
 			}
-			
+
 		    column = table.convertColumnIndexToModel(column);
 			switch (column) {
 			case 0: {
@@ -239,8 +239,10 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 			c.setOpaque(true);
 			if ( isSelected) {
 				c.setBackground(table.getSelectionBackground());
+				c.setForeground((Color)UIManager.get("Table.selectionForeground"));
 			} else {
 				c.setBackground(table.getBackground());
+				c.setForeground(table.getForeground());
 			}
 			Border b = null;
 			if ( hasFocus ) {

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurationPanel.java
@@ -25,6 +25,7 @@ import net.sf.openrocket.rocketvisitors.ListComponents;
 import net.sf.openrocket.rocketvisitors.ListMotorMounts;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.StateChangeListener;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 @SuppressWarnings("serial")
 public class FlightConfigurationPanel extends JPanel implements StateChangeListener {
@@ -68,7 +69,7 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 		separationConfigurationPanel = new SeparationConfigurationPanel(this, rocket);
 		tabs.add(trans.get("edtmotorconfdlg.lbl.Stagetab"), separationConfigurationPanel);
 
-		newConfButton = new JButton(trans.get("edtmotorconfdlg.but.Newconfiguration"));
+		newConfButton = new SelectColorButton(trans.get("edtmotorconfdlg.but.Newconfiguration"));
 		newConfButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -85,7 +86,7 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 		
 		this.add(newConfButton,"skip 1,gapright para");
 		
-		renameConfButton = new JButton(trans.get("edtmotorconfdlg.but.Renameconfiguration"));
+		renameConfButton = new SelectColorButton(trans.get("edtmotorconfdlg.but.Renameconfiguration"));
 		renameConfButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -95,7 +96,7 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 		});
 		this.add(renameConfButton,"gapright para");
 		
-		removeConfButton = new JButton(trans.get("edtmotorconfdlg.but.Removeconfiguration"));
+		removeConfButton = new SelectColorButton(trans.get("edtmotorconfdlg.but.Removeconfiguration"));
 		removeConfButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -105,7 +106,7 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 		});
 		this.add(removeConfButton,"gapright para");
 		
-		copyConfButton = new JButton(trans.get("edtmotorconfdlg.but.Copyconfiguration"));
+		copyConfButton = new SelectColorButton(trans.get("edtmotorconfdlg.but.Copyconfiguration"));
 		copyConfButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
@@ -25,6 +25,7 @@ import net.sf.openrocket.gui.components.StyledLabel.Style;
 import net.sf.openrocket.gui.dialogs.flightconfiguration.IgnitionSelectionDialog;
 import net.sf.openrocket.gui.dialogs.flightconfiguration.MotorMountConfigurationPanel;
 import net.sf.openrocket.gui.dialogs.motor.MotorChooserDialog;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 import net.sf.openrocket.motor.IgnitionEvent;
 import net.sf.openrocket.motor.Motor;
 import net.sf.openrocket.motor.MotorConfiguration;
@@ -77,7 +78,7 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 		this.add(cards, "grow, wrap");
 
 		//// Select motor
-		selectMotorButton = new JButton(trans.get("MotorConfigurationPanel.btn.selectMotor"));
+		selectMotorButton = new SelectColorButton(trans.get("MotorConfigurationPanel.btn.selectMotor"));
 		selectMotorButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -87,7 +88,7 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 		this.add(selectMotorButton, "split, align right, sizegroup button");
 
 		//// Remove motor button
-		removeMotorButton = new JButton(trans.get("MotorConfigurationPanel.btn.removeMotor"));
+		removeMotorButton = new SelectColorButton(trans.get("MotorConfigurationPanel.btn.removeMotor"));
 		removeMotorButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -97,7 +98,7 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 		this.add(removeMotorButton, "sizegroup button");
 
 		//// Select Ignition button
-		selectIgnitionButton = new JButton(trans.get("MotorConfigurationPanel.btn.selectIgnition"));
+		selectIgnitionButton = new SelectColorButton(trans.get("MotorConfigurationPanel.btn.selectIgnition"));
 		selectIgnitionButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -107,7 +108,7 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 		this.add(selectIgnitionButton, "sizegroup button");
 
 		//// Reset Ignition button
-		resetIgnitionButton = new JButton(trans.get("MotorConfigurationPanel.btn.resetIgnition"));
+		resetIgnitionButton = new SelectColorButton(trans.get("MotorConfigurationPanel.btn.resetIgnition"));
 		resetIgnitionButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
@@ -20,6 +20,7 @@ import net.sf.openrocket.rocketcomponent.*;
 import net.sf.openrocket.rocketcomponent.DeploymentConfiguration.DeployEvent;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 public class RecoveryConfigurationPanel extends FlightConfigurablePanel<RecoveryDevice> {
 
@@ -38,7 +39,7 @@ public class RecoveryConfigurationPanel extends FlightConfigurablePanel<Recovery
 		this.add(scroll, "span, grow, wrap");
 
 		//// Select deployment
-		selectDeploymentButton = new JButton(trans.get("edtmotorconfdlg.but.Selectdeployment"));
+		selectDeploymentButton = new SelectColorButton(trans.get("edtmotorconfdlg.but.Selectdeployment"));
 		selectDeploymentButton.setEnabled(false);
 		selectDeploymentButton.addActionListener(new ActionListener() {
 			@Override
@@ -49,7 +50,7 @@ public class RecoveryConfigurationPanel extends FlightConfigurablePanel<Recovery
 		this.add(selectDeploymentButton, "split, align right, sizegroup button");
 
 		//// Reset deployment
-		resetDeploymentButton = new JButton(trans.get("edtmotorconfdlg.but.Resetdeployment"));
+		resetDeploymentButton = new SelectColorButton(trans.get("edtmotorconfdlg.but.Resetdeployment"));
 		resetDeploymentButton.setEnabled(false);
 		resetDeploymentButton.addActionListener(new ActionListener() {
 			@Override

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
@@ -22,6 +22,7 @@ import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.rocketcomponent.StageSeparationConfiguration;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialStage> {
 	private static final long serialVersionUID = -1556652925279847316L;
@@ -40,7 +41,7 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialS
 		this.add(scroll, "span, grow, wrap");
 		
 		//// Select deployment
-		selectSeparationButton = new JButton(trans.get("edtmotorconfdlg.but.Selectseparation"));
+		selectSeparationButton = new SelectColorButton(trans.get("edtmotorconfdlg.but.Selectseparation"));
 		selectSeparationButton.setEnabled(false);
 		selectSeparationButton.addActionListener(new ActionListener() {
 			@Override
@@ -51,7 +52,7 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialS
 		this.add(selectSeparationButton, "split, align right, sizegroup button");
 		
 		//// Reset deployment
-		resetDeploymentButton = new JButton(trans.get("edtmotorconfdlg.but.Resetseparation"));
+		resetDeploymentButton = new SelectColorButton(trans.get("edtmotorconfdlg.but.Resetseparation"));
 		resetDeploymentButton.setEnabled(false);
 		resetDeploymentButton.addActionListener(new ActionListener() {
 			@Override

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
@@ -23,6 +23,7 @@ import net.sf.openrocket.gui.util.Icons;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.startup.Preferences;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 import org.jfree.chart.ChartPanel;
 
@@ -69,7 +70,7 @@ public class SimulationPlotDialog extends JDialog {
 		panel.add(check, "split, left");
 		
 		//// Zoom in button
-		JButton button = new JButton(Icons.ZOOM_IN);
+		JButton button = new SelectColorButton(Icons.ZOOM_IN);
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -84,7 +85,7 @@ public class SimulationPlotDialog extends JDialog {
 		panel.add(button, "gapleft rel");
 		
 		//// Reset Zoom button.
-		button = new JButton(Icons.ZOOM_RESET);
+		button = new SelectColorButton(Icons.ZOOM_RESET);
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -95,7 +96,7 @@ public class SimulationPlotDialog extends JDialog {
 		
 		
 		//// Zoom out button
-		button = new JButton(Icons.ZOOM_OUT);
+		button = new SelectColorButton(Icons.ZOOM_OUT);
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -132,7 +133,7 @@ public class SimulationPlotDialog extends JDialog {
 		panel.add(new JPanel(), "growx");
 		
 		//// Close button
-		button = new JButton(trans.get("dlg.but.close"));
+		button = new SelectColorButton(trans.get("dlg.but.close"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/preset/ButtonColumn.java
+++ b/swing/src/net/sf/openrocket/gui/preset/ButtonColumn.java
@@ -18,6 +18,8 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 
+import net.sf.openrocket.gui.widgets.SelectColorButton;
+
 /**
  *  The ButtonColumn class provides a renderer and an editor that looks like a
  *  JButton. The renderer and editor will then be used for a specified column
@@ -61,8 +63,8 @@ public class ButtonColumn extends AbstractCellEditor
 		this.table = table;
 		this.action = action;
 
-		renderButton = new JButton();
-		editButton = new JButton();
+		renderButton = new SelectColorButton();
+		editButton = new SelectColorButton();
 		editButton.setFocusPainted( false );
 		editButton.addActionListener( this );
 		originalBorder = editButton.getBorder();

--- a/swing/src/net/sf/openrocket/gui/preset/PresetEditorDialog.java
+++ b/swing/src/net/sf/openrocket/gui/preset/PresetEditorDialog.java
@@ -63,6 +63,7 @@ import net.sf.openrocket.preset.loader.MaterialHolder;
 import net.sf.openrocket.rocketcomponent.Transition;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 /**
  * Preset editor for creating new preset components.
@@ -366,7 +367,7 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 			panel.setMinimumSize(new Dimension(200, 200));
 			ncPanel.add(panel, "cell 4 3, span 1 3");
 			panel.setLayout(null);
-			ncImageBtn = new JButton("No Image");
+			ncImageBtn = new SelectColorButton("No Image");
 			ncImageBtn.setMaximumSize(new Dimension(75, 75));
 			ncImageBtn.setMinimumSize(new Dimension(75, 75));
 			panel.add(ncImageBtn);
@@ -492,7 +493,7 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 			panel.setMinimumSize(new Dimension(200, 200));
 			trPanel.add(panel, "cell 4 6");
 			panel.setLayout(null);
-			trImageBtn = new JButton("No Image");
+			trImageBtn = new SelectColorButton("No Image");
 			trImageBtn.setMaximumSize(new Dimension(75, 75));
 			trImageBtn.setMinimumSize(new Dimension(75, 75));
 			panel.add(trImageBtn);
@@ -570,7 +571,7 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 			panel.setMinimumSize(new Dimension(200, 200));
 			btPanel.add(panel, "cell 4 3");
 			panel.setLayout(null);
-			btImageBtn = new JButton("No Image");
+			btImageBtn = new SelectColorButton("No Image");
 			btImageBtn.setMaximumSize(new Dimension(75, 75));
 			btImageBtn.setMinimumSize(new Dimension(75, 75));
 			panel.add(btImageBtn);
@@ -648,7 +649,7 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 			panel.setMinimumSize(new Dimension(200, 200));
 			tcPanel.add(panel, "cell 4 3");
 			panel.setLayout(null);
-			tcImageBtn = new JButton("No Image");
+			tcImageBtn = new SelectColorButton("No Image");
 			tcImageBtn.setMaximumSize(new Dimension(75, 75));
 			tcImageBtn.setMinimumSize(new Dimension(75, 75));
 			panel.add(tcImageBtn);
@@ -719,7 +720,7 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 			panel.setMinimumSize(new Dimension(200, 200));
 			bhPanel.add(panel, "cell 4 2");
 			panel.setLayout(null);
-			bhImageBtn = new JButton("No Image");
+			bhImageBtn = new SelectColorButton("No Image");
 			bhImageBtn.setMaximumSize(new Dimension(75, 75));
 			bhImageBtn.setMinimumSize(new Dimension(75, 75));
 			panel.add(bhImageBtn);
@@ -798,7 +799,7 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 			panel.setMinimumSize(new Dimension(200, 200));
 			crPanel.add(panel, "cell 4 3");
 			panel.setLayout(null);
-			crImageBtn = new JButton("No Image");
+			crImageBtn = new SelectColorButton("No Image");
 			crImageBtn.setMaximumSize(new Dimension(75, 75));
 			crImageBtn.setMinimumSize(new Dimension(75, 75));
 			panel.add(crImageBtn);
@@ -876,7 +877,7 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 			panel.setMinimumSize(new Dimension(200, 200));
 			ebPanel.add(panel, "cell 4 3");
 			panel.setLayout(null);
-			ebImageBtn = new JButton("No Image");
+			ebImageBtn = new SelectColorButton("No Image");
 			ebImageBtn.setMaximumSize(new Dimension(75, 75));
 			ebImageBtn.setMinimumSize(new Dimension(75, 75));
 			panel.add(ebImageBtn);
@@ -954,7 +955,7 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 			panel.setMinimumSize(new Dimension(200, 200));
 			llPanel.add(panel, "cell 4 3");
 			panel.setLayout(null);
-			llImageBtn = new JButton("No Image");
+			llImageBtn = new SelectColorButton("No Image");
 			llImageBtn.setMaximumSize(new Dimension(75, 75));
 			llImageBtn.setMinimumSize(new Dimension(75, 75));
 			panel.add(llImageBtn);
@@ -1051,7 +1052,7 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 			panel.setMinimumSize(new Dimension(200, 200));
 			rbPanel.add(panel, "cell 4 4");
 			panel.setLayout(null);
-			rbImageBtn = new JButton("No Image");
+			rbImageBtn = new SelectColorButton("No Image");
 			rbImageBtn.setMaximumSize(new Dimension(75, 75));
 			rbImageBtn.setMinimumSize(new Dimension(75, 75));
 			panel.add(rbImageBtn);
@@ -1129,7 +1130,7 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 			panel.setMinimumSize(new Dimension(200, 200));
 			stPanel.add(panel, "cell 4 3");
 			panel.setLayout(null);
-			stImageBtn = new JButton("No Image");
+			stImageBtn = new SelectColorButton("No Image");
 			stImageBtn.setMaximumSize(new Dimension(75, 75));
 			stImageBtn.setMinimumSize(new Dimension(75, 75));
 			panel.add(stImageBtn);
@@ -1221,7 +1222,7 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 			panel.setMinimumSize(new Dimension(200, 200));
 			pcPanel.add(panel, "cell 1 3, span 1 3");
 			panel.setLayout(null);
-			pcImageBtn = new JButton("No Image");
+			pcImageBtn = new SelectColorButton("No Image");
 			pcImageBtn.setMaximumSize(new Dimension(75, 75));
 			pcImageBtn.setMinimumSize(new Dimension(75, 75));
 			panel.add(pcImageBtn);
@@ -1244,7 +1245,7 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 		JPanel buttonPane = new JPanel();
 		getContentPane().add(buttonPane, BorderLayout.SOUTH);
 		buttonPane.setLayout(new MigLayout("", "[130px][176.00px][131.00px]", "[29px]"));
-		JButton btnSaveAndNew = new JButton("Save and New");
+		JButton btnSaveAndNew = new SelectColorButton("Save and New");
 		btnSaveAndNew.addMouseListener(new MouseAdapter() {
 			@Override
 			public void mouseClicked(MouseEvent arg0) {
@@ -1253,7 +1254,7 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 		});
 		buttonPane.add(btnSaveAndNew, "cell 0 0,alignx left,aligny top");
 		
-		JButton okButton = new JButton("Save and Close");
+		JButton okButton = new SelectColorButton("Save and Close");
 		okButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent event) {
@@ -1266,7 +1267,7 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 		buttonPane.add(okButton, "cell 1 0,alignx left,aligny top");
 		getRootPane().setDefaultButton(okButton);
 		
-		JButton cancelButton = new JButton("Close");
+		JButton cancelButton = new SelectColorButton("Close");
 		cancelButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent event) {

--- a/swing/src/net/sf/openrocket/gui/scalefigure/ScaleSelector.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/ScaleSelector.java
@@ -13,6 +13,7 @@ import javax.swing.JPanel;
 
 import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.gui.util.Icons;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 import net.sf.openrocket.util.StateChangeListener;
 
 @SuppressWarnings("serial")
@@ -43,7 +44,7 @@ public class ScaleSelector extends JPanel {
 		this.scrollPane = scroll;
 
 		// Zoom out button
-		JButton button = new JButton(Icons.ZOOM_OUT);
+		JButton button = new SelectColorButton(Icons.ZOOM_OUT);
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -96,7 +97,7 @@ public class ScaleSelector extends JPanel {
 		add(scaleSelector, "gap rel");
 
 		// Zoom in button
-		button = new JButton(Icons.ZOOM_IN);
+		button = new SelectColorButton(Icons.ZOOM_IN);
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationConditionsPanel.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationConditionsPanel.java
@@ -26,6 +26,7 @@ import net.sf.openrocket.simulation.SimulationOptions;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.UnitGroup;
 import net.sf.openrocket.util.Chars;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 public class SimulationConditionsPanel extends JPanel {
 	private static final Translator trans = Application.getTranslator();
@@ -425,7 +426,7 @@ public class SimulationConditionsPanel extends JPanel {
 	
 		
 		
-		JButton restoreDefaults = new JButton(trans.get("simedtdlg.but.resettodefault"));
+		JButton restoreDefaults = new SelectColorButton(trans.get("simedtdlg.but.resettodefault"));
 		restoreDefaults.addActionListener(new ActionListener() {
 			
 			@Override
@@ -440,7 +441,7 @@ public class SimulationConditionsPanel extends JPanel {
 		});
 		this.add(restoreDefaults, "span, split 3, skip, gapbottom para, gapright para, right");
 		
-		JButton saveDefaults = new JButton(trans.get("simedtdlg.but.savedefault"));
+		JButton saveDefaults = new SelectColorButton(trans.get("simedtdlg.but.savedefault"));
 		saveDefaults.addActionListener(new ActionListener() {
 			
 			@Override

--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationEditDialog.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationEditDialog.java
@@ -23,6 +23,7 @@ import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.document.Simulation;
 import net.sf.openrocket.gui.components.ConfigurationComboBox;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.rocketcomponent.FlightConfiguration;
 import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
@@ -182,7 +183,7 @@ public class SimulationEditDialog extends JDialog {
 		
 		
 		//// Open Plot button
-		JButton button = new JButton(trans.get("SimulationEditDialog.btn.plot") + " >>");
+		JButton button = new SelectColorButton(trans.get("SimulationEditDialog.btn.plot") + " >>");
 		button.addActionListener(new ActionListener() {
 			
 			@Override
@@ -199,7 +200,7 @@ public class SimulationEditDialog extends JDialog {
 		}
 		
 		//// Run simulation button
-		button = new JButton(trans.get("SimulationEditDialog.btn.simulateAndPlot"));
+		button = new SelectColorButton(trans.get("SimulationEditDialog.btn.simulateAndPlot"));
 		if (!isSingleEdit()) {
 			button.setText(trans.get("SimulationEditDialog.btn.simulate"));
 		}
@@ -219,7 +220,7 @@ public class SimulationEditDialog extends JDialog {
 		simEditPanel.add(button, " align right, tag ok");
 		
 		//// Close button 
-		JButton close = new JButton(trans.get("dlg.but.close"));
+		JButton close = new SelectColorButton(trans.get("dlg.but.close"));
 		close.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -253,7 +254,7 @@ public class SimulationEditDialog extends JDialog {
 			
 			plotExportPanel.add(tabbedPane, "grow, wrap");
 			
-			JButton button = new JButton("<< " + trans.get("SimulationEditDialog.btn.edit"));
+			JButton button = new SelectColorButton("<< " + trans.get("SimulationEditDialog.btn.edit"));
 			button.addActionListener(new ActionListener() {
 				
 				@Override
@@ -265,7 +266,7 @@ public class SimulationEditDialog extends JDialog {
 			
 			plotExportPanel.add(button, "spanx, split 3, align left");
 			
-			final JButton ok = new JButton(trans.get("SimulationEditDialog.btn.plot"));
+			final JButton ok = new SelectColorButton(trans.get("SimulationEditDialog.btn.plot"));
 			
 			tabbedPane.addChangeListener(new ChangeListener() {
 				
@@ -307,7 +308,7 @@ public class SimulationEditDialog extends JDialog {
 			plotExportPanel.add(ok, "tag ok, split 2");
 			
 			//// Close button 
-			JButton close = new JButton(trans.get("dlg.but.close"));
+			JButton close = new SelectColorButton(trans.get("dlg.but.close"));
 			close.addActionListener(new ActionListener() {
 				@Override
 				public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationExportPanel.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationExportPanel.java
@@ -39,6 +39,7 @@ import net.sf.openrocket.simulation.FlightDataType;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.Unit;
 import net.sf.openrocket.unit.UnitGroup;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 public class SimulationExportPanel extends JPanel {
 	
@@ -141,7 +142,7 @@ public class SimulationExportPanel extends JPanel {
 		panel.add(new JScrollPane(table), "wmin 300lp, width 300lp, height 1, grow 100, wrap");
 		
 		// Select all/none buttons
-		button = new JButton(trans.get("SimExpPan.but.Selectall"));
+		button = new SelectColorButton(trans.get("SimExpPan.but.Selectall"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -150,7 +151,7 @@ public class SimulationExportPanel extends JPanel {
 		});
 		panel.add(button, "split 2, growx 1, sizegroup selectbutton");
 		
-		button = new JButton(trans.get("SimExpPan.but.Selectnone"));
+		button = new SelectColorButton(trans.get("SimExpPan.but.Selectnone"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -206,7 +207,7 @@ public class SimulationExportPanel extends JPanel {
 		
 		/*
 		// Export button
-		button = new JButton(trans.get("SimExpPan.but.Exporttofile"));
+		button = new SelectColorButton(trans.get("SimExpPan.but.Exporttofile"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationOptionsPanel.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationOptionsPanel.java
@@ -46,6 +46,7 @@ import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.startup.Preferences;
 import net.sf.openrocket.unit.UnitGroup;
 import net.sf.openrocket.util.GeodeticComputationStrategy;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 import com.google.inject.Key;
 
@@ -159,7 +160,7 @@ class SimulationOptionsPanel extends JPanel {
 		sub.add(subsub, "spanx, wrap para");
 		
 		// Reset to default button
-		JButton button = new JButton(trans.get("simedtdlg.but.resettodefault"));
+		JButton button = new SelectColorButton(trans.get("simedtdlg.but.resettodefault"));
 		// Reset the time step to its default value (
 		button.setToolTipText(trans.get("simedtdlg.but.ttip.resettodefault")
 				+ UnitGroup.UNITS_SHORT_TIME
@@ -193,7 +194,7 @@ class SimulationOptionsPanel extends JPanel {
 		sub.add(desc, "aligny 0, hmin 100lp, growx, wrap para");
 		
 		
-		final JButton addExtension = new JButton(trans.get("simedtdlg.SimExt.add"));
+		final JButton addExtension = new SelectColorButton(trans.get("simedtdlg.SimExt.add"));
 		final JPopupMenu menu = getExtensionMenu();
 		addExtension.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent ev) {
@@ -335,7 +336,7 @@ class SimulationOptionsPanel extends JPanel {
 			this.add(new JPanel(), "spanx, split, growx, right");
 			
 			if (findConfigurator(extension) != null) {
-				button = new JButton(Icons.CONFIGURE);
+				button = new SelectColorButton(Icons.CONFIGURE);
 				button.addActionListener(new ActionListener() {
 					@Override
 					public void actionPerformed(ActionEvent e) {
@@ -348,7 +349,7 @@ class SimulationOptionsPanel extends JPanel {
 			}
 			
 			if (extension.getDescription() != null) {
-				button = new JButton(Icons.HELP);
+				button = new SelectColorButton(Icons.HELP);
 				button.addActionListener(new ActionListener() {
 					@Override
 					public void actionPerformed(ActionEvent e) {
@@ -357,7 +358,7 @@ class SimulationOptionsPanel extends JPanel {
 						JPanel panel = new JPanel(new MigLayout("fill"));
 						DescriptionArea area = new DescriptionArea(extension.getDescription(), 10, 0);
 						panel.add(area, "width 400lp, wrap para");
-						JButton close = new JButton(trans.get("button.close"));
+						JButton close = new SelectColorButton(trans.get("button.close"));
 						close.addActionListener(new ActionListener() {
 							@Override
 							public void actionPerformed(ActionEvent e) {
@@ -374,7 +375,7 @@ class SimulationOptionsPanel extends JPanel {
 				this.add(button, "right");
 			}
 			
-			button = new JButton(Icons.DELETE);
+			button = new SelectColorButton(Icons.DELETE);
 			button.addActionListener(new ActionListener() {
 				@Override
 				public void actionPerformed(ActionEvent arg0) {

--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationPlotPanel.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationPlotPanel.java
@@ -36,6 +36,7 @@ import net.sf.openrocket.simulation.FlightEvent;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.Unit;
 import net.sf.openrocket.util.Utils;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 /**
  * Panel that displays the simulation plot options to the user.
@@ -222,7 +223,7 @@ public class SimulationPlotPanel extends JPanel {
 		
 		
 		////  All + None buttons
-		JButton button = new JButton(trans.get("simplotpanel.but.All"));
+		JButton button = new SelectColorButton(trans.get("simplotpanel.but.All"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -234,7 +235,7 @@ public class SimulationPlotPanel extends JPanel {
 		this.add(button, "split 2, gapleft para, gapright para, growx, sizegroup buttons");
 		
 		//// None
-		button = new JButton(trans.get("simplotpanel.but.None"));
+		button = new SelectColorButton(trans.get("simplotpanel.but.None"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -248,7 +249,7 @@ public class SimulationPlotPanel extends JPanel {
 		
 		
 		//// New Y axis plot type
-		button = new JButton(trans.get("simplotpanel.but.NewYaxisplottype"));
+		button = new SelectColorButton(trans.get("simplotpanel.but.NewYaxisplottype"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -301,7 +302,7 @@ public class SimulationPlotPanel extends JPanel {
 		
 		/*
 		//// Plot flight
-		button = new JButton(trans.get("simplotpanel.but.Plotflight"));
+		button = new SelectColorButton(trans.get("simplotpanel.but.Plotflight"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -463,7 +464,7 @@ public class SimulationPlotPanel extends JPanel {
 			this.add(axisSelector);
 			
 			
-			JButton button = new JButton(Icons.DELETE);
+			JButton button = new SelectColorButton(Icons.DELETE);
 			//// Remove this plot
 			button.setToolTipText(trans.get("simplotpanel.but.ttip.Removethisplot"));
 			button.setBorderPainted(false);

--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationRunDialog.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationRunDialog.java
@@ -49,6 +49,7 @@ import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.Unit;
 import net.sf.openrocket.unit.UnitGroup;
 import net.sf.openrocket.util.MathUtil;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 
 public class SimulationRunDialog extends JDialog {
@@ -160,7 +161,7 @@ public class SimulationRunDialog extends JDialog {
 		panel.add(progressBar, "spanx, growx, wrap para");
 
 		// Add cancel button
-		JButton cancel = new JButton(trans.get("dlg.but.cancel"));
+		JButton cancel = new SelectColorButton(trans.get("dlg.but.cancel"));
 		cancel.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/util/GUIUtil.java
+++ b/swing/src/net/sf/openrocket/gui/util/GUIUtil.java
@@ -276,6 +276,8 @@ public class GUIUtil {
 					}
 				}
 			}
+			// Set the select foreground for buttons to not be black on a blue background
+			UIManager.put("Button.selectForeground", Color.WHITE);
 		} catch (Exception e) {
 			log.warn("Error setting LAF: " + e);
 		}

--- a/swing/src/net/sf/openrocket/gui/widgets/SelectColorButton.java
+++ b/swing/src/net/sf/openrocket/gui/widgets/SelectColorButton.java
@@ -1,0 +1,42 @@
+package net.sf.openrocket.gui.widgets;
+
+
+import javax.swing.Action;
+import javax.swing.Icon;
+import javax.swing.JButton;
+import javax.swing.UIManager;
+import java.awt.Graphics;
+
+public class SelectColorButton extends JButton {
+    public SelectColorButton() {
+    }
+
+    public SelectColorButton(Icon icon) {
+        super(icon);
+    }
+
+    public SelectColorButton(String text) {
+        super(text);
+    }
+
+    public SelectColorButton(Action a) {
+        super(a);
+    }
+
+    public SelectColorButton(String text, Icon icon) {
+        super(text, icon);
+    }
+
+
+
+    @Override
+    public void paint(Graphics g) {
+        if (getModel().isArmed()) {
+            setForeground(UIManager.getColor("Button.selectForeground"));
+        }
+        else {
+            setForeground(UIManager.getColor("Button.foreground"));
+        }
+        super.paint(g);
+    }
+}

--- a/swing/src/net/sf/openrocket/gui/widgets/SelectColorToggleButton.java
+++ b/swing/src/net/sf/openrocket/gui/widgets/SelectColorToggleButton.java
@@ -1,11 +1,17 @@
 package net.sf.openrocket.gui.widgets;
 
-import net.sf.openrocket.gui.components.StageSelector;
-
-import javax.swing.*;
+import javax.swing.JToggleButton;
+import javax.swing.Action;
+import javax.swing.Icon;
+import javax.swing.UIManager;
 import java.awt.Graphics;
-import java.awt.Color;
 
+/**
+ * This class is a replacement for the standard JToggleButton. Its purpose is to be able
+ * to control the foreground color for when the button is (de)selected.
+ *
+ * @author Sibo Van Gool <sibo.vangool@hotmail.com>
+ */
 public class SelectColorToggleButton extends JToggleButton {
     public SelectColorToggleButton(Action a) {
         super(a);

--- a/swing/src/net/sf/openrocket/gui/widgets/SelectColorToggleButton.java
+++ b/swing/src/net/sf/openrocket/gui/widgets/SelectColorToggleButton.java
@@ -1,0 +1,51 @@
+package net.sf.openrocket.gui.widgets;
+
+import net.sf.openrocket.gui.components.StageSelector;
+
+import javax.swing.*;
+import java.awt.Graphics;
+import java.awt.Color;
+
+public class SelectColorToggleButton extends JToggleButton {
+    public SelectColorToggleButton(Action a) {
+        super(a);
+    }
+
+    public SelectColorToggleButton(String text) {
+        super(text);
+    }
+
+    public SelectColorToggleButton() {
+    }
+
+    public SelectColorToggleButton(Icon icon) {
+        super(icon);
+    }
+
+    public SelectColorToggleButton(Icon icon, boolean selected) {
+        super(icon, selected);
+    }
+
+    public SelectColorToggleButton(String text, boolean selected) {
+        super(text, selected);
+    }
+
+    public SelectColorToggleButton(String text, Icon icon) {
+        super(text, icon);
+    }
+
+    public SelectColorToggleButton(String text, Icon icon, boolean selected) {
+        super(text, icon, selected);
+    }
+
+    @Override
+    public void paint(Graphics g) {
+        if (isSelected()) {
+            setForeground(UIManager.getColor("ToggleButton.selectForeground"));
+        }
+        else {
+            setForeground(UIManager.getColor("ToggleButton.foreground"));
+        }
+        super.paint(g);
+    }
+}

--- a/swing/src/net/sf/openrocket/simulation/extension/AbstractSwingSimulationExtensionConfigurator.java
+++ b/swing/src/net/sf/openrocket/simulation/extension/AbstractSwingSimulationExtensionConfigurator.java
@@ -14,6 +14,7 @@ import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.document.Simulation;
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.l10n.Translator;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 import com.google.inject.Inject;
 
@@ -45,7 +46,7 @@ public abstract class AbstractSwingSimulationExtensionConfigurator<E extends Sim
 		
 		panel.add(getConfigurationComponent((E) extension, simulation, sub), "grow, wrap para");
 		
-		JButton close = new JButton(trans.get("button.close"));
+		JButton close = new SelectColorButton(trans.get("button.close"));
 		close.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/simulation/extension/impl/ScriptingConfigurator.java
+++ b/swing/src/net/sf/openrocket/simulation/extension/impl/ScriptingConfigurator.java
@@ -22,6 +22,7 @@ import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.components.StyledLabel.Style;
 import net.sf.openrocket.plugin.Plugin;
 import net.sf.openrocket.simulation.extension.AbstractSwingSimulationExtensionConfigurator;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
@@ -103,7 +104,7 @@ public class ScriptingConfigurator extends AbstractSwingSimulationExtensionConfi
 		
 		panel.add(new JPanel(), "growx");
 		
-		JButton button = new JButton(trans.get("SimulationExtension.scripting.text.trusted.clear"));
+		JButton button = new SelectColorButton(trans.get("SimulationExtension.scripting.text.trusted.clear"));
 		button.setToolTipText(trans.get("SimulationExtension.scripting.text.trusted.clear.ttip"));
 		button.addActionListener(new ActionListener() {
 			@Override

--- a/swing/src/net/sf/openrocket/startup/OSXSetup.java
+++ b/swing/src/net/sf/openrocket/startup/OSXSetup.java
@@ -93,6 +93,9 @@ final class OSXSetup {
 			// Set the foreground of active tabs to black; there was a bug where you had a white background and white foreground
 			UIManager.put("TabbedPane.foreground", Color.black);
 
+			// Set the select foreground for buttons to not be black on a blue background
+			UIManager.put("ToggleButton.selectForeground", Color.WHITE);
+
 		} catch (final Throwable t) {
 			// None of the preceding is critical to the app,
 			// so at worst case log an error and continue

--- a/swing/src/net/sf/openrocket/utils/ComponentPresetEditor.java
+++ b/swing/src/net/sf/openrocket/utils/ComponentPresetEditor.java
@@ -44,6 +44,7 @@ import net.sf.openrocket.preset.loader.MaterialHolder;
 import net.sf.openrocket.preset.xml.OpenRocketComponentDTO;
 import net.sf.openrocket.preset.xml.OpenRocketComponentSaver;
 import net.sf.openrocket.startup.Application;
+import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -205,7 +206,7 @@ public class ComponentPresetEditor extends JPanel implements PresetResultListene
 		});
 		
 		
-		JButton addBtn = new JButton("Add");
+		JButton addBtn = new SelectColorButton("Add");
 		addBtn.addMouseListener(new MouseAdapter() {
 			@Override
 			public void mouseClicked(MouseEvent arg0) {


### PR DESCRIPTION
This PR fixes #968 for the most part, where some highlight colors or button colors were hardly readable.

The tables from the motor configuration now get assigned the correct foreground color (white) upon selection. This was fixed by changing the foreground in setSelected in FlightConfigurablePanel.

Also toggle buttons, such as the stage selector buttons, are fixed by adding and using a custom JToggleButton implementation, SelectColorToggleButton, which sets the foreground color correctly.

Finally the color of JButtons that are pressed is also fixed by a custom JButton implementation, SelectColorButton.

The only thing that I could not fix were the buttons in pop-up dialogs. For this to work, you would have to create a custom implementation of the JOptionPane.showConfirmDialog with custom buttons (the SelectColorButtons).

Here is a [jar file](https://www.dropbox.com/s/e9m9mmm7uhslwqh/OpenRocket-968.jar?dl=0) for testing.