### PR TITLE
Don't save backward-compatible radialdirection for ParallelStage

### DIFF
--- a/core/src/net/sf/openrocket/file/openrocket/savers/RocketComponentSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/savers/RocketComponentSaver.java
@@ -111,7 +111,9 @@ public class RocketComponentSaver {
 			if (c instanceof FinSet || c instanceof TubeFinSet) {
 				elements.add("<rotation>" + angleOffset + "</rotation>");
 			}
-			else if (!(c instanceof RailButton) && !(c instanceof PodSet)) {
+			else if (!(c instanceof ParallelStage) &&
+					 !(c instanceof PodSet) &&					 
+					 !(c instanceof RailButton)) {
 				elements.add("<radialdirection>" + angleOffset + "</radialdirection>");
 			}
 		}


### PR DESCRIPTION
Note that rockets having parallel stages saved before this PR will still show warning; save and reload should make the warning go away.

Fixes #1196