### PR TITLE
Improve parachute preset code/gui

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/Parachute.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Parachute.java
@@ -9,22 +9,23 @@ import net.sf.openrocket.util.MathUtil;
 
 public class Parachute extends RecoveryDevice {
 	private static final Translator trans = Application.getTranslator();
-	private final double defaultDiameter = 0.3;
+	private final double DEFAULT_DIAMETER = 0.3;
 	private double diameter;
 	public static double DEFAULT_CD = 0.8;
-	private final Material defaultLineMaterial;
+	private final Material DEFAULT_LINE_MATERIAL;
 	private Material lineMaterial;
-	private final int defaultLineCount = 6;
-	private int lineCount = defaultLineCount;
-	private final double defaultLineLength = 0.3;
-	private double lineLength = defaultLineLength;
+	private final int DEFAULT_LINE_COUNT = 6;
+	private int lineCount;
+	private final double DEFAULT_LINE_LENGTH = 0.3;
+	private double lineLength = DEFAULT_LINE_LENGTH;
 	private final double InitialPackedLength = this.length;
 	private final double InitialPackedRadius = this.radius;
 
 	public Parachute() {
-		this.diameter = defaultDiameter;
+		this.diameter = DEFAULT_DIAMETER;
+		lineCount = DEFAULT_LINE_COUNT;
 		this.lineMaterial = Application.getPreferences().getDefaultComponentMaterial(Parachute.class, Material.Type.LINE);
-		defaultLineMaterial= lineMaterial;
+		DEFAULT_LINE_MATERIAL = lineMaterial;
 		super.displayOrder_side = 11;		// Order for displaying the component in the 2D side view
 		super.displayOrder_back = 9;		// Order for displaying the component in the 2D back view
 	}
@@ -173,7 +174,7 @@ public class Parachute extends RecoveryDevice {
 		if ((preset.has(ComponentPreset.DIAMETER)) && preset.get(ComponentPreset.DIAMETER) > 0) {
 			this.diameter = preset.get(ComponentPreset.DIAMETER);
 		} else {
-			this.diameter = defaultDiameter;
+			this.diameter = DEFAULT_DIAMETER;
 		}
 		//	//	Set preset parachute drag coefficient
 		 if ((preset.has(ComponentPreset.PARACHUTE_CD)) && preset.get(ComponentPreset.PARACHUTE_CD) > 0){
@@ -187,13 +188,13 @@ public class Parachute extends RecoveryDevice {
 		if ((preset.has(ComponentPreset.LINE_COUNT)) && preset.get(ComponentPreset.LINE_COUNT) > 0) {
 			this.lineCount = preset.get(ComponentPreset.LINE_COUNT);
 		} else {
-			this.lineCount = defaultLineCount;
+			this.lineCount = DEFAULT_LINE_COUNT;
 		}
 		//	//	Set preset parachute line length
 		if ((preset.has(ComponentPreset.LINE_LENGTH)) && preset.get(ComponentPreset.LINE_LENGTH) > 0) {
 			this.lineLength = preset.get(ComponentPreset.LINE_LENGTH);
 		} else {
-			this.lineLength = defaultLineLength;
+			this.lineLength = DEFAULT_LINE_LENGTH;
 		}
 		//	//	Set preset parachute line material
 			//	NEED a better way to set preset if field is empty ----
@@ -203,10 +204,10 @@ public class Parachute extends RecoveryDevice {
 			if (count > 12 ) {
 				this.lineMaterial = preset.get(ComponentPreset.LINE_MATERIAL);
 			} else {
-				this.lineMaterial = defaultLineMaterial;
+				this.lineMaterial = DEFAULT_LINE_MATERIAL;
 			}
 		} else {
-			this.lineMaterial = defaultLineMaterial;
+			this.lineMaterial = DEFAULT_LINE_MATERIAL;
 		}
 
 		//	//	Set preset parachute packed length

--- a/core/src/net/sf/openrocket/rocketcomponent/Parachute.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Parachute.java
@@ -105,10 +105,12 @@ public class Parachute extends RecoveryDevice {
 		if (MathUtil.equals(this.lineLength, length))
 			return;
 		this.lineLength = length;
-		if (getLineCount() != 0)
+		if (getLineCount() != 0) {
 			fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
-		else
+			clearPreset();
+		} else {
 			fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
+		}
 	}
 
 	public final Material getLineMaterial() {
@@ -127,8 +129,10 @@ public class Parachute extends RecoveryDevice {
 		if (mat.equals(lineMaterial))
 			return;
 		this.lineMaterial = mat;
-		if (getLineCount() != 0)
+		if (getLineCount() != 0) {
+			clearPreset();
 			fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
+		}
 		else
 			fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 	}

--- a/core/src/net/sf/openrocket/rocketcomponent/Parachute.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Parachute.java
@@ -17,13 +17,14 @@ public class Parachute extends RecoveryDevice {
 	private final int DEFAULT_LINE_COUNT = 6;
 	private int lineCount;
 	private final double DEFAULT_LINE_LENGTH = 0.3;
-	private double lineLength = DEFAULT_LINE_LENGTH;
+	private double lineLength;
 	private final double InitialPackedLength = this.length;
 	private final double InitialPackedRadius = this.radius;
 
 	public Parachute() {
 		this.diameter = DEFAULT_DIAMETER;
 		lineCount = DEFAULT_LINE_COUNT;
+		lineLength = DEFAULT_LINE_LENGTH;
 		this.lineMaterial = Application.getPreferences().getDefaultComponentMaterial(Parachute.class, Material.Type.LINE);
 		DEFAULT_LINE_MATERIAL = lineMaterial;
 		super.displayOrder_side = 11;		// Order for displaying the component in the 2D side view

--- a/core/src/net/sf/openrocket/rocketcomponent/Parachute.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Parachute.java
@@ -9,24 +9,31 @@ import net.sf.openrocket.util.MathUtil;
 
 public class Parachute extends RecoveryDevice {
 	private static final Translator trans = Application.getTranslator();
-	
-	public static double DEFAULT_CD = 0.8;
-	
+	private final double defaultDiameter = 0.3;
 	private double diameter;
+	public static double DEFAULT_CD = 0.8;
+	private final Material defaultLineMaterial;
+	private Material lineMaterial;
+	private final int defaultLineCount = 6;
+	private int lineCount = defaultLineCount;
+	private final double defaultLineLength = 0.3;
+	private double lineLength = defaultLineLength;
 	private final double InitialPackedLength = this.length;
 	private final double InitialPackedRadius = this.radius;
 
-	private Material lineMaterial;
-	private int lineCount = 6;
-	private double lineLength = 0.3;
-
 	public Parachute() {
-		this.diameter = 0.3;
+		this.diameter = defaultDiameter;
 		this.lineMaterial = Application.getPreferences().getDefaultComponentMaterial(Parachute.class, Material.Type.LINE);
+		defaultLineMaterial= lineMaterial;
 		super.displayOrder_side = 11;		// Order for displaying the component in the 2D side view
 		super.displayOrder_back = 9;		// Order for displaying the component in the 2D back view
 	}
-	
+
+	@Override
+	public String getComponentName() {
+		//// Parachute
+		return trans.get("Parachute.Parachute");
+	}
 	
 	public double getDiameter() {
 		return diameter;
@@ -38,15 +45,72 @@ public class Parachute extends RecoveryDevice {
 				((Parachute) listener).setDiameter(d);
 			}
 		}
-
 		if (MathUtil.equals(this.diameter, d))
 			return;
 		this.diameter = d;
 		clearPreset();
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
-	
-	
+
+	@Override
+	public double getArea() {
+		return Math.PI * MathUtil.pow2(diameter / 2);
+	}
+
+	public void setArea(double area) {
+		for (RocketComponent listener : configListeners) {
+			if (listener instanceof Parachute) {
+				((Parachute) listener).setArea(area);
+			}
+		}
+		if (MathUtil.equals(getArea(), area))
+			return;
+		diameter = MathUtil.safeSqrt(area / Math.PI) * 2;
+		clearPreset();
+		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
+	}
+
+	@Override
+	public double getComponentCD(double mach) {
+		return cd; // TODO: HIGH:  Better parachute CD estimate?
+	}
+
+	public final int getLineCount() {
+		return lineCount;
+	}
+
+	public final void setLineCount(int n) {
+		for (RocketComponent listener : configListeners) {
+			if (listener instanceof Parachute) {
+				((Parachute) listener).setLineCount(n);
+			}
+		}
+		if (this.lineCount == n)
+			return;
+		this.lineCount = n;
+		clearPreset();
+		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
+	}
+
+	public final double getLineLength() {
+		return lineLength;
+	}
+
+	public final void setLineLength(double length) {
+		for (RocketComponent listener : configListeners) {
+			if (listener instanceof Parachute) {
+				((Parachute) listener).setLineLength(length);
+			}
+		}
+		if (MathUtil.equals(this.lineLength, length))
+			return;
+		this.lineLength = length;
+		if (getLineCount() != 0)
+			fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
+		else
+			fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
+	}
+
 	public final Material getLineMaterial() {
 		return lineMaterial;
 	}
@@ -57,7 +121,6 @@ public class Parachute extends RecoveryDevice {
 				((Parachute) listener).setLineMaterial(mat);
 			}
 		}
-
 		if (mat.getType() != Material.Type.LINE) {
 			throw new IllegalArgumentException("Attempted to set non-line material " + mat);
 		}
@@ -70,80 +133,10 @@ public class Parachute extends RecoveryDevice {
 			fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 	}
 	
-	
-	public final int getLineCount() {
-		return lineCount;
-	}
-	
-	public final void setLineCount(int n) {
-		for (RocketComponent listener : configListeners) {
-			if (listener instanceof Parachute) {
-				((Parachute) listener).setLineCount(n);
-			}
-		}
-
-		if (this.lineCount == n)
-			return;
-		this.lineCount = n;
-		clearPreset();
-		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
-	}
-	
-	public final double getLineLength() {
-		return lineLength;
-	}
-	
-	public final void setLineLength(double length) {
-		for (RocketComponent listener : configListeners) {
-			if (listener instanceof Parachute) {
-				((Parachute) listener).setLineLength(length);
-			}
-		}
-
-		if (MathUtil.equals(this.lineLength, length))
-			return;
-		this.lineLength = length;
-		if (getLineCount() != 0)
-			fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
-		else
-			fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
-	}
-	
-	
-	@Override
-	public double getComponentCD(double mach) {
-		return DEFAULT_CD; // TODO: HIGH:  Better parachute CD estimate?
-	}
-	
-	@Override
-	public double getArea() {
-		return Math.PI * MathUtil.pow2(diameter / 2);
-	}
-	
-	public void setArea(double area) {
-		for (RocketComponent listener : configListeners) {
-			if (listener instanceof Parachute) {
-				((Parachute) listener).setArea(area);
-			}
-		}
-
-		if (MathUtil.equals(getArea(), area))
-			return;
-		diameter = MathUtil.safeSqrt(area / Math.PI) * 2;
-		clearPreset();
-		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
-	}
-	
 	@Override
 	public double getComponentMass() {
 		return super.getComponentMass() +
 				getLineCount() * getLineLength() * getLineMaterial().getDensity();
-	}
-	
-	@Override
-	public String getComponentName() {
-		//// Parachute
-		return trans.get("Parachute.Parachute");
 	}
 	
 	@Override
@@ -156,11 +149,11 @@ public class Parachute extends RecoveryDevice {
 		return false;
 	}
 
-
 	@Override
 	protected void loadFromPreset(ComponentPreset preset) {
 
-		// BEGIN Substitute parachute description for component name
+		// SUBSTITUTE preset parachute values for existing component values
+		//	//	Set preset parachute description
 		if (preset.has(ComponentPreset.DESCRIPTION)) {
 			String temporaryName = preset.get(ComponentPreset.DESCRIPTION);
 			int size = temporaryName.length();
@@ -172,89 +165,76 @@ public class Parachute extends RecoveryDevice {
 		} else {
 			this.name = getComponentName();
 		}
-		// END Substitute parachute description for component name
-
-		if (preset.has(ComponentPreset.DIAMETER)) {
+		//	//	Set preset parachute diameter
+		if ((preset.has(ComponentPreset.DIAMETER)) && preset.get(ComponentPreset.DIAMETER) > 0) {
 			this.diameter = preset.get(ComponentPreset.DIAMETER);
+		} else {
+			this.diameter = defaultDiameter;
 		}
-
-		 // BEGIN Implement parachute cd
-		 if (preset.has(ComponentPreset.PARACHUTE_CD)) {
-			 if (preset.get(ComponentPreset.PARACHUTE_CD) > 0) {
+		//	//	Set preset parachute drag coefficient
+		 if ((preset.has(ComponentPreset.PARACHUTE_CD)) && preset.get(ComponentPreset.PARACHUTE_CD) > 0){
 		 		cdAutomatic = false;
 		 		cd = preset.get(ComponentPreset.PARACHUTE_CD);
-		 		}
-			 else {
-				 cdAutomatic = true;
-				 cd = Parachute.DEFAULT_CD;
-		 		}
 		 } else {
 			 cdAutomatic = true;
 			 cd = Parachute.DEFAULT_CD;
 		 }
-		 // END Implement parachute cd
+		//	//	Set preset parachute line count
+		if ((preset.has(ComponentPreset.LINE_COUNT)) && preset.get(ComponentPreset.LINE_COUNT) > 0) {
+			this.lineCount = preset.get(ComponentPreset.LINE_COUNT);
+		} else {
+			this.lineCount = defaultLineCount;
+		}
+		//	//	Set preset parachute line length
+		if ((preset.has(ComponentPreset.LINE_LENGTH)) && preset.get(ComponentPreset.LINE_LENGTH) > 0) {
+			this.lineLength = preset.get(ComponentPreset.LINE_LENGTH);
+		} else {
+			this.lineLength = defaultLineLength;
+		}
+		//	//	Set preset parachute line material
+			//	NEED a better way to set preset if field is empty ----
+		if ((preset.has(ComponentPreset.LINE_MATERIAL))) {
+			String lineMaterialEmpty = preset.get(ComponentPreset.LINE_MATERIAL).toString();
+			int count = lineMaterialEmpty.length();
+			if (count > 12 ) {
+				this.lineMaterial = preset.get(ComponentPreset.LINE_MATERIAL);
+			} else {
+				this.lineMaterial = defaultLineMaterial;
+			}
+		} else {
+			this.lineMaterial = defaultLineMaterial;
+		}
 
-		// BEGIN Implement parachute length, diameter, and volume
-		//// BEGIN Implement parachute packed length
-		if (preset.has(ComponentPreset.PACKED_LENGTH)) {
+		//	//	Set preset parachute packed length
+		if ((preset.has(ComponentPreset.PACKED_LENGTH)) && preset.get(ComponentPreset.PACKED_LENGTH) > 0) {
 			this.PackedLength = preset.get(ComponentPreset.PACKED_LENGTH);
-			if (PackedLength > 0) {
-				length = PackedLength;
-			}
-			else {
-				length = InitialPackedLength;
-			}
+			length = PackedLength;
 		} else {
 			length = InitialPackedLength;
 		}
-		//// END Implement parachute packed length
-		//// BEGIN Implement parachute packed diameter
-		if (preset.has(ComponentPreset.PACKED_DIAMETER)) {
+		//	// Set preset parachute packed diameter
+		if ((preset.has(ComponentPreset.PACKED_DIAMETER)) && preset.get(ComponentPreset.PACKED_DIAMETER) > 0) {
 			this.PackedDiameter = preset.get(ComponentPreset.PACKED_DIAMETER);
-			if (PackedDiameter > 0) {
-				radius = PackedDiameter / 2;
-			}
-			if (PackedDiameter <= 0) {
-				radius = InitialPackedRadius;
-			}
+			radius = PackedDiameter / 2;
 		} else {
 			radius = InitialPackedRadius;
-	}
-		//// END Implement parachute packed diameter
-		//// BEGIN Size parachute packed diameter within parent inner diameter
+		}
+		//	// Size parachute packed diameter within parent inner diameter
 		if (length > 0 && radius > 0) {
 			double parachuteVolume = (Math.PI * Math.pow(radius, 2) * length);
 			setRadiusAutomatic(true);
 			length = parachuteVolume / (Math.PI * Math.pow(getRadius(), 2));
-
 		}
-		//// END Size parachute packed diameter within parent inner diameter
-		// END Implement parachute length, diameter, and volume
 
-		// BEGIN Activate Override Mass Preset
-		if (preset.has(ComponentPreset.MASS)) {
+		// SUBSTITUTE / ACTIVATE Override Mass Preset
+		if ((preset.has(ComponentPreset.MASS))&& (preset.get(ComponentPreset.MASS)) > 0){
 			this.overrideMass = (preset.get(ComponentPreset.MASS));
-			if (overrideMass > 0) {
-				massOverridden = true;
-			} else {
-				this.overrideMass = 0;
-				massOverridden = false;
-			}
+			massOverridden = true;
 		} else {
 			this.overrideMass = 0;
 			massOverridden = false;
 		}
-		// END Activate Override Mass Preset
 
-		if (preset.has(ComponentPreset.LINE_COUNT)) {
-			this.lineCount = preset.get(ComponentPreset.LINE_COUNT);
-		}
-		if (preset.has(ComponentPreset.LINE_LENGTH)) {
-			this.lineLength = preset.get(ComponentPreset.LINE_LENGTH);
-		}
-		if (preset.has(ComponentPreset.LINE_MATERIAL)) {
-			this.lineMaterial = preset.get(ComponentPreset.LINE_MATERIAL);
-		}
 		super.loadFromPreset(preset);
 	}
 

--- a/core/src/net/sf/openrocket/rocketcomponent/RecoveryDevice.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RecoveryDevice.java
@@ -20,28 +20,29 @@ import net.sf.openrocket.util.MathUtil;
  */
 public abstract class RecoveryDevice extends MassObject implements FlightConfigurableComponent {
 	////
-	protected double DragCoefficient;
 	protected double PackedDiameter;
 	protected double PackedLength;
 	////
+	protected double DragCoefficient;
 	protected double cd = Parachute.DEFAULT_CD;
 	protected boolean cdAutomatic = true;
-	
+	////
+	private final Material.Surface defaultMaterial;
 	private Material.Surface material;
-	
+
 	private FlightConfigurableParameterSet<DeploymentConfiguration> deploymentConfigurations;
 	
 	public RecoveryDevice() {
-		this.deploymentConfigurations = new FlightConfigurableParameterSet<DeploymentConfiguration>( new DeploymentConfiguration());
+		this.deploymentConfigurations =
+				new FlightConfigurableParameterSet<DeploymentConfiguration>( new DeploymentConfiguration());
+		defaultMaterial = (Material.Surface) Application.getPreferences().getDefaultComponentMaterial(RecoveryDevice.class, Material.Type.SURFACE);
 		setMaterial(Application.getPreferences().getDefaultComponentMaterial(RecoveryDevice.class, Material.Type.SURFACE));
 	}
 	
 	public abstract double getArea();
 	
 	public abstract double getComponentCD(double mach);
-	
-	
-	
+
 	public double getCD() {
 		return getCD(0);
 	}
@@ -125,17 +126,27 @@ public abstract class RecoveryDevice extends MassObject implements FlightConfigu
 	public double getComponentMass() {
 		return getArea() * getMaterial().getDensity();
 	}
-	
+
 	@Override
 	protected void loadFromPreset(ComponentPreset preset) {
+	//	//	Set preset parachute line material
+		//	NEED a better way to set preset if field is empty ----
 		if (preset.has(ComponentPreset.MATERIAL)) {
-			Material m = preset.get(ComponentPreset.MATERIAL);
-			this.material = (Material.Surface) m;
+			String surfaceMaterialEmpty = preset.get(ComponentPreset.MATERIAL).toString();
+			int count = surfaceMaterialEmpty.length();
+			if (count > 12 ) {
+				Material m = preset.get(ComponentPreset.MATERIAL);
+				this.material = (Material.Surface) m;
+			} else {
+				this.material = defaultMaterial;
+			}
+		} else {
+			this.material = defaultMaterial;
 		}
 		super.loadFromPreset(preset);
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
-	
+
 	@Override
 	protected RocketComponent copyWithOriginalID() {
 		RecoveryDevice copy = (RecoveryDevice) super.copyWithOriginalID();

--- a/core/src/net/sf/openrocket/rocketcomponent/RecoveryDevice.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RecoveryDevice.java
@@ -64,6 +64,7 @@ public abstract class RecoveryDevice extends MassObject implements FlightConfigu
 			return;
 		this.cd = cd;
 		this.cdAutomatic = false;
+		clearPreset();
 		fireComponentChangeEvent(ComponentChangeEvent.AERODYNAMIC_CHANGE);
 	}
 	


### PR DESCRIPTION
Corrected drag coefficient return from “DEFAULT_CD” to cd.” Condensed code related to setting parachute preset values. Added code to set parachute characteristics to default values when a particular characteristic data field either does not exist, is empty, or (when numerical) has a value that is not greater than zero.

![Parachutes Elements n_02](https://user-images.githubusercontent.com/68821492/169758672-c29d4241-31d4-46dc-98ec-e60ad5b1ab01.png)

Here's a [jar file](https://www.dropbox.com/s/ajxks4e430eh44j/OpenRocket.1371.jar?dl=0) for testing 

Added removal of preset status upon changes to parachute Cd, line length, and line material (jar file updated).