### PR TITLE
Fix the invalid link to CONTRIBUTING.MD in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ OpenRocket is an Open Source project licensed under the [GNU GPL](https://www.gn
 
 Contributing
 ------------
-OpenRocket needs help to become even better. Implementing features, writing documentation and creating example designs are just a few ways of helping. If you are interested in helping make OpenRocket the best rocket simulator out there, please [click here for information on how to get involved](http://openrocket.sourceforge.net/getinvolved.html) and [read the practicalities of contributing here](CONTRIBUTING.md).
+OpenRocket needs help to become even better. Implementing features, writing documentation and creating example designs are just a few ways of helping. If you are interested in helping make OpenRocket the best rocket simulator out there, please [click here for information on how to get involved](http://openrocket.sourceforge.net/getinvolved.html) and [read the practicalities of contributing here]( CONTRIBUTING.md).
 
 **Contributors**
 - Sampo Niskanen, main developer

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ OpenRocket is an Open Source project licensed under the [GNU GPL](https://www.gn
 
 Contributing
 ------------
-OpenRocket needs help to become even better. Implementing features, writing documentation and creating example designs are just a few ways of helping. If you are interested in helping make OpenRocket the best rocket simulator out there, please [click here for information on how to get involved](http://openrocket.sourceforge.net/getinvolved.html) and [read the practicalities of contributing here]( CONTRIBUTING.md).
+OpenRocket needs help to become even better. Implementing features, writing documentation and creating example designs are just a few ways of helping. If you are interested in helping make OpenRocket the best rocket simulator out there, please [click here for information on how to get involved](http://openrocket.sourceforge.net/getinvolved.html) and [read the practicalities of contributing here](CONTRIBUTING.md).
 
 **Contributors**
 - Sampo Niskanen, main developer

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ OpenRocket is an Open Source project licensed under the [GNU GPL](https://www.gn
 
 Contributing
 ------------
-OpenRocket needs help to become even better. Implementing features, writing documentation and creating example designs are just a few ways of helping. If you are interested in helping make OpenRocket the best rocket simulator out there, please [click here for information on how to get involved](http://openrocket.sourceforge.net/getinvolved.html) and [read the practicalities of contributing here](.github/CONTRIBUTING.md).
+OpenRocket needs help to become even better. Implementing features, writing documentation and creating example designs are just a few ways of helping. If you are interested in helping make OpenRocket the best rocket simulator out there, please [click here for information on how to get involved](http://openrocket.sourceforge.net/getinvolved.html) and [read the practicalities of contributing here](CONTRIBUTING.md).
 
 **Contributors**
 - Sampo Niskanen, main developer


### PR DESCRIPTION
Under the contributing section of the README, the link at "read the practicalities of contributing here" links to .github/CONTRIBUTING.md, however a recent commit moved that file out of the github folder so now that link is invalid.
This PR fixes that link.