### PR TITLE
Improve Bug Report formatting

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/BugReportDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/BugReportDialog.java
@@ -71,7 +71,7 @@ public class BugReportDialog extends JDialog {
 				  "gapleft para, split 2, gapright rel");
 		panel.add(new URLLabel(REPORT_EMAIL_URL, REPORT_EMAIL), "growx, wrap para");
 
-		final JEditorPane editorPane = new JEditorPane("text/html", message.replace("\n", "<br>"));
+		final JEditorPane editorPane = new JEditorPane("text/html", formatNewlineHTML(message));
 		editorPane.putClientProperty(JTextPane.HONOR_DISPLAY_PROPERTIES, true);
 		editorPane.setPreferredSize(new Dimension(600, 400));
 		editorPane.setEditable(true);
@@ -240,6 +240,17 @@ public class BugReportDialog extends JDialog {
 		for (LogLine l : logs) {
 			sb.append(l.toString()).append('\n');
 		}
+	}
+
+	/**
+	 * Replace newline character \n to an HTML newline. Instead of just using a <br> tag, we replace newlines with a
+	 * paragraph tag with zero margin. This is so that when you copy the HTML text and paste it somewhere, that the
+	 * HTML newlines are also interpreted as newlines in the new text. A <br> tag would just be replaced by a space.
+	 * @param text text to be formatted
+	 * @return text with HTML newlines
+	 */
+	private static String formatNewlineHTML(String text) {
+		return text.replaceAll("\n(.*?)(?=(\n|$))", "<p style=\"margin-top: 0\">$1</p>");
 	}
 	
 }

--- a/swing/src/net/sf/openrocket/gui/dialogs/BugReportDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/BugReportDialog.java
@@ -14,10 +14,12 @@ import java.util.TreeSet;
 
 import javax.swing.JButton;
 import javax.swing.JDialog;
+import javax.swing.JEditorPane;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
+import javax.swing.JTextPane;
 
 import com.jogamp.opengl.JoglVersion;
 
@@ -68,11 +70,13 @@ public class BugReportDialog extends JDialog {
 		panel.add(new JLabel(trans.get("bugreport.dlg.otherwise") + " "),
 				  "gapleft para, split 2, gapright rel");
 		panel.add(new URLLabel(REPORT_EMAIL_URL, REPORT_EMAIL), "growx, wrap para");
-		
-		
-		final JTextArea textArea = new JTextArea(message, 20, 70);
-		textArea.setEditable(true);
-		panel.add(new JScrollPane(textArea), "grow, wrap");
+
+		final JEditorPane editorPane = new JEditorPane("text/html", message.replace("\n", "<br>"));
+		editorPane.putClientProperty(JTextPane.HONOR_DISPLAY_PROPERTIES, true);
+		editorPane.setPreferredSize(new Dimension(600, 400));
+		editorPane.setEditable(true);
+		editorPane.setCaretPosition(0);		// Scroll to the top by default
+		panel.add(new JScrollPane(editorPane), "grow, wrap");
 		
 		panel.add(new StyledLabel(trans.get("bugreport.lbl.Theinformation"), -1), "wrap para");
 		
@@ -106,17 +110,18 @@ public class BugReportDialog extends JDialog {
 		
 		StringBuilder sb = new StringBuilder();
 		
-		sb.append("---------- Bug report ----------\n");
+		sb.append("<html>---------- Bug report ----------\n");
 		sb.append('\n');
-		sb.append("Include detailed steps on how to trigger the bug:\n");
+		sb.append("<b>Include detailed steps on how to trigger the bug:</b>\n");
+		sb.append("<i>(You can edit text directly in this window)</i>\n");
 		sb.append('\n');
 		sb.append("1. \n");
 		sb.append("2. \n");
 		sb.append("3. \n");
 		sb.append('\n');
 		
-		sb.append("What does the software do and what in your opinion should it do in the " +
-				"case described above:\n");
+		sb.append("<b>What does the software do and what in your opinion should it do in the " +
+				"case described above:</b>\n");
 		sb.append('\n');
 		sb.append('\n');
 		sb.append('\n');
@@ -133,7 +138,7 @@ public class BugReportDialog extends JDialog {
 		addSystemInformation(sb);
 		sb.append("---------- Error log ----------\n");
 		addErrorLog(sb);
-		sb.append("---------- End of bug report ----------\n");
+		sb.append("---------- End of bug report ----------</html>\n");
 		sb.append('\n');
 		
 		BugReportDialog reportDialog = new BugReportDialog(parent,
@@ -152,14 +157,15 @@ public class BugReportDialog extends JDialog {
 	public static void showExceptionDialog(Window parent, Thread t, Throwable e) {
 		StringBuilder sb = new StringBuilder();
 		
-		sb.append("---------- Bug report ----------\n");
+		sb.append("<html>---------- Bug report ----------\n");
 		sb.append('\n');
-		sb.append("Please include a description about what actions you were " +
-				"performing when the exception occurred:\n");
+		sb.append("<b>Please include a description about what actions you were " +
+				"performing when the exception occurred:</b>\n");
+		sb.append("<i>(You can edit text directly in this window)</i>\n");
 		sb.append('\n');
-		sb.append('\n');
-		sb.append('\n');
-		sb.append('\n');
+		sb.append("1. \n");
+		sb.append("2. \n");
+		sb.append("3. \n");
 		
 		
 		sb.append("Include your email address (optional; it helps if we can " +
@@ -191,7 +197,7 @@ public class BugReportDialog extends JDialog {
 		addSystemInformation(sb);
 		sb.append("---------- Error log ----------\n");
 		addErrorLog(sb);
-		sb.append("---------- End of bug report ----------\n");
+		sb.append("---------- End of bug report ----------</html>\n");
 		sb.append('\n');
 		
 		BugReportDialog reportDialog =

--- a/swing/src/net/sf/openrocket/logging/LogLine.java
+++ b/swing/src/net/sf/openrocket/logging/LogLine.java
@@ -1,6 +1,7 @@
 package net.sf.openrocket.logging;
 
 import java.io.PrintWriter;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -127,7 +128,7 @@ public class LogLine implements Comparable<LogLine> {
 	public String toString() {
 		if (formattedMessage == null) {
 			String str;
-			str = String.format("%4d %10.3f %-" + LogLevel.LENGTH + "s %s %s",
+			str = String.format(Locale.ENGLISH, "%4d %10.3f %-" + LogLevel.LENGTH + "s %s %s",
 					count, timestamp / 1000.0, (level != null) ? level.toString() : "NULL",
 					getLocation(),
 					message);


### PR DESCRIPTION
This PR does not have an issue tied to it, but it is a quick fix to improving bug reports. This PR puts the lines "_Include detailed steps on how to trigger the bug:_" and "_What does the software do and what in your opinion should it do in the case described above:_" in bold and adds a line "_(You can edit text directly in this window)_" because I was shamefully unaware this was possible until recently.

Old bug report:
<img width="1577" alt="Screenshot 2022-01-28 at 22 55 58" src="https://user-images.githubusercontent.com/11031519/151626998-ff991f8b-b64b-4039-84c1-336efdd6a2aa.png">


New bug report:
<img width="1573" alt="Screenshot 2022-01-28 at 22 32 28" src="https://user-images.githubusercontent.com/11031519/151624923-0e546580-d954-4d17-b1ab-198b2716845e.png">

I thought this would be useful, because I have seen in the past that people just post their bug report without any indication of how the bug was created, after which we often have to close the issue due to lack of information. My goal with this PR is to guide users to elaborating their bug report.

Oh yeah and I've also edited the LogLine number formatting to use as default the English LOCALE. This makes it so that the timestamp number (the second number in the 'Error log' lines, e.g. for line '13 4.070 DEBUG (JarUtil.java:40) Found jar file using codeSource', '4.070' is the timestamp number) will be formatted the same for all users. I've encountered bug reports that had a dot as a decimal separator, but on my machine, a comma was used instead. The English LOCALE uses a dot separator by default.

Here is a [jar file](https://drive.google.com/file/d/1okdw97oTxezoTOpao0z8WLEnD6dfxBRD/view?usp=sharing) for testing.