### PR TITLE
Adds Ability To Export Simulation Graph/Chart As PNG

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -96,6 +96,7 @@ FileHelper.ALL_DESIGNS_FILTER = All rocket designs (*.ork; *.rkt)
 FileHelper.OPENROCKET_DESIGN_FILTER = OpenRocket designs (*.ork)
 FileHelper.ROCKSIM_DESIGN_FILTER = RockSim designs (*.rkt)
 FileHelper.OPEN_ROCKET_COMPONENT_FILTER = OpenRocket presets (*.orc)
+FileHelper.PNG_FILTER = PNG image (*.png)
 FileHelper.IMAGES = Image files
 
 

--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -1274,7 +1274,7 @@ TCMotorSelPan.btn.close = Close
 ! PlotDialog
 PlotDialog.CheckBox.Showdatapoints = Show data points
 PlotDialog.lbl.Chart = left click drag to zoom area. mouse wheel to zoom. ctrl-mouse wheel to zoom x axis only. ctrl-left click drag to pan.  right click drag to zoom dynamically.
-
+PlotDialog.btn.saveAsImage = Save As Image
 ComponentTree.ttip.massoverride = mass override
 ComponentTree.ttip.cgoverride = cg override
 ! "main" prefix is used for the main application dialog

--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -1274,7 +1274,7 @@ TCMotorSelPan.btn.close = Close
 ! PlotDialog
 PlotDialog.CheckBox.Showdatapoints = Show data points
 PlotDialog.lbl.Chart = left click drag to zoom area. mouse wheel to zoom. ctrl-mouse wheel to zoom x axis only. ctrl-left click drag to pan.  right click drag to zoom dynamically.
-PlotDialog.btn.saveAsImage = Save As Image
+PlotDialog.btn.exportImage = Export Image
 
 ComponentTree.ttip.massoverride = mass override
 ComponentTree.ttip.cgoverride = cg override

--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -1275,6 +1275,7 @@ TCMotorSelPan.btn.close = Close
 PlotDialog.CheckBox.Showdatapoints = Show data points
 PlotDialog.lbl.Chart = left click drag to zoom area. mouse wheel to zoom. ctrl-mouse wheel to zoom x axis only. ctrl-left click drag to pan.  right click drag to zoom dynamically.
 PlotDialog.btn.saveAsImage = Save As Image
+
 ComponentTree.ttip.massoverride = mass override
 ComponentTree.ttip.cgoverride = cg override
 ! "main" prefix is used for the main application dialog

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
@@ -117,7 +117,7 @@ public class SimulationPlotDialog extends JDialog {
 		panel.add(button, "gapleft rel");
 
 		//// Print chart button
-		button = new SelectColorButton("Save As Image");
+		button = new SelectColorButton(trans.get("PlotDialog.btn.saveAsImage"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -171,7 +171,7 @@ public class SimulationPlotDialog extends JDialog {
 		chooser.setFileFilter(FileHelper.PNG_FILTER);
 		chooser.setCurrentDirectory(((SwingPreferences) Application.getPreferences()).getDefaultDirectory());
 
-		/* Ensures No Problems When Choosing File */
+		//// Ensures No Problems When Choosing File
 		if (chooser.showSaveDialog(this) != JFileChooser.APPROVE_OPTION)
 			return false;
 
@@ -184,7 +184,7 @@ public class SimulationPlotDialog extends JDialog {
 			return false;
 		}
 
-		/* Uses JFreeChart Built In PNG Export Method */
+		//// Uses JFreeChart Built In PNG Export Method
 		try{
 			ChartUtilities.saveChartAsPNG(file, chart, chartPanel.getWidth(), chartPanel.getHeight());
 		} catch(Exception e){

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
@@ -117,7 +117,7 @@ public class SimulationPlotDialog extends JDialog {
 		panel.add(button, "gapleft rel");
 
 		//// Print chart button
-		button = new SelectColorButton(trans.get("PlotDialog.btn.saveAsImage"));
+		button = new SelectColorButton(trans.get("PlotDialog.btn.exportImage"));
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
@@ -117,11 +117,11 @@ public class SimulationPlotDialog extends JDialog {
 		panel.add(button, "gapleft rel");
 
 		//// Print chart button
-		button = new SelectColorButton(Icons.FILE_PRINT);
+		button = new SelectColorButton("Save As Image");
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				doPngExport(jChart);
+				doPngExport(chartPanel,jChart);
 			}
 		});
 		panel.add(button, "gapleft rel");
@@ -165,9 +165,10 @@ public class SimulationPlotDialog extends JDialog {
 		GUIUtil.rememberWindowSize(this);
 	}
 
-	private boolean doPngExport(JFreeChart chart){
+	private boolean doPngExport(ChartPanel chartPanel, JFreeChart chart){
 		JFileChooser chooser = new JFileChooser();
-		chooser.setFileFilter(FileHelper.getImageFileFilter());
+		chooser.setAcceptAllFileFilterUsed(false);
+		chooser.setFileFilter(FileHelper.PNG_FILTER);
 		chooser.setCurrentDirectory(((SwingPreferences) Application.getPreferences()).getDefaultDirectory());
 
 		/* Ensures No Problems When Choosing File */
@@ -185,7 +186,7 @@ public class SimulationPlotDialog extends JDialog {
 
 		/* Uses JFreeChart Built In PNG Export Method */
 		try{
-			ChartUtilities.saveChartAsPNG(file, chart, 1000, 500);
+			ChartUtilities.saveChartAsPNG(file, chart, chartPanel.getWidth(), chartPanel.getHeight());
 		} catch(Exception e){
 			return false;
 		}

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
@@ -6,26 +6,32 @@ import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
+import java.io.File;
 import java.util.ArrayList;
 
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JDialog;
+import javax.swing.JFileChooser;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 
 import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.document.Simulation;
 import net.sf.openrocket.gui.components.StyledLabel;
+import net.sf.openrocket.gui.util.FileHelper;
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.gui.util.Icons;
+import net.sf.openrocket.gui.util.SwingPreferences;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.startup.Preferences;
 import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 import org.jfree.chart.ChartPanel;
+import org.jfree.chart.ChartUtilities;
+import org.jfree.chart.JFreeChart;
 
 /**
  * Dialog that shows a plot of a simulation results based on user options.
@@ -50,6 +56,7 @@ public class SimulationPlotDialog extends JDialog {
 		this.add(panel);
 		
 		final ChartPanel chartPanel = new SimulationChart(myPlot.getJFreeChart());
+		final JFreeChart jChart = myPlot.getJFreeChart();
 		panel.add(chartPanel, "grow, wrap 20lp");
 		
 		//// Description text
@@ -108,6 +115,16 @@ public class SimulationPlotDialog extends JDialog {
 			}
 		});
 		panel.add(button, "gapleft rel");
+
+		//// Print chart button
+		button = new SelectColorButton(Icons.FILE_PRINT);
+		button.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				doPngExport(jChart);
+			}
+		});
+		panel.add(button, "gapleft rel");
 		
 		//// Add series selection box
 		ArrayList<String> stages = new ArrayList<String>();
@@ -141,16 +158,42 @@ public class SimulationPlotDialog extends JDialog {
 			}
 		});
 		panel.add(button, "right");
-		
 		this.setLocationByPlatform(true);
 		this.pack();
 		
 		GUIUtil.setDisposableDialogOptions(this, button);
 		GUIUtil.rememberWindowSize(this);
 	}
-	
-	
-	
+
+	private boolean doPngExport(JFreeChart chart){
+		JFileChooser chooser = new JFileChooser();
+		chooser.setFileFilter(FileHelper.getImageFileFilter());
+		chooser.setCurrentDirectory(((SwingPreferences) Application.getPreferences()).getDefaultDirectory());
+
+		/* Ensures No Problems When Choosing File */
+		if (chooser.showSaveDialog(this) != JFileChooser.APPROVE_OPTION)
+			return false;
+
+		File file = chooser.getSelectedFile();
+		if (file == null)
+			return false;
+
+		file = FileHelper.forceExtension(file, "png");
+		if (!FileHelper.confirmWrite(file, this)) {
+			return false;
+		}
+
+		/* Uses JFreeChart Built In PNG Export Method */
+		try{
+			ChartUtilities.saveChartAsPNG(file, chart, 1000, 500);
+		} catch(Exception e){
+			return false;
+		}
+
+		return true;
+	}
+
+
 	/**
 	 * Static method that shows a plot with the specified parameters.
 	 * 

--- a/swing/src/net/sf/openrocket/gui/util/FileHelper.java
+++ b/swing/src/net/sf/openrocket/gui/util/FileHelper.java
@@ -56,6 +56,10 @@ public final class FileHelper {
 	public static final FileFilter CSV_FILTER =
 			new SimpleFileFilter(trans.get("FileHelper.CSV_FILTER"), ".csv");
 
+	/** File filter for PNG files (*.png) */
+	public static final FileFilter PNG_FILTER =
+			new SimpleFileFilter(trans.get("FileHelper.PNG_FILTER"), ".png");
+
 
 
 


### PR DESCRIPTION
### This PR adds the feature of exporting a simulation graph/chart as a PNG. 

The button for this is placed next to the zoom button at the bottom of the Simulation Graph/Chart Page.

_How I Did It:_ I simply reused some of the zoom button code to make a button, created a basic method employing JFileChooser so the user can pick where they want the image saved, and lastly used the JFreeChart -> ChartUtilities -> saveChartAsPNG method to export the chart as a PNG.

_Background:_ I was using this software for a project and was curious if this feature existed. I went to website and found that it was still on the Planned feature list but never seemed to be implemented, even in the 22.02 beta. I had a bit of spare time and decided that I would add the feature myself.

[**Link To Jar File For Testing (Hosted On OneDrive)**](https://1drv.ms/u/s!AmD6PPALFydSl3FVxPjJZaDnhNue)

**_Here Is An Example Exported Chart:_**
![examplechartexport jpg](https://user-images.githubusercontent.com/45955060/159145583-dedbcd2c-2258-44db-9439-23287e1f9f5d.png)
