### PR TITLE
[#1286] Use table row selection listener to update sim button state

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/SimulationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/SimulationPanel.java
@@ -35,6 +35,8 @@ import javax.swing.JTable;
 import javax.swing.KeyStroke;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.text.DefaultEditorKit;
 
@@ -565,8 +567,16 @@ public class SimulationPanel extends JPanel {
 					}
 				} else if (e.getButton() == MouseEvent.BUTTON3 && e.getClickCount() == 1){
                     doPopup(e);
-				} else {
+				}
+			}
+		});
+
+		simulationTable.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
+			private int previousRow = -1;
+			public void valueChanged(ListSelectionEvent event) {
+				if (simulationTable.getSelectedRow() != previousRow) {
 					updateButtonStates();
+					previousRow = simulationTable.getSelectedRow();
 				}
 			}
 		});


### PR DESCRIPTION
This PR solves #1286 where the sim buttons frequently did not update (i.e. remain disabled) when you quickly opened the simulation tab. Steps to reproduce: open 'A simple model rocket', quickly click on the 'Flight simulations' tab and quickly select any one of the simulations. The 'Edit simulation', 'Run simulations', 'Delete simulations' and 'Plot / Export' would frequently remain disabled.

This PR just implements a row selection listener in the sim table instead of the mouse click listener, which seems to solve the issue.