### PR TITLE
[fixes #987] Use warning dialog for thrust curve import issues

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -792,6 +792,12 @@ FinSetConfig.lbl.relativeto = relative to
 !FinMarkingGuide
 FinMarkingGuide.lbl.Front = Front
 
+! MotorDatabaseLoaderDialog
+MotorDbLoaderDlg.title = Error upon thrust curve import
+MotorDbLoaderDlg.message1 = Thrust curve
+MotorDbLoaderDlg.message2 = will be ignored during import.
+MotorDbLoaderDlg.message3 = You can try replacing, deleting or manually editing the thrust curve file to fix this issue.
+
 ! MotorDatabaseLoadingDialog
 MotorDbLoadDlg.title = Loading motors
 MotorDbLoadDlg.Loadingmotors = Loading motors...

--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -794,9 +794,8 @@ FinMarkingGuide.lbl.Front = Front
 
 ! MotorDatabaseLoaderDialog
 MotorDbLoaderDlg.title = Error upon thrust curve import
-MotorDbLoaderDlg.message1 = Thrust curve
-MotorDbLoaderDlg.message2 = will be ignored during import.
-MotorDbLoaderDlg.message3 = You can try replacing, deleting or manually editing the thrust curve file to fix this issue.
+MotorDbLoaderDlg.message1 = Thrust curve '<b>'{0}'</b>' will be ignored during import.
+MotorDbLoaderDlg.message2 = You can try replacing, deleting or manually editing the thrust curve file to fix this issue.
 
 ! MotorDatabaseLoadingDialog
 MotorDbLoadDlg.title = Loading motors

--- a/swing/src/net/sf/openrocket/database/MotorDatabaseLoader.java
+++ b/swing/src/net/sf/openrocket/database/MotorDatabaseLoader.java
@@ -6,6 +6,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
+import java.text.MessageFormat;
 import java.util.List;
 
 import net.sf.openrocket.l10n.Translator;
@@ -144,9 +145,8 @@ public class MotorDatabaseLoader extends AsynchronousDatabaseLoader {
 			catch (IllegalArgumentException e) {
 				Translator trans = Application.getTranslator();
 				String message = "<html><body><p style='width: 400px;'><i>" + e.getMessage() +
-						"</i>.<br><br>" + trans.get("MotorDbLoaderDlg.message1") + " '<b>" + f.getU() + "</b>' " +
-						trans.get("MotorDbLoaderDlg.message2")
-						+ "<br>" + trans.get("MotorDbLoaderDlg.message3") + "</p></body></html>";
+						"</i>.<br><br>" + MessageFormat.format( trans.get("MotorDbLoaderDlg.message1"), f.getU()) +
+						"<br>" + trans.get("MotorDbLoaderDlg.message2") + "</p></body></html>";
 				JOptionPane.showMessageDialog(null,
 						message, trans.get("MotorDbLoaderDlg.title"), JOptionPane.WARNING_MESSAGE);
 			}

--- a/swing/src/net/sf/openrocket/database/MotorDatabaseLoader.java
+++ b/swing/src/net/sf/openrocket/database/MotorDatabaseLoader.java
@@ -8,6 +8,7 @@ import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.util.List;
 
+import net.sf.openrocket.l10n.Translator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +23,8 @@ import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.BugException;
 import net.sf.openrocket.util.Pair;
 
+import javax.swing.JOptionPane;
+
 /**
  * An asynchronous database loader that loads the internal thrust curves
  * and external user-supplied thrust curves to a ThrustCurveMotorSetDatabase.
@@ -32,7 +35,7 @@ import net.sf.openrocket.util.Pair;
 public class MotorDatabaseLoader extends AsynchronousDatabaseLoader {
 	
 	private final static Logger log = LoggerFactory.getLogger(MotorDatabaseLoader.class);
-	
+
 	private static final String THRUSTCURVE_DIRECTORY = "datafiles/thrustcurves/";
 	private static final long STARTUP_DELAY = 0;
 	
@@ -135,7 +138,18 @@ public class MotorDatabaseLoader extends AsynchronousDatabaseLoader {
 	private void loadFile(GeneralMotorLoader loader, Pair<String, InputStream> f) {
 		try {
 			List<ThrustCurveMotor.Builder> motors = loader.load(f.getV(), f.getU());
-			addMotorsFromBuilders(motors);
+			try {
+				addMotorsFromBuilders(motors);
+			}
+			catch (IllegalArgumentException e) {
+				Translator trans = Application.getTranslator();
+				String message = "<html><body><p style='width: 400px;'><i>" + e.getMessage() +
+						"</i>.<br><br>" + trans.get("MotorDbLoaderDlg.message1") + " '<b>" + f.getU() + "</b>' " +
+						trans.get("MotorDbLoaderDlg.message2")
+						+ "<br>" + trans.get("MotorDbLoaderDlg.message3") + "</p></body></html>";
+				JOptionPane.showMessageDialog(null,
+						message, trans.get("MotorDbLoaderDlg.title"), JOptionPane.WARNING_MESSAGE);
+			}
 			f.getV().close();
 		} catch (IOException e) {
 			log.warn("IOException while loading file " + f.getU() + ": " + e, e);

--- a/swing/src/net/sf/openrocket/gui/dialogs/SwingWorkerDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/SwingWorkerDialog.java
@@ -57,7 +57,7 @@ public class SwingWorkerDialog extends JDialog implements PropertyChangeListener
 	
 	
 	private SwingWorkerDialog(Window parent, String title, String label, SwingWorker<?, ?> w) {
-		super(parent, title, ModalityType.APPLICATION_MODAL);
+		super(parent, title, ModalityType.DOCUMENT_MODAL);
 		
 		this.worker = w;
 		w.addPropertyChangeListener(this);

--- a/swing/src/net/sf/openrocket/startup/providers/BlockingMotorDatabaseProvider.java
+++ b/swing/src/net/sf/openrocket/startup/providers/BlockingMotorDatabaseProvider.java
@@ -34,7 +34,7 @@ import com.google.inject.Provider;
 public class BlockingMotorDatabaseProvider implements Provider<ThrustCurveMotorSetDatabase> {
 	
 	private static final Logger log = LoggerFactory.getLogger(BlockingMotorDatabaseProvider.class);
-	
+
 	@Inject
 	private Translator trans;
 	
@@ -99,7 +99,7 @@ public class BlockingMotorDatabaseProvider implements Provider<ThrustCurveMotorS
 	
 	private class LoadingDialog extends JDialog {
 		private LoadingDialog() {
-			super(null, trans.get("MotorDbLoadDlg.title"), ModalityType.APPLICATION_MODAL);
+			super(null, trans.get("MotorDbLoadDlg.title"), ModalityType.DOCUMENT_MODAL);
 			
 			JPanel panel = new JPanel(new MigLayout("fill"));
 			panel.add(new JLabel(trans.get("MotorDbLoadDlg.Loadingmotors")), "wrap para");


### PR DESCRIPTION
This PR fixes #987 where an issue in a user defined thrust curve file would throw an exception, thus crashing OR. This PR shows a warning dialog instead and ignores the faulty thrust curve file.

The warning dialog looks as follows:
![image](https://user-images.githubusercontent.com/11031519/133000029-e8f10315-f130-48f3-b2a2-35b458c42259.png)

Here is a [jar file](https://drive.google.com/file/d/1RGKhM87h_tnvKAoE2h72aREDLXgJyD-u/view?usp=sharing) for testing (note, you need to have [RATT.eng](https://github.com/openrocket/openrocket/files/7150168/RATT.eng.zip) in your user defined thrust curve directory to be able to test this issue, as stated in #987.