### PR TITLE
[fixes #1088] Select new motor config + others

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurationPanel.java
@@ -82,6 +82,7 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 				motorConfigurationPanel.table.setColumnSelectionInterval(lastCol, lastCol);
 				configurationChanged(ComponentChangeEvent.MOTOR_CHANGE);
 				configurationChanged(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);	// Trigger select
+				motorConfigurationPanel.selectMotor();
 			}
 			
 		});
@@ -115,6 +116,7 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 				addOrCopyConfiguration(true);
 				configurationChanged(ComponentChangeEvent.MOTOR_CHANGE);
 				configurationChanged(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);	// Trigger select
+				motorConfigurationPanel.selectMotor();
 			}
 		});
 		this.add(copyConfButton, "wrap");

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurationPanel.java
@@ -81,6 +81,7 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 				motorConfigurationPanel.table.setRowSelectionInterval(lastRow, lastRow);
 				motorConfigurationPanel.table.setColumnSelectionInterval(lastCol, lastCol);
 				configurationChanged(ComponentChangeEvent.MOTOR_CHANGE);
+				configurationChanged(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);	// Trigger select
 			}
 			
 		});
@@ -113,6 +114,7 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 			public void actionPerformed(ActionEvent e) {
 				addOrCopyConfiguration(true);
 				configurationChanged(ComponentChangeEvent.MOTOR_CHANGE);
+				configurationChanged(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);	// Trigger select
 			}
 		});
 		this.add(copyConfButton, "wrap");

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
@@ -204,7 +204,7 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 		}
 	}
 
-	private void selectMotor() {
+	public void selectMotor() {
 		MotorMount curMount = getSelectedComponent();		
 		FlightConfigurationId fcid= getSelectedConfigurationId();
         if ( (null == fcid )||( null == curMount )){

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
@@ -4,16 +4,20 @@ import java.awt.CardLayout;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 
+import javax.swing.AbstractAction;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
+import javax.swing.KeyStroke;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
 import javax.swing.event.TableModelEvent;
@@ -56,7 +60,7 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 	protected FlightConfigurableTableModel<MotorMount> configurationTableModel;
 
 	MotorConfigurationPanel(final FlightConfigurationPanel flightConfigurationPanel, Rocket rocket) {
-		super(flightConfigurationPanel,rocket);
+		super(flightConfigurationPanel, rocket);
 
 		motorChooserDialog = new MotorChooserDialog(SwingUtilities.getWindowAncestor(flightConfigurationPanel));
 
@@ -66,20 +70,20 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 			JLabel label = new StyledLabel(trans.get("lbl.motorMounts"), Style.BOLD);
 			subpanel.add(label, "wrap");
 
-			MotorMountConfigurationPanel mountConfigPanel = new MotorMountConfigurationPanel(this,rocket);
+			MotorMountConfigurationPanel mountConfigPanel = new MotorMountConfigurationPanel(this, rocket);
 			subpanel.add(mountConfigPanel, "grow");
 			this.add(subpanel, "split, w 200lp, growy");
 		}
 
 		cards = new JPanel(new CardLayout());
-		this.add( cards );
-		
+		this.add(cards);
+
 		JLabel helpText = new JLabel(trans.get("MotorConfigurationPanel.lbl.nomotors"));
-		cards.add(helpText, HELP_LABEL );
-		
+		cards.add(helpText, HELP_LABEL);
+
 		JScrollPane scroll = new JScrollPane(table);
-		cards.add(scroll, TABLE_LABEL );
-		
+		cards.add(scroll, TABLE_LABEL);
+
 		this.add(cards, "grow, wrap");
 
 		//// Select motor
@@ -121,6 +125,15 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 			}
 		});
 		this.add(resetIgnitionButton, "sizegroup button, wrap");
+
+		// Set 'Enter' key action to open the motor selection dialog
+		table.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "Enter");
+		table.getActionMap().put("Enter", new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent ae) {
+				selectMotor();
+			}
+		});
 
 		updateButtonState();
 


### PR DESCRIPTION
This PR fixes #1088, with the following changes:

1. When creating a new configuration or copying an existing one, a selection event is triggered so that the 'Select motor' button etc. become enabled
2. When creating/copying a configuration, the Select motor dialog automatically opens. I found this was a good suggestion from @neilweinstock, as this is the action that you almost always want
3. When a motor configuration in the motor configuration table is selected, hitting the 'Enter' key opens the Select motor dialog. (be aware: e.g. just switching to the 'Motors & Configuration' tab and then hitting 'Enter' is not enough, you really have to click on the configuration in the table and only then is the Enter hotkey applicable)

Here is a [jar file](https://drive.google.com/file/d/1UwDfazRc6PjIsbYZAEkILyMNX2fM5CNu/view?usp=sharing) for testing.