### PR TITLE
[#1344] Clear preset when centering ring/bulkhead length is changed

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/RingComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RingComponent.java
@@ -100,6 +100,7 @@ public abstract class RingComponent extends StructuralComponent implements BoxBo
 			return;
 		
 		this.length = l;
+		clearPreset();
 		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
 	}
 	


### PR DESCRIPTION
This PR fixes #1344 by clearing the preset of the centering ring and bulkhead when the length (thickness) changes.