### PR TITLE
[#1375] Fix preset not "resetting" nose cone / transition shape parameter

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/Transition.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Transition.java
@@ -257,7 +257,7 @@ public class Transition extends SymmetricComponent implements InsideColorCompone
 		if (type == null) {
 			throw new IllegalArgumentException("setType called with null argument");
 		}
-		if (this.type == type)
+		if ((this.type == type) && (this.clipped == type.isClippable()) && (this.shapeParameter == type.defaultParameter()))
 			return;
 		this.type = type;
 		this.clipped = type.isClippable();
@@ -284,7 +284,7 @@ public class Transition extends SymmetricComponent implements InsideColorCompone
 			return;
 		this.shapeParameter = MathUtil.clamp(n, type.minParameter(), type.maxParameter());
 
-		// Need to clearPreset when shape type changes.
+		// Need to clearPreset when shape parameter changes.
 		clearPreset();
 
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);


### PR DESCRIPTION
The return statement in setType in Transition.java did not take into account that clipped or shapeparameter may be different, even though shape hasn't changed.