### PR TITLE
[fixes #1101] Select motor mount when selecting motor configuration

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -209,7 +209,7 @@ public class BasicFrame extends JFrame {
 		//// Rocket design
 		tabbedPane.addTab(trans.get("BasicFrame.tab.Rocketdesign"), null, designTab());
 		//// Flight configurations
-		tabbedPane.addTab(trans.get("BasicFrame.tab.Flightconfig"), null, new FlightConfigurationPanel(document));
+		tabbedPane.addTab(trans.get("BasicFrame.tab.Flightconfig"), null, new FlightConfigurationPanel(this, document));
 		//// Flight simulations
 		tabbedPane.addTab(trans.get("BasicFrame.tab.Flightsim"), null, simulationPanel);
 
@@ -1690,10 +1690,14 @@ public class BasicFrame extends JFrame {
 		}
 	}
 
+	public void setSelectedComponent(RocketComponent component) {
+		this.selectionModel.setSelectedComponent(component);
+	}
+
 	public void stateChanged(ChangeEvent e) {
 		JTabbedPane tabSource = (JTabbedPane) e.getSource();
-		String tab = tabSource.getTitleAt(tabSource.getSelectedIndex());
-		if (tab.equals(trans.get("BasicFrame.tab.Flightsim"))) {
+		int tab = tabSource.getSelectedIndex();
+		if (tab == SIMULATION_TAB) {
 			simulationPanel.activating();
 		}
 	}

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
@@ -132,7 +132,7 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 		table.changeSelection(row, col, true, false);
 	}
 
-	private final void installTableListener() {
+	protected void installTableListener() {
 		table.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
 
 			@Override

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurationPanel.java
@@ -36,7 +36,8 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 	
 	private final OpenRocketDocument document;
 	private final Rocket rocket;
-	
+
+	private final BasicFrame basicFrame;
 	private final JButton newConfButton, renameConfButton, removeConfButton, copyConfButton;
 	
 	private final JTabbedPane tabs;
@@ -48,9 +49,10 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 	private final static int RECOVERY_TAB_INDEX = 1;
 	private final static int SEPARATION_TAB_INDEX = 2;
 
-	public FlightConfigurationPanel(OpenRocketDocument doc) {
+	public FlightConfigurationPanel(BasicFrame basicFrame, OpenRocketDocument doc) {
 		super(new MigLayout("fill","[grow][][][][][grow]"));
-		
+
+		this.basicFrame = basicFrame;
 		this.document = doc;
 		this.rocket = doc.getRocket();
 		this.rocket.addChangeListener(this);
@@ -252,7 +254,11 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 		}
 
 	}
-	
+
+	public void setSelectedComponent(RocketComponent component) {
+		this.basicFrame.setSelectedComponent(component);
+	}
+
 	@Override
 	public void stateChanged(EventObject e) {
 		updateButtonState();

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
@@ -4,6 +4,8 @@ import java.awt.CardLayout;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -21,12 +23,12 @@ import javax.swing.JTable;
 import javax.swing.KeyStroke;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
 import javax.swing.event.TableModelEvent;
 import javax.swing.event.TableModelListener;
 
 import net.miginfocom.swing.MigLayout;
-import net.sf.openrocket.gui.components.StyledLabel;
-import net.sf.openrocket.gui.components.StyledLabel.Style;
 import net.sf.openrocket.gui.dialogs.flightconfiguration.IgnitionSelectionDialog;
 import net.sf.openrocket.gui.dialogs.flightconfiguration.MotorMountConfigurationPanel;
 import net.sf.openrocket.gui.dialogs.motor.MotorChooserDialog;
@@ -40,6 +42,7 @@ import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
 import net.sf.openrocket.rocketcomponent.InnerTube;
 import net.sf.openrocket.rocketcomponent.MotorMount;
 import net.sf.openrocket.rocketcomponent.Rocket;
+import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.unit.UnitGroup;
 import net.sf.openrocket.util.Chars;
 
@@ -203,6 +206,40 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 		});
 		
 		return configurationTable;
+	}
+
+	@Override
+	protected void installTableListener() {
+		super.installTableListener();
+
+		table.getColumnModel().getSelectionModel().addListSelectionListener(new ListSelectionListener() {
+			@Override
+			public void valueChanged(ListSelectionEvent e) {
+				updateComponentSelection(e);
+			}
+		});
+
+		table.addFocusListener(new FocusListener() {
+			@Override
+			public void focusGained(FocusEvent e) {
+				updateComponentSelection(new ListSelectionEvent(this, 0, 0, false));
+			}
+
+			@Override
+			public void focusLost(FocusEvent e) {
+
+			}
+		});
+	}
+
+	public void updateComponentSelection(ListSelectionEvent e) {
+		if (e.getValueIsAdjusting()) {
+			return;
+		}
+		MotorMount mount = getSelectedComponent();
+		if (mount instanceof RocketComponent) {
+			flightConfigurationPanel.setSelectedComponent((RocketComponent) mount);
+		}
 	}
 
 	protected void updateButtonState() {


### PR DESCRIPTION
This PR adds the feature from #1101 where if you select a configuration in the motor configuration table, the corresponding motor mount also gets selected in the rocket preview to visually aid users which part of their design they're editing.


https://user-images.githubusercontent.com/11031519/153752939-38d8f7fe-0aa4-429a-a214-0b01e3a8ecb4.mov



Here is a [jar file](https://drive.google.com/file/d/1TwyoYG4tUbAD_1QJWGyqzOG3tCS2nmea/view?usp=sharing) for testing.