### PR TITLE
Streamer changes exit preset status

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/Streamer.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Streamer.java
@@ -156,6 +156,7 @@ public class Streamer extends RecoveryDevice {
 	@Override
 	public double getComponentCD(double mach) {
 		double density = this.getMaterial().getDensity();
+		double cd;	
 		cd = 0.034 * ((density + 0.025) / 0.105) * (stripLength + 1) / stripLength;
 		cd = MathUtil.min(cd, MAX_COMPUTED_CD);
 		return cd;

--- a/core/src/net/sf/openrocket/rocketcomponent/Streamer.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Streamer.java
@@ -40,7 +40,7 @@ public class Streamer extends RecoveryDevice {
 		if (MathUtil.equals(this.stripLength, stripLength))
 			return;
 		this.stripLength = stripLength;
-		clearPreset();
+//		clearPreset();
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 	
@@ -95,6 +95,7 @@ public class Streamer extends RecoveryDevice {
 		double area = getArea();
 		stripWidth = MathUtil.safeSqrt(area / ratio);
 		stripLength = ratio * stripWidth;
+		clearPreset(); // ----
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 	
@@ -117,6 +118,7 @@ public class Streamer extends RecoveryDevice {
 		double ratio = Math.max(getAspectRatio(), 0.01);
 		stripWidth = MathUtil.safeSqrt(area / ratio);
 		stripLength = ratio * stripWidth;
+		clearPreset(); // ----
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 	
@@ -136,6 +138,14 @@ public class Streamer extends RecoveryDevice {
 		if ( preset.has(ComponentPreset.WIDTH)) {
 			this.stripWidth = preset.get(ComponentPreset.WIDTH);
 		}
+		// ----	Set Cd value when preset is selected after manual Cd change
+		double density = this.getMaterial().getDensity();
+		double cd;
+		cd = 0.034 * ((density + 0.025) / 0.105) * (stripLength + 1) / stripLength;
+		cd = MathUtil.min(cd, MAX_COMPUTED_CD);
+ 		this.cd = cd;
+		this.cdAutomatic = true;
+		// ----
 		super.loadFromPreset(preset);
 		// Fix the length to the stripWidth since RocketComponent assigns ComponentPreset.LENGTH to length.
 		this.length = this.stripWidth;
@@ -146,8 +156,6 @@ public class Streamer extends RecoveryDevice {
 	@Override
 	public double getComponentCD(double mach) {
 		double density = this.getMaterial().getDensity();
-		double cd;
-		
 		cd = 0.034 * ((density + 0.025) / 0.105) * (stripLength + 1) / stripLength;
 		cd = MathUtil.min(cd, MAX_COMPUTED_CD);
 		return cd;

--- a/core/src/net/sf/openrocket/rocketcomponent/Streamer.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Streamer.java
@@ -95,7 +95,7 @@ public class Streamer extends RecoveryDevice {
 		double area = getArea();
 		stripWidth = MathUtil.safeSqrt(area / ratio);
 		stripLength = ratio * stripWidth;
-		clearPreset(); // ----
+		clearPreset();
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 	
@@ -118,7 +118,7 @@ public class Streamer extends RecoveryDevice {
 		double ratio = Math.max(getAspectRatio(), 0.01);
 		stripWidth = MathUtil.safeSqrt(area / ratio);
 		stripLength = ratio * stripWidth;
-		clearPreset(); // ----
+		clearPreset();
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 	
@@ -138,14 +138,14 @@ public class Streamer extends RecoveryDevice {
 		if ( preset.has(ComponentPreset.WIDTH)) {
 			this.stripWidth = preset.get(ComponentPreset.WIDTH);
 		}
-		// ----	Set Cd value when preset is selected after manual Cd change
+		//	Set Cd value when preset is selected after manual Cd change
 		double density = this.getMaterial().getDensity();
 		double cd;
 		cd = 0.034 * ((density + 0.025) / 0.105) * (stripLength + 1) / stripLength;
 		cd = MathUtil.min(cd, MAX_COMPUTED_CD);
  		this.cd = cd;
 		this.cdAutomatic = true;
-		// ----
+
 		super.loadFromPreset(preset);
 		// Fix the length to the stripWidth since RocketComponent assigns ComponentPreset.LENGTH to length.
 		this.length = this.stripWidth;


### PR DESCRIPTION
Changing a streamer characteristic exits preset status; except for streamer length. Selection of a preset streamer when not in preset status (such as re-selecting the same preset streamer after changing one of its characteristics), sets all characteristics (including Cd and automatic checkbox); previously, the Cd and automatic checkbox were not set/reset after a manual Cd change.

Here's a [jar file](https://www.dropbox.com/s/4du4zi5nzyz6qlw/OpenRocket_PR1376.jar?dl=0) for testing.

I believe that this PR and PR #1371 will complete Issue #1344 except for centering ring and bulkhead length.