### PR TITLE
[#1397] Fix streamer packed length updating strip width

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/Streamer.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Streamer.java
@@ -63,17 +63,6 @@ public class Streamer extends RecoveryDevice {
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 	
-	@Override
-	public void setLength(double length) {
-		for (RocketComponent listener : configListeners) {
-			if (listener instanceof Streamer) {
-				((Streamer) listener).setStripWidth(length);
-			}
-		}
-
-		setStripWidth(length);
-	}
-	
 	
 	public double getAspectRatio() {
 		if (stripWidth > 0.0001)


### PR DESCRIPTION
Don't ask me why, but in the streamer the setLength method (which changes the packed length) was overridden to change the strip width. This PR fixes #1397.