### PR TITLE
Sort preset dialog by manufacturer by default

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetTable.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetTable.java
@@ -154,6 +154,7 @@ public class ComponentPresetTable extends JTable {
 		this.setModel(tableModel);
 		this.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 		this.setRowSorter(sorter);
+		sorter.toggleSortOrder(2);		// Sort by the first column (manufacturer) by default
 
 		for ( TableColumn hiddenColumn : hiddenColumns ) {
 			tableColumnModel.setColumnVisible(hiddenColumn, false);


### PR DESCRIPTION
The preset dialog did not have the correct sorting (by manufacturer) by default, leading to e.g. in the parachute presets the lower-case b2 manufacturer being all the way on the bottom of the table.