### PR TITLE
[fixes #311] Fix undo selection after component edit

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/componenttree/ComponentTreeModel.java
+++ b/swing/src/net/sf/openrocket/gui/main/componenttree/ComponentTreeModel.java
@@ -138,7 +138,7 @@ public class ComponentTreeModel implements TreeModel, ComponentChangeListener {
 	
 	@Override
 	public void componentChanged(ComponentChangeEvent e) {
-		if (e.isTreeChange() || e.isUndoChange() || e.isMassChange()) {
+		if (e.isTreeChange() || e.isUndoChange()) {
 			// Tree must be fully updated also in case of an undo change 
 			fireTreeStructureChanged(e.getSource());
 			if (e.isTreeChange() && e.isUndoChange()) {


### PR DESCRIPTION
This PR fixes #311 where the selected component in the component tree would deselect after editing it + newly added components would not be selected by default.

I believe the error laid in `ComponentTreeModel.java` where in the `componentChanged()` method the component tree's structure was updated after a mass change event (so when a component was edited/added). A tree structure change triggered the `clearSelection()` method in the `TreeSelectionModel`. The mass change condition triggering a tree structure change doesn't seem logical in the first place since a mass change does not affect the tree structure, so I just removed the `e.isMassChange()` condition for the tree structure change.

Here is a [jar file](https://drive.google.com/file/d/1S60ITDdWgnnDp9Lo0EFOP5bIY3mk2GXY/view?usp=sharing) for testing.