### PR TITLE
Allow execution with Java 17

### DIFF
--- a/core/src/net/sf/openrocket/startup/Application.java
+++ b/core/src/net/sf/openrocket/startup/Application.java
@@ -22,7 +22,7 @@ public final class Application {
 	private static Injector injector;
 
 	// Supported Java Runtime Environment versions in which OR is allowed to run (e.g. '11' for Java 11)
-	public static int[] SUPPORTED_JRE_VERSIONS = {11};
+	public static int[] SUPPORTED_JRE_VERSIONS = {11, 17};
 	
 	/**
 	 * Return whether to use additional safety code checks.


### PR DESCRIPTION
Let's allow OR to run with either 11 or 17, so we can see whether we can migrate it.