### PR TITLE
[fixes #1134] Fix AxialOffset TubeFinSet

### DIFF
--- a/swing/src/net/sf/openrocket/gui/configdialog/TubeFinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/TubeFinSetConfig.java
@@ -147,8 +147,8 @@ public class TubeFinSetConfig extends RocketComponentConfig {
 			}
 		});
 
-		panel.add(new UnitSelector(m), "growx");
-		panel.add(new BasicSlider(m.getSliderModel(
+		panel.add(new UnitSelector(axialOffsetModel), "growx");
+		panel.add(new BasicSlider(axialOffsetModel.getSliderModel(
 				new DoubleModel(component.getParent(), "Length", -1.0, UnitGroup.UNITS_NONE),
 				new DoubleModel(component.getParent(), "Length"))),
 				"w 100lp, wrap para");


### PR DESCRIPTION
This PR fixes #1134 where the axial offset of a tube fin set did not work and had an effect on the fin rotation instead.

Here is a [jar file](https://drive.google.com/file/d/1kBh2XPi0OjkGSA8HM78nsVOdaVdVSQhs/view?usp=sharing) for testing.