### PR TITLE
[#1172] Add new shockcord materials

### DIFF
--- a/core/src/net/sf/openrocket/database/Databases.java
+++ b/core/src/net/sf/openrocket/database/Databases.java
@@ -90,6 +90,28 @@ public class Databases {
 		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Tubular nylon (11 mm, 7/16 in)", 0.013));
 		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Tubular nylon (14 mm, 9/16 in)", 0.016));
 		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Tubular nylon (25 mm, 1 in)", 0.029));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Kevlar thread 138  (0.4 mm, 1/64 in)", 0.00014808));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Kevlar thread 207  (0.5 mm, 1/64 in)", 0.00023622));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Kevlar thread 346  (0.7 mm, 1/32 in)", 0.00047243));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Kevlar thread 415  (0.8 mm, 1/32 in)", 0.00055117));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Kevlar thread 800 (1.1 mm, 3/64 in)", 0.00099211));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Kevlar 12-strand (3.2 mm, 1/8 in)", 0.00967306));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Kevlar 12-strand (4.8 mm, 3/16 in)", 0.01785797));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Kevlar 12-strand (6.4 mm, 1/4 in)", 0.02976328));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Kevlar 12-strand (7.9 mm, 5/16 in)", 0.04464491));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Kevlar 12-strand (10 mm, 3/8 in)", 0.05952655));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Kevlar 12-strand (11 mm, 7/16 in)", 0.07440819));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Kevlar 12-strand (13 mm, 1/2 in)", 0.11607678));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Kevlar 12-strand (14 mm, 9/16 in)", 0.20834293));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Kevlar 12-strand (16 mm, 5/8 in)", 0.28721562));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Kevlar 12-strand (19 mm, 3/4 in)", 0.3497185));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Kevlar 12-strand (25 mm, 1 in)", 0.45686629));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Nylon flat webbing md. (10 mm, 3/8 in)", 0.00951444));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Nylon flat webbing md. (13 mm, 1/2  in)", 0.01334208));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Nylon flat webbing md. (16 mm, 5/8 in)", 0.01618548));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Nylon flat webbing lg. (14 mm, 9/16 in)", 0.02723097));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Nylon flat webbing lg. (25 mm, 1 in)", 0.03969816));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Paraline small IIIA (6.4 mm, 1.4 in)", 0.00371829));
 		
 		
 		// Add user-defined materials

--- a/core/src/net/sf/openrocket/database/Databases.java
+++ b/core/src/net/sf/openrocket/database/Databases.java
@@ -112,6 +112,13 @@ public class Databases {
 		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Nylon flat webbing lg. (14 mm, 9/16 in)", 0.02723097));
 		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Nylon flat webbing lg. (25 mm, 1 in)", 0.03969816));
 		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Paraline small IIIA (6.4 mm, 1.4 in)", 0.00371829));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Elastic rubber band (flat 3.2 mm, 1/8 in)", 0.00297638));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Elastic rubber band (flat 6.4 mm, 1/4 in)", 0.00613107));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Elastic braided cord (flat 3.2 mm, 1/8 in)", 0.00106));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Elastic braided cord (flat 4 mm, 5/32 in)", 0.002));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Elastic braided cord (flat 6.4 mm, 1/4 in)", 0.00254));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Elastic braided cord (round 2 mm, 1/16 in)", 0.0035));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Elastic braided cord (round 2.5 mm, 3/32 in)", 0.0038));
 		
 		
 		// Add user-defined materials

--- a/core/src/net/sf/openrocket/database/Databases.java
+++ b/core/src/net/sf/openrocket/database/Databases.java
@@ -119,6 +119,8 @@ public class Databases {
 		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Elastic braided cord (flat 6.4 mm, 1/4 in)", 0.00254));
 		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Elastic braided cord (round 2 mm, 1/16 in)", 0.0035));
 		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Elastic braided cord (round 2.5 mm, 3/32 in)", 0.0038));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Elastic braided cord (flat 10 mm, 3/8 in)", 0.00381));
+		LINE_MATERIAL.add(newMaterial(Material.Type.LINE, "Elastic braided cord (flat 13 mm, 1/2 in)", 0.00551172));
 		
 		
 		// Add user-defined materials


### PR DESCRIPTION
This PR adds a bunch of new shock cord materials. All credits go to @hcraigmiller who gathered the data.

Added materials, format: '"{ Material name }", { density (in kg/m) }':

- "Kevlar thread 138  (0.4 mm, 1/64 in)", 0.00014808
- "Kevlar thread 207  (0.5 mm, 1/64 in)", 0.00023622
- "Kevlar thread 346  (0.7 mm, 1/32 in)", 0.00047243
- "Kevlar thread 415  (0.8 mm, 1/32 in)", 0.00055117
- "Kevlar thread 800 (1.1 mm, 3/64 in)", 0.00099211
- "Kevlar 12-strand (3.2 mm, 1/8 in)", 0.00967306
- "Kevlar 12-strand (4.8 mm, 3/16 in)", 0.01785797
- "Kevlar 12-strand (6.4 mm, 1/4 in)", 0.02976328
- "Kevlar 12-strand (7.9 mm, 5/16 in)", 0.04464491
- "Kevlar 12-strand (10 mm, 3/8 in)", 0.05952655
- "Kevlar 12-strand (11 mm, 7/16 in)", 0.07440819
- "Kevlar 12-strand (13 mm, 1/2 in)", 0.11607678
- "Kevlar 12-strand (14 mm, 9/16 in)", 0.20834293
- "Kevlar 12-strand (16 mm, 5/8 in)", 0.28721562
- "Kevlar 12-strand (19 mm, 3/4 in)", 0.3497185
- "Kevlar 12-strand (25 mm, 1 in)", 0.45686629
- "Nylon flat webbing md. (10 mm, 3/8 in)", 0.00951444
- "Nylon flat webbing md. (13 mm, 1/2  in)", 0.01334208
- "Nylon flat webbing md. (16 mm, 5/8 in)", 0.01618548
- "Nylon flat webbing lg. (14 mm, 9/16 in)", 0.02723097
- "Nylon flat webbing lg. (25 mm, 1 in)", 0.03969816
- "Paraline small IIIA (6.4 mm, 1.4 in)", 0.00371829

Preview:
<img width="850" alt="image" src="https://user-images.githubusercontent.com/11031519/156483320-db65cc85-d938-48c4-8913-b78e4ef81ac3.png">
