### PR TITLE
Revised presets to allow .orc files re parachute spill holes and canopy surface area

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -15,6 +15,7 @@
 ! Set to the name of the current translation file (used for debugging purposes)
 debug.currentFile = messages.properties
 
+
 ! RocketActions
 RocketActions.checkbox.Donotaskmeagain = Do not ask me again
 RocketActions.lbl.Youcanchangedefop = You can change the default operation in the preferences.
@@ -42,6 +43,7 @@ RocketActions.MoveUpAct.ttip.Moveup = Move this component upwards.
 RocketActions.MoveDownAct.Movedown = Move down
 RocketActions.MoveDownAct.ttip.Movedown = Move this component downwards.
 
+
 ! RocketPanel
 RocketPanel.FigTypeAct.SideView = Side view
 RocketPanel.FigTypeAct.BackView = Back view
@@ -49,10 +51,10 @@ RocketPanel.FigTypeAct.Figure3D = 3D Figure
 RocketPanel.FigTypeAct.Finished = 3D Finished
 RocketPanel.FigTypeAct.Unfinished = 3D Unfinished
 
-
 RocketPanel.lbl.Flightcfg = Flight configuration:
 RocketPanel.lbl.infoMessage = <html>Click to select &nbsp;&nbsp; Shift+click to select other &nbsp;&nbsp; Double-click to edit &nbsp;&nbsp; Click+drag to move
 RocketPanel.lbl.ViewType          = View Type:
+
 
 ! BasicFrame
 BasicFrame.tab.Rocketdesign = Rocket design
@@ -84,10 +86,12 @@ button.ok = OK
 button.cancel = Cancel
 button.close = Close
 
+
 ! Common labels used in buttons of dialog windows
 dlg.but.ok = OK
 dlg.but.cancel = Cancel
 dlg.but.close = Close
+
 
 ! General file type names
 FileHelper.CSV_FILTER = Comma Separated Files (*.csv)
@@ -125,6 +129,7 @@ printdlg.but.settings = Settings
 PrintDialog.error.preview.title = Unable to open preview
 PrintDialog.error.preview.desc1 = Unable to open PDF preview.
 PrintDialog.error.preview.desc2 = Please use the "Save as PDF" option instead.
+
 
 !PrintSettingsDialog
 PrintSettingsDialog.title = Print settings
@@ -176,6 +181,7 @@ debuglogdlg.lbl.Stacktrace = Stack trace:
 ! MotorChooserDialog
 MotorChooserDialog.title = Select a rocket motor
 
+
 ! Edit Motor configuration dialog
 edtmotorconfdlg.col.configuration = Configuration
 edtmotorconfdlg.but.Removeconfiguration = Remove Configuration
@@ -206,10 +212,12 @@ edtmotorconfdlg.but.Selectseparation = Select separation
 edtmotorconfdlg.tbl.Stageheader = Stage
 edtmotorconfdlg.tbl.Separationheader = Separation
 
+
 ! Rename FlightConfiguration Dialog
 RenameConfigDialog.title = Rename Configuration
 RenameConfigDialog.lbl.name = Name for flight configuration:
 RenameConfigDialog.but.reset = Reset to default
+
 
 ! Example design dialog
 exdesigndlg.but.open = Open
@@ -237,6 +245,7 @@ matedtpan.but.ttip.revertall = Delete all user-defined materials
 matedtpan.title.Deletealluser-defined = Delete all user-defined materials?
 matedtpan.title.Revertall = Revert all?
 matedtpan.lbl.edtmaterials = Editing materials will not affect existing rocket designs.
+
 
 !MaterialModel
 MaterialModel.title.Material = Material
@@ -331,6 +340,7 @@ generalprefs.lbl.language = Interface language
 generalprefs.languages.default = System default
 generalprefs.lbl.languageEffect = The language will change the next time you start OpenRocket.
 
+
 ! Software update checker
 update.dlg.error.title = Unable to retrieve update information
 update.dlg.error = An error occurred while communicating with the server.
@@ -349,6 +359,7 @@ update.dlg.updateAvailable.combo.noDownloads = No downloads available
 update.fetcher.badResponse = Bad response code from server: %d
 update.fetcher.badConnection = Could not connect to the GitHub server. Please check your internet connection.
 update.fetcher.malformedURL = Malformed URL: %s
+
 
 ! Simulation edit dialog
 simedtdlg.but.runsimulation = Run simulation
@@ -473,8 +484,6 @@ GeodeticComputationStrategy.wgs84.name = WGS84 ellipsoid
 GeodeticComputationStrategy.wgs84.desc = <html>Perform geodetic computations on the WGS84 reference ellipsoid using Vincenty's method.<br>Slower and unnecessary in most cases.
 
 
-
-
 ! Simulation Panel
 simpanel.but.newsimulation = New simulation
 simpanel.but.editsimulation = Edit simulation
@@ -511,6 +520,7 @@ simpanel.ttip.noData = No simulation data available.
 simpanel.ttip.noWarnings = <font color=\"gray\">No warnings.</font>
 simpanel.ttip.warnings = <font color=\"red\">Warnings:</font>
 
+
 ! SimulationRunDialog
 SimuRunDlg.title.RunSim = Running simulations\u2026
 SimuRunDlg.lbl.Running = Running\u2026
@@ -528,7 +538,9 @@ BasicEventSimulationEngine.error.NaNResult = Simulation resulted in not-a-number
 
 RK4SimulationStepper.error.valuesTooLarge = Simulation values exceeded limits.  Try selecting a shorter time step.
 
+
 SimulationModifierTree.OptimizationParameters = Optimization Parameters
+
 
 ! SimulationExportPanel
 SimExpPan.border.Vartoexport = Variables to export
@@ -570,6 +582,7 @@ customExpression.Units = Units
 customExpression.Operator = Operator
 customExpression.Description = Description
 
+
 ! Custom expression panel
 customExpressionPanel.but.NewExpression = New expression
 customExpressionPanel.but.ttip.NewExpression = Add a new custom expression
@@ -594,11 +607,14 @@ ExpressionBuilderDialog.led.ttip.Expression = Expression must use only known sym
 ExpressionBuilderDialog.CopyToOtherSimulations = Copy to other simulations
 ExpressionBuilderDialog.CopyToOtherSimulations.ttip = <html>Make a copy of this expression in other simulations in this document.<br>Will not overwrite or modify any existing expressions in other simulations.
 
+
 ! Custom expression variable selector
 CustomVariableSelector.title = Variable Selector
 
+
 ! Custom operator selector
 CustomOperatorSelector.title = Operator Selector
+
 
 ! Operators
 Operator.plus = Addition
@@ -639,6 +655,7 @@ Operator.binf = Gives the fraction of values in a given range (1st parameter) in
 Operator.trapz = Integrates the given range using trapezoidal integration
 Operator.tnear = Find the time corresponding to the point in a range (1st parameter) nearest to a given value (2nd parameter)
 
+
 ! MotorPlot
 MotorPlot.title.Motorplot = Motor plot
 MotorPlot.but.Select = Select
@@ -650,6 +667,7 @@ MotorPlot.txt.Manufacturer = Manufacturer:
 MotorPlot.txt.Type = Type:
 MotorPlot.txt.Delays = Delays:
 MotorPlot.txt.Comment = Comment:\n
+
 
 ! Simulation plot panel
 simplotpanel.title.Plotsim = Plot / Export simulation
@@ -672,6 +690,7 @@ simplotpanel.RIGHT_NAME = Right
 simplotpanel.CUSTOM = Custom
 SimulationPlotPanel.error.noPlotSelected = Please add one or more variables to plot on the Y-axis.
 SimulationPlotPanel.error.noPlotSelected.title = Nothing to plot
+
 
 ! Component add buttons
 compaddbuttons.AxialStage = Stage
@@ -708,6 +727,7 @@ compaddbuttons.lbl.insertstage = Insert the stage after the current stage or as 
 compaddbuttons.askPosition.Inserthere = Insert here
 compaddbuttons.askPosition.Addtotheend = Add to the end
 compaddbuttons.askPosition.Cancel = Cancel
+
 
 ! Component Analysis Dialog
 componentanalysisdlg.componentanalysis = Component analysis
@@ -748,6 +768,7 @@ componentanalysisdlg.TabStability.Col.Component = Component
 componentanalysisdlg.TOTAL = Total
 componentanalysisdlg.noWarnings = <html><i><font color=\"gray\">No warnings.</font></i>
 
+
 ! Custom Material dialog
 custmatdlg.title.Custommaterial = Custom material
 custmatdlg.lbl.Materialname = Material name:
@@ -776,6 +797,7 @@ ringcompcfg.note.desc = Note: An inner tube will not affect the aerodynamics of 
 
 
 ! Body Tube Config
+BodyTube.BodyTube = Body Tube
 BodyTubecfg.lbl.Bodytubelength = Length:
 BodyTubecfg.lbl.Outerdiameter = Outer diameter:
 BodyTubecfg.lbl.Innerdiameter = Inner diameter:
@@ -789,6 +811,7 @@ BodyTubecfg.checkbox.ttip.Automatic = Use the diameter of the previous/next comp
 BodyTubecfg.checkbox.ttip.Automatic_noReferenceComponent = There is no previous/next component to take the diameter of
 BodyTubecfg.checkbox.ttip.Automatic_alreadyAuto = The previous/next component already has its auto setting turned on
 BodyTubecfg.checkbox.Filled = Filled
+
 
 ! FinSetConfig
 FinSetConfig.tab.Fintabs = Fin tabs
@@ -808,17 +831,21 @@ FinSetConfig.lbl.Tabposition = Tab position:
 FinSetConfig.ttip.Tabposition = The position of the fin tab.
 FinSetConfig.lbl.relativeto = relative to
 
+
 !FinMarkingGuide
 FinMarkingGuide.lbl.Front = Front
+
 
 ! MotorDatabaseLoaderDialog
 MotorDbLoaderDlg.title = Error upon thrust curve import
 MotorDbLoaderDlg.message1 = Thrust curve '<b>'{0}'</b>' will be ignored during import.
 MotorDbLoaderDlg.message2 = You can try replacing, deleting or manually editing the thrust curve file to fix this issue.
 
+
 ! MotorDatabaseLoadingDialog
 MotorDbLoadDlg.title = Loading motors
 MotorDbLoadDlg.Loadingmotors = Loading motors\u2026
+
 
 ! AppearanceConfig
 AppearanceCfg.lbl.Appearance = Appearance
@@ -844,11 +871,13 @@ AppearanceCfg.lbl.ttip.separateLeftSideRightSide = Use a separate appearance for
 AppearanceCfg.lbl.AppearanceEdges = Appearance for edges:
 AppearanceCfg.lbl.ttip.AppearanceEdges = Select the appearance that should be used for the edges
 
+
 ! Texture Wrap Modes
 TextureWrap.Repeat = Repeat
 TextureWrap.Mirror = Repeat & Mirror
 TextureWrap.Clamp = Clamp Edge Pixels
 TextureWrap.Sticker = Sticker
+
 
 ! RocketConfig
 RocketCfg.lbl.Designname = Design name:
@@ -856,6 +885,7 @@ RocketCfg.lbl.Designer = Designer:
 RocketCfg.lbl.Comments = Comments:
 RocketCfg.lbl.Revisionhistory = Revision history:
 RocketCfg.lbl.Material = Material:
+
 
 ! RocketComponentConfig
 RocketCompCfg.lbl.Componentname = Component name:
@@ -903,6 +933,8 @@ RocketCompCfg.ttip.Endcapped = Whether the end of the shoulder is capped.
 RocketCompCfg.title.Noseconeshoulder = Nose cone shoulder
 RocketCompCfg.title.Aftshoulder = Aft shoulder
 RocketCompCfg.border.Foreshoulder = Fore shoulder
+
+
 !RocketCompCfg.lbl.Length = Length:
 RocketCompCfg.lbl.InstanceCount = Instance Count
 RocketCompCfg.lbl.InstanceSeparation = Instance Separation
@@ -911,23 +943,29 @@ RocketCompCfg.tab.Inside = Inside
 RocketCompCfg.tab.RightSide = Right Side
 RocketCompCfg.tab.LeftSide = Left Side
 
+
 ! BulkheadConfig
+Bulkhead.Bulkhead = Bulkhead
 BulkheadCfg.tab.Diameter = Diameter:
 BulkheadCfg.tab.Thickness = Thickness:
 BulkheadCfg.tab.General = General
 BulkheadCfg.tab.Generalproperties = General properties
 
+
 !CenteringRingConfig
+CenteringRing.CenteringRing = Centering Ring
 CenteringRingCfg.tab.Outerdiam = Outer diameter:
 CenteringRingCfg.tab.Innerdiam = Inner diameter:
 CenteringRingCfg.tab.Thickness = Thickness:
 CenteringRingCfg.tab.General = General
 CenteringRingCfg.tab.Generalproperties = General properties
 
+
 !ComponentConfigDialog
 ComponentCfgDlg.configuration = configuration
 ComponentCfgDlg.configuration1 =
 ComponentCfgDlg.Modify = Modify
+
 
 !StageConfig
 StageConfig.tab.Separation = Separation
@@ -939,6 +977,7 @@ StageConfig.parallel.radius = Radial Distance
 StageConfig.parallel.angle = Angle
 StageConfig.parallel.count = Number of Copies
 StageConfig.parallel.offset = Offset Value
+
 
 !EllipticalFinSetConfig
 EllipticalFinSetCfg.Nbroffins = Number of fins:
@@ -954,7 +993,9 @@ EllipticalFinSetCfg.General = General
 EllipticalFinSetCfg.Generalproperties = General properties
 EllipticalFinSetCfg.ttip.Fincant = The angle that the fins are canted with respect to the rocket body.
 
+
 !FreeformFinSetConfig
+FreeformFinSet.FreeformFinSet = Freeform Fin Set
 FreeformFinSetCfg.tab.General = General
 FreeformFinSetCfg.tab.ttip.General = General properties
 FreeformFinSetCfg.tab.Shape = Shape
@@ -975,7 +1016,9 @@ FreeformFinSetConfig.lbl.ctrlClick = Ctrl+click: Remove point
 FreeformFinSetConfig.lbl.scaleFin = Scale Fin
 FreeformFinSetConfig.lbl.exportCSV = Export CSV
 
+
 !TubeFinSetConfig
+TubeFinSet.TubeFinSet = Tube Fin Set
 TubeFinSetCfg.lbl.Nbroffins = Number of fins:
 TubeFinSetCfg.lbl.Length = Length:
 TubeFinSetCfg.lbl.Outerdiam = Outer diameter:
@@ -985,7 +1028,9 @@ TubeFinSetCfg.lbl.Thickness = Thickness:
 TubeFinSetCfg.lbl.Finrotation = Fin rotation:
 TubeFinSetCfg.lbl.ttip.Finrotation = The angle of the first fin in the fin set.
 
+
 !InnerTubeConfig
+InnerTube.InnerTube = Inner Tube
 InnerTubeCfg.tab.Motor = Motor
 InnerTubeCfg.tab.ttip.Motor = Motor mount configuration
 InnerTubeCfg.tab.Cluster = Cluster
@@ -1004,7 +1049,9 @@ InnerTubeCfg.lbl.longA2 = This also duplicates all components attached to this i
 InnerTubeCfg.but.Resetsettings = Reset settings
 InnerTubeCfg.but.ttip.Resetsettings = Reset the separation and rotation to the default values
 
+
 ! LaunchLugConfig
+LaunchLug.Launchlug = Launch Lug
 LaunchLugCfg.lbl.Length = Length:
 LaunchLugCfg.lbl.Outerdiam = Outer diameter:
 LaunchLugCfg.lbl.Innerdiam = Inner diameter:
@@ -1015,7 +1062,9 @@ LaunchLugCfg.lbl.plus = plus
 LaunchLugCfg.tab.General = General
 LaunchLugCfg.tab.Generalprop = General properties
 
+
 ! RailButtonConfig
+RailButton.RailButton = Rail Button
 RailBtnCfg.lbl.OuterDiam = Outer Diameter:
 RailBtnCfg.lbl.TotalHeight = Total Height
 RailBtnCfg.lbl.Angle = Rotation:
@@ -1023,6 +1072,7 @@ RailBtnCfg.lbl.PosRelativeTo = Position relative to:
 RailBtnCfg.lbl.Plus = plus
 RailBtnCfg.tab.General = General
 RailBtnCfg.tab.GeneralProp = General properties
+
 
 ! MassComponentConfig
 MassComponentCfg.lbl.Mass = Mass:
@@ -1039,6 +1089,7 @@ MassComponentCfg.lbl.Radialdistance = Radial distance:
 MassComponentCfg.lbl.Radialdirection = Radial direction:
 MassComponentCfg.but.Reset = Reset
 MassComponentCfg.lbl.type = Mass type
+
 
 ! MotorConfig
 MotorCfg.checkbox.compmotormount = This component is a motor mount
@@ -1058,7 +1109,9 @@ MotorCfg.but.Selectmotor = Select motor
 MotorCfg.but.Removemotor = Remove motor
 MotorCfg.lbl.motorLabel = None
 
+
 ! NoseConeConfig
+NoseCone.NoseCone = Nose Cone
 NoseConeCfg.lbl.Noseconeshape = Nose cone shape:
 NoseConeCfg.lbl.Shapeparam = Shape parameter:
 NoseConeCfg.lbl.Noseconelength = Length:
@@ -1074,9 +1127,19 @@ NoseConeCfg.tab.ttip.General = General properties
 NoseConeCfg.tab.Shoulder = Shoulder
 NoseConeCfg.tab.ttip.Shoulder = Shoulder properties
 
+
 ! ParachuteConfig
+! ParachuteConfig
+Parachute.Parachute = Parachute
+! Manufacturer = table.column.Manufacturer = Manufacturer
+! Part number = table.column.PartNo = Part Number
+! Description = table.column.Description = Description
 ParachuteCfg.lbl.Canopy = Canopy:
+ParachuteCfg.lbl.CanopyShape = Canopy shape:
 ParachuteCfg.lbl.Diameter = Diameter:
+ParachuteCfg.lbl.SpillDia = Spill hole diameter:
+ParachuteCfg.lbl.SurfaceArea = Surface area:
+! Canopy material = !SURFACE_MATERIAL
 ParachuteCfg.combo.MaterialModel = The component material affects the weight of the component.
 ParachuteCfg.lbl.longA1 = <html>Drag coefficient C<sub>D</sub>:
 ParachuteCfg.lbl.longB1 = <html>The drag coefficient relative to the total area of the parachute.<br>
@@ -1085,11 +1148,13 @@ ParachuteCfg.lbl.longB3 = A typical value for parachutes is 0.8.
 ParachuteCfg.lbl.Shroudlines = Shroud lines:
 ParachuteCfg.lbl.Numberoflines = Number of lines:
 ParachuteCfg.lbl.Linelength = Line length:
+! Line material = ! LINE _MATERIAL
 ParachuteCfg.lbl.Material = Material:
 ParachuteCfg.lbl.Posrelativeto = Position relative to:
 ParachuteCfg.lbl.plus = plus
 ParachuteCfg.lbl.Packedlength = Packed length:
 ParachuteCfg.lbl.Packeddiam = Packed diameter:
+! Mass = MassComponentCfg.lbl.Mass = Mass:
 ParachuteCfg.lbl.Deploysat = Deploys at:
 ParachuteCfg.lbl.seconds = seconds
 ParachuteCfg.lbl.Altitude = Altitude:
@@ -1102,7 +1167,9 @@ ParachuteCfg.lbl.Radialdirection = Radial direction:
 ParachuteCfg.but.Reset = Reset
 ParachuteCfg.lbl.plusdelay = plus
 
+
 ! ShockCordConfig
+ShockCord.ShockCord = Shock Cord
 ShockCordCfg.lbl.Shockcordlength = Shock cord length:
 ShockCordCfg.lbl.Shockcordmaterial = Shock cord material:
 ShockCordCfg.lbl.Posrelativeto = Position relative to:
@@ -1117,7 +1184,9 @@ ShockCordCfg.but.Reset = Reset
 ShockCordCfg.tab.General = General
 ShockCordCfg.tab.ttip.General = General properties
 
+
 !SleeveConfig
+Sleeve.Sleeve = Sleeve
 SleeveCfg.tab.Outerdiam = Outer diameter:
 SleeveCfg.tab.Innerdiam = Inner diameter:
 SleeveCfg.tab.Wallthickness = Wall thickness:
@@ -1125,7 +1194,9 @@ SleeveCfg.tab.Length = Length:
 SleeveCfg.tab.General = General
 SleeveCfg.tab.Generalproperties = General properties
 
+
 ! StreamerConfig
+Streamer.Streamer = Streamer
 StreamerCfg.lbl.Striplength = Strip length:
 StreamerCfg.lbl.Stripwidth = Strip width:
 StreamerCfg.lbl.Striparea = Strip area:
@@ -1153,6 +1224,7 @@ StreamerCfg.lbl.Radialdirection = Radial direction:
 StreamerCfg.but.Reset = Reset
 StreamerCfg.lbl.plusdelay = plus
 
+
 ! ThicknessRingComponentConfig
 ThicknessRingCompCfg.tab.Outerdiam = Outer diameter:
 ThicknessRingCompCfg.tab.Innerdiam = Inner diameter:
@@ -1161,7 +1233,9 @@ ThicknessRingCompCfg.tab.Length = Length:
 ThicknessRingCompCfg.tab.General = General
 ThicknessRingCompCfg.tab.Generalprop = General properties
 
+
 ! TransitionConfig
+Transition.Transition = Transition
 TransitionCfg.lbl.Transitionshape = Transition shape:
 TransitionCfg.checkbox.Clipped = Clipped
 TransitionCfg.lbl.Shapeparam = Shape parameter:
@@ -1179,7 +1253,9 @@ TransitionCfg.tab.Generalproperties = General properties
 TransitionCfg.tab.Shoulder = Shoulder
 TransitionCfg.tab.Shoulderproperties = Shoulder properties
 
+
 ! TrapezoidFinSetConfig
+TrapezoidFinSet.TrapezoidFinSet = Trapezoidal Fin Set
 TrapezoidFinSetCfg.lbl.Nbroffins = Number of fins:
 TrapezoidFinSetCfg.lbl.ttip.Nbroffins = The number of fins in the fin set.
 TrapezoidFinSetCfg.lbl.Finrotation = Fin rotation:
@@ -1198,6 +1274,7 @@ TrapezoidFinSetCfg.lbl.plus = plus
 TrapezoidFinSetCfg.tab.General = General
 TrapezoidFinSetCfg.tab.Generalproperties = General properties
 
+
 ! Fin Fillets
 FinSetCfg.lbl.Finfilletmaterial = Fillet material:
 FinSetCfg.lbl.Filletradius = Fillet radius:
@@ -1205,12 +1282,14 @@ FinsetCfg.ttip.Finfillets1 = <HTML>Adds the predicted mass of fin fillets to the
 FinsetCfg.ttip.Finfillets2 = Assumes the fillet is concave and tangent to the body tube and fin.<br>
 FinsetCfg.ttip.Finfillets3 = Zero radius will give no fillet.  
 
+
 ! Save RKT Warning Dialog
 SaveRktWarningDialog.txt1=Exporting to RockSim file format does not support all features of OpenRocket.
 SaveRktWarningDialog.donotshow=Do not show this dialog again
 
 saveAs.openrocket.title=Save as OpenRocket ork file
 saveAs.rocksim.title=Export as RockSim rkt file
+
 
 ! StorageOptionChooser
 StorageOptChooser.lbl.Simdatatostore = Simulated data to store:
@@ -1228,6 +1307,7 @@ StorageOptChooser.lbl.longD1 = An estimate on how large the resulting file would
 StorageOptChooser.ttip.Saveopt = Save options
 StorageOptChooser.lbl.Estfilesize = Estimated file size:
 StorageOptChooser.lbl.Saveopt = Save options
+
 
 ! ThrustCurveMotorSelectionPanel
 TCMotorSelPan.lbl.Selrocketmotor = Select rocket motor:
@@ -1268,7 +1348,6 @@ TCMotorSelPan.noDescription = No description available.
 TCMotorSelPan.btn.checkAll = Select All
 TCMotorSelPan.btn.checkNone = Clear All
 TCMotorSelPan.btn.close = Close
-
 
 
 ! PlotDialog
@@ -1353,17 +1432,15 @@ main.menu.debug = Debug
 main.menu.debug.whatisthismenu = What is this menu?
 main.menu.debug.createtestrocket = Create test rocket
 
-! database
+
 ! Translate here all material database
-!
-
-Material.CUSTOM = Custom
-
 ! Material database
 Databases.materials.types.Bulk = Bulk
 Databases.materials.types.Line = Line
 Databases.materials.types.Surface = Surface
 Databases.materials.types.Custom = Custom
+Material.CUSTOM = Custom
+
 
 ! BULK_MATERIAL
 material.acrylic = Acrylic
@@ -1394,7 +1471,9 @@ material.styrofoam_blue_foam_xps = Styrofoam \"Blue foam\" (XPS)
 material.titanium = Titanium
 material.quantum_tubing = Quantum tubing
 material.blue_tube = Blue tube
-!SURFACE_MATERIAL
+
+
+! SURFACE_MATERIAL
 material.ripstop_nylon = Ripstop nylon
 material.mylar = Mylar
 material.polyethylene_thin = Polyethylene (thin)
@@ -1403,6 +1482,8 @@ material.silk = Silk
 material.paper_office = Paper (office)
 material.cellophane = Cellophane
 material.crepe_paper = Cr\u00eape paper
+
+
 ! LINE_MATERIAL
 material.thread_heavy_duty = Thread (heavy-duty)
 material.elastic_cord_round_2_mm_1_16_in = Elastic cord (round 2 mm, 1/16 in)
@@ -1416,6 +1497,7 @@ material.tubular_nylon_11_mm_7_16_in = Tubular nylon (11 mm, 7/16 in)
 material.tubular_nylon_14_mm_9_16_in = Tubular nylon (14 mm, 9/16 in)
 material.tubular_nylon_25_mm_1_in = Tubular nylon (25 mm, 1 in)
 
+
 ! ExternalComponent
 ExternalComponent.Rough = Rough
 ExternalComponent.Unfinished = Unfinished
@@ -1423,12 +1505,14 @@ ExternalComponent.Regularpaint = Regular paint
 ExternalComponent.Smoothpaint = Smooth paint
 ExternalComponent.Polished = Polished
 
+
 ! LineStyle
 LineStyle.Solid = Solid
 LineStyle.Dashed = Dashed
 LineStyle.Dotted = Dotted
 LineStyle.Dash-dotted = Dash-dotted
 LineStyle.Defaultstyle = Default style
+
 
 ! Shape
 Shape.Conical = Conical
@@ -1478,17 +1562,8 @@ RocketComponent.Direction.RADIAL = "Radial"
 RocketComponent.Direction.ANGULAR = "Angular"
 
 
-! LaunchLug
-LaunchLug.Launchlug = Launch Lug
-! LaunchButton
-RailButton.RailButton = Rail Button
-! NoseCone
-NoseCone.NoseCone = Nose Cone
-! Transition
-Transition.Transition = Transition
 !Stage
 Stage.Stage = Stage
-
 Stage.SeparationEvent.UPPER_IGNITION = Upper stage motor ignition
 Stage.SeparationEvent.IGNITION = Current stage motor ignition
 Stage.SeparationEvent.BURNOUT = Current stage motor burnout
@@ -1496,22 +1571,19 @@ Stage.SeparationEvent.EJECTION = Current stage ejection charge
 Stage.SeparationEvent.LAUNCH = Launch
 Stage.SeparationEvent.NEVER = Never
 
+
+! BoosterSet
 BoosterSet.BoosterSet = Booster Set
 
+
+! PodSet
 PodSet.PodSet = Pod Set
 
-! BodyTube
-BodyTube.BodyTube = Body Tube
+
 ! TubeCoupler
 TubeCoupler.TubeCoupler = Tube Coupler
-!InnerTube
-InnerTube.InnerTube = Inner Tube
-! TrapezoidFinSet
-TrapezoidFinSet.TrapezoidFinSet = Trapezoidal Fin Set
-! FreeformFinSet
-FreeformFinSet.FreeformFinSet = Freeform Fin Set
-! TubeFinSEt
-TubeFinSet.TubeFinSet = Tube Fin Set
+
+
 !MassComponent
 MassComponent.MassComponent = Mass Component
 MassComponent.Altimeter = Altimeter
@@ -1521,25 +1593,17 @@ MassComponent.Tracker = Tracker
 MassComponent.Payload = Payload
 MassComponent.RecoveryHardware = Recovery Hardware
 MassComponent.Battery = Battery
-! Parachute
-Parachute.Parachute = Parachute
-! ShockCord
-ShockCord.ShockCord = Shock Cord
-! Bulkhead
-Bulkhead.Bulkhead = Bulkhead
-! CenteringRing
-CenteringRing.CenteringRing = Centering Ring
+
+
 ! EngineBlock
 EngineBlock.EngineBlock = Engine Block
-! Streamer
-Streamer.Streamer = Streamer
-! Sleeve
-Sleeve.Sleeve = Sleeve
+
 
 !Rocket
 Rocket.motorCount.Nomotor = No motors
 Rocket.motorCount.noStageMotors = None
 Rocket.compname.Rocket = Rocket
+
 
 !MotorMount
 MotorMount.IgnitionEvent.AUTOMATIC = Automatic (launch or ejection charge)
@@ -1590,8 +1654,10 @@ ComponentIcons.Recoveryhardware = Recovery Hardware
 ComponentIcons.Payload = Payload
 ComponentIcons.Deploymentcharge = Deployment Charge
 
+
 ! StageAction
 StageAction.Stage = Stage
+
 
 ! RecoveryDevice
 RecoveryDevice.DeployEvent.LAUNCH = Launch (plus NN seconds)
@@ -1627,6 +1693,7 @@ FlightEvent.Type.ALTITUDE = Altitude change
 FlightEvent.Type.TUMBLE = Tumbling
 FlightEvent.Type.EXCEPTION = Exception
 
+
 ! ThrustCurveMotorColumns
 TCurveMotorCol.MANUFACTURER = Manufacturer
 TCurveMotorCol.COMMON_NAME = Name
@@ -1643,6 +1710,7 @@ TCurveMotor.ttip.burnTime = Burn time:
 TCurveMotor.ttip.totalImpulse = Total impulse:
 TCurveMotor.ttip.launchMass = Launch mass:
 TCurveMotor.ttip.emptyMass = Empty mass:
+
 
 ! RocketInfo
 RocketInfo.lengthLine.Length = Length
@@ -1664,6 +1732,7 @@ RocketInfo.Mach = (Mach
 RocketInfo.velocityValue = N/A
 RocketInfo.accelerationValue = N/A
 
+
 ! FinSet
 FinSet.CrossSection.SQUARE = Square
 FinSet.CrossSection.ROUNDED = Rounded
@@ -1671,6 +1740,7 @@ FinSet.CrossSection.AIRFOIL = Airfoil
 FinSet.TabRelativePosition.FRONT = Root chord leading edge
 FinSet.TabRelativePosition.CENTER = Root chord midpoint
 FinSet.TabRelativePosition.END = Root chord trailing edge
+
 
 ! FlightDataType
 FlightDataType.TYPE_TIME = Time
@@ -1730,6 +1800,7 @@ FlightDataType.TYPE_LONGITUDE = Longitude
 FlightDataType.TYPE_CORIOLIS_ACCELERATION = Coriolis acceleration
 FlightDataType.TYPE_GRAVITY = Gravitational acceleration
 
+
 ! PlotConfiguration
 PlotConfiguration.Verticalmotion = Vertical motion vs. time
 PlotConfiguration.Totalmotion = Total motion vs. time
@@ -1740,6 +1811,7 @@ PlotConfiguration.Rollcharacteristics = Roll characteristics
 PlotConfiguration.Angleofattack = Angle of attack and orientation vs. time
 PlotConfiguration.Simulationtime = Simulation time step and computation time
 PlotConfiguration.Groundtrack = Ground track
+
 
 ! Warning
 Warning.LargeAOA.str1 = Large angle of attack encountered.
@@ -1761,6 +1833,7 @@ Warning.ZERO_RADIUS_BODY = Zero length bodies may not result in accurate simulat
 Warning.TUBE_STABILITY = Tube fin stability calculations may not be accurate.
 Warning.TUBE_SEPARATION = Space between tube fins may not result in accurate simulations.
 Warning.TUBE_OVERLAP = Overlapping tube fins may not result in accurate simulations.
+
 
 ! Scale dialog
 ScaleDialog.lbl.scaleRocket = Entire rocket
@@ -1784,7 +1857,8 @@ ScaleDialog.undo.scaleRocket = Scale rocket
 ScaleDialog.undo.scaleComponent = Scale component
 ScaleDialog.undo.scaleComponents = Scale components
 
-!icons
+
+! icons
 Icons.Undo = Undo
 Icons.Redo = Redo
 
@@ -1799,13 +1873,15 @@ OpenRocketPrintable.Centeringringtemplates = Centering Ring templates
 OpenRocketDocument.Redo = Redo
 OpenRocketDocument.Undo = Undo
 
-!EllipticalFinSet
+
+! EllipticalFinSet
 EllipticalFinSet.Ellipticalfinset = Elliptical Fin Set
+
 
 ! Optimization
 
-! Modifiers
 
+! Modifiers
 optimization.modifier.nosecone.length = Length
 optimization.modifier.nosecone.length.desc = Optimize the nose cone length.
 optimization.modifier.nosecone.diameter = Diameter
@@ -1861,7 +1937,6 @@ optimization.modifier.launchlug.thickness.desc = Optimize the launch lug thickne
 optimization.modifier.launchlug.position = Position
 optimization.modifier.launchlug.position.desc = Optimize the launch lug position along the rocket body.
 
-
 optimization.modifier.internalcomponent.position = Position
 optimization.modifier.internalcomponent.position.desc = Optimize the position of the component relative to the parent component.
 
@@ -1896,8 +1971,6 @@ optimization.modifier.motormount.overhang = Motor overhang
 optimization.modifier.motormount.overhang.desc = Optimize the motor overhang.
 optimization.modifier.motormount.delay = Motor ignition delay
 optimization.modifier.motormount.delay.desc = Optimize the motor ignition delay.
-
-
 
 
 ! General rocket design optimization dialog
@@ -1975,6 +2048,7 @@ OptimizationPlotDialog.plot2d.evals = Evaluations
 OptimizationPlotDialog.plot.ttip.stability = Stability:
 OptimizationPlotDialog.plot.label.optimum = Optimum
 
+
 ! Optimization parameters
 MaximumAltitudeParameter.name = Apogee altitude
 MaximumVelocityParameter.name = Maximum velocity
@@ -1991,6 +2065,7 @@ CompassRose.lbl.north = N
 CompassRose.lbl.east  = E
 CompassRose.lbl.south = S
 CompassRose.lbl.west  = W
+
 
 ! Compass directions with subdirections.  These might not be localized even if the directions on the compass rose are.
 CompassSelectionButton.lbl.N = N
@@ -2033,12 +2108,14 @@ PresetModel.lbl.database = From database\u2026
 DecalModel.lbl.select = <none>
 DecalModel.lbl.choose = From file\u2026
 
+
 ! Export Decal Dialog
 ExportDecalDialog.title = Export Decal
 ExportDecalDialog.decalList.lbl = Decal
 ExportDecalDialog.exception = Unable to write decal to file ''{0}''
 ExportDecalDialog.source.title = No decal source file
 ExportDecalDialog.source.exception = Could not find decal source file ''{0}''.<br><br>Would you like to look for this file?
+
 
 ! Component Preset Chooser Dialog
 ComponentPresetChooserDialog.title = Choose component preset
@@ -2080,6 +2157,7 @@ table.column.Sides = Sides
 table.column.LineCount = Line Count
 table.column.LineLength = Line Length
 table.column.LineMaterial = Line Material
+
 
 ! Edit Decal Dialog
 EditDecalDialog.title = Edit decal
@@ -2124,7 +2202,7 @@ MotorConfigurationPanel.description = <b>Select the motors and motor ignition ev
 MotorDescriptionSubstitutor.description = Motors in the configuration
 
 
-!Photo Panel
+! Photo Panel
 PhotoFrame.title = Photo Studio
 PhotoFrame.desc = Create realistic 3D images of the rocket
 PhotoFrame.menu.file.save = Save Image\u2026
@@ -2137,7 +2215,8 @@ PhotoFrame.menu.window = Window
 PhotoFrame.menu.window.size = Size
 PhotoFrame.menu.window.size.portrait = {0} Portrait
 
-!Photo Settings
+
+! Photo Settings
 PhotoSettingsConfig.title = Settings
 PhotoSettingsConfig.colorChooser.title = Color Chooser
 

--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -1129,7 +1129,6 @@ NoseConeCfg.tab.ttip.Shoulder = Shoulder properties
 
 
 ! ParachuteConfig
-! ParachuteConfig
 Parachute.Parachute = Parachute
 ! Manufacturer = table.column.Manufacturer = Manufacturer
 ! Part number = table.column.PartNo = Part Number

--- a/core/src/net/sf/openrocket/preset/ComponentPreset.java
+++ b/core/src/net/sf/openrocket/preset/ComponentPreset.java
@@ -151,15 +151,19 @@ public class ComponentPreset implements Comparable<ComponentPreset>, Serializabl
 				ComponentPreset.MANUFACTURER,
 				ComponentPreset.PARTNO,
 				ComponentPreset.DESCRIPTION,
+				ComponentPreset.CANOPY_SHAPE,
 				ComponentPreset.DIAMETER,
-				ComponentPreset.SIDES,
+				ComponentPreset.SPILL_DIA,
+				ComponentPreset.SURFACE_AREA,
 				ComponentPreset.PARACHUTE_CD,
-				ComponentPreset.PACKED_DIAMETER,
-				ComponentPreset.PACKED_LENGTH,
+				ComponentPreset.MATERIAL,
+				ComponentPreset.SIDES,
 				ComponentPreset.LINE_COUNT,
 				ComponentPreset.LINE_LENGTH,
 				ComponentPreset.LINE_MATERIAL,
-				ComponentPreset.MATERIAL });
+				ComponentPreset.PACKED_LENGTH,
+				ComponentPreset.PACKED_DIAMETER,
+				ComponentPreset.MASS });
 
 		TypedKey<?>[] displayedColumns;
 
@@ -210,18 +214,31 @@ public class ComponentPreset implements Comparable<ComponentPreset>, Serializabl
 	public final static TypedKey<Boolean> FILLED = new TypedKey<Boolean>("Filled", Boolean.class);
 	public final static TypedKey<Double> MASS = new TypedKey<Double>("Mass", Double.class, UnitGroup.UNITS_MASS);
 	public final static TypedKey<Double> DIAMETER = new TypedKey<Double>("Diameter", Double.class, UnitGroup.UNITS_LENGTH);
-	public final static TypedKey<Integer> SIDES = new TypedKey<Integer>("Sides", Integer.class);
-	public static final TypedKey<Double> PARACHUTE_CD = new TypedKey<Double>("DragCoefficient", Double.class, UnitGroup.UNITS_COEFFICIENT);
-	public final static TypedKey<Double> PACKED_LENGTH = new TypedKey<Double>("PackedLength", Double.class, UnitGroup.UNITS_LENGTH);
-	public final static TypedKey<Double> PACKED_DIAMETER = new TypedKey<Double>("PackedDiameter", Double.class, UnitGroup.UNITS_LENGTH);
-	public final static TypedKey<Integer> LINE_COUNT = new TypedKey<Integer>("LineCount", Integer.class);
-	public final static TypedKey<Double> LINE_LENGTH = new TypedKey<Double>("LineLength", Double.class, UnitGroup.UNITS_LENGTH);
-	public final static TypedKey<Material> LINE_MATERIAL = new TypedKey<Material>("LineMaterial", Material.class);
 	public final static TypedKey<byte[]> IMAGE = new TypedKey<byte[]>("Image", byte[].class);
 	public final static TypedKey<Double> STANDOFF_HEIGHT = new TypedKey<Double>("StandoffHeight", Double.class, UnitGroup.UNITS_LENGTH);
 	public final static TypedKey<Double> FLANGE_HEIGHT = new TypedKey<Double>("FlangeHeight", Double.class, UnitGroup.UNITS_LENGTH);
 
+//	PARACHUTE SPECIFIC
+	//	Parachute manufacturer declaration = MANUFACTURER
+	//	Parachute part number declaration = PARTNO
+	//	Parachute description declaration = DESCRIPTION
+	public final static TypedKey<Shape> CANOPY_SHAPE = new TypedKey<Shape>("CanopyShape", Shape.class);
+	//	Parachute diameter declaration = DIAMETER
+	public final static TypedKey<Double> SPILL_DIA = new TypedKey<Double>("SpillDia", Double.class, UnitGroup.UNITS_LENGTH);
+	public final static TypedKey<Double> SURFACE_AREA = new TypedKey<Double>("SurfaceArea", Double.class, UnitGroup.UNITS_LENGTH);
+	public static final TypedKey<Double> PARACHUTE_CD = new TypedKey<Double>("DragCoefficient", Double.class, UnitGroup.UNITS_COEFFICIENT);
+	//	Parachute canopy material declaration = MATERIAL
+	public final static TypedKey<Integer> SIDES = new TypedKey<Integer>("Sides", Integer.class);
+	public final static TypedKey<Integer> LINE_COUNT = new TypedKey<Integer>("LineCount", Integer.class);
+	public final static TypedKey<Double> LINE_LENGTH = new TypedKey<Double>("LineLength", Double.class, UnitGroup.UNITS_LENGTH);
+	public final static TypedKey<Material> LINE_MATERIAL = new TypedKey<Material>("LineMaterial", Material.class);
+	public final static TypedKey<Double> PACKED_LENGTH = new TypedKey<Double>("PackedLength", Double.class, UnitGroup.UNITS_LENGTH);
+	public final static TypedKey<Double> PACKED_DIAMETER = new TypedKey<Double>("PackedDiameter", Double.class, UnitGroup.UNITS_LENGTH);
+	//	Parachute mass declaration = MASS
+
 	public final static List<TypedKey<?>> ORDERED_KEY_LIST = Collections.unmodifiableList(Arrays.asList(
+
+			//	DO NOT add to this list without redefining “table.column”
 			LEGACY,
 			MANUFACTURER,
 			PARTNO,
@@ -243,19 +260,13 @@ public class ComponentPreset implements Comparable<ComponentPreset>, Serializabl
 			FILLED,
 			DIAMETER,
 			SIDES,
-			/** DO NOT add new presets to this list without defining table.column
-			PARACHUTE_CD,
-			PACKED_LENGTH,
-			PACKED_DIAMETER,
-			*/
 			LINE_COUNT,
 			LINE_LENGTH,
 			LINE_MATERIAL,
 			MASS,
 			FINISH,
 			MATERIAL
-			));
-
+	));
 
 	// package scope constructor to encourage use of factory.
 	ComponentPreset() {

--- a/core/src/net/sf/openrocket/rocketcomponent/Parachute.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Parachute.java
@@ -195,41 +195,41 @@ public class Parachute extends RecoveryDevice {
 		 // END Implement parachute cd
 
 		// BEGIN Implement parachute length, diameter, and volume
-		//// BEGIN Implement parachute packed length
+		//	// BEGIN Implement parachute packed length
 		if (preset.has(ComponentPreset.PACKED_LENGTH)) {
 			this.PackedLength = preset.get(ComponentPreset.PACKED_LENGTH);
 			if (PackedLength > 0) {
-				length = PackedLength;
+				length = PackedLength;				// Conditions: PackedLength exists, PackedLength > 0
 			}
-			if (PackedLength <= 0) {
-				length = InitialPackedLength;
+			else
+				length = InitialPackedLength;		// Conditions: PackedLength exists, PackedLength !> 0
 			}
-		} else {
-			length = InitialPackedLength;
+		else {
+			length = InitialPackedLength;			// Conditions: PackedLength does not exist
 		}
-		//// END Implement parachute packed length
-		//// BEGIN Implement parachute packed diameter
+		//	// END Implement parachute packed length
+		//	// BEGIN Implement parachute packed diameter
 		if (preset.has(ComponentPreset.PACKED_DIAMETER)) {
 			this.PackedDiameter = preset.get(ComponentPreset.PACKED_DIAMETER);
 			if (PackedDiameter > 0) {
-				radius = PackedDiameter / 2;
+				radius = PackedDiameter / 2;		// Conditions: PackedDiameter exists, PackedDiameter > 0
 			}
-			if (PackedDiameter <= 0) {
-				radius = InitialPackedRadius;
-			}
-		} else {
-			radius = InitialPackedRadius;
-	}
-		//// END Implement parachute packed diameter
-		//// BEGIN Size parachute packed diameter within parent inner diameter
+			else
+				radius = InitialPackedRadius;		// Conditions: PackedDiameter exists, PackedDiameter !> 0
+		}
+		else {
+			radius = InitialPackedRadius;			// Conditions: PackedDiameter does not exist
+		}
+		//	// END Implement parachute packed diameter
+		//	// BEGIN Size parachute packed diameter within parent inner diameter
 		if (length > 0 && radius > 0) {
 			double parachuteVolume = (Math.PI * Math.pow(radius, 2) * length);
 			setRadiusAutomatic(true);
 			length = parachuteVolume / (Math.PI * Math.pow(getRadius(), 2));
 
 		}
-		//// END Size parachute packed diameter within parent inner diameter
-		// END Implement parachute length, diameter, and volume
+		//	// END Size parachute packed diameter within parent inner diameter
+		//// END Implement parachute length, diameter, and volume
 
 		// BEGIN Activate Override Mass Preset
 		if (preset.has(ComponentPreset.MASS)) {

--- a/swing/src/net/sf/openrocket/gui/preset/PresetEditorDialog.java
+++ b/swing/src/net/sf/openrocket/gui/preset/PresetEditorDialog.java
@@ -188,26 +188,31 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 	private DoubleModel stMass;
 	private ImageIcon stImage;
 	private JButton stImageBtn;
-	
-	private JTextField pcPartNoTextField;
-	private JTextField pcDescTextField;
-	private JTextField pcSides;
-	private JTextField pcLineCount;
-	private DoubleModel pcDiameter;
-	private DoubleModel pcLineLength;
-	private MaterialChooser pcLineMaterialChooser;
-	private DoubleModel pcMass;
 	private ImageIcon pcImage;
 	private JButton pcImageBtn;
-	
 	private final JFileChooser imageChooser = createImageChooser();
-	
 	private JPanel componentOverlayPanel;
-	
 	private PresetResultListener resultListener;
-	
 	private static Map<String, String> componentMap = new HashMap<String, String>();
-	
+
+//	Parachute Specific
+	//	Manufacturer = private JTextField mfgTextField;
+	private JTextField pcPartNoTextField;
+	private JTextField pcDescTextField;
+	private DoubleModel pcDiameter;
+	private DoubleModel pcSpillDia;
+	private DoubleModel pcSurfaceArea;
+	private DoubleModel pcDragCoefficient;
+	//	Canopy material = private MaterialChooser materialChooser;
+	private JTextField pcSides;
+	private JTextField pcLineCount;
+	private DoubleModel pcLineLength;
+	private MaterialChooser pcLineMaterialChooser;
+	private DoubleModel pcPackedLength;
+	private DoubleModel pcPackedDiameter;
+	private DoubleModel pcMass;
+
+
 	private static final String NOSE_CONE_KEY = "NoseCone.NoseCone";
 	private static final String BODY_TUBE_KEY = "BodyTube.BodyTube";
 	private static final String TUBE_COUPLER_KEY = "TubeCoupler.TubeCoupler";
@@ -1305,7 +1310,7 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 	}
 	
 	/**
-	 * Create an image chooser.  Currently png and jpg are supported.
+	 * Create an image chooser.  Currently,png and jpg are supported.
 	 *
 	 * @return a file chooser that looks for image files
 	 */
@@ -1320,7 +1325,7 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 	}
 	
 	/**
-	 * To support editing of an existing preset, the swing components need to be prepopulated with the field data.
+	 * To support editing of an existing preset, the swing components need to be pre-populated with the field data.
 	 *
 	 * @param preset the preset to edit
 	 */
@@ -1594,38 +1599,61 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 				rbImageBtn.setIcon(llImage);
 			}
 			break;
-		case PARACHUTE:
-			setMaterial(materialChooser, preset, matHolder, Material.Type.SURFACE, ComponentPreset.MATERIAL);
-			typeCombo.setSelectedItem(trans.get(PARACHUTE_KEY));
-			pcDescTextField.setText(preset.get(ComponentPreset.DESCRIPTION));
-			if (preset.has(ComponentPreset.LINE_COUNT)) {
-				pcLineCount.setText(preset.get(ComponentPreset.LINE_COUNT).toString());
-			}
-			if (preset.has(ComponentPreset.SIDES)) {
-				pcSides.setText(preset.get(ComponentPreset.SIDES).toString());
-			}
-			if (preset.has(ComponentPreset.MASS)) {
-				pcMass.setValue(preset.get(ComponentPreset.MASS));
-				pcMass.setCurrentUnit(UnitGroup.UNITS_MASS.getDefaultUnit());
-			}
-			if (preset.has(ComponentPreset.DIAMETER)) {
-				pcDiameter.setValue(preset.get(ComponentPreset.DIAMETER));
-				pcDiameter.setCurrentUnit(UnitGroup.UNITS_LENGTH.getDefaultUnit());
-			}
-			if (preset.has(ComponentPreset.LINE_LENGTH)) {
-				pcLineLength.setValue(preset.get(ComponentPreset.LINE_LENGTH));
-				pcLineLength.setCurrentUnit(UnitGroup.UNITS_LENGTH.getDefaultUnit());
-			}
-			pcPartNoTextField.setText(preset.get(ComponentPreset.PARTNO));
-			if (preset.has(ComponentPreset.IMAGE)) {
-				pcImage = new ImageIcon(byteArrayToImage(preset.get(ComponentPreset.IMAGE)));
-				pcImageBtn.setIcon(pcImage);
-			}
-			setMaterial(pcLineMaterialChooser, preset, matHolder, Material.Type.LINE, ComponentPreset.LINE_MATERIAL);
-			//                pcLineMaterialChooser.setModel(new MaterialModel(PresetEditorDialog.this, Material.Type.LINE));
-			
-			//                pcLineMaterialChooser.getModel().setSelectedItem(preset.get(ComponentPreset.LINE_MATERIAL));
-			break;
+			case PARACHUTE:
+				typeCombo.setSelectedItem(trans.get(PARACHUTE_KEY));
+				pcPartNoTextField.setText(preset.get(ComponentPreset.PARTNO));
+				pcDescTextField.setText(preset.get(ComponentPreset.DESCRIPTION));
+				/*
+				if (preset.has(ComponentPreset.CANOPY_SHAPE)) {
+					pcCanopyShapeTextField.setText(preset.get(ComponentPreset.CANOPY_SHAPE));
+				} */
+				if (preset.has(ComponentPreset.DIAMETER)) {
+					pcDiameter.setValue(preset.get(ComponentPreset.DIAMETER));
+					pcDiameter.setCurrentUnit(UnitGroup.UNITS_LENGTH.getDefaultUnit());
+				}
+				if (preset.has(ComponentPreset.SPILL_DIA)) {
+					pcSpillDia.setValue(preset.get(ComponentPreset.SPILL_DIA));
+					pcSpillDia.setCurrentUnit(UnitGroup.UNITS_LENGTH.getDefaultUnit());
+				}
+				if (preset.has(ComponentPreset.SURFACE_AREA)) {
+					pcSurfaceArea.setValue(preset.get(ComponentPreset.SURFACE_AREA));
+					pcSurfaceArea.setCurrentUnit(UnitGroup.UNITS_LENGTH.getDefaultUnit());
+				}
+				if (preset.has(ComponentPreset.PARACHUTE_CD)) {
+					pcDragCoefficient.setValue(preset.get(ComponentPreset.PARACHUTE_CD));
+					pcDragCoefficient.setCurrentUnit(UnitGroup.UNITS_COEFFICIENT.getDefaultUnit());
+				}
+				setMaterial(materialChooser, preset, matHolder, Material.Type.SURFACE, ComponentPreset.MATERIAL);
+				if (preset.has(ComponentPreset.SIDES)) {
+					pcSides.setText(preset.get(ComponentPreset.SIDES).toString());
+				}
+				if (preset.has(ComponentPreset.LINE_COUNT)) {
+					pcLineCount.setText(preset.get(ComponentPreset.LINE_COUNT).toString());
+				}
+				if (preset.has(ComponentPreset.LINE_LENGTH)) {
+					pcLineLength.setValue(preset.get(ComponentPreset.LINE_LENGTH));
+					pcLineLength.setCurrentUnit(UnitGroup.UNITS_LENGTH.getDefaultUnit());
+				}
+				setMaterial(pcLineMaterialChooser, preset, matHolder, Material.Type.LINE, ComponentPreset.LINE_MATERIAL);
+					//    pcLineMaterialChooser.setModel(new MaterialModel(PresetEditorDialog.this, Material.Type.LINE));
+					//    pcLineMaterialChooser.getModel().setSelectedItem(preset.get(ComponentPreset.LINE_MATERIAL));
+				if (preset.has(ComponentPreset.PACKED_LENGTH)) {
+					pcPackedLength.setValue(preset.get(ComponentPreset.PACKED_LENGTH));
+					pcPackedLength.setCurrentUnit(UnitGroup.UNITS_LENGTH.getDefaultUnit());
+				}
+				if (preset.has(ComponentPreset.PACKED_DIAMETER)) {
+					pcPackedDiameter.setValue(preset.get(ComponentPreset.PACKED_DIAMETER));
+					pcPackedDiameter.setCurrentUnit(UnitGroup.UNITS_LENGTH.getDefaultUnit());
+				}
+				if (preset.has(ComponentPreset.MASS)) {
+					pcMass.setValue(preset.get(ComponentPreset.MASS));
+					pcMass.setCurrentUnit(UnitGroup.UNITS_MASS.getDefaultUnit());
+				}
+				if (preset.has(ComponentPreset.IMAGE)) {
+					pcImage = new ImageIcon(byteArrayToImage(preset.get(ComponentPreset.IMAGE)));
+					pcImageBtn.setIcon(pcImage);
+				}
+				break;
 		case STREAMER:
 			setMaterial(materialChooser, preset, matHolder, Material.Type.SURFACE, ComponentPreset.MATERIAL);
 			typeCombo.setSelectedItem(trans.get(STREAMER_KEY));
@@ -2157,17 +2185,14 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 		TypedPropertyMap props = new TypedPropertyMap();
 		try {
 			props.put(ComponentPreset.TYPE, ComponentPreset.Type.PARACHUTE);
-			props.put(ComponentPreset.DIAMETER, pcDiameter.getValue());
-			props.put(ComponentPreset.DESCRIPTION, pcDescTextField.getText());
-			props.put(ComponentPreset.PARTNO, pcPartNoTextField.getText());
 			props.put(ComponentPreset.MANUFACTURER, Manufacturer.getManufacturer(mfgTextField.getText()));
-			if (!pcLineCount.getText().equals("")) {
-				props.put(ComponentPreset.LINE_COUNT, Integer.parseInt(pcLineCount.getText()));
-			}
-			if (!pcSides.getText().equals("")) {
-				props.put(ComponentPreset.SIDES, Integer.parseInt(pcSides.getText()));
-			}
-			props.put(ComponentPreset.LINE_LENGTH, pcLineLength.getValue());
+			props.put(ComponentPreset.PARTNO, pcPartNoTextField.getText());
+			props.put(ComponentPreset.DESCRIPTION, pcDescTextField.getText());
+			//	INSERT Canopy Shape
+			props.put(ComponentPreset.DIAMETER, pcDiameter.getValue());
+			props.put(ComponentPreset.SPILL_DIA, pcSpillDia.getValue());
+			props.put(ComponentPreset.SURFACE_AREA, pcSurfaceArea.getValue());
+			props.put(ComponentPreset.PARACHUTE_CD, pcDragCoefficient.getValue());
 			Material material = (Material) materialChooser.getSelectedItem();
 			if (material != null) {
 				props.put(ComponentPreset.MATERIAL, material);
@@ -2176,6 +2201,13 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 				JOptionPane.showMessageDialog(null, "A material must be selected.", "Error", JOptionPane.ERROR_MESSAGE);
 				return null;
 			}
+			if (!pcSides.getText().equals("")) {
+				props.put(ComponentPreset.SIDES, Integer.parseInt(pcSides.getText()));
+			}
+			if (!pcLineCount.getText().equals("")) {
+				props.put(ComponentPreset.LINE_COUNT, Integer.parseInt(pcLineCount.getText()));
+			}
+			props.put(ComponentPreset.LINE_LENGTH, pcLineLength.getValue());
 			material = (Material) pcLineMaterialChooser.getSelectedItem();
 			if (material != null) {
 				props.put(ComponentPreset.LINE_MATERIAL, material);

--- a/swing/src/net/sf/openrocket/gui/preset/PresetEditorDialog.java
+++ b/swing/src/net/sf/openrocket/gui/preset/PresetEditorDialog.java
@@ -201,6 +201,7 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 	private JTextField pcDescTextField;
 	private DoubleModel pcDiameter;
 	private DoubleModel pcSpillDia;
+	private JTextField pcCanopyShapeTextField;
 	private DoubleModel pcSurfaceArea;
 	private DoubleModel pcDragCoefficient;
 	//	Canopy material = private MaterialChooser materialChooser;
@@ -1603,10 +1604,6 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 				typeCombo.setSelectedItem(trans.get(PARACHUTE_KEY));
 				pcPartNoTextField.setText(preset.get(ComponentPreset.PARTNO));
 				pcDescTextField.setText(preset.get(ComponentPreset.DESCRIPTION));
-				/*
-				if (preset.has(ComponentPreset.CANOPY_SHAPE)) {
-					pcCanopyShapeTextField.setText(preset.get(ComponentPreset.CANOPY_SHAPE));
-				} */
 				if (preset.has(ComponentPreset.DIAMETER)) {
 					pcDiameter.setValue(preset.get(ComponentPreset.DIAMETER));
 					pcDiameter.setCurrentUnit(UnitGroup.UNITS_LENGTH.getDefaultUnit());
@@ -1614,6 +1611,9 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 				if (preset.has(ComponentPreset.SPILL_DIA)) {
 					pcSpillDia.setValue(preset.get(ComponentPreset.SPILL_DIA));
 					pcSpillDia.setCurrentUnit(UnitGroup.UNITS_LENGTH.getDefaultUnit());
+				}
+				if (preset.has(ComponentPreset.CANOPY_SHAPE)) {
+					pcCanopyShapeTextField.setText(preset.get(ComponentPreset.CANOPY_SHAPE));
 				}
 				if (preset.has(ComponentPreset.SURFACE_AREA)) {
 					pcSurfaceArea.setValue(preset.get(ComponentPreset.SURFACE_AREA));
@@ -2188,9 +2188,9 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 			props.put(ComponentPreset.MANUFACTURER, Manufacturer.getManufacturer(mfgTextField.getText()));
 			props.put(ComponentPreset.PARTNO, pcPartNoTextField.getText());
 			props.put(ComponentPreset.DESCRIPTION, pcDescTextField.getText());
-			//	INSERT Canopy Shape
 			props.put(ComponentPreset.DIAMETER, pcDiameter.getValue());
 			props.put(ComponentPreset.SPILL_DIA, pcSpillDia.getValue());
+			props.put(ComponentPreset.CANOPY_SHAPE, pcCanopyShape.getText()));
 			props.put(ComponentPreset.SURFACE_AREA, pcSurfaceArea.getValue());
 			props.put(ComponentPreset.PARACHUTE_CD, pcDragCoefficient.getValue());
 			Material material = (Material) materialChooser.getSelectedItem();


### PR DESCRIPTION
A large number of the new parachute products have spill holes (c.f. Issue #817), and simply adding those fields to the .orc file, without changes to how the presets are handled, was causing OpenRocket to throw errors. These changes allow these fields to not exists or  to exist with or without data, without throwing an error. This also means that the parachute .orc files will not need to be updated when spill holes are implemented.