### PR TITLE
Update SoftwareUpdater to use .sh for Linux update

### DIFF
--- a/swing/src/net/sf/openrocket/communication/AssetHandler.java
+++ b/swing/src/net/sf/openrocket/communication/AssetHandler.java
@@ -28,6 +28,7 @@ public class AssetHandler {
         mapExtensionToPlatform.put(".dmg", UpdatePlatform.MAC_OS);
         mapExtensionToPlatform.put(".exe", UpdatePlatform.WINDOWS);
         mapExtensionToPlatform.put(".AppImage", UpdatePlatform.LINUX);
+        mapExtensionToPlatform.put(".sh", UpdatePlatform.LINUX);
         mapExtensionToPlatform.put(".jar", UpdatePlatform.JAR);
 
         mapPlatformToName.put(UpdatePlatform.MAC_OS, "Mac OS");


### PR DESCRIPTION
Since the new release will use a .sh file for the Linux packager, the software updater needed to be updated for this.