### PR TITLE
[fixes #1189] Fix Shine slider too small

### DIFF
--- a/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
@@ -553,18 +553,18 @@ public class AppearancePanel extends JPanel {
 		// Set the initial value to the reset state, not the shine value of the default appearance of this component
 		if (mDefault.getValue() && previousUserSelectedAppearance != null)
 			shineModel.setValue(previousUserSelectedAppearance.getShine());
-		JSpinner spin = new JSpinner(shineModel.getSpinnerModel());
-		spin.setEditor(new SpinnerEditor(spin));
-		BasicSlider slide = new BasicSlider(shineModel.getSliderModel(0, 1));
-		UnitSelector unit = new UnitSelector(shineModel);
+		final JSpinner spinShine = new JSpinner(shineModel.getSpinnerModel());
+		spinShine.setEditor(new SpinnerEditor(spinShine));
+		final BasicSlider slideShine = new BasicSlider(shineModel.getSliderModel(0, 1));
+		final UnitSelector unitShine = new UnitSelector(shineModel);
 
-		mDefault.addEnableComponent(slide, false);
-		mDefault.addEnableComponent(spin, false);
-		mDefault.addEnableComponent(unit, false);
+		mDefault.addEnableComponent(slideShine, false);
+		mDefault.addEnableComponent(spinShine, false);
+		mDefault.addEnableComponent(unitShine, false);
 
-		panel.add(spin, "split 3, w 50");
-		panel.add(unit);
-		panel.add(slide, "w 50");
+		panel.add(spinShine, "split 3, w 50");
+		panel.add(unitShine);
+		panel.add(slideShine, "w 50");
 
 		// Offset
 		panel.add(new JLabel(trans.get("AppearanceCfg.lbl.texture.offset")));

--- a/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
@@ -549,7 +549,7 @@ public class AppearancePanel extends JPanel {
 		// Shine
 		panel.add(new JLabel(trans.get("AppearanceCfg.lbl.shine")));
 		DoubleModel shineModel = new DoubleModel(builder, "Shine",
-				UnitGroup.UNITS_RELATIVE);
+				UnitGroup.UNITS_RELATIVE, 0, 1);
 		JSpinner spin = new JSpinner(shineModel.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		BasicSlider slide = new BasicSlider(shineModel.getSliderModel(0, 1));
@@ -583,10 +583,10 @@ public class AppearancePanel extends JPanel {
 		// Opacity
 		panel.add(new JLabel(trans.get("AppearanceCfg.lbl.opacity")));
 		DoubleModel opacityModel = new DoubleModel(builder, "Opacity",
-				UnitGroup.UNITS_RELATIVE);
+				UnitGroup.UNITS_RELATIVE, 0, 1);
 		JSpinner spinOpacity = new JSpinner(opacityModel.getSpinnerModel());
 		spinOpacity.setEditor(new SpinnerEditor(spinOpacity));
-		JSlider slideOpacity = new JSlider(opacityModel.getSliderModel(0, 1));
+		BasicSlider slideOpacity = new BasicSlider(opacityModel.getSliderModel(0, 1));
 		UnitSelector unitOpacity = new UnitSelector(opacityModel);
 
 		mDefault.addEnableComponent(slideOpacity, false);

--- a/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
@@ -550,6 +550,9 @@ public class AppearancePanel extends JPanel {
 		panel.add(new JLabel(trans.get("AppearanceCfg.lbl.shine")));
 		DoubleModel shineModel = new DoubleModel(builder, "Shine",
 				UnitGroup.UNITS_RELATIVE, 0, 1);
+		// Set the initial value to the reset state, not the shine value of the default appearance of this component
+		if (mDefault.getValue() && previousUserSelectedAppearance != null)
+			shineModel.setValue(previousUserSelectedAppearance.getShine());
 		JSpinner spin = new JSpinner(shineModel.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		BasicSlider slide = new BasicSlider(shineModel.getSliderModel(0, 1));

--- a/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
@@ -18,7 +18,6 @@ import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.JOptionPane;
 import javax.swing.JSpinner;
-import javax.swing.JSlider;
 import javax.swing.JTabbedPane;
 import javax.swing.colorchooser.ColorSelectionModel;
 import javax.swing.event.ChangeEvent;
@@ -553,7 +552,7 @@ public class AppearancePanel extends JPanel {
 				UnitGroup.UNITS_RELATIVE);
 		JSpinner spin = new JSpinner(shineModel.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
-		JSlider slide = new JSlider(shineModel.getSliderModel(0, 1));
+		BasicSlider slide = new BasicSlider(shineModel.getSliderModel(0, 1));
 		UnitSelector unit = new UnitSelector(shineModel);
 
 		mDefault.addEnableComponent(slide, false);


### PR DESCRIPTION
This PR fixes #1189 where the shine slider was too small because it used a JSlider instead of BasicSlider.

Additionally, this PR also adds clamping for both the opacity and shine slider so that it is limited to 0 - 100 %.

(Extra: apparently the changes from PR #970 were not present in unstable, no clue why because normally it got merged but anyway, now it's back)

(Already tested in the #1189 thread).