### PR TITLE
[fixes #997] Fix Photo Studio exhaust effects starting at top stage

### DIFF
--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoPanel.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoPanel.java
@@ -422,7 +422,7 @@ public class PhotoPanel extends JPanel implements GLEventListener {
 		AxialStage bottomStage = configuration.getBottomStage();
 		int bottomStageNumber = 0;
 		if (bottomStage != null)
-			bottomStage.getStageNumber();
+			bottomStageNumber = bottomStage.getStageNumber();
 		//final int currentStageNumber = configuration.getActiveStages()[configuration.getActiveStages().length-1];
 		//final AxialStage currentStage = (AxialStage)configuration.getRocket().getChild( bottomStageNumber);
 


### PR DESCRIPTION
This PR fixes #997. The issue was that the exhaust effects' start point was at the top stage, as can be [seen here](https://github.com/openrocket/openrocket/issues/997#issuecomment-1010332110), instead of on the bottom stage. The fix was very simple, because there was already logic implemented to use the bottom stage motor for the exhaust effects, but the problem was that there was a bottomStage.getStageNumber() method that was never assigned to the bottomStageNumber variable, causing it to always remain 0. This PR just simply assigns bottomStageNumber _et voila_.

Here is a [jar file](https://drive.google.com/file/d/1hB3dAN6-dkGASg09Qa_YFd-YLpUdWWq3/view?usp=sharing) for testing.