### PR TITLE
[fixes #1176] Add JRE version checking at startup

### DIFF
--- a/core/src/net/sf/openrocket/startup/Application.java
+++ b/core/src/net/sf/openrocket/startup/Application.java
@@ -22,7 +22,7 @@ public final class Application {
 	private static Injector injector;
 
 	// Supported Java Runtime Environment versions in which OR is allowed to run (e.g. '11' for Java 11)
-	public static int[] SUPPORTED_JRE_VERSIONS = {11, 12, 13};
+	public static int[] SUPPORTED_JRE_VERSIONS = {11};
 	
 	/**
 	 * Return whether to use additional safety code checks.

--- a/core/src/net/sf/openrocket/startup/Application.java
+++ b/core/src/net/sf/openrocket/startup/Application.java
@@ -20,6 +20,9 @@ public final class Application {
 	private static ExceptionHandler exceptionHandler;
 	
 	private static Injector injector;
+
+	// Supported Java Runtime Environment versions in which OR is allowed to run (e.g. '11' for Java 11)
+	public static int[] SUPPORTED_JRE_VERSIONS = {11, 12, 13};
 	
 	/**
 	 * Return whether to use additional safety code checks.

--- a/swing/src/net/sf/openrocket/startup/SwingStartup.java
+++ b/swing/src/net/sf/openrocket/startup/SwingStartup.java
@@ -107,7 +107,7 @@ public class SwingStartup {
 				if (IntStream.of(Application.SUPPORTED_JRE_VERSIONS).noneMatch(c -> c == version)) {
 					String title = "Unsupported Java version";
 					String message1 = "Unsupported Java version: %s";
-					String message2 = "Supported versions: %s";
+					String message2 = "Supported version(s): %s";
 					String message3 = "Please change the Java Runtime Environment version or install OpenRocket using a packaged installer.";
 
 					StringBuilder message = new StringBuilder();

--- a/swing/src/net/sf/openrocket/startup/SwingStartup.java
+++ b/swing/src/net/sf/openrocket/startup/SwingStartup.java
@@ -5,7 +5,10 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.io.File;
 import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.stream.IntStream;
 
+import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import javax.swing.Timer;
 import javax.swing.ToolTipManager;
@@ -49,7 +52,7 @@ public class SwingStartup {
 	 * OpenRocket startup main method.
 	 */
 	public static void main(final String[] args) throws Exception {
-		
+
 		// Check for "openrocket.debug" property before anything else
 		checkDebugStatus();
 
@@ -60,6 +63,11 @@ public class SwingStartup {
 		// Initialize logging first so we can use it
 		initializeLogging();
 		log.info("Starting up OpenRocket version {}", BuildProperties.getVersion());
+
+		// Check JRE version
+		if (!checkJREVersion()) {
+			return;
+		}
 		
 		// Check that we're not running headless
 		log.info("Checking for graphics head");
@@ -84,7 +92,45 @@ public class SwingStartup {
 		log.info("Startup complete");
 		
 	}
-	
+
+	/**
+	 * Checks whether the Java Runtime Engine version is supported.
+	 *
+	 * @return true if the JRE is supported, false if not
+	 */
+	private static boolean checkJREVersion() {
+		String JREVersion = System.getProperty("java.version");
+		if (JREVersion != null) {
+			try {
+				// We're only interested in the big decimal part of the JRE version
+				int version = Integer.parseInt(JREVersion.split("\\.")[0]);
+				if (IntStream.of(Application.SUPPORTED_JRE_VERSIONS).noneMatch(c -> c == version)) {
+					String title = "Unsupported Java version";
+					String message1 = "Unsupported Java version: %s";
+					String message2 = "Supported versions: %s";
+					String message3 = "Please change the Java Runtime Environment version or install OpenRocket using a packaged installer.";
+
+					StringBuilder message = new StringBuilder();
+					message.append(String.format(message1, JREVersion));
+					message.append("\n");
+					String[] supported = Arrays.stream(Application.SUPPORTED_JRE_VERSIONS)
+							.mapToObj(String::valueOf)
+							.toArray(String[]::new);
+					message.append(String.format(message2, String.join(", ", supported)));
+					message.append("\n\n");
+					message.append(message3);
+
+					JOptionPane.showMessageDialog(null, message.toString(),
+							title, JOptionPane.ERROR_MESSAGE);
+					return false;
+				}
+			} catch (NumberFormatException e) {
+				log.warn("Malformed JRE version - " + JREVersion);
+			}
+		}
+		return true;
+	}
+
 	/**
 	 * Set proper system properties if openrocket.debug is defined.
 	 */


### PR DESCRIPTION
This PR fixes #1176 by adding JRE version checking at startup. If an unsupported Java version is detected, the following popup will show and the application is closed afterwards:
<img width="894" alt="image" src="https://user-images.githubusercontent.com/11031519/156083620-d8a8eb4d-f5a6-4dbd-accf-e245cd78eeb8.png">

Currently the following Java versions are included as being supported: 11, 12 & 13 (I think these are the supported versions?)

Note: the packaged installers already have a fixed (and correct) JRE versions, e.g. 22.02.beta.01 will show JRE version 11 if you check in the Debug Report.

Here is a [jar file](https://github.com/openrocket/openrocket/suites/5482436783/artifacts/174946436) for testing. (Note: if you wanna test different JRE versions and are running on Linux or macOS, I recommend [jEnv](https://www.jenv.be/))