### PR TITLE
[#1285] Improve Motors & Configurations UI scalability

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/MotorMountConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/MotorMountConfigurationPanel.java
@@ -35,7 +35,7 @@ public class MotorMountConfigurationPanel extends JPanel {
 		
 		table.addMouseListener(new GUIUtil.BooleanTableClickListener(table));
 		JScrollPane scroll = new JScrollPane(table);
-		this.add(scroll, "w 200lp, h 150lp, grow");
+		this.add(scroll, "w 200lp, h 150lp, grow, pushy");
 
 	}
 }

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurationPanel.java
@@ -139,7 +139,7 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 
 		updateButtonState();
 
-		this.add(tabs, "spanx, grow, wrap rel");
+		this.add(tabs, "spanx, grow, pushy, wrap rel");
 	}
 
 	/**

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
@@ -75,12 +75,12 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 					"<html><b>" + trans.get("lbl.motorMounts") + "</b></html>"));
 
 			MotorMountConfigurationPanel mountConfigPanel = new MotorMountConfigurationPanel(this, rocket);
-			subpanel.add(mountConfigPanel, "grow");
-			this.add(subpanel, "split, growy");
+			subpanel.add(mountConfigPanel, "grow, pushy");
+			this.add(subpanel, "split, growy, pushy");
 		}
 
 		cards = new JPanel(new CardLayout());
-		this.add(cards);
+		this.add(cards, "pushy");
 
 		JLabel helpText = new JLabel(trans.get("MotorConfigurationPanel.lbl.nomotors"));
 		cards.add(helpText, HELP_LABEL );
@@ -90,7 +90,7 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 				BorderFactory.createEtchedBorder(),
 				"<html><b>" + trans.get("MotorConfigurationPanel.lbl.motorConfiguration") + "</b></html>"));
 		JScrollPane scroll = new JScrollPane(table);
-		configurationPanel.add(scroll, "spanx, grow, wrap");
+		configurationPanel.add(scroll, "spanx, grow, pushy, wrap");
 
 		//// Select motor
 		selectMotorButton = new SelectColorButton(trans.get("MotorConfigurationPanel.btn.selectMotor"));
@@ -134,7 +134,7 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 
 		cards.add(configurationPanel, TABLE_LABEL );
 
-		this.add(cards, "gapleft para, grow, wrap");
+		this.add(cards, "gapleft para, grow, pushy, wrap");
 
 		// Set 'Enter' key action to open the motor selection dialog
 		table.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
@@ -41,7 +41,7 @@ public class RecoveryConfigurationPanel extends FlightConfigurablePanel<Recovery
 		super(flightConfigurationPanel,rocket);
 
 		JScrollPane scroll = new JScrollPane(table);
-		this.add(scroll, "span, grow, wrap");
+		this.add(scroll, "span, grow, pushy, wrap");
 
 		//// Select deployment
 		selectDeploymentButton = new SelectColorButton(trans.get("edtmotorconfdlg.but.Selectdeployment"));

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
@@ -45,7 +45,7 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialS
 		super(flightConfigurationPanel,rocket);
 		
 		JScrollPane scroll = new JScrollPane(table);
-		this.add(scroll, "span, grow, wrap");
+		this.add(scroll, "span, grow, pushy, wrap");
 		
 		//// Select deployment
 		selectSeparationButton = new SelectColorButton(trans.get("edtmotorconfdlg.but.Selectseparation"));


### PR DESCRIPTION
This PR fixes #1285 by improving the scalability of the Motors & Configurations tab UI.

Demo:

https://user-images.githubusercontent.com/11031519/169719394-1603079e-019c-4b32-8b98-bcd15c8e4fd4.mov



Again, @hcraigmiller and @JoePfeiffer  could you verify a correct working on Windows/Linux?

Here is a [jar file](https://github.com/openrocket/openrocket/suites/6612001183/artifacts/248785892) for testing.