### PR TITLE
[fixes #1128] Fix SimulationPlot range with boosters dataset

### DIFF
--- a/core/src/net/sf/openrocket/simulation/FlightData.java
+++ b/core/src/net/sf/openrocket/simulation/FlightData.java
@@ -137,6 +137,10 @@ public class FlightData {
 	public FlightDataBranch getBranch(int n) {
 		return branches.get(n);
 	}
+
+	public List<FlightDataBranch> getBranches() {
+		return branches;
+	}
 	
 	
 

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlot.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlot.java
@@ -134,7 +134,11 @@ public class SimulationPlot {
 		// Fill the auto-selections based on first branch selected.
 		FlightDataBranch mainBranch = simulation.getSimulatedData().getBranch(0);
 		this.filled = config.fillAutoAxes(mainBranch);
-		List<Axis> axes = filled.getAllAxes();
+
+		// Compute the axes based on the min and max value of all branches
+		PlotConfiguration plotConfig = filled.clone();
+		plotConfig.fitAxes(simulation.getSimulatedData().getBranches());
+		List<Axis> minMaxAxes = plotConfig.getAllAxes();
 
 		// Create the data series for both axes
 		XYSeriesCollection[] data = new XYSeriesCollection[2];
@@ -250,15 +254,8 @@ public class SimulationPlot {
 			// Check whether axis has any data
 			if (data[axisno].getSeriesCount() > 0) {
 				// Create and set axis
-				double min = axes.get(axisno).getMinValue();
-				double max = axes.get(axisno).getMaxValue();
-
-				for (Object series : data[axisno].getSeries()) {
-					if (series instanceof XYSeries) {
-						min = Math.min(min, ((XYSeries) series).getMinY());
-						max = Math.max(max, ((XYSeries) series).getMaxY());
-					}
-				}
+				double min = minMaxAxes.get(axisno).getMinValue();
+				double max = minMaxAxes.get(axisno).getMaxValue();
 
 				NumberAxis axis = new PresetNumberAxis(min, max);
 				axis.setLabel(axisLabel[axisno]);

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlot.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlot.java
@@ -25,6 +25,7 @@ import net.sf.openrocket.simulation.FlightDataType;
 import net.sf.openrocket.simulation.FlightEvent;
 import net.sf.openrocket.unit.Unit;
 import net.sf.openrocket.unit.UnitGroup;
+import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.LinearInterpolator;
 
 import net.sf.openrocket.utils.DecimalFormatter;
@@ -48,7 +49,6 @@ import org.jfree.chart.renderer.xy.XYLineAndShapeRenderer;
 import org.jfree.chart.title.LegendTitle;
 import org.jfree.chart.title.TextTitle;
 import org.jfree.data.Range;
-import org.jfree.data.xy.XYDataItem;
 import org.jfree.data.xy.XYDataset;
 import org.jfree.data.xy.XYSeries;
 import org.jfree.data.xy.XYSeriesCollection;
@@ -252,9 +252,16 @@ public class SimulationPlot {
 				// Create and set axis
 				double min = axes.get(axisno).getMinValue();
 				double max = axes.get(axisno).getMaxValue();
+
+				for (Object series : data[axisno].getSeries()) {
+					if (series instanceof XYSeries) {
+						min = Math.min(min, ((XYSeries) series).getMinY());
+						max = Math.max(max, ((XYSeries) series).getMaxY());
+					}
+				}
+
 				NumberAxis axis = new PresetNumberAxis(min, max);
 				axis.setLabel(axisLabel[axisno]);
-				//				axis.setRange(axes.get(i).getMinValue(), axes.get(i).getMaxValue());
 				plot.setRangeAxis(axisno, axis);
 				axis.setLabelFont(new Font("Dialog", Font.BOLD, 14));
 


### PR DESCRIPTION
This PR fixes #1128, the simulation plot behavior under boosters (and multi-stage rockets)

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/11031519/157867206-b33a856a-765e-41cc-bfb3-eb6b53aaa485.png">
