### PR TITLE
[fixes #1192] Use default 3D component color mid-grey + 30% shine

### DIFF
--- a/core/src/net/sf/openrocket/appearance/AppearanceBuilder.java
+++ b/core/src/net/sf/openrocket/appearance/AppearanceBuilder.java
@@ -51,7 +51,7 @@ public class AppearanceBuilder extends AbstractChangeSource {
 	*	Clears the builder cache and set to build blank appearances
 	*/
 	private void resetToDefaults() {
-		paint = new Color(127, 127, 127);
+		paint = new Color(187, 187, 187);
 		shine = 0.3;
 		offsetU = offsetV = 0;
 		centerU = centerV = 0;

--- a/core/src/net/sf/openrocket/appearance/AppearanceBuilder.java
+++ b/core/src/net/sf/openrocket/appearance/AppearanceBuilder.java
@@ -51,8 +51,8 @@ public class AppearanceBuilder extends AbstractChangeSource {
 	*	Clears the builder cache and set to build blank appearances
 	*/
 	private void resetToDefaults() {
-		paint = new Color(0, 0, 0);
-		shine = 0;
+		paint = new Color(127, 127, 127);
+		shine = 0.3;
 		offsetU = offsetV = 0;
 		centerU = centerV = 0;
 		scaleU = scaleV = 1;


### PR DESCRIPTION
This PR fixes #1192 by setting the default 3D component color to a mid-grey #7F7F7F + default 30% shine.

Preview:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/11031519/156058474-5e38062a-f662-451d-ab94-6ebdf3236ec9.png">