### PR TITLE
consider instance count in component mass

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
@@ -1377,7 +1377,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 			massSubtotal += rc.getSectionMass();
 		}
 		
-		return massSubtotal;
+		return massSubtotal * getInstanceCount();
 	}
 	
 	/**


### PR DESCRIPTION
Fixes #1291 (I think)

The more I think about it, the more I think the resolution of the actual bug report is "works as intended".  If you're looking at one fin, you should get one fin's mass in the tooltip.

On the other hand, the report alerted me to the fact that when hovering over the podset that is the finset's parent, it doesn't reflect the number of pods.  Just as a finset's mass should reflect the number of fins, a podset's mass should reflect the number of pods.

So this PR ends up not changing the mass reported for a finset or other component that is a child of a podset (still only one fin, in this case), but does change the reported mass of the parent podset.

So whether this fully or only partially fixes the issue depends on whether people agree with me on the correct behavior.