### PR TITLE
[fixes #899] Use only filename in save/export filename input

### DIFF
--- a/core/src/net/sf/openrocket/document/OpenRocketDocument.java
+++ b/core/src/net/sf/openrocket/document/OpenRocketDocument.java
@@ -34,7 +34,7 @@ import net.sf.openrocket.util.ArrayList;
  */
 public class OpenRocketDocument implements ComponentChangeListener {
 	private static final Logger log = LoggerFactory.getLogger(OpenRocketDocument.class);
-	
+	private final List<String> file_extensions = Arrays.asList("ork", "rkt");	// Possible extensions of an OpenRocket document
 	/**
 	 * The minimum number of undo levels that are stored.
 	 */
@@ -191,6 +191,23 @@ public class OpenRocketDocument implements ComponentChangeListener {
 	 * @return	the File handler object for the document
 	 */
 	public File getFile() {
+		return file;
+	}
+
+	/**
+	 * returns the File handler object for the document without the file extension (e.g. '.ork' removed)
+	 * @return the File handler object for the document without the file extension
+	 */
+	public File getFileNoExtension() {
+		if (file == null) return null;
+		int index = file.getAbsolutePath().lastIndexOf('.');
+		if (index > 0) {
+			String filename = file.getAbsolutePath().substring(0, index);
+			String extension = file.getAbsolutePath().substring(index + 1);
+			if (file_extensions.contains(extension)) {
+				return new File(filename);
+			}
+		}
 		return file;
 	}
 	

--- a/swing/src/net/sf/openrocket/gui/main/SaveAsFileChooser.java
+++ b/swing/src/net/sf/openrocket/gui/main/SaveAsFileChooser.java
@@ -3,6 +3,9 @@ package net.sf.openrocket.gui.main;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import javax.swing.JFileChooser;
 
@@ -33,12 +36,11 @@ public class SaveAsFileChooser extends JFileChooser {
 
 		this.setAcceptAllFileFilterUsed(true);
 
-		File defaultFilename = document.getFile();
+		File defaultFilename = document.getFileNoExtension();
 		
 		switch( type ) {
 		default:
 		case OPENROCKET:
-			defaultFilename = FileHelper.forceExtension(defaultFilename,"ork");
 			this.setDialogTitle(trans.get("saveAs.openrocket.title"));
 			storageChooser = new StorageOptionChooser(document, document.getDefaultStorageOptions());
 			this.setAccessory(storageChooser);
@@ -46,7 +48,6 @@ public class SaveAsFileChooser extends JFileChooser {
 			this.setFileFilter(FileHelper.OPENROCKET_DESIGN_FILTER);
 			break;
 		case ROCKSIM:
-			defaultFilename = FileHelper.forceExtension(defaultFilename,"rkt");
 			this.setDialogTitle(trans.get("saveAs.rocksim.title"));
 			storageChooser = null;
 			this.addChoosableFileFilter(FileHelper.ROCKSIM_DESIGN_FILTER);


### PR DESCRIPTION
This PR fixes #899. I decided to follow @hcraigmiller's suggestion and only use the filename, without file extension, in the 'File name' text input. This not only fixes the issue that @neilweinstock experienced, but is also more logical imo and is often seen in more modern software (e.g. Adobe software).

Here is a [jar file](https://drive.google.com/file/d/1EsEPEzPkPm6bwYNiGW-N7x_bxJAs7TqV/view?usp=sharing) for testing.