### PR TITLE
Fix nose cone subsonic pressure drag computation

### DIFF
--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/SymmetricComponentCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/SymmetricComponentCalc.java
@@ -392,7 +392,7 @@ public class SymmetricComponentCalc extends RocketComponentCalc {
 		double minDeriv = (interpolator.getValue(min + 0.01) - minValue) / 0.01;
 		
 		// These should not occur, but might cause havoc for the interpolation
-		if ((cdMach0 >= minValue - 0.01) || (minDeriv <= 0.01)) {
+		if ((cdMach0 >= minValue - 0.001) || (minDeriv <= 0.01)) {
 			return;
 		}
 		
@@ -400,7 +400,7 @@ public class SymmetricComponentCalc extends RocketComponentCalc {
 		double a = minValue - cdMach0;
 		double b = minDeriv / a;
 		
-		for (double m = 0; m < minValue; m += 0.05) {
+		for (double m = 0; m < min; m += 0.05) {
 			interpolator.addPoint(m, a * Math.pow(m, b) + cdMach0);
 		}
 	}


### PR DESCRIPTION
Previously the nose cone pressure drag coefficient subsonic range was interpolated in the Mach range 0...minY value, while it should be interpolated in the range 0...minX.

minY is typically 0.1 - 0.3, while minX is typically ~0.9, meaning there was a large range in which the pressure drag was interpolated linearly instead of exponentially.

Also the value `minValue - 0.01` could become negative in some cases (e.g. tangent ogive) resulting in a constant ~0.01 pressure drag. This might have a minor impact on a flight simulation, so one more zero was added.

The below image shows the impact before vs after:
![Conical nose cone pressure drag](https://user-images.githubusercontent.com/1436281/155017110-fba409b5-d196-4150-847b-e8c9cc644d27.png)
