### PR TITLE
Added gitignores for IntelliJ-files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@
 .idea/dictionaries
 .idea/vcs.xml
 .idea/jsLibraryMappings.xml
+.idea/codeStyles/
+.idea/runConfigurations.xml
 
 # Sensitive or high-churn files:
 .idea/dataSources.ids

--- a/.idea/ant.xml
+++ b/.idea/ant.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AntConfiguration">
+    <buildFile url="file://$PROJECT_DIR$/build.xml" />
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -46,7 +46,7 @@
       </profile-state>
     </entry>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_9" default="false" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_10" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>


### PR DESCRIPTION
When working in the IntelliJ IDE, it creates some files that I very often have to ignore or unstage when making commits. This PR adds some common IntelliJ-files that should be ignored to the gitignore.

Besides that, it also updates the .idea/misc.xml-file to use project language level 10 instead of the previous version 9. This is the minimum level that is necessary to compile some of the OR functions. (Right now I always had to manually change the language level every time I switched to another branch)

I also added .idea/ant.xml for ant building inside IntelliJ.