### PR TITLE
Don't need to save <radialdirection> for pod sets, since there's no backward compatibility issue with them

### DIFF
--- a/core/src/net/sf/openrocket/file/openrocket/savers/RocketComponentSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/savers/RocketComponentSaver.java
@@ -111,7 +111,7 @@ public class RocketComponentSaver {
 			if (c instanceof FinSet || c instanceof TubeFinSet) {
 				elements.add("<rotation>" + angleOffset + "</rotation>");
 			}
-			else if (!(c instanceof RailButton)) {
+			else if (!(c instanceof RailButton) && !(c instanceof PodSet)) {
 				elements.add("<radialdirection>" + angleOffset + "</radialdirection>");
 			}
 		}


### PR DESCRIPTION
closes #1150 