### PR TITLE
Include contribution for Dutch translation

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/AboutDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/AboutDialog.java
@@ -49,7 +49,8 @@ public class AboutDialog extends JDialog {
 			"Sky Dart Team (Russian)<br>" +
 			"Mauro Biasutti (Italian)<br>" +
 			"Vladimir Beran (Czech)<br>" +
-			"Polish Rocketry Society / \u0141ukasz & Alex Kazanski (Polish)<br><br>" +
+			"Polish Rocketry Society / \u0141ukasz & Alex Kazanski (Polish)<br>" +
+			"Sibo Van Gool (Dutch)<br><br>" +
 			"See all contributors at <br>https://github.com/openrocket/openrocket/graphs/contributors<br><br>" +
 			"<b>OpenRocket utilizes the following libraries:</b><br><br>" +
 			"MiG Layout (http://www.miglayout.com/)<br>" +


### PR DESCRIPTION
I know this seems like [this meme](https://i.kym-cdn.com/entries/icons/original/000/030/329/cover1.jpg), but I thought it would be best to include my credentials in the translation-credits in the 'About'-dialog (go to the application ribbon > 'OpenRocket' > 'About OpenRocket').

![image](https://user-images.githubusercontent.com/11031519/136071153-fe09c76c-e28c-4939-a61c-d222a9ef26b2.png)
