### PR TITLE
[fixes #1070] Add backward compatibility OR 15.03

### DIFF
--- a/core/src/net/sf/openrocket/file/openrocket/savers/RocketComponentSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/savers/RocketComponentSaver.java
@@ -83,6 +83,10 @@ public class RocketComponentSaver {
 				// no-op.  Instance counts are set via named cluster configurations
 			} else {
 				emitInteger(elements, "instancecount", c.getInstanceCount());
+				// TODO: delete this when no backward compatibility with OR 15.03 is needed anymore
+				if (c instanceof FinSet || c instanceof TubeFinSet) {
+					emitInteger(elements, "fincount", c.getInstanceCount());
+				}
 			}
 			
 			if (c instanceof LineInstanceable) {
@@ -103,6 +107,13 @@ public class RocketComponentSaver {
 			final String angleMethod = anglePos.getAngleMethod().name().toLowerCase(Locale.ENGLISH);
 			final double angleOffset = anglePos.getAngleOffset()*180.0/Math.PI;
 			elements.add("<angleoffset method=\"" + angleMethod + "\">" + angleOffset + "</angleoffset>");
+			// TODO: delete this when no backward compatibility with OR 15.03 is needed anymore
+			if (c instanceof FinSet || c instanceof TubeFinSet) {
+				elements.add("<rotation>" + angleOffset + "</rotation>");
+			}
+			else {
+				elements.add("<radialdirection>" + angleOffset + "</radialdirection>");
+			}
 		}
 		
 		// Save position unless "AFTER"
@@ -110,6 +121,8 @@ public class RocketComponentSaver {
 			// The type names are currently equivalent to the enum names except for case.
 			String axialMethod = c.getAxialMethod().name().toLowerCase(Locale.ENGLISH);
 			elements.add("<axialoffset method=\"" + axialMethod + "\">" + c.getAxialOffset() + "</axialoffset>");
+			// TODO: delete this when no backward compatibility with OR 15.03 is needed anymore
+			elements.add("<position type=\"" + axialMethod + "\">" + c.getAxialOffset() + "</position>");
 		}
 		
 		// Overrides


### PR DESCRIPTION
This PR fixes #1070 which was a call to increase backward compatibility to OR 15.03.

I added duplicate tags to the .ork file so that .ork files in the new release contain both the tags of the new release and tags of OR 15.03 (so that it can still read in the files). The duplicated tags:

- `axialoffset` (added the `position` tag)
- `angleoffset` (added `rotation` for FinSet and TubeFinSet and `radialdirection` for other components)
- `instancecount` (added `fincount` for FinSet and TubeFinSet)

radiusoffset and instanceseparation were no issue in the backward compatibility, as the features they are referencing to were not yet implemented in OR 15.03 (as far as I could see in the code, correct me if I'm wrong).

_I also added comments to delete the duplicate tags once we want to break compatibility with 15.03, which I think we should at one point, because having those duplicate tags permanently is messy._

Here is a [jar file](https://drive.google.com/file/d/1byA0O4mQYW-kocaqmRObM6tqUOBz5i04/view?usp=sharing) for testing.