### PR TITLE
[fixes #244] Multi-selection in Motors, Recovery & Stages panels

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -1694,6 +1694,11 @@ public class BasicFrame extends JFrame {
 		this.selectionModel.setSelectedComponent(component);
 	}
 
+	public void setSelectedComponents(List<RocketComponent> components) {
+		this.selectionModel.setSelectedComponents(components);
+	}
+
+
 	public void stateChanged(ChangeEvent e) {
 		JTabbedPane tabSource = (JTabbedPane) e.getSource();
 		int tab = tabSource.getSelectedIndex();

--- a/swing/src/net/sf/openrocket/gui/main/DocumentSelectionModel.java
+++ b/swing/src/net/sf/openrocket/gui/main/DocumentSelectionModel.java
@@ -2,6 +2,7 @@ package net.sf.openrocket.gui.main;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 
 import javax.swing.ListSelectionModel;
@@ -29,7 +30,7 @@ public class DocumentSelectionModel {
 	
 	private final OpenRocketDocument document;
 	
-	private RocketComponent componentSelection = null;
+	private final List<RocketComponent> componentSelection = new LinkedList<>();
 	private Simulation[] simulationSelection = NO_SIMULATION;
 
 	private TreeSelectionModel componentTreeSelectionModel = null; 
@@ -72,23 +73,33 @@ public class DocumentSelectionModel {
 
 	/**
 	 * Return the currently selected rocket component.  Returns <code>null</code>
-	 * if no rocket component is selected.
+	 * if no rocket component is selected. If there is more than one component selected,
+	 * the first selected component is returned.
 	 * 
 	 * @return	the currently selected rocket component, or <code>null</code>.
 	 */
 	public RocketComponent getSelectedComponent() {
-		return componentSelection;
+		if (componentSelection == null || componentSelection.size() == 0) return null;
+		return componentSelection.get(0);
 	}
 	
 	public void setSelectedComponent(RocketComponent component) {
-		componentSelection = component;
+		componentSelection.clear();
+		componentSelection.add(component);
 		clearSimulationSelection();
 	
 		TreePath path = ComponentTreeModel.makeTreePath(component);
 		componentTreeSelectionModel.setSelectionPath(path);
 	}
 
+	public void setSelectedComponents(List<RocketComponent> components) {
+		componentSelection.clear();
+		componentSelection.addAll(components);
+		clearSimulationSelection();
 
+		List<TreePath> paths = ComponentTreeModel.makeTreePaths(components);
+		componentTreeSelectionModel.setSelectionPaths(paths.toArray(new TreePath[0]));
+	}
 
 	
 
@@ -131,10 +142,10 @@ public class DocumentSelectionModel {
 	
 	
 	public void clearComponentSelection() {
-		if (componentSelection == null)
+		if (componentSelection == null || componentSelection.size() == 0)
 			return;
 		
-		componentSelection = null;
+		componentSelection.clear();
 		if (componentTreeSelectionModel != null)
 			componentTreeSelectionModel.clearSelection();
 		
@@ -168,12 +179,13 @@ public class DocumentSelectionModel {
 		public void valueChanged(TreeSelectionEvent e) {
 			TreePath path = componentTreeSelectionModel.getSelectionPath();
 			if (path == null) {
-				componentSelection = null;
+				componentSelection.clear();
 				fireDocumentSelection(DocumentSelectionListener.COMPONENT_SELECTION_CHANGE);
 				return;
 			}
-			
-			componentSelection = (RocketComponent)path.getLastPathComponent();
+
+			componentSelection.clear();
+			componentSelection.add((RocketComponent)path.getLastPathComponent());
 			
 			clearSimulationSelection();
 			fireDocumentSelection(DocumentSelectionListener.COMPONENT_SELECTION_CHANGE);

--- a/swing/src/net/sf/openrocket/gui/main/componenttree/ComponentTreeModel.java
+++ b/swing/src/net/sf/openrocket/gui/main/componenttree/ComponentTreeModel.java
@@ -199,6 +199,21 @@ public class ComponentTreeModel implements TreeModel, ComponentChangeListener {
 		
 		return new TreePath(list.toArray());
 	}
+
+	/**
+	 * Return TreePaths corresponding to the specified rocket components.
+	 *
+	 * @param components	the rocket components
+	 * @return				a list of TreePaths corresponding to the different RocketComponents (one path for each component)
+	 */
+	public static List<TreePath> makeTreePaths(List<RocketComponent> components) {
+		List<TreePath> result = new LinkedList<>();
+
+		for (RocketComponent component : components) {
+			result.add(makeTreePath(component));
+		}
+		return result;
+	}
 	
 	
 	/**

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurationPanel.java
@@ -297,6 +297,10 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 		this.basicFrame.setSelectedComponent(component);
 	}
 
+	public void setSelectedComponents(List<RocketComponent> components) {
+		this.basicFrame.setSelectedComponents(components);
+	}
+
 	@Override
 	public void stateChanged(EventObject e) {
 		updateButtonState();

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
@@ -45,6 +45,7 @@ import net.sf.openrocket.rocketcomponent.MotorMount;
 import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.unit.UnitGroup;
+import net.sf.openrocket.util.ArrayList;
 import net.sf.openrocket.util.Chars;
 
 @SuppressWarnings("serial")
@@ -237,10 +238,16 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 		if (e.getValueIsAdjusting()) {
 			return;
 		}
-		MotorMount mount = getSelectedComponent();
-		if (mount instanceof RocketComponent) {
-			flightConfigurationPanel.setSelectedComponent((RocketComponent) mount);
+		List<MotorMount> mounts = getSelectedComponents();
+		if (mounts == null || mounts.size() == 0) return;
+		List<RocketComponent> components = new ArrayList<>();
+		for (MotorMount mount : mounts) {
+			if (mount instanceof RocketComponent) {
+				components.add((RocketComponent) mount);
+			}
 		}
+
+		flightConfigurationPanel.setSelectedComponents(components);
 	}
 
 	protected void updateButtonState() {

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
@@ -9,6 +9,7 @@ import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.util.List;
 
 import javax.swing.BorderFactory;
 import javax.swing.AbstractAction;
@@ -189,7 +190,7 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 		JTable configurationTable = new JTable(configurationTableModel);
 		configurationTable.getTableHeader().setReorderingAllowed(false);
 		configurationTable.setCellSelectionEnabled(true);
-		configurationTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+		configurationTable.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
 		configurationTable.setDefaultRenderer(Object.class, new MotorTableCellRenderer());
 
 		configurationTable.addMouseListener(new MouseAdapter() {
@@ -261,86 +262,140 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 	}
 
 	public void selectMotor() {
-		MotorMount curMount = getSelectedComponent();		
-		FlightConfigurationId fcid= getSelectedConfigurationId();
-        if ( (null == fcid )||( null == curMount )){
-            return;
-        }
+		List<MotorMount> mounts = getSelectedComponents();
+		List<FlightConfigurationId> fcIds = getSelectedConfigurationIds();
+		if ((mounts == null) || (fcIds == null) || mounts.size() == 0 || fcIds.size() == 0) {
+			return;
+		}
 
-        if( fcid.equals( FlightConfigurationId.DEFAULT_VALUE_FCID)){
-        	throw new IllegalStateException("Attempting to set a motor on the default FCID.");
-        }
+		boolean update = false;
+		MotorMount initMount = mounts.get(0);
+		FlightConfigurationId initFcId = fcIds.get(0);
 
-        double initDelay = curMount.getMotorConfig(fcid).getEjectionDelay();
+		for (FlightConfigurationId fcId : fcIds) {
+			if (fcId.equals( FlightConfigurationId.DEFAULT_VALUE_FCID)) {
+				throw new IllegalStateException("Attempting to set a motor on the default FCID.");
+			}
+		}
 
-		motorChooserDialog.setMotorMountAndConfig( fcid, curMount );
+        double initDelay = initMount.getMotorConfig(initFcId).getEjectionDelay();
+
+		motorChooserDialog.setMotorMountAndConfig(initFcId, initMount);
 		motorChooserDialog.setVisible(true);
 
         Motor mtr = motorChooserDialog.getSelectedMotor();
 		double d = motorChooserDialog.getSelectedDelay();
-		if (mtr != null) {
-			if (mtr == curMount.getMotorConfig(fcid).getMotor() && d == initDelay) {
-				return;
-			}
-	        final MotorConfiguration templateConfig = curMount.getMotorConfig(fcid);
-	        final MotorConfiguration newConfig = new MotorConfiguration( curMount, fcid, templateConfig);
-	        newConfig.setMotor(mtr);
-			newConfig.setEjectionDelay(d);
-			curMount.setMotorConfig( newConfig, fcid);
 
+
+		if (mtr != null) {
+			for (MotorMount mount : mounts) {
+				for (FlightConfigurationId fcId : fcIds) {
+					if (mtr != mount.getMotorConfig(fcId).getMotor() || d != initDelay) {
+						update = true;
+
+						final MotorConfiguration templateConfig = mount.getMotorConfig(fcId);
+						final MotorConfiguration newConfig = new MotorConfiguration(mount, fcId, templateConfig);
+						newConfig.setMotor(mtr);
+						newConfig.setEjectionDelay(d);
+						mount.setMotorConfig(newConfig, fcId);
+					}
+				}
+			}
+		}
+
+		if (update) {
 			fireTableDataChanged(ComponentChangeEvent.MOTOR_CHANGE);
 		}
 	}
 
 	private void removeMotor() {
-		MotorMount curMount = getSelectedComponent();		
-		FlightConfigurationId fcid= getSelectedConfigurationId();
-        if ( (null == fcid )||( null == curMount )){
+		List<MotorMount> mounts = getSelectedComponents();
+		List<FlightConfigurationId> fcIds = getSelectedConfigurationIds();
+		if ((mounts == null) || (fcIds == null) || mounts.size() == 0 || fcIds.size() == 0) {
             return;
         }
-        
-        curMount.setMotorConfig( null, fcid); 
+
+		for (MotorMount mount : mounts) {
+			for (FlightConfigurationId fcId : fcIds) {
+				mount.setMotorConfig(null, fcId);
+			}
+		}
 		
 		fireTableDataChanged(ComponentChangeEvent.MOTOR_CHANGE);
 	}
 
 	private void selectIgnition() {
-		MotorMount curMount = getSelectedComponent();
-		FlightConfigurationId fcid = getSelectedConfigurationId();
-		if ((null == fcid) || (null == curMount)) {
+		List<MotorMount> mounts = getSelectedComponents();
+		List<FlightConfigurationId> fcIds = getSelectedConfigurationIds();
+		if ((mounts == null) || (fcIds == null) || mounts.size() == 0 || fcIds.size() == 0) {
 			return;
 		}
 
-		MotorConfiguration curInstance = curMount.getMotorConfig(fcid);
-		IgnitionEvent initialIgnitionEvent = curInstance.getIgnitionEvent();
-		double initialIgnitionDelay = curInstance.getIgnitionDelay();
+		boolean update = false;
+		MotorMount initMount = mounts.get(0);
+		FlightConfigurationId initFcId = fcIds.get(0);
+
+		MotorConfiguration initConfig = initMount.getMotorConfig(initFcId);
+		IgnitionEvent initialIgnitionEvent = initConfig.getIgnitionEvent();
+		double initialIgnitionDelay = initConfig.getIgnitionDelay();
 
 		// this call also performs the update changes
 		IgnitionSelectionDialog ignitionDialog = new IgnitionSelectionDialog(
 				SwingUtilities.getWindowAncestor(this.flightConfigurationPanel),
-				fcid,
-				curMount);
+				initFcId,
+				initMount);
 		ignitionDialog.setVisible(true);
 
-		if (!initialIgnitionEvent.equals(curInstance.getIgnitionEvent()) || (initialIgnitionDelay != curInstance.getIgnitionDelay())) {
+		if (!initialIgnitionEvent.equals(initConfig.getIgnitionEvent()) || (initialIgnitionDelay != initConfig.getIgnitionDelay())) {
+			update = true;
+		}
+
+		for (int i = 0; i < mounts.size(); i++) {
+			for (int j = 0; j < fcIds.size(); j++) {
+				if ((i == 0) && (j == 0)) break;
+
+				MotorConfiguration config = mounts.get(i).getMotorConfig(fcIds.get(j));
+				initialIgnitionEvent = config.getIgnitionEvent();
+				initialIgnitionDelay = config.getIgnitionDelay();
+
+				config.setIgnitionEvent(initConfig.getIgnitionEvent());
+				config.setIgnitionDelay(initConfig.getIgnitionDelay());
+
+				if (!initialIgnitionEvent.equals(config.getIgnitionEvent()) || (initialIgnitionDelay != config.getIgnitionDelay())) {
+					update = true;
+				}
+			}
+		}
+
+		if (update) {
 			fireTableDataChanged(ComponentChangeEvent.MOTOR_CHANGE);
 		}
 	}
 
 
 	private void resetIgnition() {
-		MotorMount curMount = getSelectedComponent();		
-		FlightConfigurationId fcid= getSelectedConfigurationId();
-        if ( (null == fcid )||( null == curMount )){
-            return;
-        }
-        MotorConfiguration curInstance = curMount.getMotorConfig(fcid);
-		IgnitionEvent initialIgnitionEvent = curInstance.getIgnitionEvent();
-		double initialIgnitionDelay = curInstance.getIgnitionDelay();
-		
-        curInstance.useDefaultIgnition();
+		List<MotorMount> mounts = getSelectedComponents();
+		List<FlightConfigurationId> fcIds = getSelectedConfigurationIds();
+		if ((mounts == null) || (fcIds == null) || mounts.size() == 0 || fcIds.size() == 0) {
+			return;
+		}
 
-		if (!initialIgnitionEvent.equals(curInstance.getIgnitionEvent()) || (initialIgnitionDelay != curInstance.getIgnitionDelay())) {
+		boolean update = false;
+		for (MotorMount mount : mounts) {
+			for (FlightConfigurationId fcId : fcIds) {
+				MotorConfiguration config = mount.getMotorConfig(fcId);
+				IgnitionEvent initialIgnitionEvent = config.getIgnitionEvent();
+				double initialIgnitionDelay = config.getIgnitionDelay();
+
+				config.useDefaultIgnition();
+
+				if (!initialIgnitionEvent.equals(config.getIgnitionEvent()) || (initialIgnitionDelay != config.getIgnitionDelay())) {
+					update = true;
+				}
+			}
+		}
+
+		if (update) {
 			fireTableDataChanged(ComponentChangeEvent.MOTOR_CHANGE);
 		}
 	}


### PR DESCRIPTION
This PR fixes #244 and adds the ability to have multi-selections in the motors, recovery and stage panels. You can perform almost every action on multiple cells: selecting a motor (selects the same motor for all selected cells), remove motor, select/reset ignition (again uniform ignition selection for all selected cells), rename configuration, remove configuration, copy configuration, select/reset deployment, and select/reset separation.

(You can do multi-selection with holding the shift-key and clicking or ctrl/command + click)

Demo:

https://user-images.githubusercontent.com/11031519/153920756-fb7369cb-98e8-4221-8d93-d44fd5d9b82a.mp4

Here is a [jar file](https://drive.google.com/file/d/14iyFTu54tBjeri9CA8ULhI3O62T__Qro/view?usp=sharing) for testing.