### PR TITLE
Check for database submodule and give instructions for including it if not found

### DIFF
--- a/swing/build.xml
+++ b/swing/build.xml
@@ -160,16 +160,46 @@
 		</for>
 	</target>
 
-	<!-- COPY orc files from source directories to build directory -->
-	<target name="copy-orc-files"
+	<!-- COPY orc files from source directories to build directory	-->
+	<target name="check-database" description="check component database">
+		<available file="${resources-src.dir}/datafiles/components/orc" property="database"/>
+	</target>
+
+	<target name="copy-orc-files" depends="check-database"
 		description="Copy orc files">
-	  
-		<copy todir="${resources.dir}/datafiles/presets">
+
+		<fail message="NOTE: ${line.separator}
+The component database is now a submodule, and must be included into ${line.separator}
+this project to build the .jar file. ${line.separator}
+${line.separator}
+If you retrieved this code by cloning the openrocket repository, you ${line.separator}
+must initialize and update the submodule.  From the command line, ${line.separator}
+this can be accomplished with ${line.separator}
+% git submodule init ${line.separator}
+% git submodule update ${line.separator}
+${line.separator}
+If you retrieved this code by downloading and uncompressing a zip file, ${line.separator}
+you must do the same for the submodule.  Download the code ${line.separator}
+from https://github.com/dbcook/openrocket-database and uncompress it.${line.separator}
+Copy the files and directories under the openrocket-database-master ${line.separator}
+into ${resources-src.dir}/datafiles/components/ ${line.separator}
+${line.separator}
+After including the database submodule, you will be able to build
+${line.separator}
+the .jar file
+">
+	  		<condition>
+				<not>
+					<isset property="database" />
+				</not>
+			</condition>
+	  	</fail>
+	  	<copy todir="${resources.dir}/datafiles/presets">
 			<fileset dir="${resources-src.dir}/datafiles/legacy_components"/>
-		 </copy>
-		<copy todir="${resources.dir}/datafiles/presets">
+	  	</copy>
+	  	<copy todir="${resources.dir}/datafiles/presets">
 			<fileset dir="${resources-src.dir}/datafiles/components/orc"/>
-		 </copy>
+	  	</copy>
 	</target>
 
 	<!-- DIST-SRC -->


### PR DESCRIPTION
Something I should have thought of but did not: there is no reasonable way for someone compiling OR to
anticipate that a submodule is now required, and the default error message doesn't give any useful clue as to what's wrong.  This PR modifies swing/build.xml so it tests for the existence of the database, and gives instructions for including it if necessary.  The instructions it gives are:

/home/joseph/openrocket/git-mybranches/swing/build.xml:190: NOTE: 
 The component database is now a submodule, and must be included into 
 this project to build the .jar file. 
 
 If you retrieved this code by cloning the openrocket repository, you 
 must initialize and update the submodule.  From the command line, 
 this can be accomplished with 
 % git submodule init 
 % git submodule update 
 
 If you retrieved this code by downloading and uncompressing a zip file, 
 you must do the same for the submodule.  Download the code 
 from https://github.com/dbcook/openrocket-database and uncompress it.
 Copy the files and directories under the openrocket-database-master 
 into /home/joseph/openrocket/git-mybranches/swing/resources-src/datafiles/components/ 
 
 After including the database submodule, you will be able to build 
 the .jar file
