### PR TITLE
[fixes #1003] Fix FinSet point clipping when further than parent body

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -1161,6 +1161,12 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 			xCur += increment;
 		}
 
+		// correct last point, if beyond a rounding error from body's end.
+		final int lastIndex = points.length - 1;
+		if (Math.abs(points[lastIndex].x - body.getLength()) < 0.000001) {
+			points[lastIndex] = points[lastIndex].setX(body.getLength()).setY(body.getAftRadius());
+		}
+
 		if( 0.0000001 < (Math.abs(xOffset) + Math.abs(yOffset))){
 			points = translatePoints(points, xOffset, yOffset);
 		}

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -1161,12 +1161,6 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 			xCur += increment;
 		}
 
-		// correct last point, if beyond a rounding error from body's end.
-		final int lastIndex = points.length - 1;
-		if( body.getLength()-0.000001 < points[lastIndex].x) {
-			points[lastIndex] = points[lastIndex].setX(body.getLength()).setY(body.getAftRadius());
-		}
-
 		if( 0.0000001 < (Math.abs(xOffset) + Math.abs(yOffset))){
 			points = translatePoints(points, xOffset, yOffset);
 		}

--- a/swing/src/net/sf/openrocket/gui/rocketfigure/FinSetShapes.java
+++ b/swing/src/net/sf/openrocket/gui/rocketfigure/FinSetShapes.java
@@ -32,9 +32,9 @@ public class FinSetShapes extends RocketComponentShape {
 
         final Transformation compositeTransform = transformation.applyTransformation(cantRotation);
 		
-		Coordinate finPoints[] = finset.getFinPoints();
-        Coordinate tabPoints[] = finset.getTabPoints();
-        Coordinate rootPoints[] = finset.getRootPoints();
+		Coordinate[] finPoints = finset.getFinPoints();
+        Coordinate[] tabPoints = finset.getTabPoints();
+        Coordinate[] rootPoints = finset.getRootPoints();
 
 		// Translate & rotate points into place
         finPoints = compositeTransform.transform( finPoints );


### PR DESCRIPTION
This PR fixes #1003 which was a bug that when a FinSet was to the right of the end of its parent body, the last point of the root of the FinSet would clip to the end of the parent body.

The problem was that the getMountPoints-method in FinSet.java contained some code that deliberately clipped the last point of the root of the FinSet to the end of the parent body, if the position of the last point was beyond the end position of the parent body.

I just removed that code block, since it seems illogical (the FinSet is allowed to go further than the parent body and the clipping only has effect on the root of the FinSet; e.g. in a freeform FinSet, all the points besides the root were allowed to go further than the parent body, so I don't see a reason why the root shouldn't be allowed to) and produces confusing results, as with #1003.

Here is a [jar file](https://drive.google.com/file/d/1NwVJbHUZDfXR8GAIHk8Tdgm48qyLOMYB/view?usp=sharing) for testing.