### PR TITLE
Add listener for changes to rocket to component analysis dialog

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
@@ -418,7 +418,8 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 
 
 
-		// Add the data updater to listen to changes in aoa and theta
+		// Add the data updater to listen to changes
+		rkt.addChangeListener(this);
 		mach.addChangeListener(this);
 		theta.addChangeListener(this);
 		aoa.addChangeListener(this);
@@ -434,9 +435,10 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 				theta.setValue(initTheta);
 
 				//System.out.println("Closing method called: " + this);
+				rkt.removeChangeListener(ComponentAnalysisDialog.this);
+				mach.removeChangeListener(ComponentAnalysisDialog.this);
 				theta.removeChangeListener(ComponentAnalysisDialog.this);
 				aoa.removeChangeListener(ComponentAnalysisDialog.this);
-				mach.removeChangeListener(ComponentAnalysisDialog.this);
 				roll.removeChangeListener(ComponentAnalysisDialog.this);
 				//System.out.println("SETTING NAN VALUES");
 				rocketPanel.setCPAOA(Double.NaN);


### PR DESCRIPTION
Fixes #1302 (Splitting FinSet causes null pointer exception closing component analysis dialog)

The problem was more general than that: the component analysis dialog simply wasn't listening to changes in the rocket. Adding the listener fixes the null pointer exception, and also makes the analysis "keep up" with changes in configuration dialogs.