### PR TITLE
Set initial spark concentration and weight to 10%

### DIFF
--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettings.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettings.java
@@ -32,12 +32,12 @@ public class PhotoSettings extends AbstractChangeSource implements FlameSettings
 	private boolean smoke = false;
 	private Color smokeColor = new Color(230, 230, 230, 102);
 	private double smokeOpacity = 0.4;
-	private boolean sparks = false;
 	private double exhaustScale = 1.0;
 	private double flameAspectRatio = 1.0;
-	
-	private double sparkConcentration = 0;
-	private double sparkWeight = 0;
+
+	private boolean sparks = false;
+	private double sparkConcentration = 0.1;
+	private double sparkWeight = 0.1;
 	
 	private Sky sky = Mountains.instance;
 	


### PR DESCRIPTION
When turning on a feathure, I believe that the user expects to see that it works, not to have to adjust its settings to see if it works. This does that.