### PR TITLE
[fixes #1119] Fix rocket rotation after component analysis

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
@@ -11,6 +11,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
 import java.util.ArrayList;
 import java.util.EventObject;
 import java.util.List;
@@ -82,6 +83,7 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 	private final JToggleButton worstToggle;
 	private boolean fakeChange = false;
 	private AerodynamicCalculator aerodynamicCalculator;
+	private double initTheta;
 
 	private final ColumnTableModel longitudeStabilityTableModel;
 	private final ColumnTableModel dragTableModel;
@@ -115,6 +117,7 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 		aoa = new DoubleModel(rocketPanel, "CPAOA", UnitGroup.UNITS_ANGLE, 0, Math.PI);
 		rocketPanel.setCPMach(Application.getPreferences().getDefaultMach());
 		mach = new DoubleModel(rocketPanel, "CPMach", UnitGroup.UNITS_COEFFICIENT, 0);
+		initTheta = rocketPanel.getFigure().getRotation();
 		rocketPanel.setCPTheta(rocketPanel.getFigure().getRotation());
 		theta = new DoubleModel(rocketPanel, "CPTheta", UnitGroup.UNITS_ANGLE, 0, 2 * Math.PI);
 		rocketPanel.setCPRoll(0);
@@ -428,6 +431,8 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 		this.addWindowListener(new WindowAdapter() {
 			@Override
 			public void windowClosed(WindowEvent e) {
+				theta.setValue(initTheta);
+
 				//System.out.println("Closing method called: " + this);
 				theta.removeChangeListener(ComponentAnalysisDialog.this);
 				aoa.removeChangeListener(ComponentAnalysisDialog.this);


### PR DESCRIPTION
This PR fixes #1119 by switching back the rocket's orientation after closing the component analysis window.

Here is a [jar file](https://drive.google.com/file/d/15myAqcD7KlMq22n3eX8GXJIHoSp3l0By/view?usp=sharing) for testing.