### PR TITLE
[fixes #1130] Fix DebugLogDialog location

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/DebugLogDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/DebugLogDialog.java
@@ -381,6 +381,7 @@ public class DebugLogDialog extends JDialog {
 		});
 		
 		GUIUtil.setDisposableDialogOptions(this, close);
+		setLocationRelativeTo(null);
 		followBox.requestFocus();
 	}
 	


### PR DESCRIPTION
This PR fixes #1130 by centering the DebugLogDialog in the center of the screen.

Here is a [jar file](https://drive.google.com/file/d/1dfHzrCmKFqP6-PgZuX3uHbislJiNOvJb/view?usp=sharing) for testing.