### PR TITLE
Revert "Refer to drag coefficient consistently as CD"

### DIFF
--- a/core/src/net/sf/openrocket/aerodynamics/AerodynamicForces.java
+++ b/core/src/net/sf/openrocket/aerodynamics/AerodynamicForces.java
@@ -51,7 +51,7 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 
 	
 	/** Axial drag coefficient, CA */
-	private double CDaxial = Double.NaN;
+	private double Caxial = Double.NaN;
 	
 	/** Total drag force coefficient, parallel to the airflow. */
 	private double CD = Double.NaN;
@@ -181,13 +181,13 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 		return CrollForce;
 	}
 
-	public void setCDaxial(double cdaxial) {
-		CDaxial = cdaxial;
+	public void setCaxial(double caxial) {
+		Caxial = caxial;
 		modID++;
 	}
 
-	public double getCDaxial() {
-		return CDaxial;
+	public double getCaxial() {
+		return Caxial;
 	}
 
 	public void setCD(double cD) {
@@ -277,7 +277,7 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 		setCroll(Double.NaN);
 		setCrollDamp(Double.NaN);
 		setCrollForce(Double.NaN);
-		setCDaxial(Double.NaN);
+		setCaxial(Double.NaN);
 		setCD(Double.NaN);
 		setPitchDampingMoment(Double.NaN);
 		setYawDampingMoment(Double.NaN);
@@ -299,7 +299,7 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 		setCroll(0);
 		setCrollDamp(0);
 		setCrollForce(0);
-		setCDaxial(0);
+		setCaxial(0);
 		setCD(0);
 		setPitchDampingMoment(0);
 		setYawDampingMoment(0);
@@ -334,7 +334,7 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 				MathUtil.equals(this.getCroll(), other.getCroll()) &&
 				MathUtil.equals(this.getCrollDamp(), other.getCrollDamp()) &&
 				MathUtil.equals(this.getCrollForce(), other.getCrollForce()) &&
-				MathUtil.equals(this.getCDaxial(), other.getCDaxial()) &&
+				MathUtil.equals(this.getCaxial(), other.getCaxial()) &&
 				MathUtil.equals(this.getCD(), other.getCD()) &&
 				MathUtil.equals(this.getPressureCD(), other.getPressureCD()) &&
 				MathUtil.equals(this.getBaseCD(), other.getBaseCD()) &&
@@ -346,7 +346,7 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 	
 	@Override
 	public int hashCode() {
-		return (int) (1000*(this.getCD()+this.getCDaxial()+this.getCNa())) + this.getCP().hashCode();
+		return (int) (1000*(this.getCD()+this.getCaxial()+this.getCNa())) + this.getCP().hashCode();
 	}
 	
 	
@@ -373,8 +373,8 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 		
 		if (!Double.isNaN(getCroll()))
 			text += "Croll:" + getCroll() + ",";
-		if (!Double.isNaN(getCDaxial()))
-			text += "CDaxial:" + getCDaxial() + ",";
+		if (!Double.isNaN(getCaxial()))
+			text += "Caxial:" + getCaxial() + ",";
 		
 		if (!Double.isNaN(getCD()))
 			text += "CD:" + getCD() + ",";

--- a/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
+++ b/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
@@ -82,11 +82,11 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 		// Calculate non-axial force data
 		calculateForceAnalysis(conditions, configuration.getRocket(), instMap, eachMap, assemblyMap, warnings);
 
-		// Calculate drag coefficient data
+		// Calculate friction data
 		AerodynamicForces rocketForces = assemblyMap.get(configuration.getRocket());
-		rocketForces.setFrictionCD(calculateFrictionCD(configuration, conditions, eachMap, warnings));
-		rocketForces.setPressureCD(calculatePressureCD(configuration, conditions, eachMap, warnings));
-		rocketForces.setBaseCD(calculateBaseCD(configuration, conditions, eachMap, warnings));
+		rocketForces.setFrictionCD(calculateFrictionDrag(configuration, conditions, eachMap, warnings));
+		rocketForces.setPressureCD(calculatePressureDrag(configuration, conditions, eachMap, warnings));
+		rocketForces.setBaseCD(calculateBaseDrag(configuration, conditions, eachMap, warnings));
 
 		Map<RocketComponent, AerodynamicForces> finalMap = new LinkedHashMap<>();
 		for(final RocketComponent comp : instMap.keySet()){
@@ -117,7 +117,7 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 				f.setFrictionCD(0);
 
 			f.setCD(f.getBaseCD() + f.getPressureCD() + f.getFrictionCD());
-			f.setCDaxial(calculateAxialCD(conditions, f.getCD()));
+			f.setCaxial(calculateAxialDrag(conditions, f.getCD()));
 
 			finalMap.put(comp, f);
 		}
@@ -177,13 +177,13 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 		AerodynamicForces total = calculateNonAxialForces(configuration, conditions, warnings);
 		
 		// Calculate friction data
-		total.setFrictionCD(calculateFrictionCD(configuration, conditions, null, warnings));
-		total.setPressureCD(calculatePressureCD(configuration, conditions, null, warnings));
-		total.setBaseCD(calculateBaseCD(configuration, conditions, null, warnings));
+		total.setFrictionCD(calculateFrictionDrag(configuration, conditions, null, warnings));
+		total.setPressureCD(calculatePressureDrag(configuration, conditions, null, warnings));
+		total.setBaseCD(calculateBaseDrag(configuration, conditions, null, warnings));
 		
 		total.setCD(total.getFrictionCD() + total.getPressureCD() + total.getBaseCD());
 		
-		total.setCDaxial(calculateAxialCD(conditions, total.getCD()));
+		total.setCaxial(calculateAxialDrag(conditions, total.getCD()));
 		
 		// Calculate pitch and yaw damping moments
 		calculateDampingMoments(configuration, conditions, total);
@@ -322,7 +322,7 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 	 * @param set				Set to handle 
 	 * @return friction drag for entire rocket
 	 */
-	private double calculateFrictionCD(FlightConfiguration configuration, FlightConditions conditions,
+	private double calculateFrictionDrag(FlightConfiguration configuration, FlightConditions conditions,
 			Map<RocketComponent, AerodynamicForces> map, WarningSet set) {
 		double c1 = 1.0, c2 = 1.0;
 		
@@ -523,7 +523,9 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 					if (map != null) {
 						map.get(c).setFrictionCD(cd / conditions.getRefArea());
 					}
+					
 				}
+				
 			}
 		}
 		
@@ -553,7 +555,7 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 	 * @param warningSet			all current warnings
 	 * @return
 	 */
-	private double calculatePressureCD(FlightConfiguration configuration, FlightConditions conditions,
+	private double calculatePressureDrag(FlightConfiguration configuration, FlightConditions conditions,
 			Map<RocketComponent, AerodynamicForces> forceMap, WarningSet warningSet) {
 		
 		double stagnation, base, total;
@@ -576,8 +578,8 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 			for(InstanceContext context: contextList ) {
 
 				// Pressure fore drag
-				double cd = calcMap.get(c).calculatePressureCD(conditions, stagnation, base,
-															   warningSet);
+				double cd = calcMap.get(c).calculatePressureDragForce(conditions, stagnation, base,
+																	  warningSet);
 				total += cd;
 
 				if (forceMap != null) {
@@ -622,8 +624,8 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 	 * @param warnings				all current warnings
 	 * @return
 	 */
-	private double calculateBaseCD(FlightConfiguration configuration, FlightConditions conditions,
-								   Map<RocketComponent, AerodynamicForces> map, WarningSet warnings) {
+	private double calculateBaseDrag(FlightConfiguration configuration, FlightConditions conditions,
+									 Map<RocketComponent, AerodynamicForces> map, WarningSet warnings) {
 		
 		double base, total;
 		
@@ -685,6 +687,8 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 		return total;
 	}
 	
+	
+	
 	/**
 	 * gets CD by the speed
 	 * @param m		Mach number for calculation
@@ -735,13 +739,13 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 	
 	
 	/**
-	 * Calculate the axial drag coefficient from the total drag coefficient.
+	 * Calculate the axial drag from the total drag coefficient.
 	 * 
 	 * @param conditions
 	 * @param cd
 	 * @return
 	 */
-	private double calculateAxialCD(FlightConditions conditions, double cd) {
+	private double calculateAxialDrag(FlightConditions conditions, double cd) {
 		double aoa = MathUtil.clamp(conditions.getAOA(), 0, Math.PI);
 		double mul;
 		

--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/FinSetCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/FinSetCalc.java
@@ -623,11 +623,11 @@ public class FinSetCalc extends RocketComponentCalc {
 	//	}
 	
 	@Override
-	public double calculatePressureCD(FlightConditions conditions,
-									  double stagnationCD, double baseCD, WarningSet warnings) {
+	public double calculatePressureDragForce(FlightConditions conditions,
+			double stagnationCD, double baseCD, WarningSet warnings) {
 		
 		double mach = conditions.getMach();
-		double cd = 0;
+		double drag = 0;
 		
 		// Pressure fore-drag
 		if (crossSection == FinSet.CrossSection.AIRFOIL ||
@@ -635,34 +635,34 @@ public class FinSetCalc extends RocketComponentCalc {
 			
 			// Round leading edge
 			if (mach < 0.9) {
-				cd = Math.pow(1 - pow2(mach), -0.417) - 1;
+				drag = Math.pow(1 - pow2(mach), -0.417) - 1;
 			} else if (mach < 1) {
-				cd = 1 - 1.785 * (mach - 0.9);
+				drag = 1 - 1.785 * (mach - 0.9);
 			} else {
-				cd = 1.214 - 0.502 / pow2(mach) + 0.1095 / pow2(pow2(mach));
+				drag = 1.214 - 0.502 / pow2(mach) + 0.1095 / pow2(pow2(mach));
 			}
 			
 		} else if (crossSection == FinSet.CrossSection.SQUARE) {
-			cd = stagnationCD;
+			drag = stagnationCD;
 		} else {
 			throw new UnsupportedOperationException("Unsupported fin profile: " + crossSection);
 		}
 		
 		// Slanted leading edge
-		cd *= pow2(cosGammaLead);
+		drag *= pow2(cosGammaLead);
 		
 		// Trailing edge drag
 		if (crossSection == FinSet.CrossSection.SQUARE) {
-			cd += baseCD;
+			drag += baseCD;
 		} else if (crossSection == FinSet.CrossSection.ROUNDED) {
-			cd += baseCD / 2;
+			drag += baseCD / 2;
 		}
 		// Airfoil assumed to have zero base drag
 		
 		// Scale to correct reference area
-		cd *= cd * span * thickness / conditions.getRefArea();
+		drag *= span * thickness / conditions.getRefArea();
 		
-		return cd;
+		return drag;
 	}
 	
 	private void calculateInterferenceFinCount(FinSet component) {

--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/LaunchLugCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/LaunchLugCalc.java
@@ -31,7 +31,7 @@ public class LaunchLugCalc extends RocketComponentCalc {
 	}
 
 	@Override
-	public double calculatePressureCD(FlightConditions conditions,
+	public double calculatePressureDragForce(FlightConditions conditions,
 			double stagnationCD, double baseCD, WarningSet warnings) {
 
 		return CDmul*stagnationCD * refArea / conditions.getRefArea();

--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/RocketComponentCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/RocketComponentCalc.java
@@ -39,6 +39,6 @@ public abstract class RocketComponentCalc {
 	 * @param warnings		set in which to store possible warnings
 	 * @return				the pressure drag of the component
 	 */
-	public abstract double calculatePressureCD(FlightConditions conditions, 
+	public abstract double calculatePressureDragForce(FlightConditions conditions, 
 			double stagnationCD, double baseCD, WarningSet warnings);
 }

--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/SymmetricComponentCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/SymmetricComponentCalc.java
@@ -179,7 +179,7 @@ public class SymmetricComponentCalc extends RocketComponentCalc {
 	private LinearInterpolator interpolator = null;
 	
 	@Override
-	public double calculatePressureCD(FlightConditions conditions,
+	public double calculatePressureDragForce(FlightConditions conditions,
 			double stagnationCD, double baseCD, WarningSet warnings) {
 		
 		// Check for simple cases first

--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/TubeFinSetCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/TubeFinSetCalc.java
@@ -622,11 +622,11 @@ public class TubeFinSetCalc extends RocketComponentCalc {
 	//	}
 	
 	@Override
-	public double calculatePressureCD(FlightConditions conditions,
+	public double calculatePressureDragForce(FlightConditions conditions,
 			double stagnationCD, double baseCD, WarningSet warnings) {
 		
 		double mach = conditions.getMach();
-		double cd = 0;
+		double drag = 0;
 		
 		// Pressure fore-drag
 		if (crossSection == FinSet.CrossSection.AIRFOIL ||
@@ -634,34 +634,34 @@ public class TubeFinSetCalc extends RocketComponentCalc {
 			
 			// Round leading edge
 			if (mach < 0.9) {
-				cd = Math.pow(1 - pow2(mach), -0.417) - 1;
+				drag = Math.pow(1 - pow2(mach), -0.417) - 1;
 			} else if (mach < 1) {
-				cd = 1 - 1.785 * (mach - 0.9);
+				drag = 1 - 1.785 * (mach - 0.9);
 			} else {
-				cd = 1.214 - 0.502 / pow2(mach) + 0.1095 / pow2(pow2(mach));
+				drag = 1.214 - 0.502 / pow2(mach) + 0.1095 / pow2(pow2(mach));
 			}
 			
 		} else if (crossSection == FinSet.CrossSection.SQUARE) {
-			cd = stagnationCD;
+			drag = stagnationCD;
 		} else {
 			throw new UnsupportedOperationException("Unsupported fin profile: " + crossSection);
 		}
 		
 		// Slanted leading edge
-		cd *= pow2(cosGammaLead);
+		drag *= pow2(cosGammaLead);
 		
 		// Trailing edge drag
 		if (crossSection == FinSet.CrossSection.SQUARE) {
-			cd += baseCD;
+			drag += baseCD;
 		} else if (crossSection == FinSet.CrossSection.ROUNDED) {
-			cd += baseCD / 2;
+			drag += baseCD / 2;
 		}
 		// Airfoil assumed to have zero base drag
 		
 		// Scale to correct reference area
-		cd *= finCount * span * thickness / conditions.getRefArea();
+		drag *= finCount * span * thickness / conditions.getRefArea();
 		
-		return cd;
+		return drag;
 	}
 	
 	private static int calculateInterferenceFinCount(TubeFinSet component) {

--- a/core/src/net/sf/openrocket/simulation/RK4SimulationStepper.java
+++ b/core/src/net/sf/openrocket/simulation/RK4SimulationStepper.java
@@ -341,7 +341,7 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 		
 
 		// Linear forces in rocket coordinates
-		store.dragForce = store.forces.getCDaxial() * dynP * refArea;
+		store.dragForce = store.forces.getCaxial() * dynP * refArea;
 		double fN = store.forces.getCN() * dynP * refArea;
 		double fSide = store.forces.getCside() * dynP * refArea;
 		
@@ -646,7 +646,7 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 		
 		if (store.forces != null) {
 			data.setValue(FlightDataType.TYPE_DRAG_COEFF, store.forces.getCD());
-			data.setValue(FlightDataType.TYPE_AXIAL_DRAG_COEFF, store.forces.getCDaxial());
+			data.setValue(FlightDataType.TYPE_AXIAL_DRAG_COEFF, store.forces.getCaxial());
 			data.setValue(FlightDataType.TYPE_FRICTION_DRAG_COEFF, store.forces.getFrictionCD());
 			data.setValue(FlightDataType.TYPE_PRESSURE_DRAG_COEFF, store.forces.getPressureCD());
 			data.setValue(FlightDataType.TYPE_BASE_DRAG_COEFF, store.forces.getBaseCD());

--- a/core/test/net/sf/openrocket/aerodynamics/SymmetricComponentCalcTest.java
+++ b/core/test/net/sf/openrocket/aerodynamics/SymmetricComponentCalcTest.java
@@ -136,7 +136,7 @@ public class SymmetricComponentCalcTest {
 			double m = i/20.0;
 			String buf = "SymmetricComponentCalc produces bad Cd at index " + i + "(m=" + m +")";
 			conditions.setMach(m);
-			double testcd = calcObj.calculatePressureCD(conditions, 0.0,  0.0, warnings) *
+			double testcd = calcObj.calculatePressureDragForce(conditions, 0.0,  0.0, warnings) *
 				conditions.getRefArea() / frontalArea;
 			assertEquals(buf, cd[(int) Math.round(m*20)], testcd, EPSILON);
 	    }


### PR DESCRIPTION
Reverts openrocket/openrocket#1273

ant unittest may put test reports in two places:  .../swing/tmp/test-reports/index.html or .../core/tmp/test-reports/index.html.  If it puts any under ...core you don't get an indication that there may also be one under .../swing.  It turns out that in addition to the unit test failures from scripting, there was also a unit test failure in simulation.  This reverts this PR so I can look into it some more and resubmit.