### PR TITLE
Move series selection in sim plot to the beginning

### DIFF
--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
@@ -83,6 +83,26 @@ public class SimulationPlotDialog extends JDialog {
 			}
 		});
 		panel.add(check, "split, left");
+
+		//// Add series selection box
+		ArrayList<String> stages = new ArrayList<String>();
+		stages.add("All");
+		stages.addAll(Util.generateSeriesLabels(simulation));
+
+		final JComboBox<String> stageSelection = new JComboBox<>(stages.toArray(new String[0]));
+		stageSelection.addItemListener(new ItemListener() {
+
+			@Override
+			public void itemStateChanged(ItemEvent e) {
+				int selectedStage = stageSelection.getSelectedIndex() - 1;
+				myPlot.setShowBranch(selectedStage);
+			}
+
+		});
+		if (stages.size() > 2) {
+			// Only show the combo box if there are at least 3 entries (ie, "All", "Main", and one other one)
+			panel.add(stageSelection, "gapleft rel");
+		}
 		
 		//// Zoom in button
 		JButton button = new SelectColorButton(Icons.ZOOM_IN);
@@ -134,29 +154,6 @@ public class SimulationPlotDialog extends JDialog {
 		});
 		panel.add(button, "gapleft rel");
 		
-		//// Add series selection box
-		ArrayList<String> stages = new ArrayList<String>();
-		stages.add("All");
-		stages.addAll(Util.generateSeriesLabels(simulation));
-		
-		final JComboBox stageSelection = new JComboBox(stages.toArray(new String[0]));
-		stageSelection.addItemListener(new ItemListener() {
-			
-			@Override
-			public void itemStateChanged(ItemEvent e) {
-				int selectedStage = stageSelection.getSelectedIndex() - 1;
-				myPlot.setShowBranch(selectedStage);
-			}
-			
-		});
-		if (stages.size() > 2) {
-			// Only show the combo box if there are at least 3 entries (ie, "All", "Main", and one other one
-			panel.add(stageSelection, "gapleft rel");
-		}
-		
-		//// Spacer for layout to push close button to the right.
-		panel.add(new JPanel(), "growx");
-		
 		//// Close button
 		button = new SelectColorButton(trans.get("dlg.but.close"));
 		button.addActionListener(new ActionListener() {
@@ -165,7 +162,7 @@ public class SimulationPlotDialog extends JDialog {
 				SimulationPlotDialog.this.dispose();
 			}
 		});
-		panel.add(button, "right");
+		panel.add(button, "gapbefore push, right");
 		this.setLocationByPlatform(true);
 		this.pack();
 		


### PR DESCRIPTION
This PR moves the series selection in the sim pot more to the beginning. Because of the export image button, it looked like the combobox was tied to exporting the image instead of the plot.
<img width="2103" alt="Screenshot 2022-06-03 at 03 59 14" src="https://user-images.githubusercontent.com/11031519/171772343-c0cbbdf3-8110-4a68-8a94-6d0c6479d9c6.png">

