### PR TITLE
Change default stage separation from next stage ignition to current stage motor burnout.

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/StageSeparationConfiguration.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/StageSeparationConfiguration.java
@@ -98,7 +98,7 @@ public class StageSeparationConfiguration implements FlightConfigurableParameter
 	private static final Translator trans = Application.getTranslator();
 	
 	
-	private SeparationEvent separationEvent = SeparationEvent.UPPER_IGNITION;
+	private SeparationEvent separationEvent = SeparationEvent.EJECTION;
 	private double separationDelay = 0;
 
 	private final List<StageSeparationConfiguration> configListeners = new LinkedList<>();


### PR DESCRIPTION
For parallel stages, this is much more likely to be the user's intent.  The previous behavior caused stage separation the moment of ignition, so the booster set essentially flew as a second, independent rocket. With this change, the parallel stage stays with the center stack until the ejection charge fires (note that OR treats a rocket with a -0 ejection delay as having an ejection charge at motor burnout).

Note that this change to the default behavior is also applied to axial stages, but is also appropriate in that case.  For the vast majority  of low power rockets, the booster burnout ignites the next stage, so "next stage ignition" and "current stage ejection charge" are simultaneous.  For high power rockets, the next stage ignition has to be customized anyway.

Fixes #1215