### PR TITLE
generalize getOuterRadius() to set radius so tubes touch for number of tubes greater than 2 (ie whenever possible)

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/TubeFinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/TubeFinSet.java
@@ -85,35 +85,37 @@ public class TubeFinSet extends ExternalComponent implements AxialPositionable, 
 	 */
 	public double getOuterRadius() {
 		if (autoRadius) {
-			// Return auto radius from front or rear
-			double r = -1;
-			RocketComponent c = this.getParent();
-			if (c != null) {
-				if (c instanceof SymmetricComponent) {
-					r = ((SymmetricComponent) c).getAftRadius();
-				}
-			}
-			if (r < 0) {
-				r = DEFAULT_RADIUS;
+			if (fins < 3) {
+				return getBodyRadius();
 			} else {
-				// for 5,6, and 8 fins, adjust the diameter to provide touching fins.
-				switch (fins) {
-				case 5:
-					r *= 1.43; //  sin(36) / (1- sin(36), 36 = 360/5/2
-					break;
-				case 7:
-					r *= 0.77; // sin(25.7) / (1- sin(25.7)
-					break;
-				case 8:
-					r *= 0.62; // sin(22.5) / (1- sin(22.5)
-					break;
-				}
+				return getTouchingRadius();
 			}
-			return r;
 		}
 		return outerRadius;
 	}
-	
+
+	/**
+	 * Return whether the tubes are touching
+	 *
+	 * @return true if touching, false if not
+	 */
+	public boolean getTubesTouching() {
+		return getOuterRadius() > getTouchingRadius() - MathUtil.EPSILON;
+	}
+
+	/**
+	 * Return the required radius for the fins to be touching
+	 *
+	 * @return required radius
+	 */
+	private double getTouchingRadius() {
+		double r = getBodyRadius();
+		final double finSep = Math.PI / fins;
+		
+		r *= Math.sin(finSep)/(1.0 - Math.sin(finSep));
+		
+		return r;
+	}
 	/**
 	 * Set the outer radius of the tube-fin.  If the radius is less than the wall thickness,
 	 * the wall thickness is decreased accordingly of the value of the radius.
@@ -355,8 +357,8 @@ public class TubeFinSet extends ExternalComponent implements AxialPositionable, 
 		List<Coordinate> bounds = new ArrayList<Coordinate>();
 		double r = getBodyRadius();
 		
-		addBound(bounds, 0, 2 * (r + outerRadius));
-		addBound(bounds, length, 2 * (r + outerRadius));
+		addBound(bounds, 0, 2 * getBoundingRadius());
+		addBound(bounds, length, 2 * getBoundingRadius());
 		
 		return bounds;
 	}
@@ -364,8 +366,8 @@ public class TubeFinSet extends ExternalComponent implements AxialPositionable, 
 	@Override
 	public BoundingBox getInstanceBoundingBox() {
 		BoundingBox box = new BoundingBox();
-		box.update(new Coordinate(0, -outerRadius, -outerRadius));
-		box.update(new Coordinate(length, outerRadius, outerRadius));
+		box.update(new Coordinate(0, -getOuterRadius(), -getOuterRadius()));
+		box.update(new Coordinate(length, getOuterRadius(), getOuterRadius()));
 		return box;
 	}
 	
@@ -413,8 +415,7 @@ public class TubeFinSet extends ExternalComponent implements AxialPositionable, 
 
 	@Override
 	public double getBoundingRadius() {
-		// TODO Auto-generated method stub
-		return 0;
+		return getBodyRadius() + getOuterRadius();
 	}
 
 	@Override


### PR DESCRIPTION
create getTubesTouching() method to determine whether tubes are touching (will also return true if they overlap)

fix several places where outerRadius was used instead of getOuterRadius()