### PR TITLE
Fix about dialog layout issues

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/AboutDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/AboutDialog.java
@@ -8,6 +8,7 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.UIManager;
 
 import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.gui.components.DescriptionArea;
@@ -101,7 +102,7 @@ public class AboutDialog extends JDialog {
 		sub.add(new StyledLabel(copyright), "ax 50%, growy, wrap para");
 		
 		sub.add(new URLLabel(OPENROCKET_URL), "ax 50%, growy, wrap para");
-		panel.add(sub, "grow");
+		panel.add(sub, "grow, pushx");
 		
 		
 		// Translation information (if present)
@@ -132,7 +133,8 @@ public class AboutDialog extends JDialog {
 		
 		DescriptionArea info = new DescriptionArea(5);
 		info.setText(CREDITS);
-		panel.add(info, "newline, width 10px, height 150lp, grow, spanx, wrap para");
+		info.setTextFont(UIManager.getFont("Label.font"));
+		panel.add(info, "newline, width 10px, height 250lp, pushy, grow, spanx, wrap para");
 		
 		//		JTextArea area = new JTextArea(CREATORS);
 		//		area.setEditable(false);
@@ -154,7 +156,6 @@ public class AboutDialog extends JDialog {
 		this.add(panel);
 		this.setTitle("OpenRocket " + version);
 		this.pack();
-		this.setResizable(false);
 		this.setLocationRelativeTo(parent);
 		
 		GUIUtil.setDisposableDialogOptions(this, close);


### PR DESCRIPTION
This PR fixes some small layout issues in the about dialog. It just bothered me that you couldn't rescale the window and that the font was not the same as the rest of OR on Mac. Those two issues are now fixed + I made the dialog a bit bigger.
<img width="3456" alt="combined" src="https://user-images.githubusercontent.com/11031519/153617345-b08e6193-8fdb-49b6-9178-f1c2a92720bc.png">

Here is a [jar file](https://drive.google.com/file/d/1ud-aCOvR0lOmKwe424wz0yjZikY0X7HH/view?usp=sharing) for testing.
