### PR TITLE
[fixes #1163 & #1175] Fix unreliable simulation creation from new flight config

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurationPanel.java
@@ -170,7 +170,7 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 	 * create simulation for new configuration
 	 */
 	private void addOrCopyConfiguration(boolean copy) {
-		Map<FlightConfigurationId, FlightConfiguration> newConfigs = new LinkedHashMap<>();
+		final Map<FlightConfigurationId, FlightConfiguration> newConfigs = new LinkedHashMap<>();
 
 		// create or copy configuration
 		if (copy) {
@@ -198,20 +198,22 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 			newConfigs.put(newId, newConfig);
 		}
 
-		for (FlightConfigurationId newId : newConfigs.keySet()) {
+		OpenRocketDocument doc = BasicFrame.findDocument(rocket);
+		if (doc == null) return;
+
+		for (Map.Entry<FlightConfigurationId, FlightConfiguration> config : newConfigs.entrySet()) {
 			// associate configuration with Id and select it
-			rocket.setFlightConfiguration(newId, newConfigs.get(newId));
+			rocket.setFlightConfiguration(config.getKey(), config.getValue());
+			rocket.setSelectedConfiguration(config.getKey());
 
 			// create simulation for configuration
 			Simulation newSim = new Simulation(rocket);
 
-			OpenRocketDocument doc = BasicFrame.findDocument(rocket);
-			if (doc != null) {
-				newSim.setName(doc.getNextSimulationName());
-				doc.addSimulation(newSim);
-			}
+			newSim.setName(doc.getNextSimulationName());
+			doc.addSimulation(newSim);
 		}
 
+		// Reset to first selected flight config
 		rocket.setSelectedConfiguration((FlightConfigurationId) newConfigs.keySet().toArray()[0]);
 	}
 	


### PR DESCRIPTION
*sigh* this was a really stupid bug from PR #1132 where I forgot one line of code that selects the newly created configuration (with `rocket.setSelectedConfiguration`).

Issues #1163 and #1175 should be fixed with this.

Here is a [jar file](https://github.com/openrocket/openrocket/suites/5480818622/artifacts/174857559) for testing.