### PR TITLE
Copy stageMap when loading a rocket's parameters from another rocket

### DIFF
--- a/core/src/net/sf/openrocket/document/OpenRocketDocument.java
+++ b/core/src/net/sf/openrocket/document/OpenRocketDocument.java
@@ -727,9 +727,7 @@ public class OpenRocketDocument implements ComponentChangeListener {
 		}
 		
 		rocket.checkComponentStructure();
-		undoHistory.get(undoPosition).checkComponentStructure();
-		undoHistory.get(undoPosition).copyWithOriginalID().checkComponentStructure();
-		rocket.loadFrom(undoHistory.get(undoPosition).copyWithOriginalID());
+		rocket.loadFrom(undoHistory.get(undoPosition));
 		rocket.checkComponentStructure();
 	}
 	

--- a/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
@@ -387,6 +387,7 @@ public class Rocket extends ComponentAssembly {
 		this.functionalModID = r.functionalModID;
 		this.refType = r.refType;
 		this.customReferenceLength = r.customReferenceLength;
+		this.stageMap = r.stageMap;		
 
 		// these flight configurations need to reference the _this_ Rocket:
 		this.configSet.setDefault(new FlightConfiguration(this));


### PR DESCRIPTION
Fixes #1007 

Also removed some superfluous copying of the rocket in OpenRocketDocument:undo()