### PR TITLE
[Fixes #1141] Fix packed length overlap

### DIFF
--- a/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
@@ -214,7 +214,7 @@ public class RocketComponentConfig extends JPanel {
 					String finishString, 
 					String partName) {
 		
-	    JPanel subPanel = new JPanel(new MigLayout());
+	    JPanel subPanel = new JPanel(new MigLayout("insets 0"));
 	    	JLabel label = new JLabel(materialString);
 		//// The component material affects the weight of the component.
 		label.setToolTipText(trans.get("RocketCompCfg.lbl.ttip.componentmaterialaffects"));

--- a/swing/src/net/sf/openrocket/gui/configdialog/ShockCordConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/ShockCordConfig.java
@@ -53,7 +53,7 @@ public class ShockCordConfig extends RocketComponentConfig {
 
 		// Material
 		//// Shock cord material:
-		panel.add(materialPanel(Material.Type.LINE, trans.get("ShockCordCfg.lbl.Shockcordmaterial"), null, "Material"), "span, wrap");
+		panel.add(materialPanel(Material.Type.LINE, trans.get("ShockCordCfg.lbl.Shockcordmaterial"), null, "Material"), "spanx 4, wrap");
 		
 
 


### PR DESCRIPTION
This PR fixes #1141 where there was an overlap issue of the packed length of the shock cord config on macOS.

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/11031519/169718757-8d6b1cce-590e-40c7-bd20-3ed4a2eb22c3.png">

@hcraigmiller @JoePfeiffer could you verify that nothing got messed up on the Windows and Linux layout?

Here is a [jar file](https://github.com/openrocket/openrocket/suites/6611911386/artifacts/248779396) for testing.