### PR TITLE
Make motor database search more robust, especially when loading files

### DIFF
--- a/core/src/net/sf/openrocket/database/motor/ThrustCurveMotorSetDatabase.java
+++ b/core/src/net/sf/openrocket/database/motor/ThrustCurveMotorSetDatabase.java
@@ -34,7 +34,7 @@ public class ThrustCurveMotorSetDatabase implements MotorDatabase {
 			for (ThrustCurveMotor m : set.getMotors()) {
 				boolean matchDescription = true;
 				boolean matchDigest = true;
-
+				
 				// unlike the description, digest must be present in search criteria to get a match
 				if (digest == null || digest != m.getDigest())
 					matchDigest = false;
@@ -45,8 +45,8 @@ public class ThrustCurveMotorSetDatabase implements MotorDatabase {
 				else if (manufacturer != null && !m.getManufacturer().matches(manufacturer))
 					matchDescription = false;
 				else if (designation != null &&
-						 !designation.equalsIgnoreCase(m.getDesignation()) &&
-						 !designation.equalsIgnoreCase(m.getCommonName()))
+						 !m.getDesignation().toUpperCase().contains(designation.toUpperCase()) &&
+						 !designation.toUpperCase().contains(m.getCommonName().toUpperCase()))
 					matchDescription = false;
 				else if (!Double.isNaN(diameter) && (Math.abs(diameter - m.getDiameter()) > 0.005))
 					matchDescription = false;

--- a/core/src/net/sf/openrocket/file/openrocket/importt/MotorHandler.java
+++ b/core/src/net/sf/openrocket/file/openrocket/importt/MotorHandler.java
@@ -1,5 +1,7 @@
 package net.sf.openrocket.file.openrocket.importt;
 
+import java.lang.Double;
+
 import java.util.HashMap;
 import java.util.Locale;
 
@@ -42,7 +44,7 @@ class MotorHandler extends AbstractElementHandler {
 	 * Return the motor to use, or null.
 	 */
 	public Motor getMotor(WarningSet warnings) {
-		return context.getMotorFinder().findMotor(type, manufacturer, designation, diameter, length, digest, warnings);
+		return context.getMotorFinder().findMotor(type, manufacturer, designation, Double.NaN, Double.NaN, digest, warnings);
 	}
 	
 	/**


### PR DESCRIPTION
Instead of requiring motor "designation" to match either the actual designation or the common name, require it to be a substring of the actual designation or that the common name be a substring of the actual designation.  Many motors in stored rocket files have "designations" that resemble, but do not match, actual designations and common names.

Don't match on diameter or length when loading files.  Motors with errors in the old database (eg M1850) would fail to be recognized.

Fixes #1174