### PR TITLE
Get correct fin span when last point in shape is lower than first point.

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/FreeformFinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FreeformFinSet.java
@@ -296,7 +296,8 @@ public class FreeformFinSet extends FinSet {
 			if (c.y > max)
 				max = c.y;
 		}
-		return max;
+
+		return max - Math.min(points.get(points.size() - 1).y, 0);
 	}
 	
 	@Override


### PR DESCRIPTION
Note that the lowest point on the fin is guaranteed to be either the first point which is at (0, 0) or the last point, which will have a y coordinate of 0 if on a body tube, greater than 0 if on an increasing transition, or less than 0 on a decreasing transition (boattail).

Fixes #1173 and #1243

I'm leery of using either RockSim or a nasty hack as ground truth, but the CP is in a much more reasonable place using the .ork file from the report of #1173
[V2_BT101_RS-22.zip](https://github.com/openrocket/openrocket/files/8263177/V2_BT101_RS-22.zip)
![v2-correctedfinspan](https://user-images.githubusercontent.com/3065196/158614508-e551e053-a87a-4961-a0a2-645913ca6f0c.png)

