### PR TITLE
Fix layout issues license dialog

### DIFF
--- a/swing/src/net/sf/openrocket/gui/components/DescriptionArea.java
+++ b/swing/src/net/sf/openrocket/gui/components/DescriptionArea.java
@@ -12,18 +12,15 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.IOException;
 
+import javax.swing.JTextPane;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
 import javax.swing.JEditorPane;
-import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
-
-import net.sf.openrocket.util.BugException;
 
 @SuppressWarnings("serial")
 public class DescriptionArea extends JScrollPane {
@@ -179,6 +176,18 @@ public class DescriptionArea extends JScrollPane {
 			
 		});
 		editorPane.scrollRectToVisible(new Rectangle(0, 0, 1, 1));
+	}
+
+	/**
+	 * Set the font to use for the text pane. If null, then the default font from OR is used.
+	 * @param font font to use
+	 */
+	public void setTextFont(Font font) {
+		if (editorPane == null) return;
+		editorPane.putClientProperty(JTextPane.HONOR_DISPLAY_PROPERTIES, true);
+		if (font != null) {
+			editorPane.setFont(font);
+		}
 	}
 	
 }

--- a/swing/src/net/sf/openrocket/gui/dialogs/BugReportDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/BugReportDialog.java
@@ -19,6 +19,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextPane;
+import javax.swing.UIManager;
 
 import com.jogamp.opengl.JoglVersion;
 
@@ -72,6 +73,7 @@ public class BugReportDialog extends JDialog {
 
 		final JEditorPane editorPane = new JEditorPane("text/html", formatNewlineHTML(message));
 		editorPane.putClientProperty(JTextPane.HONOR_DISPLAY_PROPERTIES, true);
+		editorPane.setFont(UIManager.getFont("Label.font"));
 		editorPane.setPreferredSize(new Dimension(600, 400));
 		editorPane.setEditable(true);
 		editorPane.setCaretPosition(0);		// Scroll to the top by default

--- a/swing/src/net/sf/openrocket/gui/dialogs/LicenseDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/LicenseDialog.java
@@ -8,6 +8,7 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.UIManager;
 
 import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.gui.components.DescriptionArea;
@@ -138,7 +139,7 @@ public class LicenseDialog extends JDialog {
 		/*****************************************************************************************************************************/
 
 		DescriptionArea info = new DescriptionArea(20);
-		info.setTextFont(null);
+		info.setTextFont(UIManager.getFont("Label.font"));
 		info.setText(orLicense + componentsLicense + fontLicense + commonmarkLicense);
 		panel.add(info, "newline, width 700lp, height 250lp, pushy, grow, spanx, wrap para");
 		

--- a/swing/src/net/sf/openrocket/gui/dialogs/LicenseDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/LicenseDialog.java
@@ -1,21 +1,13 @@
 package net.sf.openrocket.gui.dialogs;
 
-import java.awt.Font;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.net.URL;
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
 
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTextArea;
 
 import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.gui.components.DescriptionArea;
@@ -39,7 +31,7 @@ public class LicenseDialog extends JDialog {
 		// OpenRocket logo
 		panel.add(new JLabel(Icons.loadImageIcon("pix/icon/icon-about.png", "OpenRocket")), "top");
 		
-		panel.add(new StyledLabel("Software Licenses", 10), "ax 50%, wrap para");
+		panel.add(new StyledLabel("Software Licenses", 10), "ax 50%, pushx, wrap para");
 
 		final String jarUrl = "jar:" + getClass().getProtectionDomain().getCodeSource().getLocation().toString();
 		final String copyrightYear = BuildProperties.getCopyrightYear();
@@ -146,8 +138,9 @@ public class LicenseDialog extends JDialog {
 		/*****************************************************************************************************************************/
 
 		DescriptionArea info = new DescriptionArea(20);
+		info.setTextFont(null);
 		info.setText(orLicense + componentsLicense + fontLicense + commonmarkLicense);
-		panel.add(info, "newline, width 600lp, height 150lp, grow, spanx, wrap para");
+		panel.add(info, "newline, width 700lp, height 250lp, pushy, grow, spanx, wrap para");
 		
 		//Close button
 		JButton close = new SelectColorButton(trans.get("dlg.but.close"));
@@ -157,7 +150,7 @@ public class LicenseDialog extends JDialog {
 				LicenseDialog.this.dispose();
 			}
 		});
-		panel.add(close, "right");
+		panel.add(close, "spanx, right");
 		
 		this.add(panel);
 		this.setTitle("OpenRocket license");


### PR DESCRIPTION
This PR fixes some layout issues that are present in the new license dialog. It concerns changing the font to match the rest of OR, making the text pane more response when enlarging the dialog, moving the Close-button to the bottom right, centering the title label even when resizing the window and making the dialog a bit bigger by default.

![Screenshot 2022-02-10 at 17 54 36](https://user-images.githubusercontent.com/11031519/153481454-10687149-219c-4d00-b5ee-fd66efac3f0f.jpg)

Whilst working on this issue, I also noticed some weirdness in the new bug report layout. I had changed the layout to HTML in a previous PR, but this caused weirdness when one of the bug report lines contained HTML-like text. In the image below you can see e.g. stack trace line '`> at java.desktop/javax.swing.JScrollPane.<init> (JScrollPane.java:306)`' that contains the text '`<init>`'. The HTML formatter interpreted this as an HTML tag, causing this awkward layout. This PR makes sure that bug report lines (stack trace, error log etc.) are not formatted like HTML, but as plaintext.
<img width="1560" alt="Screenshot 2022-02-10 at 18 04 09" src="https://user-images.githubusercontent.com/11031519/153481796-8f11e4e2-f92d-42b8-823c-5ba3fcc7fbc1.png">

Here is a [jar file](https://drive.google.com/file/d/1FUrepZArcyhUy7sA8Bf11IclH_O-0-FN/view?usp=sharing) for testing.