### PR TITLE
fixes #1304 Improve thrust curve import dialog

### DIFF
--- a/swing/src/net/sf/openrocket/database/MotorDatabaseLoader.java
+++ b/swing/src/net/sf/openrocket/database/MotorDatabaseLoader.java
@@ -1,5 +1,6 @@
 package net.sf.openrocket.database;
 
+import java.awt.Dialog;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -24,6 +25,7 @@ import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.BugException;
 import net.sf.openrocket.util.Pair;
 
+import javax.swing.JDialog;
 import javax.swing.JOptionPane;
 
 /**
@@ -147,8 +149,10 @@ public class MotorDatabaseLoader extends AsynchronousDatabaseLoader {
 				String message = "<html><body><p style='width: 400px;'><i>" + e.getMessage() +
 						"</i>.<br><br>" + MessageFormat.format( trans.get("MotorDbLoaderDlg.message1"), f.getU()) +
 						"<br>" + trans.get("MotorDbLoaderDlg.message2") + "</p></body></html>";
-				JOptionPane.showMessageDialog(null,
-						message, trans.get("MotorDbLoaderDlg.title"), JOptionPane.WARNING_MESSAGE);
+				JOptionPane pane = new JOptionPane(message, JOptionPane.WARNING_MESSAGE);
+				JDialog dialog = pane.createDialog(null, trans.get("MotorDbLoaderDlg.title"));
+				dialog.setModalityType(Dialog.ModalityType.DOCUMENT_MODAL);
+				dialog.setVisible(true);
 			}
 			f.getV().close();
 		} catch (IOException e) {

--- a/swing/src/net/sf/openrocket/database/MotorDatabaseLoader.java
+++ b/swing/src/net/sf/openrocket/database/MotorDatabaseLoader.java
@@ -146,8 +146,10 @@ public class MotorDatabaseLoader extends AsynchronousDatabaseLoader {
 			}
 			catch (IllegalArgumentException e) {
 				Translator trans = Application.getTranslator();
+				File thrustCurveDir = ((SwingPreferences) Application.getPreferences()).getDefaultUserThrustCurveFile();
+				File fullPath = new File(thrustCurveDir, f.getU());
 				String message = "<html><body><p style='width: 400px;'><i>" + e.getMessage() +
-						"</i>.<br><br>" + MessageFormat.format( trans.get("MotorDbLoaderDlg.message1"), f.getU()) +
+						"</i>.<br><br>" + MessageFormat.format( trans.get("MotorDbLoaderDlg.message1"), fullPath.getPath()) +
 						"<br>" + trans.get("MotorDbLoaderDlg.message2") + "</p></body></html>";
 				JOptionPane pane = new JOptionPane(message, JOptionPane.WARNING_MESSAGE);
 				JDialog dialog = pane.createDialog(null, trans.get("MotorDbLoaderDlg.title"));


### PR DESCRIPTION
This PR fixes #1304 where the thrust curve error dialog was not accessible due to the loading motor dialog's modality. Additionally the full file path of the erroneous thrustcurve is now shown instead of only the thrustcurve name