### PR TITLE
[fixes #1092] Draw root edge of fin tab

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -909,7 +909,7 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 			return new Coordinate[]{};
 		}
 	
-		final int pointCount = 4;
+		final int pointCount = 5;
 		Coordinate[] points = new Coordinate[pointCount];
 		final Coordinate finFront = this.getFinFront();
 		
@@ -932,6 +932,7 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 		points[1] = new Coordinate(xTabFront, yTabBottom );
 		points[2] = new Coordinate(xTabTrail, yTabBottom );
 		points[3] = new Coordinate(xTabTrail, yTabTrail);
+		points[4] = new Coordinate(xTabFront, yTabFront);
 
 		return points;
 	}


### PR DESCRIPTION
This PR fixes the root edge of the fin tab not being drawn, as stated in #1092. It's a simple fix: just append the start coordinate point of the fin tab to the coordinate list so that a final line is drawn from the last point to the starting point.

Result:
![image](https://user-images.githubusercontent.com/11031519/151662821-2fed7402-52ab-4cfd-af24-5126a36ca3c8.png)

Here is a [jar file](https://drive.google.com/file/d/1E9MXXx5Beghgu31Zyjt2TjfjZc_IDJgm/view?usp=sharing) for testing.