### PR TITLE
Remove <legacy/> tag from four manufacturers that do not appear in Dave's database

### DIFF
--- a/swing/resources-src/datafiles/legacy_components/bms-legacy.orc
+++ b/swing/resources-src/datafiles/legacy_components/bms-legacy.orc
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <OpenRocketComponent>
     <Version>0.1</Version>
-    <Legacy />
     <Materials>
         <Material UnitsOfMeasure="g/cm3">
             <Name>Balsa</Name>

--- a/swing/resources-src/datafiles/legacy_components/fliskits-legacy.orc
+++ b/swing/resources-src/datafiles/legacy_components/fliskits-legacy.orc
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <OpenRocketComponent>
     <Version>0.1</Version>
-    <Legacy />
     <Materials>
         <Material UnitsOfMeasure="g/cm3">
             <Name>Balsa</Name>

--- a/swing/resources-src/datafiles/legacy_components/giantleaprocketry-legacy.orc
+++ b/swing/resources-src/datafiles/legacy_components/giantleaprocketry-legacy.orc
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <OpenRocketComponent>
     <Version>0.1</Version>
-    <Legacy />
     <Materials>
         <Material UnitsOfMeasure="g/cm3">
             <Name>Birch</Name>

--- a/swing/resources-src/datafiles/legacy_components/publicmissiles-legacy.orc
+++ b/swing/resources-src/datafiles/legacy_components/publicmissiles-legacy.orc
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <OpenRocketComponent>
     <Version>0.1</Version>
-    <Legacy />
     <Materials>
         <Material UnitsOfMeasure="g/m">
             <Name>1/16 In. braided nylon</Name>


### PR DESCRIPTION
It turns out four manufacturers with entries in our legacy database do not appear in Daves database, namely
Balsa Machining Services
Public Missiles Ltd
Fliskits
Giant Leap Rocketry

This removes the <legacy/> tag from those four manufacturer's .orc files, so the user will see these parts whether "show legacy database" is clicked or not.  The remainder of our legacy database files are still marked as "legacy".

Long term, I'd really like to see these files compared against the current catalogs from those manufacturers and proofed versions submitted to Dave as PRs. Short term, I don't see that we need to delay the beta for it.