### PR TITLE
Adds additional presets for use in .orc files without throwing errors

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -1075,8 +1075,16 @@ NoseConeCfg.tab.Shoulder = Shoulder
 NoseConeCfg.tab.ttip.Shoulder = Shoulder properties
 
 ! ParachuteConfig
+Parachute.Parachute = Parachute
+! Manufacturer see: table.column.Manufacturer = Manufacturer
+! Part number see: table.column.PartNo = Part Number
+! Description see: table.column.Description = Description
 ParachuteCfg.lbl.Canopy = Canopy:
+ParachuteCfg.lbl.CanopyShape = Canopy shape:
 ParachuteCfg.lbl.Diameter = Diameter:
+ParachuteCfg.lbl.SpillDia = Spill hole diameter:
+ParachuteCfg.lbl.SurfaceArea = Surface area:
+! Canopy material see: !SURFACE_MATERIAL
 ParachuteCfg.combo.MaterialModel = The component material affects the weight of the component.
 ParachuteCfg.lbl.longA1 = <html>Drag coefficient C<sub>D</sub>:
 ParachuteCfg.lbl.longB1 = <html>The drag coefficient relative to the total area of the parachute.<br>
@@ -1085,11 +1093,13 @@ ParachuteCfg.lbl.longB3 = A typical value for parachutes is 0.8.
 ParachuteCfg.lbl.Shroudlines = Shroud lines:
 ParachuteCfg.lbl.Numberoflines = Number of lines:
 ParachuteCfg.lbl.Linelength = Line length:
+! Line material see: LINE _MATERIAL
 ParachuteCfg.lbl.Material = Material:
 ParachuteCfg.lbl.Posrelativeto = Position relative to:
 ParachuteCfg.lbl.plus = plus
 ParachuteCfg.lbl.Packedlength = Packed length:
 ParachuteCfg.lbl.Packeddiam = Packed diameter:
+! Mass see: MassComponentCfg.lbl.Mass = Mass:
 ParachuteCfg.lbl.Deploysat = Deploys at:
 ParachuteCfg.lbl.seconds = seconds
 ParachuteCfg.lbl.Altitude = Altitude:
@@ -1400,7 +1410,7 @@ material.mylar = Mylar
 material.polyethylene_thin = Polyethylene (thin)
 material.polyethylene_heavy = Polyethylene (heavy)
 material.silk = Silk
-material.paper_office = Paper (office)
+! Material "paper" see: material.paper_office = Paper (office)
 material.cellophane = Cellophane
 material.crepe_paper = Cr\u00eape paper
 ! LINE_MATERIAL
@@ -1521,8 +1531,7 @@ MassComponent.Tracker = Tracker
 MassComponent.Payload = Payload
 MassComponent.RecoveryHardware = Recovery Hardware
 MassComponent.Battery = Battery
-! Parachute
-Parachute.Parachute = Parachute
+
 ! ShockCord
 ShockCord.ShockCord = Shock Cord
 ! Bulkhead

--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -1076,15 +1076,11 @@ NoseConeCfg.tab.ttip.Shoulder = Shoulder properties
 
 ! ParachuteConfig
 Parachute.Parachute = Parachute
-! Manufacturer see: table.column.Manufacturer = Manufacturer
-! Part number see: table.column.PartNo = Part Number
-! Description see: table.column.Description = Description
 ParachuteCfg.lbl.Canopy = Canopy:
 ParachuteCfg.lbl.CanopyShape = Canopy shape:
 ParachuteCfg.lbl.Diameter = Diameter:
 ParachuteCfg.lbl.SpillDia = Spill hole diameter:
 ParachuteCfg.lbl.SurfaceArea = Surface area:
-! Canopy material see: !SURFACE_MATERIAL
 ParachuteCfg.combo.MaterialModel = The component material affects the weight of the component.
 ParachuteCfg.lbl.longA1 = <html>Drag coefficient C<sub>D</sub>:
 ParachuteCfg.lbl.longB1 = <html>The drag coefficient relative to the total area of the parachute.<br>
@@ -1093,13 +1089,11 @@ ParachuteCfg.lbl.longB3 = A typical value for parachutes is 0.8.
 ParachuteCfg.lbl.Shroudlines = Shroud lines:
 ParachuteCfg.lbl.Numberoflines = Number of lines:
 ParachuteCfg.lbl.Linelength = Line length:
-! Line material see: LINE _MATERIAL
 ParachuteCfg.lbl.Material = Material:
 ParachuteCfg.lbl.Posrelativeto = Position relative to:
 ParachuteCfg.lbl.plus = plus
 ParachuteCfg.lbl.Packedlength = Packed length:
 ParachuteCfg.lbl.Packeddiam = Packed diameter:
-! Mass see: MassComponentCfg.lbl.Mass = Mass:
 ParachuteCfg.lbl.Deploysat = Deploys at:
 ParachuteCfg.lbl.seconds = seconds
 ParachuteCfg.lbl.Altitude = Altitude:
@@ -1410,7 +1404,6 @@ material.mylar = Mylar
 material.polyethylene_thin = Polyethylene (thin)
 material.polyethylene_heavy = Polyethylene (heavy)
 material.silk = Silk
-! Material "paper" see: material.paper_office = Paper (office)
 material.cellophane = Cellophane
 material.crepe_paper = Cr\u00eape paper
 ! LINE_MATERIAL

--- a/core/src/net/sf/openrocket/preset/ComponentPreset.java
+++ b/core/src/net/sf/openrocket/preset/ComponentPreset.java
@@ -151,15 +151,18 @@ public class ComponentPreset implements Comparable<ComponentPreset>, Serializabl
 				ComponentPreset.MANUFACTURER,
 				ComponentPreset.PARTNO,
 				ComponentPreset.DESCRIPTION,
+				ComponentPreset.CANOPY_SHAPE,
 				ComponentPreset.DIAMETER,
+				ComponentPreset.SPILL_DIA,
+				ComponentPreset.SURFACE_AREA,
+				ComponentPreset.MATERIAL,
 				ComponentPreset.SIDES,
-				ComponentPreset.PARACHUTE_CD,
-				ComponentPreset.PACKED_DIAMETER,
-				ComponentPreset.PACKED_LENGTH,
 				ComponentPreset.LINE_COUNT,
 				ComponentPreset.LINE_LENGTH,
 				ComponentPreset.LINE_MATERIAL,
-				ComponentPreset.MATERIAL });
+				ComponentPreset.PARACHUTE_CD,
+				ComponentPreset.PACKED_DIAMETER,
+				ComponentPreset.PACKED_LENGTH });
 
 		TypedKey<?>[] displayedColumns;
 
@@ -210,18 +213,30 @@ public class ComponentPreset implements Comparable<ComponentPreset>, Serializabl
 	public final static TypedKey<Boolean> FILLED = new TypedKey<Boolean>("Filled", Boolean.class);
 	public final static TypedKey<Double> MASS = new TypedKey<Double>("Mass", Double.class, UnitGroup.UNITS_MASS);
 	public final static TypedKey<Double> DIAMETER = new TypedKey<Double>("Diameter", Double.class, UnitGroup.UNITS_LENGTH);
-	public final static TypedKey<Integer> SIDES = new TypedKey<Integer>("Sides", Integer.class);
-	public static final TypedKey<Double> PARACHUTE_CD = new TypedKey<Double>("DragCoefficient", Double.class, UnitGroup.UNITS_COEFFICIENT);
-	public final static TypedKey<Double> PACKED_LENGTH = new TypedKey<Double>("PackedLength", Double.class, UnitGroup.UNITS_LENGTH);
-	public final static TypedKey<Double> PACKED_DIAMETER = new TypedKey<Double>("PackedDiameter", Double.class, UnitGroup.UNITS_LENGTH);
-	public final static TypedKey<Integer> LINE_COUNT = new TypedKey<Integer>("LineCount", Integer.class);
-	public final static TypedKey<Double> LINE_LENGTH = new TypedKey<Double>("LineLength", Double.class, UnitGroup.UNITS_LENGTH);
-	public final static TypedKey<Material> LINE_MATERIAL = new TypedKey<Material>("LineMaterial", Material.class);
 	public final static TypedKey<byte[]> IMAGE = new TypedKey<byte[]>("Image", byte[].class);
 	public final static TypedKey<Double> STANDOFF_HEIGHT = new TypedKey<Double>("StandoffHeight", Double.class, UnitGroup.UNITS_LENGTH);
 	public final static TypedKey<Double> FLANGE_HEIGHT = new TypedKey<Double>("FlangeHeight", Double.class, UnitGroup.UNITS_LENGTH);
 
+	//	PARACHUTE SPECIFIC
+	//	Parachute Manufacturer declaration see: MANUFACTURER
+	//	Parachute Part Number declaration see: PARTNO
+	//	Parachute Description declaration see: DESCRIPTION
+	public final static TypedKey<Shape> CANOPY_SHAPE = new TypedKey<Shape>("CanopyShape", Shape.class);
+	//	Parachute diameter declaration see: DIAMETER
+	public final static TypedKey<Double> SPILL_DIA = new TypedKey<Double>("SpillDia", Double.class, UnitGroup.UNITS_LENGTH);
+	public final static TypedKey<Double> SURFACE_AREA = new TypedKey<Double>("SurfaceArea", Double.class, UnitGroup.UNITS_LENGTH);
+	public static final TypedKey<Double> PARACHUTE_CD = new TypedKey<Double>("DragCoefficient", Double.class, UnitGroup.UNITS_COEFFICIENT);
+	//	Parachute canopy material declaration see: MATERIAL
+	public final static TypedKey<Integer> SIDES = new TypedKey<Integer>("Sides", Integer.class);
+	public final static TypedKey<Integer> LINE_COUNT = new TypedKey<Integer>("LineCount", Integer.class);
+	public final static TypedKey<Double> LINE_LENGTH = new TypedKey<Double>("LineLength", Double.class, UnitGroup.UNITS_LENGTH);
+	public final static TypedKey<Material> LINE_MATERIAL = new TypedKey<Material>("LineMaterial", Material.class);
+	public final static TypedKey<Double> PACKED_LENGTH = new TypedKey<Double>("PackedLength", Double.class, UnitGroup.UNITS_LENGTH);
+	public final static TypedKey<Double> PACKED_DIAMETER = new TypedKey<Double>("PackedDiameter", Double.class, UnitGroup.UNITS_LENGTH);
+	//	Parachute Mass declaration see: MASS
+
 	public final static List<TypedKey<?>> ORDERED_KEY_LIST = Collections.unmodifiableList(Arrays.asList(
+		//	DO NOT add to this list without redefining “table.column”
 			LEGACY,
 			MANUFACTURER,
 			PARTNO,
@@ -243,11 +258,6 @@ public class ComponentPreset implements Comparable<ComponentPreset>, Serializabl
 			FILLED,
 			DIAMETER,
 			SIDES,
-			/** DO NOT add new presets to this list without defining table.column
-			PARACHUTE_CD,
-			PACKED_LENGTH,
-			PACKED_DIAMETER,
-			*/
 			LINE_COUNT,
 			LINE_LENGTH,
 			LINE_MATERIAL,

--- a/swing/src/net/sf/openrocket/gui/preset/PresetEditorDialog.java
+++ b/swing/src/net/sf/openrocket/gui/preset/PresetEditorDialog.java
@@ -188,13 +188,21 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 	private DoubleModel stMass;
 	private ImageIcon stImage;
 	private JButton stImageBtn;
-	
+
+	//	Parachute Specific
+	//	Manufacturer see: private JTextField mfgTextField;
 	private JTextField pcPartNoTextField;
 	private JTextField pcDescTextField;
+	private DoubleModel pcDiameter;
+	private DoubleModel pcSpillDia;
+	private DoubleModel pcSurfaceArea;
+	private DoubleModel pcDragCoefficient;
+	//	Canopy material = private MaterialChooser materialChooser;
 	private JTextField pcSides;
 	private JTextField pcLineCount;
-	private DoubleModel pcDiameter;
 	private DoubleModel pcLineLength;
+	private DoubleModel pcPackedLength;
+	private DoubleModel pcPackedDiameter;
 	private MaterialChooser pcLineMaterialChooser;
 	private DoubleModel pcMass;
 	private ImageIcon pcImage;
@@ -1597,34 +1605,46 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 		case PARACHUTE:
 			setMaterial(materialChooser, preset, matHolder, Material.Type.SURFACE, ComponentPreset.MATERIAL);
 			typeCombo.setSelectedItem(trans.get(PARACHUTE_KEY));
+			pcPartNoTextField.setText(preset.get(ComponentPreset.PARTNO));
 			pcDescTextField.setText(preset.get(ComponentPreset.DESCRIPTION));
-			if (preset.has(ComponentPreset.LINE_COUNT)) {
-				pcLineCount.setText(preset.get(ComponentPreset.LINE_COUNT).toString());
-			}
-			if (preset.has(ComponentPreset.SIDES)) {
-				pcSides.setText(preset.get(ComponentPreset.SIDES).toString());
-			}
-			if (preset.has(ComponentPreset.MASS)) {
-				pcMass.setValue(preset.get(ComponentPreset.MASS));
-				pcMass.setCurrentUnit(UnitGroup.UNITS_MASS.getDefaultUnit());
-			}
 			if (preset.has(ComponentPreset.DIAMETER)) {
 				pcDiameter.setValue(preset.get(ComponentPreset.DIAMETER));
 				pcDiameter.setCurrentUnit(UnitGroup.UNITS_LENGTH.getDefaultUnit());
+			}
+			if (preset.has(ComponentPreset.PARACHUTE_CD)) {
+				pcDragCoefficient.setValue(preset.get(ComponentPreset.PARACHUTE_CD));
+				pcDragCoefficient.setCurrentUnit(UnitGroup.UNITS_COEFFICIENT.getDefaultUnit());
+			}
+			setMaterial(materialChooser, preset, matHolder, Material.Type.SURFACE, ComponentPreset.MATERIAL);
+			if (preset.has(ComponentPreset.SIDES)) {
+				pcSides.setText(preset.get(ComponentPreset.SIDES).toString());
+			}
+			if (preset.has(ComponentPreset.LINE_COUNT)) {
+				pcLineCount.setText(preset.get(ComponentPreset.LINE_COUNT).toString());
 			}
 			if (preset.has(ComponentPreset.LINE_LENGTH)) {
 				pcLineLength.setValue(preset.get(ComponentPreset.LINE_LENGTH));
 				pcLineLength.setCurrentUnit(UnitGroup.UNITS_LENGTH.getDefaultUnit());
 			}
-			pcPartNoTextField.setText(preset.get(ComponentPreset.PARTNO));
+			setMaterial(pcLineMaterialChooser, preset, matHolder, Material.Type.LINE, ComponentPreset.LINE_MATERIAL);
+			//    pcLineMaterialChooser.setModel(new MaterialModel(PresetEditorDialog.this, Material.Type.LINE));
+			//    pcLineMaterialChooser.getModel().setSelectedItem(preset.get(ComponentPreset.LINE_MATERIAL));
+			if (preset.has(ComponentPreset.PACKED_LENGTH)) {
+				pcPackedLength.setValue(preset.get(ComponentPreset.PACKED_LENGTH));
+				pcPackedLength.setCurrentUnit(UnitGroup.UNITS_LENGTH.getDefaultUnit());
+			}
+			if (preset.has(ComponentPreset.PACKED_DIAMETER)) {
+				pcPackedDiameter.setValue(preset.get(ComponentPreset.PACKED_DIAMETER));
+				pcPackedDiameter.setCurrentUnit(UnitGroup.UNITS_LENGTH.getDefaultUnit());
+			}
+			if (preset.has(ComponentPreset.MASS)) {
+				pcMass.setValue(preset.get(ComponentPreset.MASS));
+				pcMass.setCurrentUnit(UnitGroup.UNITS_MASS.getDefaultUnit());
+			}
 			if (preset.has(ComponentPreset.IMAGE)) {
 				pcImage = new ImageIcon(byteArrayToImage(preset.get(ComponentPreset.IMAGE)));
 				pcImageBtn.setIcon(pcImage);
 			}
-			setMaterial(pcLineMaterialChooser, preset, matHolder, Material.Type.LINE, ComponentPreset.LINE_MATERIAL);
-			//                pcLineMaterialChooser.setModel(new MaterialModel(PresetEditorDialog.this, Material.Type.LINE));
-			
-			//                pcLineMaterialChooser.getModel().setSelectedItem(preset.get(ComponentPreset.LINE_MATERIAL));
 			break;
 		case STREAMER:
 			setMaterial(materialChooser, preset, matHolder, Material.Type.SURFACE, ComponentPreset.MATERIAL);
@@ -2157,17 +2177,10 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 		TypedPropertyMap props = new TypedPropertyMap();
 		try {
 			props.put(ComponentPreset.TYPE, ComponentPreset.Type.PARACHUTE);
-			props.put(ComponentPreset.DIAMETER, pcDiameter.getValue());
-			props.put(ComponentPreset.DESCRIPTION, pcDescTextField.getText());
-			props.put(ComponentPreset.PARTNO, pcPartNoTextField.getText());
 			props.put(ComponentPreset.MANUFACTURER, Manufacturer.getManufacturer(mfgTextField.getText()));
-			if (!pcLineCount.getText().equals("")) {
-				props.put(ComponentPreset.LINE_COUNT, Integer.parseInt(pcLineCount.getText()));
-			}
-			if (!pcSides.getText().equals("")) {
-				props.put(ComponentPreset.SIDES, Integer.parseInt(pcSides.getText()));
-			}
-			props.put(ComponentPreset.LINE_LENGTH, pcLineLength.getValue());
+			props.put(ComponentPreset.PARTNO, pcPartNoTextField.getText());
+			props.put(ComponentPreset.DESCRIPTION, pcDescTextField.getText());
+			props.put(ComponentPreset.PARACHUTE_CD, pcDragCoefficient.getValue());
 			Material material = (Material) materialChooser.getSelectedItem();
 			if (material != null) {
 				props.put(ComponentPreset.MATERIAL, material);
@@ -2176,6 +2189,13 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 				JOptionPane.showMessageDialog(null, "A material must be selected.", "Error", JOptionPane.ERROR_MESSAGE);
 				return null;
 			}
+			if (!pcLineCount.getText().equals("")) {
+				props.put(ComponentPreset.LINE_COUNT, Integer.parseInt(pcLineCount.getText()));
+			}
+			if (!pcSides.getText().equals("")) {
+				props.put(ComponentPreset.SIDES, Integer.parseInt(pcSides.getText()));
+			}
+			props.put(ComponentPreset.LINE_LENGTH, pcLineLength.getValue());
 			material = (Material) pcLineMaterialChooser.getSelectedItem();
 			if (material != null) {
 				props.put(ComponentPreset.LINE_MATERIAL, material);

--- a/swing/src/net/sf/openrocket/gui/preset/PresetEditorDialog.java
+++ b/swing/src/net/sf/openrocket/gui/preset/PresetEditorDialog.java
@@ -190,7 +190,6 @@ public class PresetEditorDialog extends JDialog implements ItemListener {
 	private JButton stImageBtn;
 
 	//	Parachute Specific
-	//	Manufacturer see: private JTextField mfgTextField;
 	private JTextField pcPartNoTextField;
 	private JTextField pcDescTextField;
 	private DoubleModel pcDiameter;


### PR DESCRIPTION
Adds packed length and diameter to preset editor; also adds labels and additional presets for .orc files so that spill hole data can be added to the .orc files without throwing warnings (does not change editor for spill holes).