### PR TITLE
[fixes #1090] Wrong FinSet tab position upon file opening

### DIFF
--- a/core/src/net/sf/openrocket/file/openrocket/importt/FinSetPointHandler.java
+++ b/core/src/net/sf/openrocket/file/openrocket/importt/FinSetPointHandler.java
@@ -62,6 +62,10 @@ class FinSetPointHandler extends AbstractElementHandler {
 	public void endHandler(String element, HashMap<String, String> attributes,
 			String content, WarningSet warnings) {
 		finset.setPoints(coordinates.toArray(new Coordinate[0]));
-		
+		// Update the tab position. This is because the tab position relies on the finset length, but because the
+		// <tabposition> tag comes before the <finpoints> tag in the .ork file, the tab position will be set first,
+		// using the default finset length, not the intended finset length that we extract in this part. So we update
+		// the tab position here to cope for the wrongly calculated tab position earlier.
+		finset.updateTabPosition();
 	}
 }

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -101,7 +101,7 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 	private static final double minimumTabArea = 1e-8;
 	private double tabHeight = 0;
 	private double tabLength = 0.05;
-	// this is always measured from the the root-lead point.
+	// this is always measured from the root-lead point.
 	private double tabPosition = 0.0;
 	private AxialMethod tabOffsetMethod = AxialMethod.MIDDLE;
 	private double tabOffset = 0.;

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -289,12 +289,12 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 		
 		tabLength = lengthRequest;
 		
-		setTabPosition();
+		updateTabPosition();
 		
 		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
 	}
-	
-	protected void setTabPosition(){
+
+	protected void updateTabPosition(){
 		this.tabPosition = this.tabOffsetMethod.getAsPosition(tabOffset, tabLength, length);
 	}
 	
@@ -305,7 +305,7 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 	 */
 	public void setTabOffset( final double offsetRequest) {
 		tabOffset = offsetRequest;
-		setTabPosition();
+		updateTabPosition();
 		
 		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
 	}

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -5,8 +5,6 @@ import java.util.*;
 import java.util.ArrayList;
 
 
-import net.sf.openrocket.appearance.Appearance;
-import net.sf.openrocket.appearance.Decal;
 import net.sf.openrocket.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -294,7 +294,7 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
 	}
 
-	protected void updateTabPosition(){
+	public void updateTabPosition(){
 		this.tabPosition = this.tabOffsetMethod.getAsPosition(tabOffset, tabLength, length);
 	}
 	

--- a/core/src/net/sf/openrocket/rocketcomponent/TrapezoidFinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/TrapezoidFinSet.java
@@ -77,7 +77,7 @@ public class TrapezoidFinSet extends FinSet {
 		if (length == r)
 			return;
 		length = Math.max(r, 0);
-		setTabPosition();
+		updateTabPosition();
 		
 		fireComponentChangeEvent(ComponentChangeEvent.AEROMASS_CHANGE);
 	}


### PR DESCRIPTION
This PR fixes #1090 where the FinSet tab position was wrong when you opened a file.

The problem was the following: the tab position (= kinda the same as the tab offset, but just transformed to cope with the offset method, tab length etc.) was calculated using the following method, which uses the `tabOffset` and `tabLength` of the fin tab, and `length`, the length of the fin:
```Java
public void updateTabPosition() {
     this.tabPosition = this.tabOffsetMethod.getAsPosition(tabOffset, tabLength, length);
}
```
Now, when loading the .ork-file and parsing the XML-contents of the FinSet, the tabOffset is read in and the `tabPosition` of the FinSet is calculated. But, the value of `tabPosition` was wrong because the `length` that `updateTabPosition()` uses was incorrect. It did not equal the actual length of the FinSet, but instead it used the default length of a FinSet (0.05).

The issue was that the `tabOffset` of the FinSet got assigned before the `length`. So you first loaded `tabOffset` and then `length`, but because `length` was not yet loaded in for `updateTabPosition()`, it just used the default FinSet length instead.

The reason why `tabOffset` is assigned before `length` is a bit stupid actually, it's because if you look in the XML-structure of the FinSet, the `<tabposition>` tag is placed before the `<finpoints>` tag (the fin length is calculated from these finpoints inside FinSetPointHandler.java):
```XML
...
<tabposition relativeto="bottom">-0.067</tabposition>
<filletradius>0.0</filletradius>
<filletmaterial type="bulk" density="680.0">Cardboard</filletmaterial>
<finpoints>
  <point x="0.0" y="0.0"/>
  <point x="0.0947058823529412" y="0.03485294117647059"/>
  <point x="0.11941176470588236" y="0.049852941176470586"/>
  <point x="0.15955882352941178" y="0.05"/>
  <point x="0.1345588235294118" y="0.0"/>
</finpoints>
...
```

So when parsing the .ork file, the parsing sees the `<tabposition>` tag first, assigns the wrong tabPosition, and then calculates the length when it reaches the `<finpoints>` tag.

---

Okay, now we know what's wrong, how do we fix it?

You could say: let's just switch the `<finpoints>` and `<tabposition>` tag and then we're good, but: this would break backward compatibility with files that still have the XML order as above.

So my solution: after the `<finpoints>` tag is parsed and the new length of the fin is assigned, I invoke the `updateTabPosition()` method to recalculate the tab position, but now with the correctly assigned fin length. Tada!

---

Alright, sorry for the long post, but it was a bit of a rabbit hole to find the root cause.

Anyway, here is a [jar file](https://drive.google.com/file/d/19dCz2ydfMQLhCZLrtjhIHAWpsQFt84Qx/view?usp=sharing) for testing.