### PR TITLE
[fixes #1254] Fix simulation plot element stretching

### DIFF
--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
@@ -3,6 +3,8 @@ package net.sf.openrocket.gui.plot;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
 import java.awt.event.InputEvent;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
@@ -58,6 +60,12 @@ public class SimulationPlotDialog extends JDialog {
 		final ChartPanel chartPanel = new SimulationChart(myPlot.getJFreeChart());
 		final JFreeChart jChart = myPlot.getJFreeChart();
 		panel.add(chartPanel, "grow, wrap 20lp");
+
+		// Ensures normal aspect-ratio of chart elements when resizing the panel
+		chartPanel.setMinimumDrawWidth(0);
+		chartPanel.setMaximumDrawWidth(Integer.MAX_VALUE);
+		chartPanel.setMinimumDrawHeight(0);
+		chartPanel.setMaximumDrawHeight(Integer.MAX_VALUE);
 		
 		//// Description text
 		JLabel label = new StyledLabel(trans.get("PlotDialog.lbl.Chart"), -2);


### PR DESCRIPTION
This PR fixes #1254: stretching of simulation plot elements when resizing the window (or when the window was too large to begin with). The elements stretched because the panel dimensions were greater than the chartPanel maximum draw dimensions.

New behavior:
<img width="1548" alt="image" src="https://user-images.githubusercontent.com/11031519/159399822-e02f0c8b-dad4-47a9-8c38-4ed4337ad738.png">

Here is a [jar file](https://github.com/openrocket/openrocket/suites/5747525932/artifacts/190744045) for testing.