### PR TITLE
[#1099] Fix button grey out on macOS

### DIFF
--- a/swing/src/net/sf/openrocket/gui/widgets/SelectColorButton.java
+++ b/swing/src/net/sf/openrocket/gui/widgets/SelectColorButton.java
@@ -38,6 +38,10 @@ public class SelectColorButton extends JButton {
         if (UIManager.getColor("Button.selectForeground") == null
                 || UIManager.getColor("Button.foreground") == null)
             return;
+
+        // Fixes the issue of the background of the button not being blue when selected on macOS
+        putClientProperty("JButton.buttonType", "segmented-only");
+
         addChangeListener(new ChangeListener() {
             @Override
             public void stateChanged(ChangeEvent e) {

--- a/swing/src/net/sf/openrocket/gui/widgets/SelectColorToggleButton.java
+++ b/swing/src/net/sf/openrocket/gui/widgets/SelectColorToggleButton.java
@@ -64,6 +64,9 @@ public class SelectColorToggleButton extends JToggleButton {
                 || UIManager.getColor("ToggleButton.foreground") == null)
             return;
 
+        // Fixes the issue of the background of the button not being blue when selected on macOS
+        putClientProperty("JButton.buttonType", "segmented-only");
+
         // Case: frame goes out of focus
         addPropertyChangeListener("Frame.active", new PropertyChangeListener() {
             @Override


### PR DESCRIPTION
This PR fixes #1099, where the ToggleButtons on macOS had a grey background instead of blue. (note when pressing down on a JButton, the background is still grey, don't know how to solve that issue, but at least let us enjoy for a moment that the fix works for JToggleButtons)

<img width="1803" alt="image" src="https://user-images.githubusercontent.com/11031519/171968050-346aa10f-bb48-4457-9394-3c0267b4820d.png">