### PR TITLE
[fixes #1001 + others] Change default tab + separation event when adding new stage

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
@@ -496,10 +496,24 @@ public class Rocket extends ComponentAssembly {
 	
 	@Override
 	public void update(){
+		updateStageNumbers();
 		updateStageMap();
 		updateConfigurations();
 	}
-	
+
+	/**
+	 * Update all the stage numbers based on their position in the component tree
+	 */
+	private void updateStageNumbers() {
+		for (RocketComponent component : getChildren()) {
+			if (component instanceof AxialStage) {
+				AxialStage stage = (AxialStage) component;
+				forgetStage(stage);
+				stage.setStageNumber(getChildPosition(stage));
+			}
+		}
+	}
+
 	private void updateStageMap(){
 		for( RocketComponent component : getChildren() ){
 			if (component instanceof AxialStage) {

--- a/core/src/net/sf/openrocket/rocketcomponent/StageSeparationConfiguration.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/StageSeparationConfiguration.java
@@ -94,7 +94,7 @@ public class StageSeparationConfiguration implements FlightConfigurableParameter
 	private static final Translator trans = Application.getTranslator();
 	
 	
-	private SeparationEvent separationEvent = SeparationEvent.NEVER;
+	private SeparationEvent separationEvent = SeparationEvent.UPPER_IGNITION;
 	private double separationDelay = 0;
 		
 	public SeparationEvent getSeparationEvent() {

--- a/swing/src/net/sf/openrocket/gui/configdialog/AxialStageConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/AxialStageConfig.java
@@ -31,7 +31,8 @@ public class AxialStageConfig extends ComponentAssemblyConfig {
 		if (component.getStageNumber() > 0) {
 			JPanel tab = separationTab((AxialStage) component);
 			tabbedPane.insertTab(trans.get("StageConfig.tab.Separation"), null, tab,
-					trans.get("StageConfig.tab.Separation.ttip"), 2);
+					trans.get("StageConfig.tab.Separation.ttip"), 0);
+			tabbedPane.setSelectedIndex(0);
 		}
 	}
 	

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
@@ -29,8 +29,12 @@ import net.sf.openrocket.gui.widgets.SelectColorButton;
 import net.sf.openrocket.motor.IgnitionEvent;
 import net.sf.openrocket.motor.Motor;
 import net.sf.openrocket.motor.MotorConfiguration;
+import net.sf.openrocket.rocketcomponent.AxialStage;
+import net.sf.openrocket.rocketcomponent.BodyTube;
+import net.sf.openrocket.rocketcomponent.ComponentChangeEvent;
 import net.sf.openrocket.rocketcomponent.FlightConfiguration;
 import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
+import net.sf.openrocket.rocketcomponent.InnerTube;
 import net.sf.openrocket.rocketcomponent.MotorMount;
 import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.unit.UnitGroup;
@@ -136,6 +140,15 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 			@Override
 			protected boolean includeComponent(MotorMount component) {
 				return component.isMotorMount();
+			}
+
+			@Override
+			public void componentChanged(ComponentChangeEvent cce) {
+				super.componentChanged(cce);
+				// This will catch a name change to cause a change in the header of the table
+				if ((cce.getSource() instanceof BodyTube || cce.getSource() instanceof InnerTube) && cce.isNonFunctionalChange()) {
+					fireTableStructureChanged();
+				}
 			}
 		};
 		

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
@@ -17,6 +17,7 @@ import net.sf.openrocket.formatting.RocketDescriptor;
 import net.sf.openrocket.gui.dialogs.flightconfiguration.SeparationSelectionDialog;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.rocketcomponent.AxialStage;
+import net.sf.openrocket.rocketcomponent.ComponentChangeEvent;
 import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
 import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.rocketcomponent.StageSeparationConfiguration;
@@ -75,6 +76,14 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialS
 				return component.getStageNumber() > 0;
 			}
 
+			@Override
+			public void componentChanged(ComponentChangeEvent cce) {
+				super.componentChanged(cce);
+				// This will catch a name change of the stage to cause a change in the header of the table
+				if (cce.getSource() instanceof AxialStage && cce.isNonFunctionalChange()) {
+					fireTableStructureChanged();
+				}
+			}
 		};
 		JTable separationTable = new JTable(separationTableModel);
 		separationTable.getTableHeader().setReorderingAllowed(false);


### PR DESCRIPTION
This PR fixes #1001 which was a request to change the default tab of the stage configuration dialog, which is a more logical choice. The default separation event is also changed to ignition of next stage instead of the default 'never'.

While working on this PR I also noticed some other issues:

- When rearranging the stages in the component tree, the stage numbers of the stages would not update accordingly. E.g. in the 'Three-staged rocket' template project, if you rearrange the Sustainer-stage to be between the two Booster stages, you would expect the Sustainer and last Booster stage to now be visible in the stages table in 'Motors & Configuration > Stages'. This was not the case, because the stage numbers of the stages did not get updated when their position in the component tree would get updated.
  - Fixed this issue by implementing a method 'updateStageNumbers' in Rocket.java to update the stage numbers
- When changing the name of a stage, the name change would not be executed in the stage table. E.g. in the 'Three-staged rocket' if you rename the final booster stage to 'Booster 2', in the stage table this stage would still be called 'Booster 2'. Only if you would rearrange the stages in the component tree, the name change would get executed.
  - Fixed this by listening for a non-functional change (i.e. a name change) inside the stage table and then triggering a change event so that the table will update if the name has changed
- Same problem as the previous one, but now with the motor table. E.g. in 'A simple model rocket', when changing the name of the inner tube, the name would not be changed in the motor table.
  - Fixed in the same way as with the stage table

Here is a [jar file](https://www.dropbox.com/s/2laxz6ajnpw4q5k/OpenRocket-1001.jar?dl=0) for testing.