### PR TITLE
[fixes #1084] Fix layout PhotoStudio Settings

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -2134,7 +2134,7 @@ PhotoSettingsConfig.lbl.lightAlt = Light Altitude
 PhotoSettingsConfig.lbl.sky = Sky
 PhotoSettingsConfig.lbl.skyColor = Sky Color
 PhotoSettingsConfig.lbl.skyImage = Sky Image
-PhotoSettingsConfig.lbl.skyCredit = Image Credit:
+PhotoSettingsConfig.lbl.skyCredit = Image Credit
 
 PhotoSettingsConfig.tab.effects = Effects
 PhotoSettingsConfig.lbl.smokeFlame = Smoke & Flame

--- a/core/resources/l10n/messages_nl.properties
+++ b/core/resources/l10n/messages_nl.properties
@@ -2100,7 +2100,7 @@ PhotoSettingsConfig.lbl.lightAlt = Lichte Hoogte
 PhotoSettingsConfig.lbl.sky = Lucht
 PhotoSettingsConfig.lbl.skyColor = Luchtkleur
 PhotoSettingsConfig.lbl.skyImage = Luchtafbeelding
-PhotoSettingsConfig.lbl.skyCredit = Afbeelding Credit:
+PhotoSettingsConfig.lbl.skyCredit = Afbeelding Credit
 
 PhotoSettingsConfig.tab.effects = Effecten
 PhotoSettingsConfig.lbl.smokeFlame = Rook & Vlam

--- a/core/resources/l10n/messages_uk_UA.properties
+++ b/core/resources/l10n/messages_uk_UA.properties
@@ -1941,7 +1941,7 @@ PhotoSettingsConfig.lbl.lightAlt = Light Altitude
 PhotoSettingsConfig.lbl.sky = Sky
 PhotoSettingsConfig.lbl.skyColor = Sky Color
 PhotoSettingsConfig.lbl.skyImage = Sky Image
-PhotoSettingsConfig.lbl.skyCredit = Image Credit:
+PhotoSettingsConfig.lbl.skyCredit = Image Credit
 
 PhotoSettingsConfig.tab.effects = Effects
 PhotoSettingsConfig.lbl.smokeFlame = Smoke & Flame

--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettingsConfig.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettingsConfig.java
@@ -162,47 +162,57 @@ public class PhotoSettingsConfig extends JTabbedPane {
 
 		addTab(trans.get("PhotoSettingsConfig.tab.orientation"), new JPanel(new MigLayout("fill", "[]100[]5[]")) {
 			{
+				// Rocket
 				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.rocket"), Style.BOLD));
 				add(new JSeparator(SwingConstants.HORIZONTAL), "span, wrap, growx");
 
+				/// Pitch
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.pitch")));
 				DoubleModel pitchModel = new DoubleModel(p, "Pitch", UnitGroup.UNITS_ANGLE);
 				add(new EditableSpinner(pitchModel.getSpinnerModel()), "growx");
 				add(new UnitSelector(pitchModel), "pushx, left, wrap");
 
+				/// Yaw
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.yaw")));
 				DoubleModel yawModel = new DoubleModel(p, "Yaw", UnitGroup.UNITS_ANGLE);
 				add(new EditableSpinner(yawModel.getSpinnerModel()), "growx");
 				add(new UnitSelector(yawModel), "wrap");
 
+				/// Roll
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.roll")));
 				DoubleModel rollModel = new DoubleModel(p, "Roll", UnitGroup.UNITS_ANGLE);
 				add(new EditableSpinner(rollModel.getSpinnerModel()), "growx");
 				add(new UnitSelector(rollModel), "wrap");
 
+				/// Advance
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.advance")));
 				DoubleModel advanceModel = new DoubleModel(p, "Advance", UnitGroup.UNITS_LENGTH);
 				add(new EditableSpinner(advanceModel.getSpinnerModel()), "growx");
 				add(new UnitSelector(advanceModel), "wrap");
 
+				// Camera
 				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.camera"), Style.BOLD));
 				add(new JSeparator(SwingConstants.HORIZONTAL), "span, wrap, growx");
 
+				/// View azimuth
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.vAz")));
 				DoubleModel viewAzModel = new DoubleModel(p, "ViewAz", UnitGroup.UNITS_ANGLE);
 				add(new EditableSpinner(viewAzModel.getSpinnerModel()), "growx");
 				add(new UnitSelector(viewAzModel), "wrap");
 
+				/// View altitude
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.vAlt")));
 				DoubleModel viewAltModle = new DoubleModel(p, "ViewAlt", UnitGroup.UNITS_ANGLE);
 				add(new EditableSpinner(viewAltModle.getSpinnerModel()), "growx");
 				add(new UnitSelector(viewAltModle), "wrap");
 
+				/// View distance
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.vDist")));
 				DoubleModel viewDistanceModel = new DoubleModel(p, "ViewDistance", UnitGroup.UNITS_LENGTH);
 				add(new EditableSpinner(viewDistanceModel.getSpinnerModel()), "growx");
 				add(new UnitSelector(viewDistanceModel), "wrap");
 
+				/// FoV
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.fov")));
 				DoubleModel fovModel = new DoubleModel(p, "Fov", UnitGroup.UNITS_ANGLE);
 				add(new EditableSpinner(fovModel.getSpinnerModel()), "growx");
@@ -212,31 +222,39 @@ public class PhotoSettingsConfig extends JTabbedPane {
 
 		addTab(trans.get("PhotoSettingsConfig.tab.environment"), new JPanel(new MigLayout("fill", "[]100[]5[]")) {
 			{
+				// Light
 				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.light"), Style.BOLD));
 				add(new JSeparator(SwingConstants.HORIZONTAL), "span, wrap, growx");
 
+				/// Sun light
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.sun")));
 				add(sunLightColorButton, "wrap");
 
+				/// Ambiance
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.amb")));
 				DoubleModel ambianceModel = new DoubleModel(p, "Ambiance", 100, UnitGroup.UNITS_NONE, 0, 100);
 				add(new EditableSpinner(ambianceModel.getSpinnerModel()), "wrap");
 
+				/// Light azimuth
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.lightAz")));
 				DoubleModel lightAzModel = new DoubleModel(p, "LightAz", UnitGroup.UNITS_ANGLE);
 				add(new EditableSpinner(lightAzModel.getSpinnerModel()), "split 2");
 				add(new UnitSelector(lightAzModel), "push, left, wrap");
 
+				/// Light altitude
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.lightAlt")));
 				DoubleModel lightAltModle = new DoubleModel(p, "LightAlt", UnitGroup.UNITS_ANGLE);
 				add(new EditableSpinner(lightAltModle.getSpinnerModel()), "wrap");
 
+				// Sky
 				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.sky"), Style.BOLD));
 				add(new JSeparator(SwingConstants.HORIZONTAL), "span, wrap, growx");
 
+				/// Sky color
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.skyColor")));
 				add(skyColorButton, "wrap");
 
+				/// Sky image
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.skyImage")));
 
 				Sky noSky = new Sky() {		// Dummy sky for 'none' selection option
@@ -276,6 +294,7 @@ public class PhotoSettingsConfig extends JTabbedPane {
 					}
 				}, "wrap");
 
+				/// Image credit
 				final JLabel creditLabel = new JLabel(trans.get("PhotoSettingsConfig.lbl.skyCredit"));
 				add(creditLabel, "wrap");
 
@@ -306,9 +325,11 @@ public class PhotoSettingsConfig extends JTabbedPane {
 
 		addTab(trans.get("PhotoSettingsConfig.tab.effects"), new JPanel(new MigLayout("fill", "[]100[]5[]")) {
 			{
+				// Smoke & Flame
 				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.smokeFlame"), Style.BOLD));
 				add(new JSeparator(SwingConstants.HORIZONTAL), "span, wrap, growx");
 
+				/// Smoke
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.smoke")));
 				BooleanModel smokeModel = new BooleanModel(p, "Smoke");
 				add(new JCheckBox(smokeModel), "split 2, w 15");
@@ -316,12 +337,14 @@ public class PhotoSettingsConfig extends JTabbedPane {
 				add(smokeColorButton, "pushx, left, wrap");
 				smokeModel.addEnableComponent(smokeColorButton);
 
+				/// Smoke opacity
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.smokeOpacity")));
 				DoubleModel smokeOpacityModel = new DoubleModel(p, "SmokeOpacity", 100, UnitGroup.UNITS_NONE, 0, 100);
 				EditableSpinner opacitySpinner = new EditableSpinner(smokeOpacityModel.getSpinnerModel());
 				add(opacitySpinner, "wrap");
 				smokeModel.addEnableComponent(opacitySpinner);
 
+				/// Flame
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.flame")));
 				BooleanModel fireModel = new BooleanModel(p, "Flame");
 				add(new JCheckBox(fireModel), "split 2, w 15");
@@ -329,6 +352,7 @@ public class PhotoSettingsConfig extends JTabbedPane {
 				add(flameColorButton, "wrap");
 				fireModel.addEnableComponent(flameColorButton);
 
+				/// Flame aspect ratio
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.flameAspect")));
 				DoubleModel flameAspectModel = new DoubleModel(p, "FlameAspectRatio", 100, UnitGroup.UNITS_NONE, 25,
 						250);
@@ -336,12 +360,14 @@ public class PhotoSettingsConfig extends JTabbedPane {
 				add(flameAspectSpinner, "wrap");
 				fireModel.addEnableComponent(flameAspectSpinner);
 
+				/// Sparks
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.sparks")));
 				BooleanModel sparksModel = new BooleanModel(p, "Sparks");
 				JCheckBox sparksCheck = new JCheckBox(sparksModel);
 				add(sparksCheck, "wrap");
 				fireModel.addEnableComponent(sparksCheck);
 
+				/// Sparks concentration
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.sparkConcentration")));
 				DoubleModel sparkConcentrationModel = new DoubleModel(p, "SparkConcentration", 100,
 						UnitGroup.UNITS_NONE, 0, 100);
@@ -349,19 +375,23 @@ public class PhotoSettingsConfig extends JTabbedPane {
 				add(sparkConcentrationSpinner, "wrap");
 				sparksModel.addEnableComponent(sparkConcentrationSpinner);
 
+				/// Spark weight
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.sparkWeight")));
 				DoubleModel sparkWeightModel = new DoubleModel(p, "SparkWeight", 100, UnitGroup.UNITS_NONE, 0, 100);
 				EditableSpinner sparkWeightSpinner = new EditableSpinner(sparkWeightModel.getSpinnerModel());
 				add(sparkWeightSpinner, "wrap");
 				sparksModel.addEnableComponent(sparkWeightSpinner);
 
+				/// Exhaust scale
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.exhaustScale")));
 				DoubleModel exhaustScaleModel = new DoubleModel(p, "ExhaustScale", 100, UnitGroup.UNITS_NONE, 0, 1000);
 				add(new EditableSpinner(exhaustScaleModel.getSpinnerModel()), "wrap");
 
+				// Effects
 				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.effects"), Style.BOLD));
 				add(new JSeparator(SwingConstants.HORIZONTAL), "span, wrap, growx");
 
+				/// Speed
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.speed")));
 				add(new JCheckBox(new BooleanModel(p, "MotionBlurred")), "wrap");
 			}

--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettingsConfig.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettingsConfig.java
@@ -304,7 +304,7 @@ public class PhotoSettingsConfig extends JTabbedPane {
 				credit.setOpaque(false);
 				credit.setFocusable(false);
 				credit.setFont(creditLabel.getFont());
-				add(credit, "span, gap left 10px");
+				add(credit);
 
 				final StateChangeListener skyChange = new StateChangeListener() {
 					@Override

--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettingsConfig.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettingsConfig.java
@@ -160,29 +160,29 @@ public class PhotoSettingsConfig extends JTabbedPane {
 		smokeColorButton.addActionListener(new ColorActionListener(p, "SmokeColor"));
 		flameColorButton.addActionListener(new ColorActionListener(p, "FlameColor"));
 
-		addTab(trans.get("PhotoSettingsConfig.tab.orientation"), new JPanel(new MigLayout("fill")) {
+		addTab(trans.get("PhotoSettingsConfig.tab.orientation"), new JPanel(new MigLayout("fill", "[]100[]5[]")) {
 			{
 				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.rocket"), Style.BOLD));
 				add(new JSeparator(SwingConstants.HORIZONTAL), "span, wrap, growx");
 
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.pitch")));
 				DoubleModel pitchModel = new DoubleModel(p, "Pitch", UnitGroup.UNITS_ANGLE);
-				add(new EditableSpinner(pitchModel.getSpinnerModel()), "w 40");
-				add(new UnitSelector(pitchModel), "wrap");
+				add(new EditableSpinner(pitchModel.getSpinnerModel()), "growx");
+				add(new UnitSelector(pitchModel), "pushx, left, wrap");
 
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.yaw")));
 				DoubleModel yawModel = new DoubleModel(p, "Yaw", UnitGroup.UNITS_ANGLE);
-				add(new EditableSpinner(yawModel.getSpinnerModel()), "w 40");
+				add(new EditableSpinner(yawModel.getSpinnerModel()), "growx");
 				add(new UnitSelector(yawModel), "wrap");
 
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.roll")));
 				DoubleModel rollModel = new DoubleModel(p, "Roll", UnitGroup.UNITS_ANGLE);
-				add(new EditableSpinner(rollModel.getSpinnerModel()), "w 40");
+				add(new EditableSpinner(rollModel.getSpinnerModel()), "growx");
 				add(new UnitSelector(rollModel), "wrap");
 
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.advance")));
 				DoubleModel advanceModel = new DoubleModel(p, "Advance", UnitGroup.UNITS_LENGTH);
-				add(new EditableSpinner(advanceModel.getSpinnerModel()), "w 40");
+				add(new EditableSpinner(advanceModel.getSpinnerModel()), "growx");
 				add(new UnitSelector(advanceModel), "wrap");
 
 				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.camera"), Style.BOLD));
@@ -190,27 +190,27 @@ public class PhotoSettingsConfig extends JTabbedPane {
 
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.vAz")));
 				DoubleModel viewAzModel = new DoubleModel(p, "ViewAz", UnitGroup.UNITS_ANGLE);
-				add(new EditableSpinner(viewAzModel.getSpinnerModel()), "w 40");
+				add(new EditableSpinner(viewAzModel.getSpinnerModel()), "growx");
 				add(new UnitSelector(viewAzModel), "wrap");
 
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.vAlt")));
 				DoubleModel viewAltModle = new DoubleModel(p, "ViewAlt", UnitGroup.UNITS_ANGLE);
-				add(new EditableSpinner(viewAltModle.getSpinnerModel()), "w 40");
+				add(new EditableSpinner(viewAltModle.getSpinnerModel()), "growx");
 				add(new UnitSelector(viewAltModle), "wrap");
 
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.vDist")));
 				DoubleModel viewDistanceModel = new DoubleModel(p, "ViewDistance", UnitGroup.UNITS_LENGTH);
-				add(new EditableSpinner(viewDistanceModel.getSpinnerModel()), "w 40");
+				add(new EditableSpinner(viewDistanceModel.getSpinnerModel()), "growx");
 				add(new UnitSelector(viewDistanceModel), "wrap");
 
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.fov")));
 				DoubleModel fovModel = new DoubleModel(p, "Fov", UnitGroup.UNITS_ANGLE);
-				add(new EditableSpinner(fovModel.getSpinnerModel()), "w 40");
+				add(new EditableSpinner(fovModel.getSpinnerModel()), "growx");
 				add(new UnitSelector(fovModel), "wrap");
 			}
 		});
 
-		addTab(trans.get("PhotoSettingsConfig.tab.environment"), new JPanel(new MigLayout("fill")) {
+		addTab(trans.get("PhotoSettingsConfig.tab.environment"), new JPanel(new MigLayout("fill", "[]100[]5[]")) {
 			{
 				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.light"), Style.BOLD));
 				add(new JSeparator(SwingConstants.HORIZONTAL), "span, wrap, growx");
@@ -224,8 +224,8 @@ public class PhotoSettingsConfig extends JTabbedPane {
 
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.lightAz")));
 				DoubleModel lightAzModel = new DoubleModel(p, "LightAz", UnitGroup.UNITS_ANGLE);
-				add(new EditableSpinner(lightAzModel.getSpinnerModel()), "w 40");
-				add(new UnitSelector(lightAzModel), "wrap");
+				add(new EditableSpinner(lightAzModel.getSpinnerModel()), "split 2");
+				add(new UnitSelector(lightAzModel), "push, left, wrap");
 
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.lightAlt")));
 				DoubleModel lightAltModle = new DoubleModel(p, "LightAlt", UnitGroup.UNITS_ANGLE);
@@ -304,7 +304,7 @@ public class PhotoSettingsConfig extends JTabbedPane {
 			}
 		});
 
-		addTab(trans.get("PhotoSettingsConfig.tab.effects"), new JPanel(new MigLayout("fill")) {
+		addTab(trans.get("PhotoSettingsConfig.tab.effects"), new JPanel(new MigLayout("fill", "[]100[]5[]")) {
 			{
 				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.smokeFlame"), Style.BOLD));
 				add(new JSeparator(SwingConstants.HORIZONTAL), "span, wrap, growx");
@@ -313,7 +313,7 @@ public class PhotoSettingsConfig extends JTabbedPane {
 				BooleanModel smokeModel = new BooleanModel(p, "Smoke");
 				add(new JCheckBox(smokeModel), "split 2, w 15");
 
-				add(smokeColorButton, "wrap");
+				add(smokeColorButton, "pushx, left, wrap");
 				smokeModel.addEnableComponent(smokeColorButton);
 
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.smokeOpacity")));

--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettingsConfig.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettingsConfig.java
@@ -296,7 +296,7 @@ public class PhotoSettingsConfig extends JTabbedPane {
 
 				/// Image credit
 				final JLabel creditLabel = new JLabel(trans.get("PhotoSettingsConfig.lbl.skyCredit"));
-				add(creditLabel, "wrap");
+				add(creditLabel);
 
 				final JTextArea credit = new JTextArea();
 				credit.setEditable(false);

--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettingsConfig.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettingsConfig.java
@@ -239,7 +239,7 @@ public class PhotoSettingsConfig extends JTabbedPane {
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.lightAz")));
 				DoubleModel lightAzModel = new DoubleModel(p, "LightAz", UnitGroup.UNITS_ANGLE);
 				add(new EditableSpinner(lightAzModel.getSpinnerModel()), "split 2");
-				add(new UnitSelector(lightAzModel), "push, left, wrap");
+				add(new UnitSelector(lightAzModel), "pushx, left, wrap");
 
 				/// Light altitude
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.lightAlt")));

--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettingsConfig.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettingsConfig.java
@@ -163,8 +163,8 @@ public class PhotoSettingsConfig extends JTabbedPane {
 		addTab(trans.get("PhotoSettingsConfig.tab.orientation"), new JPanel(new MigLayout("fill", "[]100[]5[]")) {
 			{
 				// Rocket
-				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.rocket"), Style.BOLD));
-				add(new JSeparator(SwingConstants.HORIZONTAL), "span, wrap, growx");
+				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.rocket"), Style.BOLD), "split, span, gapright para");
+				add(new JSeparator(SwingConstants.HORIZONTAL), "wrap, growx");
 
 				/// Pitch
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.pitch")));
@@ -191,8 +191,8 @@ public class PhotoSettingsConfig extends JTabbedPane {
 				add(new UnitSelector(advanceModel), "wrap");
 
 				// Camera
-				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.camera"), Style.BOLD));
-				add(new JSeparator(SwingConstants.HORIZONTAL), "span, wrap, growx");
+				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.camera"), Style.BOLD), "split, gapright para, span");
+				add(new JSeparator(SwingConstants.HORIZONTAL), "wrap, growx");
 
 				/// View azimuth
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.vAz")));
@@ -223,8 +223,8 @@ public class PhotoSettingsConfig extends JTabbedPane {
 		addTab(trans.get("PhotoSettingsConfig.tab.environment"), new JPanel(new MigLayout("fill", "[]100[]5[]")) {
 			{
 				// Light
-				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.light"), Style.BOLD));
-				add(new JSeparator(SwingConstants.HORIZONTAL), "span, wrap, growx");
+				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.light"), Style.BOLD), "split, span, gapright para");
+				add(new JSeparator(SwingConstants.HORIZONTAL), "wrap, growx");
 
 				/// Sun light
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.sun")));
@@ -247,8 +247,8 @@ public class PhotoSettingsConfig extends JTabbedPane {
 				add(new EditableSpinner(lightAltModle.getSpinnerModel()), "wrap");
 
 				// Sky
-				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.sky"), Style.BOLD));
-				add(new JSeparator(SwingConstants.HORIZONTAL), "span, wrap, growx");
+				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.sky"), Style.BOLD), "split, span, gapright para");
+				add(new JSeparator(SwingConstants.HORIZONTAL), "wrap, growx");
 
 				/// Sky color
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.skyColor")));
@@ -326,8 +326,8 @@ public class PhotoSettingsConfig extends JTabbedPane {
 		addTab(trans.get("PhotoSettingsConfig.tab.effects"), new JPanel(new MigLayout("fill", "[]100[]5[]")) {
 			{
 				// Smoke & Flame
-				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.smokeFlame"), Style.BOLD));
-				add(new JSeparator(SwingConstants.HORIZONTAL), "span, wrap, growx");
+				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.smokeFlame"), Style.BOLD), "split, span, gapright para");
+				add(new JSeparator(SwingConstants.HORIZONTAL), "wrap, growx");
 
 				/// Smoke
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.smoke")));
@@ -388,8 +388,8 @@ public class PhotoSettingsConfig extends JTabbedPane {
 				add(new EditableSpinner(exhaustScaleModel.getSpinnerModel()), "wrap");
 
 				// Effects
-				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.effects"), Style.BOLD));
-				add(new JSeparator(SwingConstants.HORIZONTAL), "span, wrap, growx");
+				add(new StyledLabel(trans.get("PhotoSettingsConfig.lbl.effects"), Style.BOLD), "split, span, gapright para");
+				add(new JSeparator(SwingConstants.HORIZONTAL), "wrap, growx");
 
 				/// Speed
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.speed")));


### PR DESCRIPTION
This PR fixes layout issues in the PhotoStudio settings panel, as described in #1084.

Value and unit widgets are now close together and in general, the labels on the left and corresponding value-unit widgets are closer together. This should make it visually easier to link a label to the corresponding value.
<img width="987" alt="Screenshot 2022-01-28 at 12 50 24" src="https://user-images.githubusercontent.com/11031519/151543312-2a6ba170-4f55-42ce-929b-5c61c27061a7.png">
<img width="987" alt="Screenshot 2022-01-28 at 12 50 26" src="https://user-images.githubusercontent.com/11031519/151543324-3eb0bb27-a9d0-4c62-9b61-85b83ea318d4.png">
<img width="987" alt="Screenshot 2022-01-28 at 12 50 29" src="https://user-images.githubusercontent.com/11031519/151543342-94ca501e-cf70-465e-879d-3a6bab5fc566.png">


Here is a [jar file](https://drive.google.com/file/d/11455wR8cO5V4abxvwg6GH6e1EDjEODeR/view?usp=sharing) for testing.