### PR TITLE
Fix loaded simulations re-running when plotting

### DIFF
--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationEditDialog.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationEditDialog.java
@@ -290,7 +290,8 @@ public class SimulationEditDialog extends JDialog {
 				@Override
 				public void actionPerformed(ActionEvent e) {
 					// If the simulation is out of date, run the simulation.
-					if (simulationList[0].getStatus() != Simulation.Status.UPTODATE) {
+					if (simulationList[0].getStatus() != Simulation.Status.UPTODATE &&
+							simulationList[0].getStatus() != Simulation.Status.LOADED) {
 						new SimulationRunDialog(SimulationEditDialog.this.parentWindow, document, simulationList[0]).setVisible(true);
 					}
 					


### PR DESCRIPTION
This PR solves an issue where simulations with loaded simulation data from the design file (e.g. the 'A simple model rocket' example) would re-run the simulations when you tried to plot them.