### PR TITLE
[fixes #1326] Update opacity slider with color button alpha change

### DIFF
--- a/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
@@ -446,18 +446,6 @@ public class AppearancePanel extends JPanel {
 
 		JButton colorButton = new SelectColorButton(new ColorIcon(builder.getPaint()));
 
-		builder.addChangeListener(new StateChangeListener() {
-			@Override
-			public void stateChanged(EventObject e) {
-				colorButton.setIcon(new ColorIcon(builder.getPaint()));
-				if (!insideBuilder)
-					c.setAppearance(builder.getAppearance());
-				else
-					((InsideColorComponent)c).getInsideColorComponentHandler().setInsideAppearance(builder.getAppearance());
-				decalModel.refresh();
-			}
-		});
-
 		colorButton.addActionListener(new ColorActionListener(builder, "Paint"));
 
 		// Texture Header Row
@@ -623,5 +611,22 @@ public class AppearancePanel extends JPanel {
 				"EdgeMode", list));
 		mDefault.addEnableComponent(combo, false);
 		panel.add(combo, "wrap");
+
+		builder.addChangeListener(new StateChangeListener() {
+			double lastOpacity = builder.getOpacity();
+			@Override
+			public void stateChanged(EventObject e) {
+				colorButton.setIcon(new ColorIcon(builder.getPaint()));
+				if (lastOpacity != builder.getOpacity()) {
+					opacityModel.stateChanged(null);
+					lastOpacity = builder.getOpacity();
+				}
+				if (!insideBuilder)
+					c.setAppearance(builder.getAppearance());
+				else
+					((InsideColorComponent)c).getInsideColorComponentHandler().setInsideAppearance(builder.getAppearance());
+				decalModel.refresh();
+			}
+		});
 	}
 }


### PR DESCRIPTION
This PR fixes #1326 and updates the opacity slider whenever an alpha change is made in the appearance color button panel.