### PR TITLE
[fixes #1166] Use [{motors}] for flight config motors placeholder

### DIFF
--- a/core/src/net/sf/openrocket/file/openrocket/savers/RocketSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/savers/RocketSaver.java
@@ -55,7 +55,7 @@ public class RocketSaver extends RocketComponentSaver {
 			}
 			
 			if (flightConfig.isNameOverridden()){
-				str += "><name>" + net.sf.openrocket.util.TextUtil.escapeXML(flightConfig.getName())
+				str += "><name>" + net.sf.openrocket.util.TextUtil.escapeXML(flightConfig.getNameRaw())
 						+ "</name></motorconfiguration>";
 			} else {
 				str += "/>";

--- a/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
@@ -34,7 +34,8 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 	private static final Logger log = LoggerFactory.getLogger(FlightConfiguration.class);
 	private static final Translator trans = Application.getTranslator();
 
-    private String configurationName=null;
+    private String configurationName;
+	public static String DEFAULT_CONFIG_NAME = "[{motors}]";
 	
 	protected final Rocket rocket;
 	protected final FlightConfigurationId fcid;
@@ -94,7 +95,7 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 			this.fcid = _fcid;
 		}
 		this.rocket = rocket;
-		this.configurationName = null;
+		this.configurationName = DEFAULT_CONFIG_NAME;
 		this.configurationInstanceId = configurationInstanceCount++;
 		
 		updateStages();
@@ -414,15 +415,31 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 	}
 	
 	public boolean isNameOverridden(){
-		return (null != this.configurationName );
+		return (!DEFAULT_CONFIG_NAME.equals(this.configurationName));
 	}
-	
+
+	/**
+	 * Return the name of this configuration, with DEFAULT_CONFIG_NAME replaced by a one line motor description.
+	 * If configurationName is null, the one line motor description is returned.
+	 * @return the flight configuration name
+	 */
 	public String getName() {
-		if( null == configurationName){
-			return this.getOneLineMotorDescription();
-		}else{
-			return configurationName;
+		if (configurationName == null) {
+			return getOneLineMotorDescription();
 		}
+		return configurationName.replace(DEFAULT_CONFIG_NAME, getOneLineMotorDescription());
+	}
+
+	/**
+	 * Return the raw configuration name, without replacing DEFAULT_CONFIG_NAME.
+	 * If the configurationName is null, DEFAULT_CONFIG_NAME is returned.
+	 * @return raw flight configuration name
+	 */
+	public String getNameRaw() {
+		if (configurationName == null) {
+			return DEFAULT_CONFIG_NAME;
+		}
+		return configurationName;
 	}
 	
 	private String getOneLineMotorDescription(){
@@ -713,9 +730,9 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 		return id; 
 	}
 
-	public void setName( final String newName) {
-		if(( null == newName ) ||( "".equals(newName))){
-			this.configurationName = null;
+	public void setName(final String newName) {
+		if ((newName == null) || ("".equals(newName))) {
+			this.configurationName = DEFAULT_CONFIG_NAME;
 			return;
 		}else if( ! this.getId().isValid()){
 			return;

--- a/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
@@ -861,7 +861,7 @@ public class Rocket extends ComponentAssembly {
 			if( this.selectedConfiguration.equals( config)){
 				shortKey = "=>" + shortKey;
 			}
-			buf.append(String.format(fmt, shortKey, config.getName() ));
+			buf.append(String.format(fmt, shortKey, config.getNameRaw() ));
 		}
 		return buf.toString();
 	}

--- a/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/RenameConfigDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/RenameConfigDialog.java
@@ -30,7 +30,7 @@ public class RenameConfigDialog extends JDialog {
 		
 		panel.add(new JLabel(trans.get("RenameConfigDialog.lbl.name")), "span, wrap rel");
 		
-		final JTextField textbox = new JTextField(rocket.getFlightConfiguration(fcid).getName());
+		final JTextField textbox = new JTextField(rocket.getFlightConfiguration(fcid).getNameRaw());
 		panel.add(textbox, "span, w 200lp, growx, wrap para");
 		
 		panel.add(new JPanel(), "growx");

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurationPanel.java
@@ -220,7 +220,7 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 		if (fcIds == null) return;
 		FlightConfigurationId initFcId = fcIds.get(0);
 		new RenameConfigDialog(SwingUtilities.getWindowAncestor(this), rocket, initFcId).setVisible(true);
-		String newName = rocket.getFlightConfiguration(initFcId).getName();
+		String newName = rocket.getFlightConfiguration(initFcId).getNameRaw();
 		for (int i = 1; i < fcIds.size(); i++) {
 			rocket.getFlightConfiguration(fcIds.get(i)).setName(newName);
 		}


### PR DESCRIPTION
This PR fixes #1166 by using [{motors}] as a placeholder text for motors in a flight configuration name (as was the case in OR 15.03). You will also notice that default configuration names like e.g. in 'A simple model rocket' will now show '[{motors}]' when you rename a configuration.