### PR TITLE
Upload built Jarfiles as Artifacts with run Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,4 +24,9 @@ jobs:
           distribution: 'adopt'
       - name: Ant build
         run: ant -noinput -buildfile build.xml clean check jar unittest
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: openrocket_build_${{ github.run_number }}
+          path: ${{github.workspace}}/swing/build/jar/OpenRocket.jar
 


### PR DESCRIPTION
This PR modifies the github workflow to upload the compiled jar file(s) as artifacts in actions. This makes the process of testing new builds a lot easier; just link the completed action in your pull request instead of having to upload your own build somewhere. Additionally, it comes with the plus that you are not blindly trusting someone to not include something nasty in their jar file, as the action is directly connected with a publicly available commit.