### PR TITLE
[Fixes Issue #1292]  Calculates per fin mass when splitting a set of fins with a mass override

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -28,8 +28,11 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 	 * Maximum allowed cant of fins.
 	 */
 	public static final double MAX_CANT_RADIANS = (15.0 * Math.PI / 180);
-	
-	public enum CrossSection {
+
+    public void setOverrideMass() {
+    }
+
+    public enum CrossSection {
 		//// Square
 		SQUARE(trans.get("FinSet.CrossSection.SQUARE"), 1.00),
 		//// Rounded

--- a/swing/src/net/sf/openrocket/gui/configdialog/FinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/FinSetConfig.java
@@ -129,6 +129,7 @@ public abstract class FinSetConfig extends RocketComponentConfig {
 							copy.setFinCount(1);
 							copy.setBaseRotation(base + i * 2 * Math.PI / count);
 							copy.setName(copy.getName() + " #" + (i + 1));
+							copy.setOverrideMass(((FinSet) component).getOverrideMass()/((FinSet) component).getFinCount());
 							parent.addChild(copy, index + i);
 						}
 					}


### PR DESCRIPTION
If a set of fins has an overridden mass, then, if the set is split into individual fins, the overridden mass is divided by the number of fins in the set and the quotient is set as the mass override for each individual fin.