### PR TITLE
[fixes #1024] Rocket optimization window too small + others

### DIFF
--- a/swing/src/net/sf/openrocket/gui/customexpression/CustomExpressionPanel.java
+++ b/swing/src/net/sf/openrocket/gui/customexpression/CustomExpressionPanel.java
@@ -56,7 +56,7 @@ public class CustomExpressionPanel extends JPanel {
 		//expressionSelectorPanel.add(scroll);
 		
 		//this.add(expressionSelectorPanel, "spany 1, height 10px, wmin 600lp, grow 100, gapright para");
-		this.add(scroll, "hmin 200lp, wmin 700lp, grow 100, wrap");
+		this.add(scroll, "hmin 200lp, wmin 700lp, grow 100, pushy, wrap");
 		
 		//DescriptionArea desc = new DescriptionArea(trans.get("customExpressionPanel.lbl.UpdateNote")+"\n\n"+trans.get("customExpressionPanel.lbl.CalcNote"), 8, -2f);
 		//desc.setViewportBorder(BorderFactory.createEmptyBorder());

--- a/swing/src/net/sf/openrocket/gui/customexpression/CustomExpressionPanel.java
+++ b/swing/src/net/sf/openrocket/gui/customexpression/CustomExpressionPanel.java
@@ -56,7 +56,7 @@ public class CustomExpressionPanel extends JPanel {
 		//expressionSelectorPanel.add(scroll);
 		
 		//this.add(expressionSelectorPanel, "spany 1, height 10px, wmin 600lp, grow 100, gapright para");
-		this.add(scroll, "hmin 200lp, wmin 700lp, grow 100, pushy, wrap");
+		this.add(scroll, "hmin 200lp, wmin 700lp, grow, pushy, wrap");
 		
 		//DescriptionArea desc = new DescriptionArea(trans.get("customExpressionPanel.lbl.UpdateNote")+"\n\n"+trans.get("customExpressionPanel.lbl.CalcNote"), 8, -2f);
 		//desc.setViewportBorder(BorderFactory.createEmptyBorder());

--- a/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
@@ -148,7 +148,7 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 		JScrollPane scrollPane = new JScrollPane(warningList);
 		////Warnings:
 		scrollPane.setBorder(BorderFactory.createTitledBorder(trans.get("componentanalysisdlg.TitledBorder.warnings")));
-		panel.add(scrollPane, "gap paragraph, spany 4, width 300lp!, growy 1, height :100lp:, wrap");
+		panel.add(scrollPane, "gap paragraph, spany 4, wmin 300lp, grow, height :100lp:, wrap");
 
 		////Angle of attack:
 		panel.add(new JLabel(trans.get("componentanalysisdlg.lbl.angleofattack")), "width 120lp!");
@@ -183,7 +183,7 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 		// Tabbed pane
 
 		JTabbedPane tabbedPane = new JTabbedPane();
-		panel.add(tabbedPane, "spanx, growx, growy");
+		panel.add(tabbedPane, "spanx, growx, growy, pushy");
 
 
 		// Create the Longitudinal Stability (CM vs CP) data table

--- a/swing/src/net/sf/openrocket/gui/dialogs/optimization/GeneralOptimizationDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/optimization/GeneralOptimizationDialog.java
@@ -602,7 +602,7 @@ public class GeneralOptimizationDialog extends JDialog {
 		});
 		panel.add(closeButton, "right");
 		
-		this.add(panel);
+		this.add(new JScrollPane(panel));
 		clearHistory();
 		updateComponents();
 		GUIUtil.setDisposableDialogOptions(this, null);

--- a/swing/src/net/sf/openrocket/gui/dialogs/optimization/GeneralOptimizationDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/optimization/GeneralOptimizationDialog.java
@@ -1,6 +1,7 @@
 package net.sf.openrocket.gui.dialogs.optimization;
 
 import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -205,7 +206,7 @@ public class GeneralOptimizationDialog extends JDialog {
 		JScrollPane scroll;
 		String tip;
 		
-		JPanel panel = new JPanel(new MigLayout("fill"));
+		JPanel panel = new JPanel(new MigLayout("fill, w 1200"));
 		
 		ChangeListener clearHistoryChangeListener = e -> clearHistory();
 		ActionListener clearHistoryActionListener = e -> clearHistory();
@@ -606,11 +607,7 @@ public class GeneralOptimizationDialog extends JDialog {
 		updateComponents();
 		GUIUtil.setDisposableDialogOptions(this, null);
 
-		// seem like a reasonable defaults
-		this.setSize(1200, 600);
-		// System.err.println("OptimizationDialog.size:     " + this.getSize());
-		this.setLocation(100, 100);
-		// System.err.println("OptimizationDialog.location: " + this.getLocation());
+		this.setLocation((parent.getWidth() - 1200)/2, 100);
 	}
 	
 	private void startOptimization() {

--- a/swing/src/net/sf/openrocket/gui/dialogs/optimization/GeneralOptimizationDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/optimization/GeneralOptimizationDialog.java
@@ -2,6 +2,7 @@ package net.sf.openrocket.gui.dialogs.optimization;
 
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -606,6 +607,9 @@ public class GeneralOptimizationDialog extends JDialog {
 		clearHistory();
 		updateComponents();
 		GUIUtil.setDisposableDialogOptions(this, null);
+
+		int screenHeight = Toolkit.getDefaultToolkit().getScreenSize().height;
+		this.setSize(new Dimension(this.getWidth(), Math.min(this.getHeight(), screenHeight - 150)));
 
 		this.setLocation((parent.getWidth() - 1200)/2, 100);
 	}

--- a/swing/src/net/sf/openrocket/gui/dialogs/optimization/GeneralOptimizationDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/optimization/GeneralOptimizationDialog.java
@@ -253,7 +253,7 @@ public class GeneralOptimizationDialog extends JDialog {
 		label = new StyledLabel(trans.get("lbl.paramsToOptimize"), Style.BOLD);
 		disableComponents.add(label);
 		panel.add(label, "split 3, flowy");
-		panel.add(scroll, "wmin 300lp, height 200lp, grow");
+		panel.add(scroll, "wmin 300lp, height 150lp, grow");
 		selectedModifierDescription = new DescriptionArea(2, -3);
 		disableComponents.add(selectedModifierDescription);
 		panel.add(selectedModifierDescription, "hmin 20lp, growx");
@@ -610,6 +610,7 @@ public class GeneralOptimizationDialog extends JDialog {
 
 		int screenHeight = Toolkit.getDefaultToolkit().getScreenSize().height;
 		this.setSize(new Dimension(this.getWidth(), Math.min(this.getHeight(), screenHeight - 150)));
+		this.pack();
 
 		this.setLocation((parent.getWidth() - 1200)/2, 100);
 	}

--- a/swing/src/net/sf/openrocket/gui/dialogs/optimization/GeneralOptimizationDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/optimization/GeneralOptimizationDialog.java
@@ -255,7 +255,7 @@ public class GeneralOptimizationDialog extends JDialog {
 		panel.add(scroll, "wmin 300lp, height 200lp, grow");
 		selectedModifierDescription = new DescriptionArea(2, -3);
 		disableComponents.add(selectedModifierDescription);
-		panel.add(selectedModifierDescription, "growx");
+		panel.add(selectedModifierDescription, "hmin 20lp, growx");
 		
 		// // Add/remove buttons
 		sub = new JPanel(new MigLayout("fill"));


### PR DESCRIPTION
This PR fixes issue #1024 where the Rocket optimization window was too small at startup, thus clipping of the bottom of the window. While I was at it, I also saw some layout issues in the custom expression window and component analysis window (there still are numerous after this PR, but those are headaches for the future).

Rocket optimization window:
![Rocket optimization](https://user-images.githubusercontent.com/11031519/151724011-58ff3fa7-1ae0-4f8c-a185-336a4cd2734e.jpg)

Custom expressions window:
![Custom expressions](https://user-images.githubusercontent.com/11031519/151724039-11ee1d26-96de-434d-bbeb-890f43bfa15f.jpg)

Component analysis window:
![Component analysis](https://user-images.githubusercontent.com/11031519/151724019-c0900cd8-8d20-4b8f-a301-e4bcc6ae472a.jpg)

Here is a [jar file](https://drive.google.com/file/d/1JDgxOBS2XKYja3hBk--91yNcaShL0Z_G/view?usp=sharing) for testing.