### PR TITLE
[fixes #1320] Remove 'Custom' material option from preference's add new material

### DIFF
--- a/core/src/net/sf/openrocket/material/Material.java
+++ b/core/src/net/sf/openrocket/material/Material.java
@@ -19,11 +19,11 @@ import net.sf.openrocket.util.MathUtil;
 public abstract class Material implements Comparable<Material> {
 	
 	private static final Translator trans = Application.getTranslator();
-	
+
 	public enum Type {
-		LINE("Databases.materials.types.Line", UnitGroup.UNITS_DENSITY_LINE),
-		SURFACE("Databases.materials.types.Surface", UnitGroup.UNITS_DENSITY_SURFACE),
 		BULK("Databases.materials.types.Bulk", UnitGroup.UNITS_DENSITY_BULK),
+		SURFACE("Databases.materials.types.Surface", UnitGroup.UNITS_DENSITY_SURFACE),
+		LINE("Databases.materials.types.Line", UnitGroup.UNITS_DENSITY_LINE),
 		CUSTOM("Databases.materials.types.Custom", UnitGroup.UNITS_DENSITY_BULK);
 		
 		private final String name;

--- a/swing/src/net/sf/openrocket/gui/dialogs/CustomMaterialDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/CustomMaterialDialog.java
@@ -4,6 +4,10 @@ import java.awt.Dialog;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
 
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -78,7 +82,13 @@ public class CustomMaterialDialog extends JDialog {
 		// Material type (if not known)
 		panel.add(new JLabel(trans.get("custmatdlg.lbl.Materialtype")));
 		if (material == null) {
-			typeBox = new JComboBox<Material.Type>(Material.Type.values());
+			// Remove the CUSTOM material option from the dropdown box
+			Material.Type[] values = Material.Type.values();
+			List<Material.Type> values_list = new LinkedList<>(Arrays.asList(values));
+			values_list.remove(Material.Type.CUSTOM);
+			values = values_list.toArray(new Material.Type[0]);
+
+			typeBox = new JComboBox<>(values);
 			typeBox.setSelectedItem(Material.Type.BULK);
 			typeBox.setEditable(false);
 			typeBox.addActionListener(new ActionListener() {


### PR DESCRIPTION
In the preference's material tab, when adding a new material there was an option to select 'Custom' as material type, which just makes no sense from a user's standpoint. It is used internally in the codebase for a bunch of stuff, but should not be included in the dropdown box. This PR removes the Custom material type from the dropdown box and thus fixes #1320.

Unit test failures due to the scripting bug.