### PR TITLE
Use correct zero point for center of gravity calculation

### DIFF
--- a/core/src/net/sf/openrocket/masscalc/MassCalculation.java
+++ b/core/src/net/sf/openrocket/masscalc/MassCalculation.java
@@ -343,6 +343,10 @@ public class MassCalculation {
 			
 			// mass data for *this component only* in the rocket-frame
 			compCM = parentTransform.transform( compCM.add(component.getPosition()) );
+
+			// setting zero as the CG position means the top of the component, which is component.getPosition()
+			final Coordinate compZero = parentTransform.transform( component.getPosition() );
+
 			if (component.getOverrideSubcomponents()) {
 				if( component.isMassive() ){
 					// if this component mass, merge it in before overriding:
@@ -352,14 +356,13 @@ public class MassCalculation {
 					this.setCM( this.getCM().setWeight(component.getOverrideMass()) );
 				}
 				if (component.isCGOverridden()) {
-					this.setCM( this.getCM().setX( compCM.x + component.getOverrideCGX()));
+					this.setCM( this.getCM().setX( compZero.x + component.getOverrideCGX()));
 				}
 			}else {
 				if (component.isMassOverridden()) {
 					compCM = compCM.setWeight( component.getOverrideMass() );
 				}
 				if (component.isCGOverridden()) {
-					final Coordinate compZero = parentTransform.transform( Coordinate.ZERO );
 					compCM = compCM.setX( compZero.x + component.getOverrideCGX() );
 				}
 				this.addMass( compCM );

--- a/core/test/net/sf/openrocket/masscalc/MassCalculatorTest.java
+++ b/core/test/net/sf/openrocket/masscalc/MassCalculatorTest.java
@@ -1064,7 +1064,7 @@ public class MassCalculatorTest extends BaseTestCase {
 		double calcTotalMass = structure.getMass();
 		assertEquals(" Booster Launch Mass is incorrect: ", expMass, calcTotalMass, EPSILON);
 
-		final double expCMx = 1.0446069131149498;
+		final double expCMx = 1.1191303646438673;
 		Coordinate expCM = new Coordinate(expCMx, 0, 0, expMass);
 		assertEquals(" Booster Launch CM.x is incorrect: ", expCM.x, structure.getCM().x, EPSILON);
 		assertEquals(" Booster Launch CM.y is incorrect: ", expCM.y, structure.getCM().y, EPSILON);
@@ -1076,7 +1076,7 @@ public class MassCalculatorTest extends BaseTestCase {
 		double boosterMOI_xx = structure.getRotationalInertia();
 		assertEquals(" Booster x-axis MOI is incorrect: ", expMOI_axial, boosterMOI_xx, EPSILON);
 
-		final double expMOI_tr = 0.036243133045;
+		final double expMOI_tr = 0.040989095911;
 		double boosterMOI_tr = structure.getLongitudinalInertia();
 		assertEquals(" Booster transverse MOI is incorrect: ", expMOI_tr, boosterMOI_tr, EPSILON);
 	}


### PR DESCRIPTION
Fixes #1034. The reference point when overriding the center of gravity is the front of the component.