### PR TITLE
[fixes #1038] Change title plot/export simulation window

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -637,6 +637,7 @@ MotorPlot.txt.Delays = Delays:
 MotorPlot.txt.Comment = Comment:\n
 
 ! Simulation plot panel
+simplotpanel.title.Plotsim = Plot / export simulation
 simplotpanel.lbl.Presetplotconf = Preset plot configurations:
 simplotpanel.lbl.Xaxistype = X axis type:
 simplotpanel.lbl.Unit = Unit:

--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationEditDialog.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationEditDialog.java
@@ -81,6 +81,7 @@ public class SimulationEditDialog extends JDialog {
 		if (!allowsPlotMode()) {
 			return;
 		}
+		setTitle(trans.get("simplotpanel.title.Plotsim"));
 		CardLayout cl = (CardLayout) (cards.getLayout());
 		cl.show(cards, PLOTMODE);
 		cards.validate();


### PR DESCRIPTION
This PR fixes #1038 by changing the title of the plot/export simulation window.

![image](https://user-images.githubusercontent.com/11031519/135174287-910a4f0f-c17f-4a06-b2de-be3674515abc.png)
 