### PR TITLE
[fixes #1058] Launch info dialog for no simulations GeneralOptimizer

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -1877,7 +1877,8 @@ optimization.modifier.motormount.delay.desc = Optimize the motor ignition delay.
 
 
 ! General rocket design optimization dialog
-
+GeneralOptimizationDialog.info.noSims.title = No simulations
+GeneralOptimizationDialog.info.noSims.message = No simulations created yet to optimize
 GeneralOptimizationDialog.title = Rocket optimization
 GeneralOptimizationDialog.goal.maximize = Maximize value
 GeneralOptimizationDialog.goal.minimize = Minimize value

--- a/swing/src/net/sf/openrocket/gui/dialogs/optimization/GeneralOptimizationDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/optimization/GeneralOptimizationDialog.java
@@ -190,12 +190,13 @@ public class GeneralOptimizationDialog extends JDialog {
 	 * @param document  the document
 	 * @param parent    the parent window
 	 */
-	public GeneralOptimizationDialog(OpenRocketDocument document, Window parent) {
+	public GeneralOptimizationDialog(OpenRocketDocument document, Window parent) throws InterruptedException {
 		super(parent, trans.get("title"));
 		
 		this.baseDocument = document;
 		this.documentCopy = document.copy();
-		
+
+		checkExistingSimulations();
 		loadOptimizationParameters();
 		loadSimulationModifiers();
 		
@@ -903,6 +904,19 @@ public class GeneralOptimizationDialog extends JDialog {
 		// Update selectable parameters
 		populateParameters();
 		
+	}
+
+	/**
+	 * Checks whether there are simulations present in the document. If not, a pop-up information
+	 * dialog launches stating that the optimizer cannot be launched.
+	 * @throws InterruptedException when no simulations present
+	 */
+	private void checkExistingSimulations() throws InterruptedException {
+		if (documentCopy.getSimulations().size() == 0) {
+			JOptionPane.showMessageDialog(null, trans.get("GeneralOptimizationDialog.info.noSims.message"),
+					trans.get("GeneralOptimizationDialog.info.noSims.title"), JOptionPane.INFORMATION_MESSAGE);
+			throw new InterruptedException("No simulations to optimize");
+		}
 	}
 	
 	private void populateSimulations() {

--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -716,7 +716,11 @@ public class BasicFrame extends JFrame {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				log.info(Markers.USER_MARKER, "Rocket optimization selected");
-				new GeneralOptimizationDialog(document, BasicFrame.this).setVisible(true);
+				try {
+					new GeneralOptimizationDialog(document, BasicFrame.this).setVisible(true);
+				} catch (InterruptedException ex) {
+					log.warn(ex.getMessage());
+				}
 			}
 		});
 		menu.add(item);


### PR DESCRIPTION
This PR fixes #1058. When the OR document does not have simulations present, it is unable to run the optimizer and would previously throw an Exception. This commit shows an info dialog for that and stops the creation of the GeneralOptimizationDialog.

![Screenshot 2021-11-11 at 01 09 00](https://user-images.githubusercontent.com/11031519/141213614-8ea25cd9-a67c-4f96-a09f-001093793701.png)

Here is a [jar file](https://drive.google.com/file/d/1SEu2FH5hq8ftiUIFsxjHbyv9gDRDce1U/view?usp=sharing) for testing.