### PR TITLE
[fixes #898 & #1168] Improve rocket view ribbon for smaller windows + add CG/CP show/hide checkbox

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -56,6 +56,7 @@ RocketPanel.lbl.ViewType          = View Type:
 RocketPanel.lbl.Zoom = Zoom:
 RocketPanel.checkbox.ShowCGCP = Show CG/CP
 RocketPanel.lbl.Stages = Stages:
+RocketPanel.ttip.Rotation = Change the rocket's roll rotation (only affects the rocket view)
 
 ! BasicFrame
 BasicFrame.tab.Rocketdesign = Rocket design

--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -53,6 +53,9 @@ RocketPanel.FigTypeAct.Unfinished = 3D Unfinished
 RocketPanel.lbl.Flightcfg = Flight configuration:
 RocketPanel.lbl.infoMessage = <html>Click to select &nbsp;&nbsp; Shift+click to select other &nbsp;&nbsp; Double-click to edit &nbsp;&nbsp; Click+drag to move
 RocketPanel.lbl.ViewType          = View Type:
+RocketPanel.lbl.Zoom = Zoom:
+RocketPanel.checkbox.ShowCGCP = Show CG/CP
+RocketPanel.lbl.Stages = Stages:
 
 ! BasicFrame
 BasicFrame.tab.Rocketdesign = Rocket design

--- a/swing/src/net/sf/openrocket/gui/components/StageSelector.java
+++ b/swing/src/net/sf/openrocket/gui/components/StageSelector.java
@@ -28,7 +28,7 @@ public class StageSelector extends JPanel implements StateChangeListener {
 	private List<JToggleButton> buttons = new ArrayList<JToggleButton>();
 	
 	public StageSelector(Rocket _rkt) {
-		super(new MigLayout("gap 0!"));
+		super(new MigLayout("gap 0!, insets 0"));
 		this.rocket = _rkt;
 		
 		updateButtons( this.rocket.getSelectedConfiguration() );

--- a/swing/src/net/sf/openrocket/gui/configdialog/FreeformFinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/FreeformFinSetConfig.java
@@ -295,7 +295,7 @@ public class FreeformFinSetConfig extends FinSetConfig {
         panel.add(new StyledLabel(trans.get("FreeformFinSetConfig.lbl.ctrlClick"), -2), "spanx 3, wrap");
         
         // row of controls at the bottom of the tab:
-        panel.add(selector, "aligny bottom, gap unrel");
+        panel.add(selector.getAsPanel(), "aligny bottom, gap unrel");
         panel.add(scaleButton, "");
         panel.add(importButton, "");
         panel.add(exportCsvButton, "");

--- a/swing/src/net/sf/openrocket/gui/figure3d/RocketFigure3d.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/RocketFigure3d.java
@@ -83,6 +83,7 @@ public class RocketFigure3d extends JPanel implements GLEventListener {
 	private Overlay extrasOverlay, caretOverlay;
 	private BufferedImage cgCaretRaster, cpCaretRaster;
 	private volatile boolean redrawExtras = true;
+	private boolean drawCarets = true;
 	
 	private final ArrayList<FigureElement> relativeExtra = new ArrayList<FigureElement>();
 	private final ArrayList<FigureElement> absoluteExtra = new ArrayList<FigureElement>();
@@ -324,7 +325,9 @@ public class RocketFigure3d extends JPanel implements GLEventListener {
 		rr.render(drawable, configuration, selection);
 		
 		drawExtras(gl, glu);
-		drawCarets(gl, glu);
+		if (drawCarets) {
+			drawCarets(gl, glu);
+		}
 		
 		// GLJPanel with GLSL Flipper relies on this:
 		gl.glFrontFace(GL.GL_CCW);
@@ -709,5 +712,12 @@ public class RocketFigure3d extends JPanel implements GLEventListener {
 			});
 		}
 	}
-	
+
+	public boolean isDrawCarets() {
+		return drawCarets;
+	}
+
+	public void setDrawCarets(boolean drawCarets) {
+		this.drawCarets = drawCarets;
+	}
 }

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketFigure.java
@@ -72,6 +72,8 @@ public class RocketFigure extends AbstractScaleFigure {
 	
 	private double rotation;
 	private Transformation axialRotation;
+
+	private boolean drawCarets = true;
     
 	/**
 	 * The shapes to be drawn are stored in this Priority Queue, where the first shape to be drawn is the one with
@@ -320,9 +322,12 @@ public class RocketFigure extends AbstractScaleFigure {
 		
 
 		// Draw relative extras
-		for (FigureElement e : relativeExtra) {
-			e.paint(g2, scale);
+		if (drawCarets) {
+			for (FigureElement e : relativeExtra) {
+				e.paint(g2, scale);
+			}
 		}
+
 		
 		// Draw absolute extras
 		g2.setTransform(baseTransform);
@@ -485,6 +490,14 @@ public class RocketFigure extends AbstractScaleFigure {
 			final int newOriginY = Math.max(getHeight(), subjectHeight + 2*borderThickness_px.height )/ 2;
 			originLocation_px = new Point(newOriginX, newOriginY);
 		}
+	}
+
+	public boolean isDrawCarets() {
+		return drawCarets;
+	}
+
+	public void setDrawCarets(boolean drawCarets) {
+		this.drawCarets = drawCarets;
 	}
 
 }

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -262,10 +262,11 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		figureHolder.add(figure3d, BorderLayout.CENTER);
 		rotationSlider.setEnabled(false);
 		scaleSelector.setEnabled(false);
-		zoomLabel.repaint();	// Makes sure the zoom label is above the scaleSelector
 
 		revalidate();
 		figureHolder.revalidate();
+
+		zoomLabel.repaint();	// Makes sure the zoom label is above the scaleSelector
 
 		figure3d.repaint();
 	}

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -5,6 +5,8 @@ import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.Point;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
@@ -120,6 +122,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 	private final ScaleScrollPane scrollPane;
 
 	private final JPanel figureHolder;
+	private JLabel zoomLabel;
 
 	private JLabel infoMessage;
 
@@ -259,6 +262,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		figureHolder.add(figure3d, BorderLayout.CENTER);
 		rotationSlider.setEnabled(false);
 		scaleSelector.setEnabled(false);
+		zoomLabel.repaint();	// Makes sure the zoom label is above the scaleSelector
 
 		revalidate();
 		figureHolder.revalidate();
@@ -328,7 +332,8 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 
 		// Zoom level selector
 		scaleSelector = new ScaleSelector(scrollPane);
-		ribbon.add(new JLabel(trans.get("RocketPanel.lbl.Zoom")), "cell 1 0, center");
+		zoomLabel = new JLabel(trans.get("RocketPanel.lbl.Zoom"));
+		ribbon.add(zoomLabel, "cell 1 0, center");
 		ribbon.add(scaleSelector, "cell 1 1");
 
 		// Show CG/CP
@@ -336,6 +341,19 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		showCGCP.setText(trans.get("RocketPanel.checkbox.ShowCGCP"));
 		showCGCP.setSelected(true);
 		ribbon.add(showCGCP, "cell 2 1, gapleft para");
+
+		showCGCP.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				if (figure != null) {
+					figure.setDrawCarets(showCGCP.isSelected());
+				}
+				if (figure3d != null) {
+					figure3d.setDrawCarets(showCGCP.isSelected());
+				}
+				updateFigures();
+			}
+		});
 
 		// Vertical separator
 		JSeparator sep = new JSeparator(SwingConstants.VERTICAL);

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -325,14 +325,19 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 
 		// Zoom level selector
 		scaleSelector = new ScaleSelector(scrollPane);
-		ribbon.add(new JLabel(trans.get("RocketPanel.lbl.Zoom")), "cell 1 0, center");
-		ribbon.add(scaleSelector, "gapleft para, cell 1 1");
+		JButton zoomOutButton = scaleSelector.getZoomOutButton();
+		JComboBox<String> scaleSelectorCombo = scaleSelector.getScaleSelectorCombo();
+		JButton zoomInButton = scaleSelector.getZoomInButton();
+		ribbon.add(zoomOutButton, "gapleft para, cell 1 1");
+		ribbon.add(new JLabel(trans.get("RocketPanel.lbl.Zoom")), "cell 2 0, spanx 2");
+		ribbon.add(scaleSelectorCombo, "cell 2 1");
+		ribbon.add(zoomInButton, "cell 3 1");
 
 		// Show CG/CP
 		JCheckBox showCGCP = new JCheckBox();
 		showCGCP.setText(trans.get("RocketPanel.checkbox.ShowCGCP"));
 		showCGCP.setSelected(true);
-		ribbon.add(showCGCP, "cell 2 1, gapleft para");
+		ribbon.add(showCGCP, "cell 4 1, gapleft para");
 
 		showCGCP.addActionListener(new ActionListener() {
 			@Override
@@ -352,21 +357,21 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		Dimension d_sep = sep.getPreferredSize();
 		d_sep.height = (int) (0.7 * ribbon.getPreferredSize().height);
 		sep.setPreferredSize(d_sep);
-		ribbon.add(sep, "cell 3 0, spany 2, gapleft para, gapright para");
+		ribbon.add(sep, "cell 5 0, spany 2, gapleft para, gapright para");
 
 		// Stage selector
 		StageSelector stageSelector = new StageSelector( rkt );
 		rkt.addChangeListener(stageSelector);
-		ribbon.add(new JLabel(trans.get("RocketPanel.lbl.Stages")), "cell 4 0, pushx");
-		ribbon.add(stageSelector, "cell 4 1, pushx");
+		ribbon.add(new JLabel(trans.get("RocketPanel.lbl.Stages")), "cell 6 0, pushx");
+		ribbon.add(stageSelector, "cell 6 1, pushx");
 
 		// Flight configuration selector
 		//// Flight configuration:
 		JLabel label = new JLabel(trans.get("RocketPanel.lbl.Flightcfg"));
-		ribbon.add(label, "cell 5 0");
+		ribbon.add(label, "cell 7 0");
 
 		final ConfigurationComboBox configComboBox = new ConfigurationComboBox(rkt);
-		ribbon.add(configComboBox, "cell 5 1, width 16%, wmin 100");
+		ribbon.add(configComboBox, "cell 7 1, width 16%, wmin 100");
 
 		add(ribbon, "growx, span, wrap");
 

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -304,10 +304,12 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 
 		setPreferredSize(new Dimension(800, 300));
 
-		// MacOS has a larger y gap than other OS'es, so this fixes that
+		// MacOS and Windows have a larger y gap than Linux, so this fixes that
 		int gap = 0;
 		if (SystemInfo.getPlatform() == SystemInfo.Platform.MAC_OS) {
 			gap = -10;
+		} else if (SystemInfo.getPlatform() == SystemInfo.Platform.WINDOWS) {
+			gap = -5;
 		}
 		JPanel ribbon = new JPanel(new MigLayout(String.format("inset 0, gapy %d, fill", gap)));
 

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -122,7 +122,6 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 	private final ScaleScrollPane scrollPane;
 
 	private final JPanel figureHolder;
-	private JLabel zoomLabel;
 
 	private JLabel infoMessage;
 
@@ -266,8 +265,6 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		revalidate();
 		figureHolder.revalidate();
 
-		zoomLabel.repaint();	// Makes sure the zoom label is above the scaleSelector
-
 		figure3d.repaint();
 	}
 
@@ -304,14 +301,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 
 		setPreferredSize(new Dimension(800, 300));
 
-		// MacOS and Windows have a larger y gap than Linux, so this fixes that
-		int gap = 0;
-		if (SystemInfo.getPlatform() == SystemInfo.Platform.MAC_OS) {
-			gap = -10;
-		} else if (SystemInfo.getPlatform() == SystemInfo.Platform.WINDOWS) {
-			gap = -5;
-		}
-		JPanel ribbon = new JPanel(new MigLayout(String.format("inset 0, gapy %d, fill", gap)));
+		JPanel ribbon = new JPanel(new MigLayout("insets 0, fill"));
 
 		// View Type drop-down
 		ComboBoxModel<VIEW_TYPE> cm = new DefaultComboBoxModel<VIEW_TYPE>(VIEW_TYPE.values()) {
@@ -335,9 +325,8 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 
 		// Zoom level selector
 		scaleSelector = new ScaleSelector(scrollPane);
-		zoomLabel = new JLabel(trans.get("RocketPanel.lbl.Zoom"));
-		ribbon.add(zoomLabel, "cell 1 0, center");
-		ribbon.add(scaleSelector, "cell 1 1");
+		ribbon.add(new JLabel(trans.get("RocketPanel.lbl.Zoom")), "cell 1 0, center");
+		ribbon.add(scaleSelector, "gapleft para, cell 1 1");
 
 		// Show CG/CP
 		JCheckBox showCGCP = new JCheckBox();

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -383,16 +383,16 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		UnitSelector us = new UnitSelector(rotationModel, true);
 		us.setHorizontalAlignment(JLabel.CENTER);
 		add(us, "alignx 50%, growx");
+		us.setToolTipText(trans.get("RocketPanel.ttip.Rotation"));
 
 		// Add the rocket figure
 		add(figureHolder, "grow, spany 2, wmin 300lp, hmin 100lp, wrap");
 
 		// Add rotation slider
-		// Minimum size to fit "360deg"
+		// Dummy label to find the minimum size to fit "360deg"
 		JLabel l = new JLabel("360" + Chars.DEGREE);
 		Dimension d = l.getPreferredSize();
 
-		// TODO: tooltip
 		add(rotationSlider = new BasicSlider(rotationModel.getSliderModel(0, 2 * Math.PI), JSlider.VERTICAL, true),
 				"ax 50%, wrap, width " + (d.width + 6) + "px:null:null, growy");
 		rotationSlider.addChangeListener(new ChangeListener() {
@@ -401,6 +401,8 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 				updateExtras();
 			}
 		});
+		rotationSlider.setToolTipText(trans.get("RocketPanel.ttip.Rotation"));
+
 
 		//// <html>Click to select &nbsp;&nbsp; Shift+click to select other &nbsp;&nbsp; Double-click to edit &nbsp;&nbsp; Click+drag to move
 		infoMessage = new JLabel(trans.get("RocketPanel.lbl.infoMessage"));

--- a/swing/src/net/sf/openrocket/gui/scalefigure/ScaleSelector.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/ScaleSelector.java
@@ -36,7 +36,7 @@ public class ScaleSelector extends JPanel {
 	}
 
 	private final ScaleScrollPane scrollPane;
-	private JComboBox<String> scaleSelector;
+	private final JComboBox<String> scaleSelector;
 
 	public ScaleSelector(ScaleScrollPane scroll) {
 		super(new MigLayout());
@@ -57,9 +57,7 @@ public class ScaleSelector extends JPanel {
 		add(button);
 
 		// Zoom level selector
-		String[] settings = SCALE_LABELS;
-		
-		scaleSelector = new JComboBox<>(settings);
+		scaleSelector = new JComboBox<>(SCALE_LABELS);
 		scaleSelector.setEditable(true);
 		setZoomText();
 		scaleSelector.addActionListener(new ActionListener() {
@@ -67,6 +65,7 @@ public class ScaleSelector extends JPanel {
 			public void actionPerformed(ActionEvent e) {
 				try {
 					String text = (String) scaleSelector.getSelectedItem();
+					if (text == null) return;
 					text = text.replaceAll("%", "").trim();
 
 					if (text.toLowerCase(Locale.getDefault()).startsWith(SCALE_FIT.toLowerCase(Locale.getDefault()))){
@@ -144,8 +143,7 @@ public class ScaleSelector extends JPanel {
 		}
 		if (currentScale > SCALE_LEVELS[SCALE_LEVELS.length / 2]) {
 			// scale is large, give next full 100%
-			double nextScale = Math.floor(currentScale + 1.05);
-			return nextScale;
+			return Math.floor(currentScale + 1.05);
 		}
 		return currentScale * 1.5;
 	}

--- a/swing/src/net/sf/openrocket/gui/scalefigure/ScaleSelector.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/ScaleSelector.java
@@ -17,7 +17,7 @@ import net.sf.openrocket.gui.widgets.SelectColorButton;
 import net.sf.openrocket.util.StateChangeListener;
 
 @SuppressWarnings("serial")
-public class ScaleSelector extends JPanel {
+public class ScaleSelector {
 
     public static final double MINIMUM_ZOOM =    0.01; // ==      1 %
     public static final double MAXIMUM_ZOOM = 1000.00; // == 10,000 %
@@ -36,16 +36,16 @@ public class ScaleSelector extends JPanel {
 	}
 
 	private final ScaleScrollPane scrollPane;
-	private final JComboBox<String> scaleSelector;
+	private final JComboBox<String> scaleSelectorCombo;
+	private final JButton zoomOutButton;
+	private final JButton zoomInButton;
 
 	public ScaleSelector(ScaleScrollPane scroll) {
-		super(new MigLayout("insets 0"));
-
 		this.scrollPane = scroll;
 
 		// Zoom out button
-		JButton button = new SelectColorButton(Icons.ZOOM_OUT);
-		button.addActionListener(new ActionListener() {
+		zoomOutButton = new SelectColorButton(Icons.ZOOM_OUT);
+		zoomOutButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				final double oldScale = scrollPane.getUserScale();
@@ -54,17 +54,16 @@ public class ScaleSelector extends JPanel {
 				setZoomText();
 			}
 		});
-		add(button);
 
 		// Zoom level selector
-		scaleSelector = new JComboBox<>(SCALE_LABELS);
-		scaleSelector.setEditable(true);
+		scaleSelectorCombo = new JComboBox<>(SCALE_LABELS);
+		scaleSelectorCombo.setEditable(true);
 		setZoomText();
-		scaleSelector.addActionListener(new ActionListener() {
+		scaleSelectorCombo.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				try {
-					String text = (String) scaleSelector.getSelectedItem();
+					String text = (String) scaleSelectorCombo.getSelectedItem();
 					if (text == null) return;
 					text = text.replaceAll("%", "").trim();
 
@@ -93,11 +92,10 @@ public class ScaleSelector extends JPanel {
 				update();
 			}
 		});
-		add(scaleSelector);
 
 		// Zoom in button
-		button = new SelectColorButton(Icons.ZOOM_IN);
-		button.addActionListener(new ActionListener() {
+		zoomInButton = new SelectColorButton(Icons.ZOOM_IN);
+		zoomInButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				double scale = scrollPane.getUserScale();
@@ -106,8 +104,27 @@ public class ScaleSelector extends JPanel {
 				update();
 			}
 		});
-		add(button);
+	}
 
+	public JPanel getAsPanel() {
+		JPanel panel = new JPanel(new MigLayout("insets 0"));
+		panel.add(zoomOutButton);
+		panel.add(scaleSelectorCombo);
+		panel.add(zoomInButton);
+
+		return panel;
+	}
+
+	public JComboBox<String> getScaleSelectorCombo() {
+		return scaleSelectorCombo;
+	}
+
+	public JButton getZoomOutButton() {
+		return zoomOutButton;
+	}
+
+	public JButton getZoomInButton() {
+		return zoomInButton;
 	}
 
 	private void setZoomText() {
@@ -116,8 +133,8 @@ public class ScaleSelector extends JPanel {
 		if (scrollPane.isFitting()) {
 			text = "Fit (" + text + ")";
 		}
-		if (!text.equals(scaleSelector.getSelectedItem()))
-			scaleSelector.setSelectedItem(text);
+		if (!text.equals(scaleSelectorCombo.getSelectedItem()))
+			scaleSelectorCombo.setSelectedItem(text);
 	}
 
 	private static double getNextLargerScale(final double currentScale) {
@@ -148,12 +165,10 @@ public class ScaleSelector extends JPanel {
 		return currentScale * 1.5;
 	}
 
-	@Override
 	public void setEnabled(boolean b){
-		for ( Component c : getComponents() ){
-			c.setEnabled(b);
-		}
-		super.setEnabled(b);
+		zoomInButton.setEnabled(b);
+		scaleSelectorCombo.setEnabled(b);
+		zoomOutButton.setEnabled(b);
 	}
 
 	public void update(){

--- a/swing/src/net/sf/openrocket/gui/scalefigure/ScaleSelector.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/ScaleSelector.java
@@ -54,7 +54,7 @@ public class ScaleSelector extends JPanel {
 				setZoomText();
 			}
 		});
-		add(button, "gap");
+		add(button);
 
 		// Zoom level selector
 		String[] settings = SCALE_LABELS;
@@ -94,7 +94,7 @@ public class ScaleSelector extends JPanel {
 				update();
 			}
 		});
-		add(scaleSelector, "gap rel");
+		add(scaleSelector);
 
 		// Zoom in button
 		button = new SelectColorButton(Icons.ZOOM_IN);
@@ -107,7 +107,7 @@ public class ScaleSelector extends JPanel {
 				update();
 			}
 		});
-		add(button, "gapleft rel");
+		add(button);
 
 	}
 

--- a/swing/src/net/sf/openrocket/gui/scalefigure/ScaleSelector.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/ScaleSelector.java
@@ -39,7 +39,7 @@ public class ScaleSelector extends JPanel {
 	private final JComboBox<String> scaleSelector;
 
 	public ScaleSelector(ScaleScrollPane scroll) {
-		super(new MigLayout());
+		super(new MigLayout("insets 0"));
 
 		this.scrollPane = scroll;
 


### PR DESCRIPTION
This PR fixes #898 and #1168 by rearranging the rocket view ribbon to be better suited for smaller windows + it adds a checkbox to hide the CG/CP markings in the rocket view. I also added a tooltip text for the rotation slider on the left, since I found it very confusing when I first opened OR what that slider actually did.

Demo:

https://user-images.githubusercontent.com/11031519/170521933-8dddacc5-478f-4f63-b725-0e797a8dabd9.mov


Here is a [jar file](https://github.com/openrocket/openrocket/suites/6673568362/artifacts/252777629) for testing.