### PR TITLE
[fixes #1190] Fix ConfigDialog Close-button cut off

### DIFF
--- a/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
@@ -149,7 +149,7 @@ public class RocketComponentConfig extends JPanel {
 		
 		updateFields();
 		
-		this.add(buttonPanel, "newline, spanx, growx, height 32!");
+		this.add(buttonPanel, "newline, spanx, growx");
 	}
 	
 	


### PR DESCRIPTION
This PR fixes #1190 where the Close-button in a component config dialog got cut off on some OS'es.

As stated by [Joe's comment](https://github.com/openrocket/openrocket/issues/1190#issuecomment-1054414042), the fix works + I tested it on macOS, Ubuntu and Windows 11 and they are not (negatively) affected by this PR.