### PR TITLE
Refactored from new Boolean and new Integer to Boolean.valueOf and Integer.valueOf due to deprecation warnings.

### DIFF
--- a/core/src/net/sf/openrocket/simulation/customexpression/CustomExpression.java
+++ b/core/src/net/sf/openrocket/simulation/customexpression/CustomExpression.java
@@ -521,7 +521,7 @@ public class CustomExpression implements Cloneable {
 	 * Used for temporary substitution when evaluating index and range expressions.
 	 */
 	public String hash() {
-		Integer hashint = new Integer(this.getExpressionString().hashCode() + symbol.hashCode());
+		Integer hashint = Integer.valueOf(this.getExpressionString().hashCode() + symbol.hashCode());
 		String hash = "$";
 		for (char c : hashint.toString().toCharArray()) {
 			if (c == '-')

--- a/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/MotorMountTableModel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/MotorMountTableModel.java
@@ -78,7 +78,7 @@ class MotorMountTableModel extends AbstractTableModel implements ComponentChange
 	public Object getValueAt(int row, int column) {
 		switch (column) {
 		case 0:
-			return new Boolean(potentialMounts.get(row).isMotorMount());
+			return Boolean.valueOf(potentialMounts.get(row).isMotorMount());
 			
 		case 1:
 			return potentialMounts.get(row).toString();

--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationPlotPanel.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationPlotPanel.java
@@ -534,7 +534,7 @@ public class SimulationPlotPanel extends JPanel {
 		public Object getValueAt(int row, int column) {
 			switch (column) {
 			case 0:
-				return new Boolean(configuration.isEventActive(eventTypes[row]));
+				return Boolean.valueOf(configuration.isEventActive(eventTypes[row]));
 				
 			case 1:
 				return eventTypes[row].toString();

--- a/swing/src/net/sf/openrocket/gui/widgets/MultiSlider.java
+++ b/swing/src/net/sf/openrocket/gui/widgets/MultiSlider.java
@@ -323,9 +323,9 @@ public class MultiSlider extends JSlider {
 				accessibleContext.firePropertyChange(
 						AccessibleContext.ACCESSIBLE_VALUE_PROPERTY,
 						(oldModel == null
-						? null : new Integer(oldModel.getValue())),
+						? null : Integer.valueOf(oldModel.getValue())),
 						(newModel == null
-						? null : new Integer(newModel.getValue())));
+						? null : Integer.valueOf(newModel.getValue())));
 			}
 		}
 
@@ -348,7 +348,7 @@ public class MultiSlider extends JSlider {
 		for (int i = 0; i < count; i++) {
 			getModelAt(i).setMinimum(minimum);
 		}
-		firePropertyChange( "minimum", new Integer( oldMin ), new Integer( minimum ) );
+		firePropertyChange("minimum", Integer.valueOf(oldMin), Integer.valueOf(minimum));
 	}
 
 	/***
@@ -367,7 +367,7 @@ public class MultiSlider extends JSlider {
 		for (int i = 0; i < count; i++) {
 			getModelAt(i).setMaximum(maximum);
 		}
-		firePropertyChange( "maximum", new Integer( oldMax ), new Integer( maximum ) );
+		firePropertyChange("maximum", Integer.valueOf(oldMax), Integer.valueOf(maximum));
 	}
 
 	/***
@@ -427,8 +427,8 @@ public class MultiSlider extends JSlider {
 		if (accessibleContext != null) {
 			accessibleContext.firePropertyChange(
 					AccessibleContext.ACCESSIBLE_VALUE_PROPERTY,
-					new Integer(oldValue),
-					new Integer(m.getValue()));
+					Integer.valueOf(oldValue),
+					Integer.valueOf(m.getValue()));
 		}
 	}
 


### PR DESCRIPTION
This request is to remove the deprecation warnings in the build process.

Deprecation warnings were received from use of "new Boolean(value)" and "new Integer(value)".  
https://docs.oracle.com/javase/9/docs/api/java/lang/Integer.html#Integer-int-

As such, refactored from new Boolean and new Integer to Boolean.valueOf and Integer.valueOf.   The valueOf method is supported in Java 8 (https://docs.oracle.com/javase/8/docs/api/java/lang/Integer.html).

All tests run cleanly.