### PR TITLE
Fix transition 'Clipped' checkbox overlapping with comment

### DIFF
--- a/swing/src/net/sf/openrocket/gui/configdialog/TransitionConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/TransitionConfig.java
@@ -48,7 +48,7 @@ public class TransitionConfig extends RocketComponentConfig {
 	public TransitionConfig(OpenRocketDocument d, RocketComponent c) {
 		super(d, c);
 		
-		final JPanel panel = new JPanel(new MigLayout("gap rel unrel", "[][65lp::][30lp::]", ""));
+		final JPanel panel = new JPanel(new MigLayout("gap rel unrel, fillx", "[][65lp::][30lp::]", ""));
 
 		////  Shape selection
 		//// Transition shape:
@@ -69,7 +69,7 @@ public class TransitionConfig extends RocketComponentConfig {
 				updateEnabled();
 			}
 		});
-		panel.add(typeBox, "span, split 2");
+		panel.add(typeBox, "span 3, split 2");
 
 		{//// Clipped
 			final JCheckBox checkbox = new JCheckBox(new BooleanModel(component, "Clipped"));


### PR DESCRIPTION
This PR fixes an overlap of the transition 'Clipped' checkbox with the comment text area on the right

OId behavior:
<img width="1728" alt="Screenshot 2022-01-29 at 23 59 17" src="https://user-images.githubusercontent.com/11031519/151680303-018e636e-151f-4b4d-a95b-c489425bfe44.png">


New behavior:
<img width="1728" alt="Screenshot 2022-01-29 at 23 59 06" src="https://user-images.githubusercontent.com/11031519/151680298-544dba7e-3442-465e-b4d7-b7445a968eb3.png">