### PR TITLE
[fixes #1078] Add opacity slider to appearance config

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -826,6 +826,7 @@ AppearanceCfg.but.edit = Edit
 AppearanceCfg.but.savedefault = Save as default appearance
 AppearanceCfg.lbl.Texture = Texture:
 AppearanceCfg.lbl.shine = Shine:
+AppearanceCfg.lbl.opacity = Opacity:
 AppearanceCfg.lbl.color.Color = Color:
 AppearanceCfg.lbl.color.diffuse = Diffuse Color:
 AppearanceCfg.lbl.color.ambient = Ambient Color:

--- a/core/src/net/sf/openrocket/appearance/AppearanceBuilder.java
+++ b/core/src/net/sf/openrocket/appearance/AppearanceBuilder.java
@@ -161,6 +161,34 @@ public class AppearanceBuilder extends AbstractChangeSource {
 		this.shine = shine;
 		fireChangeEvent();
 	}
+
+	/**
+	 * Returns the opacity of the paint color, expressed in percentages, where 0 is fully transparent and 1 is fully opaque
+	 * @return opacity value of the pain color, expressed in a percentage
+	 */
+	public double getOpacity() {
+		if (this.paint == null) {
+			return 100;
+		}
+		return (double) this.paint.getAlpha() / 255;
+	}
+
+	/**
+	 * Sets the opacity/alpha of the paint color.
+	 *
+	 * @param opacity new opacity value expressed in a percentage, where 0 is fully transparent and 1 is fully opaque
+	 */
+	public void setOpacity(double opacity) {
+		if (this.paint == null) {
+			return;
+		}
+
+		// Clamp opacity between 0 and 1
+		opacity = Math.max(0, Math.min(1, opacity));
+
+		this.paint.setAlpha((int) (opacity * 255));
+		fireChangeEvent();
+	}
 	
 	/**
 	*	gets the current offset axis U used

--- a/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
@@ -581,15 +581,22 @@ public class AppearancePanel extends JPanel {
 		mDefault.addEnableComponent(offsetV, false);
 		panel.add(offsetV, "wrap, w 40");
 
-		// Repeat
-		panel.add(new JLabel(trans.get("AppearanceCfg.lbl.texture.repeat")));
-		EdgeMode[] list = new EdgeMode[EdgeMode.values().length];
-		System.arraycopy(EdgeMode.values(), 0, list, 0,
-				EdgeMode.values().length);
-		JComboBox<EdgeMode> combo = new JComboBox<EdgeMode>(new EnumModel<EdgeMode>(builder,
-				"EdgeMode", list));
-		mDefault.addEnableComponent(combo, false);
-		panel.add(combo);
+		// Opacity
+		panel.add(new JLabel(trans.get("AppearanceCfg.lbl.opacity")));
+		DoubleModel opacityModel = new DoubleModel(builder, "Opacity",
+				UnitGroup.UNITS_RELATIVE);
+		JSpinner spinOpacity = new JSpinner(opacityModel.getSpinnerModel());
+		spinOpacity.setEditor(new SpinnerEditor(spinOpacity));
+		JSlider slideOpacity = new JSlider(opacityModel.getSliderModel(0, 1));
+		UnitSelector unitOpacity = new UnitSelector(opacityModel);
+
+		mDefault.addEnableComponent(slideOpacity, false);
+		mDefault.addEnableComponent(spinOpacity, false);
+		mDefault.addEnableComponent(unitOpacity, false);
+
+		panel.add(spinOpacity, "split 3, w 50");
+		panel.add(unitOpacity);
+		panel.add(slideOpacity, "w 50");
 
 		// Rotation
 		panel.add(new JLabel(trans.get("AppearanceCfg.lbl.texture.rotation")));
@@ -604,5 +611,15 @@ public class AppearancePanel extends JPanel {
 				-Math.PI, Math.PI));
 		mDefault.addEnableComponent(bs, false);
 		panel.add(bs, "w 50, wrap");
+
+		// Repeat
+		panel.add(new JLabel(trans.get("AppearanceCfg.lbl.texture.repeat")), "skip 2");
+		EdgeMode[] list = new EdgeMode[EdgeMode.values().length];
+		System.arraycopy(EdgeMode.values(), 0, list, 0,
+				EdgeMode.values().length);
+		JComboBox<EdgeMode> combo = new JComboBox<EdgeMode>(new EnumModel<EdgeMode>(builder,
+				"EdgeMode", list));
+		mDefault.addEnableComponent(combo, false);
+		panel.add(combo, "wrap");
 	}
 }


### PR DESCRIPTION
This PR fixes #1078 by adding an opacity slider to the appearance config dialog:

https://user-images.githubusercontent.com/11031519/156026176-9c48d7d9-eb94-4b14-a869-e1e2eb287cae.mov

(I choose to use the term 'Opacity' instead of 'Transparency'. I know that the color picker has 'Transparency', but 'Opacity' is more common in all the programs I've worked with so far).

Here is a [jar file](https://github.com/openrocket/openrocket/suites/5477442873/artifacts/174667095) for testing.