### PR TITLE
Refactor friction drag

### DIFF
--- a/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
+++ b/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
@@ -585,6 +585,7 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 		final InstanceMap imap = configuration.getActiveInstances();
 	    for(Map.Entry<RocketComponent, ArrayList<InstanceContext>> entry: imap.entrySet() ) {
 			final RocketComponent c = entry.getKey();
+
 			if (!c.isAerodynamic())
 				continue;
 
@@ -596,7 +597,7 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 				double cd = calcMap.get(c).calculatePressureCD(conditions, stagnation, base,
 															   warningSet);
 				total += cd;
-
+				
 				if (forceMap != null) {
 					forceMap.get(c).setPressureCD(cd);
 				}
@@ -625,7 +626,7 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 				}
 			}
 		}
-			
+		
 		return total;
 	}
 	

--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/FinSetCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/FinSetCalc.java
@@ -621,6 +621,12 @@ public class FinSetCalc extends RocketComponentCalc {
 	//		}
 	//		
 	//	}
+
+	@Override
+	public double calculateFrictionCD(FlightConditions conditions, double componentCf, WarningSet warnings) {
+		double cd = componentCf * (1 + 2 * thickness / macLength) * 2;
+		return cd;
+	}
 	
 	@Override
 	public double calculatePressureCD(FlightConditions conditions,

--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/FinSetCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/FinSetCalc.java
@@ -624,7 +624,7 @@ public class FinSetCalc extends RocketComponentCalc {
 
 	@Override
 	public double calculateFrictionCD(FlightConditions conditions, double componentCf, WarningSet warnings) {
-		double cd = componentCf * (1 + 2 * thickness / macLength) * 2;
+		double cd = componentCf * (1 + 2 * thickness / macLength) * 2 * finArea / conditions.getRefArea();
 		return cd;
 	}
 	

--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/LaunchLugCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/LaunchLugCalc.java
@@ -31,6 +31,12 @@ public class LaunchLugCalc extends RocketComponentCalc {
 	}
 
 	@Override
+	public double calculateFrictionCD(FlightConditions conditions, double componentCf, WarningSet warnings) {
+		// launch lug doesn't add enough area to worry about
+		return 0;
+	}
+
+	@Override
 	public double calculatePressureCD(FlightConditions conditions,
 			double stagnationCD, double baseCD, WarningSet warnings) {
 

--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/RocketComponentCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/RocketComponentCalc.java
@@ -28,6 +28,16 @@ public abstract class RocketComponentCalc {
 	public abstract void calculateNonaxialForces(FlightConditions conditions, Transformation transform,
 												 AerodynamicForces forces, WarningSet warnings);
 
+
+	/**
+	 * Calculates the friction drag of the component.
+	 *
+	 * @param conditions    the flight conditions
+	 * @param componentCF   component coefficient of friction, calculated in BarrowmanCalculator
+	 * @param warnings      set in which to to store possible warnings
+	 * @return              the friction drag coefficient of the component
+	 */
+	public abstract double calculateFrictionCD(FlightConditions conditions, double componentCf, WarningSet warnings);
 	
 	/**
 	 * Calculates the pressure drag of the component.  This component does NOT include
@@ -37,7 +47,7 @@ public abstract class RocketComponentCalc {
 	 * @param stagnationCD	the current stagnation drag coefficient
 	 * @param baseCD		the current base drag coefficient
 	 * @param warnings		set in which to store possible warnings
-	 * @return				the pressure drag of the component
+	 * @return				the pressure drag coefficient of the component
 	 */
 	public abstract double calculatePressureCD(FlightConditions conditions, 
 			double stagnationCD, double baseCD, WarningSet warnings);

--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/SymmetricComponentCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/SymmetricComponentCalc.java
@@ -45,6 +45,7 @@ public class SymmetricComponentCalc extends RocketComponentCalc {
 	private final double frontalArea;
 	private final double fullVolume;
 	private final double planformArea, planformCenter;
+	private final double wetArea;
 	private final double sinphi;
 	
 	public SymmetricComponentCalc(RocketComponent c) {
@@ -53,7 +54,6 @@ public class SymmetricComponentCalc extends RocketComponentCalc {
 			throw new IllegalArgumentException("Illegal component type " + c);
 		}
 		SymmetricComponent component = (SymmetricComponent) c;
-		
 
 		length = component.getLength();
 		foreRadius = component.getForeRadius();
@@ -63,6 +63,8 @@ public class SymmetricComponentCalc extends RocketComponentCalc {
 		fullVolume = component.getFullVolume();
 		planformArea = component.getComponentPlanformArea();
 		planformCenter = component.getComponentPlanformCenter();
+
+		wetArea = component.getComponentWetArea();
 		
 		if (component instanceof BodyTube) {
 			shape = null;
@@ -174,7 +176,10 @@ public class SymmetricComponentCalc extends RocketComponentCalc {
 				conditions.getSinAOA() * conditions.getSincAOA()); // sin(aoa)^2 / aoa
 	}
 	
-	
+	@Override
+	public double calculateFrictionCD(FlightConditions conditions, double componentCf, WarningSet warningSet) {
+		return componentCf * wetArea / conditions.getRefArea();
+	}
 
 	private LinearInterpolator interpolator = null;
 	

--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/TubeFinSetCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/TubeFinSetCalc.java
@@ -672,5 +672,11 @@ public class TubeFinSetCalc extends RocketComponentCalc {
 		
 		return 3 * component.getFinCount();
 	}
+
+	@Override
+	public double calculateFrictionCD(FlightConditions conditions, double componentCf, WarningSet warnings) {
+		// launch lug doesn't add enough area to worry about
+		return 0;
+	}
 	
 }


### PR DESCRIPTION
Clean up code for BarrowmanCalculator::calculateFrictionCD() and move code for computing friction CD to the appropriate subclasses of RocketComponentCalc.

Two unit test failures are from scripting issues

Simulation results for a tube fin rocket match the (wildly inaccurate) results from before this PR:
|Motor|Old|New|Flight Data|
|--------|----|------|--------------|
|C6|2549|2549|695.5|
|B6|734|734|352|
|A8|211|211|N/A|