### PR TITLE
[fixes #1246] Use TransitionShapeModel for Transition type ComboBox

### DIFF
--- a/swing/src/net/sf/openrocket/gui/adaptors/TransitionShapeModel.java
+++ b/swing/src/net/sf/openrocket/gui/adaptors/TransitionShapeModel.java
@@ -1,0 +1,64 @@
+package net.sf.openrocket.gui.adaptors;
+
+import net.sf.openrocket.rocketcomponent.ComponentChangeEvent;
+import net.sf.openrocket.rocketcomponent.ComponentChangeListener;
+import net.sf.openrocket.rocketcomponent.RocketComponent;
+import net.sf.openrocket.rocketcomponent.Transition;
+
+import javax.swing.AbstractListModel;
+import javax.swing.ComboBoxModel;
+
+public class TransitionShapeModel extends AbstractListModel<Transition.Shape>
+        implements ComboBoxModel<Transition.Shape>, ComponentChangeListener {
+    private final RocketComponent component;
+    private final Transition.Shape[] typeList = Transition.Shape.values();
+    private Transition.Shape previousType;
+
+    public TransitionShapeModel(RocketComponent component) {
+        this.component = component;
+        if (component instanceof Transition) {
+            previousType = ((Transition) component).getType();
+            setSelectedItem(previousType);
+            component.addComponentChangeListener(this);
+        }
+    }
+
+    @Override
+    public void setSelectedItem(Object item) {
+        if (!(component instanceof Transition) || !(item instanceof Transition.Shape)) {
+            return;
+        }
+
+        ((Transition) component).setType((Transition.Shape) item);
+    }
+
+    @Override
+    public Object getSelectedItem() {
+        if (component instanceof Transition) {
+            return ((Transition) component).getType();
+        }
+        return null;
+    }
+
+    @Override
+    public int getSize() {
+        return typeList.length;
+    }
+
+    @Override
+    public Transition.Shape getElementAt(int index) {
+        return typeList[index];
+    }
+
+    @Override
+    public void componentChanged(ComponentChangeEvent e) {
+        if (!(component instanceof Transition)) {
+            return;
+        }
+
+        if (previousType != ((Transition) component).getType()) {
+            previousType = ((Transition) component).getType();
+            fireContentsChanged(this, 0, 0);
+        }
+    }
+}

--- a/swing/src/net/sf/openrocket/gui/configdialog/NoseConeConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/NoseConeConfig.java
@@ -16,6 +16,7 @@ import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.gui.SpinnerEditor;
 import net.sf.openrocket.gui.adaptors.BooleanModel;
 import net.sf.openrocket.gui.adaptors.DoubleModel;
+import net.sf.openrocket.gui.adaptors.TransitionShapeModel;
 import net.sf.openrocket.gui.components.BasicSlider;
 import net.sf.openrocket.gui.components.DescriptionArea;
 import net.sf.openrocket.gui.components.UnitSelector;
@@ -52,18 +53,15 @@ public class NoseConeConfig extends RocketComponentConfig {
 		{//// Nose cone shape:
 			panel.add(new JLabel(trans.get("NoseConeCfg.lbl.Noseconeshape")));
 
-			Transition.Shape selected = ((NoseCone) component).getType();
-			Transition.Shape[] typeList = Transition.Shape.values();
-
-			final JComboBox<Transition.Shape> typeBox = new JComboBox<Transition.Shape>(typeList);
+			final JComboBox<Transition.Shape> typeBox = new JComboBox<>(new TransitionShapeModel(c));
 			typeBox.setEditable(false);
-			typeBox.setSelectedItem(selected);
 			typeBox.addActionListener(new ActionListener() {
 				@Override
 				public void actionPerformed(ActionEvent e) {
 					Transition.Shape s = (Transition.Shape) typeBox.getSelectedItem();
-					((NoseCone) component).setType(s);
-					description.setText(PREDESC + s.getNoseConeDescription());
+					if (s != null) {
+						description.setText(PREDESC + s.getNoseConeDescription());
+					}
 					updateEnabled();
 				}
 			});

--- a/swing/src/net/sf/openrocket/gui/configdialog/TransitionConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/TransitionConfig.java
@@ -15,6 +15,7 @@ import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.gui.SpinnerEditor;
 import net.sf.openrocket.gui.adaptors.BooleanModel;
 import net.sf.openrocket.gui.adaptors.DoubleModel;
+import net.sf.openrocket.gui.adaptors.TransitionShapeModel;
 import net.sf.openrocket.gui.components.BasicSlider;
 import net.sf.openrocket.gui.components.DescriptionArea;
 import net.sf.openrocket.gui.components.UnitSelector;
@@ -54,18 +55,15 @@ public class TransitionConfig extends RocketComponentConfig {
 		//// Transition shape:
 		panel.add(new JLabel(trans.get("TransitionCfg.lbl.Transitionshape")));
 		
-		Transition.Shape selected = ((Transition) component).getType();
-		Transition.Shape[] typeList = Transition.Shape.values();
-		
-		typeBox = new JComboBox<Transition.Shape>(typeList);
+		typeBox = new JComboBox<>(new TransitionShapeModel(c));
 		typeBox.setEditable(false);
-		typeBox.setSelectedItem(selected);
 		typeBox.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				Transition.Shape s = (Transition.Shape) typeBox.getSelectedItem();
-				((Transition) component).setType(s);
-				description.setText(PREDESC + s.getTransitionDescription());
+				if (s != null) {
+					description.setText(PREDESC + s.getTransitionDescription());
+				}
 				updateEnabled();
 			}
 		});


### PR DESCRIPTION
This fixes fixes #1246 by implementing a TransitionShapeModel for the JComboBox of the Nose Cone config and Transition Config. This ensures that the type combobox is updated when the nose cone/transition type is changed.