### PR TITLE
[fixes #1076] Fix preset combobox not updating

### DIFF
--- a/swing/src/net/sf/openrocket/gui/adaptors/PresetModel.java
+++ b/swing/src/net/sf/openrocket/gui/adaptors/PresetModel.java
@@ -7,6 +7,7 @@ import javax.swing.AbstractListModel;
 import javax.swing.ComboBoxModel;
 import javax.swing.SwingUtilities;
 
+import net.sf.openrocket.database.ComponentPresetDatabase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,6 +76,7 @@ public class PresetModel extends AbstractListModel implements ComboBoxModel, Com
 			SwingUtilities.invokeLater(new Runnable() {
 				@Override
 				public void run() {
+					((ComponentPresetDatabase) Application.getComponentPresetDao()).addDatabaseListener(PresetModel.this);
 					ComponentPresetChooserDialog dialog =
 							new ComponentPresetChooserDialog(SwingUtilities.getWindowAncestor(parent), component);
 					dialog.setVisible(true);
@@ -82,6 +84,7 @@ public class PresetModel extends AbstractListModel implements ComboBoxModel, Com
 					if (preset != null) {
 						setSelectedItem(preset);
 					}
+					((ComponentPresetDatabase) Application.getComponentPresetDao()).removeChangeListener(PresetModel.this);
 				}
 			});
 		} else {

--- a/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
@@ -22,7 +22,6 @@ import javax.swing.JTextArea;
 import javax.swing.JTextField;
 
 import net.miginfocom.swing.MigLayout;
-import net.sf.openrocket.database.ComponentPresetDatabase;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.gui.SpinnerEditor;
 import net.sf.openrocket.gui.adaptors.BooleanModel;
@@ -94,7 +93,6 @@ public class RocketComponentConfig extends JPanel {
 		if (component.getPresetType() != null) {
 			// If the component supports a preset, show the preset selection box.
 			presetModel = new PresetModel(this, document, component);
-			((ComponentPresetDatabase) Application.getComponentPresetDao()).addDatabaseListener(presetModel);
 			presetComboBox = new JComboBox(presetModel);
 			presetComboBox.setEditable(false);
 			this.add(presetComboBox, "");
@@ -623,7 +621,6 @@ public class RocketComponentConfig extends JPanel {
 		for (Invalidatable i : invalidatables) {
 			i.invalidate();
 		}
-		((ComponentPresetDatabase) Application.getComponentPresetDao()).removeChangeListener(presetModel);
 	}
 	
 

--- a/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
@@ -67,8 +67,6 @@ public class ComponentPresetChooserDialog extends JDialog {
 	private List<ComponentPreset> presets;
 	private ComponentPreset.Type presetType;
 	
-	private boolean okClicked = false;
-	
 	
 	public ComponentPresetChooserDialog(Window owner, RocketComponent component) {
 		super(owner, trans.get("title"), Dialog.ModalityType.APPLICATION_MODAL);
@@ -154,30 +152,20 @@ public class ComponentPresetChooserDialog extends JDialog {
 		panel.add(new JLabel(Chars.UP_ARROW + " " + trans.get("lbl.favorites")), "spanx, gapleft 5px, wrap para");
 		
 		
-		// OK / Cancel buttons
-		JButton okButton = new SelectColorButton(trans.get("dlg.but.ok"));
-		okButton.addActionListener(new ActionListener() {
+		// Close buttons
+		JButton closeButton = new SelectColorButton(trans.get("dlg.but.close"));
+		closeButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				close(true);
+				ComponentPresetChooserDialog.this.setVisible(false);
 			}
 		});
-		panel.add(okButton, "tag ok, spanx, split");
-		
-		//// Cancel button
-		JButton cancelButton = new SelectColorButton(trans.get("dlg.but.cancel"));
-		cancelButton.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				close(false);
-			}
-		});
-		panel.add(cancelButton, "tag cancel");
+		panel.add(closeButton, "spanx, right, tag close");
 		
 		this.add(panel);
 		
 		GUIUtil.rememberWindowSize(this);
-		GUIUtil.setDisposableDialogOptions(this, okButton);
+		GUIUtil.setDisposableDialogOptions(this, closeButton);
 
 		updateFilters();
 	}
@@ -270,8 +258,6 @@ public class ComponentPresetChooserDialog extends JDialog {
 	 * @return	the selected motor, or <code>null</code> if no motor has been selected or the selection was canceled.
 	 */
 	public ComponentPreset getSelectedComponentPreset() {
-		if (!okClicked)
-			return null;
 		int row = componentSelectionTable.getSelectedRow();
 		if (row < 0) {
 			// Nothing selected.
@@ -279,11 +265,6 @@ public class ComponentPresetChooserDialog extends JDialog {
 		}
 		row = componentSelectionTable.convertRowIndexToModel(row);
 		return presets.get(row);
-	}
-	
-	public void close(boolean ok) {
-		okClicked = ok;
-		this.setVisible(false);
 	}
 	
 	private void updateFilters() {

--- a/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
@@ -111,7 +111,7 @@ public class ComponentPresetChooserDialog extends JDialog {
 		sub.add(filterLabel, "gapright para");
 		
 		filterText = new JTextField();
-		sub.add(filterText, "width 50:320, growx");
+		sub.add(filterText, "width 50:320, pushx, growx");
 		filterText.getDocument().addDocumentListener(new DocumentListener() {
 			@Override
 			public void changedUpdate(DocumentEvent e) {
@@ -129,7 +129,7 @@ public class ComponentPresetChooserDialog extends JDialog {
 			}
 		});
 		
-		panel.add(sub, "growx, ay 0, gapright para");
+		panel.add(sub, "growx, pushx, ay 0, gapright para");
 
 		// need to create componentSelectionTable before filter checkboxes,
 		// but add to panel after
@@ -147,7 +147,7 @@ public class ComponentPresetChooserDialog extends JDialog {
 		
 		JScrollPane scrollpane = new JScrollPane();
 		scrollpane.setViewportView(componentSelectionTable);
-		panel.add(scrollpane, "grow, width 700lp, height 300lp, spanx, wrap rel");
+		panel.add(scrollpane, "grow, width 700lp, height 300lp, pushy, spanx, wrap rel");
 		
 		panel.add(new JLabel(Chars.UP_ARROW + " " + trans.get("lbl.favorites")), "spanx, gapleft 5px, wrap para");
 		


### PR DESCRIPTION
This PR had the following changes over the preset combox/component preset window:

1. **Ok/Cancel button in component preset window replaced by a single Close button**
_(The previous function of the cancel button was just to ignore the preset selection from the preset table; kinda useless in the first place)_
2. **Preset combobox now properly listens to changes in the preset preferences**
The problem was: PresetModel, the CheckboxModel responsible of updating the preset combox, was added as a preset database listener, and removed when the RocketComponentConfig dialog was invalidated. Now, here comes the stupid part of the bug: `setComponent()` of ComponentConfigDialog calls the `pack()` method, which invalidates RocketComponentConfig just to be able to resize its window. This removed PresetModel as a database listener.
The fix was to move the database listener assignment of PresetModel internally to PresetModel itself
3. **I couldn't help myself to fix some layout issues in the component preset window (sorry, not sorry 🙃):**
<img width="3456" alt="combined" src="https://user-images.githubusercontent.com/11031519/151893366-e0d05149-d4f6-44f4-921f-7087ba7523a8.png">

Here is a [jar file](https://drive.google.com/file/d/14T6Ie0KBnJiZEK5frn7dqjoTr7JbLqEo/view?usp=sharing) for testing.