### PR TITLE
[fixes #989 & #992] Fix 3D view going blank + high CPU usage

### DIFF
--- a/swing/src/net/sf/openrocket/gui/widgets/SelectColorButton.java
+++ b/swing/src/net/sf/openrocket/gui/widgets/SelectColorButton.java
@@ -5,38 +5,49 @@ import javax.swing.Action;
 import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.UIManager;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
 import java.awt.Graphics;
 
 public class SelectColorButton extends JButton {
     public SelectColorButton() {
+        addChangeListenerSelectColor();
     }
 
     public SelectColorButton(Icon icon) {
         super(icon);
+        addChangeListenerSelectColor();
     }
 
     public SelectColorButton(String text) {
         super(text);
+        addChangeListenerSelectColor();
     }
 
     public SelectColorButton(Action a) {
         super(a);
+        addChangeListenerSelectColor();
     }
 
     public SelectColorButton(String text, Icon icon) {
         super(text, icon);
+        addChangeListenerSelectColor();
     }
 
-
-
-    @Override
-    public void paint(Graphics g) {
-        if (getModel().isArmed()) {
-            setForeground(UIManager.getColor("Button.selectForeground"));
-        }
-        else {
-            setForeground(UIManager.getColor("Button.foreground"));
-        }
-        super.paint(g);
+    private void addChangeListenerSelectColor() {
+        addChangeListener(new ChangeListener() {
+            @Override
+            public void stateChanged(ChangeEvent e) {
+                if (UIManager.getColor("Button.selectForeground") == null
+                        || UIManager.getColor("Button.foreground") == null)
+                    return;
+                if (getModel().isArmed()) {
+                    setForeground(UIManager.getColor("Button.selectForeground"));
+                }
+                else {
+                    setForeground(UIManager.getColor("Button.foreground"));
+                }
+            }
+        });
     }
 }

--- a/swing/src/net/sf/openrocket/gui/widgets/SelectColorButton.java
+++ b/swing/src/net/sf/openrocket/gui/widgets/SelectColorButton.java
@@ -35,12 +35,12 @@ public class SelectColorButton extends JButton {
     }
 
     private void addChangeListenerSelectColor() {
+        if (UIManager.getColor("Button.selectForeground") == null
+                || UIManager.getColor("Button.foreground") == null)
+            return;
         addChangeListener(new ChangeListener() {
             @Override
             public void stateChanged(ChangeEvent e) {
-                if (UIManager.getColor("Button.selectForeground") == null
-                        || UIManager.getColor("Button.foreground") == null)
-                    return;
                 if (getModel().isArmed()) {
                     setForeground(UIManager.getColor("Button.selectForeground"));
                 }

--- a/swing/src/net/sf/openrocket/gui/widgets/SelectColorToggleButton.java
+++ b/swing/src/net/sf/openrocket/gui/widgets/SelectColorToggleButton.java
@@ -4,12 +4,8 @@ import javax.swing.JToggleButton;
 import javax.swing.Action;
 import javax.swing.Icon;
 import javax.swing.UIManager;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
-import java.awt.Graphics;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.MouseEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 
 /**
  * This class is a replacement for the standard JToggleButton. Its purpose is to be able
@@ -57,13 +53,34 @@ public class SelectColorToggleButton extends JToggleButton {
         addChangeListenerSelectColor();
     }
 
+    /**
+     * This method sets the foreground color of the button. If the button is selected, then the selectForeground is used.
+     * If the frame that the button is in goes out of focus or if the button is unselected, then the foreground is used.
+     *
+     * This is to fix an issue on OSX devices where the foreground color would be black on blue (hardly readable)
+     */
     private void addChangeListenerSelectColor() {
-        addChangeListener(new ChangeListener() {
+        if (UIManager.getColor("ToggleButton.selectForeground") == null
+                || UIManager.getColor("ToggleButton.foreground") == null)
+            return;
+
+        // Case: frame goes out of focus
+        addPropertyChangeListener("Frame.active", new PropertyChangeListener() {
             @Override
-            public void stateChanged(ChangeEvent e) {
-                if (UIManager.getColor("ToggleButton.selectForeground") == null
-                        || UIManager.getColor("ToggleButton.foreground") == null)
-                    return;
+            public void propertyChange(PropertyChangeEvent evt) {
+                if (isSelected() && (boolean)evt.getNewValue()) {
+                    setForeground(UIManager.getColor("ToggleButton.selectForeground"));
+                }
+                else {
+                    setForeground(UIManager.getColor("ToggleButton.foreground"));
+                }
+            }
+        });
+
+        // Case: button is clicked
+        addPropertyChangeListener("ancestor", new PropertyChangeListener() {
+            @Override
+            public void propertyChange(PropertyChangeEvent evt) {
                 if (isSelected()) {
                     setForeground(UIManager.getColor("ToggleButton.selectForeground"));
                 }

--- a/swing/src/net/sf/openrocket/gui/widgets/SelectColorToggleButton.java
+++ b/swing/src/net/sf/openrocket/gui/widgets/SelectColorToggleButton.java
@@ -4,7 +4,12 @@ import javax.swing.JToggleButton;
 import javax.swing.Action;
 import javax.swing.Icon;
 import javax.swing.UIManager;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
 import java.awt.Graphics;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseEvent;
 
 /**
  * This class is a replacement for the standard JToggleButton. Its purpose is to be able
@@ -15,43 +20,57 @@ import java.awt.Graphics;
 public class SelectColorToggleButton extends JToggleButton {
     public SelectColorToggleButton(Action a) {
         super(a);
+        addChangeListenerSelectColor();
     }
 
     public SelectColorToggleButton(String text) {
         super(text);
+        addChangeListenerSelectColor();
     }
 
     public SelectColorToggleButton() {
+        addChangeListenerSelectColor();
     }
 
     public SelectColorToggleButton(Icon icon) {
         super(icon);
+        addChangeListenerSelectColor();
     }
 
     public SelectColorToggleButton(Icon icon, boolean selected) {
         super(icon, selected);
+        addChangeListenerSelectColor();
     }
 
     public SelectColorToggleButton(String text, boolean selected) {
         super(text, selected);
+        addChangeListenerSelectColor();
     }
 
     public SelectColorToggleButton(String text, Icon icon) {
         super(text, icon);
+        addChangeListenerSelectColor();
     }
 
     public SelectColorToggleButton(String text, Icon icon, boolean selected) {
         super(text, icon, selected);
+        addChangeListenerSelectColor();
     }
 
-    @Override
-    public void paint(Graphics g) {
-        if (isSelected()) {
-            setForeground(UIManager.getColor("ToggleButton.selectForeground"));
-        }
-        else {
-            setForeground(UIManager.getColor("ToggleButton.foreground"));
-        }
-        super.paint(g);
+    private void addChangeListenerSelectColor() {
+        addChangeListener(new ChangeListener() {
+            @Override
+            public void stateChanged(ChangeEvent e) {
+                if (UIManager.getColor("ToggleButton.selectForeground") == null
+                        || UIManager.getColor("ToggleButton.foreground") == null)
+                    return;
+                if (isSelected()) {
+                    setForeground(UIManager.getColor("ToggleButton.selectForeground"));
+                }
+                else {
+                    setForeground(UIManager.getColor("ToggleButton.foreground"));
+                }
+            }
+        });
     }
 }


### PR DESCRIPTION
This PR (I do very much hope) fixes #989 and #992 where the editor view went blank when switching to the 3D view + where a very high increase in CPU usage was noticed. Okay, so I did an oopsie in my PR of fixing bad highlight colors. The code written to change the foreground for the SelectColorButton and SelectColorToggleButton should never have been put inside the paint-method. Not only does this cause a very high CPU usage, it also messes up the init-method calling of the editor window (which caused it to go blank).

I added the foreground updating in a changelistener and only let that code execute on OSX-devices (i.e. devices that have a custom Button.selectForeground or ToggleButton.selectForeground defined).

Tested on Mac OSX Big Sur to check the functionality and testen on Windows 10 Home to test the 3D view going blank (CPU usage not tested).

Here is a [jar file](https://www.dropbox.com/s/ptur74vl7o5qwhl/OpenRocket-989.jar?dl=0) for testing.