### PR TITLE
Check for active upper stage before dropping booster

### DIFF
--- a/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
+++ b/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
@@ -425,24 +425,28 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 			}
 			
 			case STAGE_SEPARATION: {
-				// Record the event.
-				currentStatus.getFlightData().addEvent(event);
-				
 				RocketComponent boosterStage = event.getSource();
 				final int stageNumber = boosterStage.getStageNumber();
-	
-				// Mark the status as having dropped the booster
-				currentStatus.getConfiguration().clearStage( stageNumber);
-						  
-				// Prepare the simulation branch
-				SimulationStatus boosterStatus = new SimulationStatus(currentStatus);
-				boosterStatus.setFlightData(new FlightDataBranch(boosterStage.getName(), FlightDataType.TYPE_TIME));
-				// Mark the booster status as only having the booster.
-				boosterStatus.getConfiguration().setOnlyStage(stageNumber);
-				toSimulate.push(boosterStatus);
-				log.info(String.format("==>> @ %g; from Branch: %s ---- Branching: %s ---- \n",
-						currentStatus.getSimulationTime(), 
-						currentStatus.getFlightData().getBranchName(), boosterStatus.getFlightData().getBranchName()));
+
+				if (currentStatus.getConfiguration().isStageActive(stageNumber-1)) {
+					// Record the event.
+					currentStatus.getFlightData().addEvent(event);
+
+					// Mark the status as having dropped the booster
+					currentStatus.getConfiguration().clearStage( stageNumber);
+					
+					// Prepare the simulation branch
+					SimulationStatus boosterStatus = new SimulationStatus(currentStatus);
+					boosterStatus.setFlightData(new FlightDataBranch(boosterStage.getName(), FlightDataType.TYPE_TIME));
+					// Mark the booster status as only having the booster.
+					boosterStatus.getConfiguration().setOnlyStage(stageNumber);
+					toSimulate.push(boosterStatus);
+					log.info(String.format("==>> @ %g; from Branch: %s ---- Branching: %s ---- \n",
+										   currentStatus.getSimulationTime(), 
+										   currentStatus.getFlightData().getBranchName(), boosterStatus.getFlightData().getBranchName()));
+				} else {
+					log.debug("upper stage is not active; not performing separation");
+				}
 				
 				break;
 			}


### PR DESCRIPTION
If there are multiple independent motor clusters in a stage, each of them can attempt a separation event. When the second event happens, there is no longer an active upper stage, so the separation results in a simulation branch with no active stages.  This causes a NaN exception as the mass is 0.

fixes #1226