### PR TITLE
[fixes #1181] Fix initial motor select in MotorChooserDialog

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/MotorChooserDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/MotorChooserDialog.java
@@ -6,6 +6,8 @@ import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
+import javax.swing.AbstractAction;
+import javax.swing.Action;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JDialog;
@@ -73,7 +75,13 @@ public class MotorChooserDialog extends JDialog implements CloseableDialog {
 		this.setModal(true);
 		this.pack();
 		this.setLocationByPlatform(true);
-		GUIUtil.installEscapeCloseOperation(this);
+		Action closeAction = new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent event) {
+				close(false);
+			}
+		};
+		GUIUtil.installEscapeCloseOperation(this, closeAction);
 		
 		JComponent focus = selectionPanel.getDefaultFocus();
 		if (focus != null) {
@@ -107,9 +115,13 @@ public class MotorChooserDialog extends JDialog implements CloseableDialog {
 	public double getSelectedDelay() {
 		return selectionPanel.getSelectedDelay();
 	}
-	
-	
-	
+
+	public void open() {
+		// Update the motor selection based on the motor table value that was already selected in a previous session.
+		selectionPanel.selectMotorFromTable();
+		setVisible(true);
+	}
+
 	@Override
 	public void close(boolean ok) {
 		okClicked = ok;

--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorSelectionPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorSelectionPanel.java
@@ -112,14 +112,7 @@ public class ThrustCurveMotorSelectionPanel extends JPanel implements MotorSelec
 		setMotorMountAndConfig( fcid, mount );
 
 	}
-	
-	/**
-	 * Sole constructor.
-	 * 
-	 * @param current	the currently selected ThrustCurveMotor, or <code>null</code> for none.
-	 * @param delay		the currently selected ejection charge delay.
-	 * @param diameter	the diameter of the motor mount.
-	 */
+
 	public ThrustCurveMotorSelectionPanel() {
 		super(new MigLayout("fill", "[grow][]"));
 
@@ -264,17 +257,7 @@ public class ThrustCurveMotorSelectionPanel extends JPanel implements MotorSelec
 			table.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
 				@Override
 				public void valueChanged(ListSelectionEvent e) {
-					int row = table.getSelectedRow();
-					if (row >= 0) {
-						row = table.convertRowIndexToModel(row);
-						ThrustCurveMotorSet motorSet = model.getMotorSet(row);
-						log.info(Markers.USER_MARKER, "Selected table row " + row + ": " + motorSet);
-						if (motorSet != selectedMotorSet) {
-							select(selectMotor(motorSet));
-						}
-					} else {
-						log.info(Markers.USER_MARKER, "Selected table row " + row + ", nothing selected");
-					}
+					selectMotorFromTable();
 				}
 			});
 			table.addMouseListener(new MouseAdapter() {
@@ -606,6 +589,23 @@ public class ThrustCurveMotorSelectionPanel extends JPanel implements MotorSelec
 		// No motor has been used
 		Collections.sort(list, MOTOR_COMPARATOR);
 		return list.get(0);
+	}
+
+	/**
+	 * Selects a new motor based on the selection in the motor table
+	 */
+	public void selectMotorFromTable() {
+		int row = table.getSelectedRow();
+		if (row >= 0) {
+			row = table.convertRowIndexToModel(row);
+			ThrustCurveMotorSet motorSet = model.getMotorSet(row);
+			log.info(Markers.USER_MARKER, "Selected table row " + row + ": " + motorSet);
+			if (motorSet != selectedMotorSet) {
+				select(selectMotor(motorSet));
+			}
+		} else {
+			log.info(Markers.USER_MARKER, "Selected table row " + row + ", nothing selected");
+		}
 	}
 
 

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
@@ -288,7 +288,7 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
         double initDelay = initMount.getMotorConfig(initFcId).getEjectionDelay();
 
 		motorChooserDialog.setMotorMountAndConfig(initFcId, initMount);
-		motorChooserDialog.setVisible(true);
+		motorChooserDialog.open();
 
         Motor mtr = motorChooserDialog.getSelectedMotor();
 		double d = motorChooserDialog.getSelectedDelay();

--- a/swing/src/net/sf/openrocket/gui/util/GUIUtil.java
+++ b/swing/src/net/sf/openrocket/gui/util/GUIUtil.java
@@ -157,9 +157,22 @@ public class GUIUtil {
 	 * @param dialog	the dialog for which to install the action.
 	 */
 	public static void installEscapeCloseOperation(final JDialog dialog) {
+		installEscapeCloseOperation(dialog, null);
+	}
+
+	/**
+	 * Add the correct action to close a JDialog when the ESC key is pressed.
+	 * The dialog is closed by sending it a WINDOW_CLOSING event.
+	 *
+	 * An additional action can be passed which will be executed upon the close action key.
+	 *
+	 * @param dialog	the dialog for which to install the action.
+	 * @param action	action to execute upon the close action
+	 */
+	public static void installEscapeCloseOperation(final JDialog dialog, Action action) {
 		Action dispatchClosing = new AbstractAction() {
 			/**
-			 * 
+			 *
 			 */
 			private static final long serialVersionUID = 9196153713666242274L;
 
@@ -172,6 +185,9 @@ public class GUIUtil {
 		JRootPane root = dialog.getRootPane();
 		root.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(ESCAPE, CLOSE_ACTION_KEY);
 		root.getActionMap().put(CLOSE_ACTION_KEY, dispatchClosing);
+		if (action != null) {
+			root.getActionMap().put(CLOSE_ACTION_KEY, action);
+		}
 	}
 	
 	


### PR DESCRIPTION
This PR fixes #1181 and ensures that an initial table selection in the motor chooser gets translated to an actual motor selection. You should use the instructions from #1181 to recreate the issues and see if it's fixed.

Here is a [jar file](https://github.com/openrocket/openrocket/suites/5465148300/artifacts/173966704) for testing.