### PR TITLE
Update snapcraft builds for dbcook's db

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "swing/resources-src/datafiles/components"]
 	path = swing/resources-src/datafiles/components
-	url = git@github.com:dbcook/openrocket-database.git
+	url = https://github.com/dbcook/openrocket-database.git

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,6 +47,7 @@ parts:
   openrocket:
     plugin: ant
     source: .
+    source-type: git
     ant-build-targets:
       - clean
       - check


### PR DESCRIPTION
The update to use dbcook's component database adds a git submodule. The
submodule configuration needs to use an https transport rather than an
ssh transport for users not logged in through git (snapcraft builds
aren't; they're in a clean room).

Additionally, the snapcraft.yaml file needs to be told the source type
is git in order to automatically udpate an pull in submodules.

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>