### PR TITLE
[fixes #1409] Remove instancecount multiplication in getSectionMass

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
@@ -1377,7 +1377,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 			massSubtotal += rc.getSectionMass();
 		}
 		
-		return massSubtotal * getInstanceCount();
+		return massSubtotal;
 	}
 	
 	/**

--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationEditDialog.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationEditDialog.java
@@ -290,7 +290,8 @@ public class SimulationEditDialog extends JDialog {
 				@Override
 				public void actionPerformed(ActionEvent e) {
 					// If the simulation is out of date, run the simulation.
-					if (simulationList[0].getStatus() != Simulation.Status.UPTODATE) {
+					if (simulationList[0].getStatus() != Simulation.Status.UPTODATE &&
+							simulationList[0].getStatus() != Simulation.Status.LOADED) {
 						new SimulationRunDialog(SimulationEditDialog.this.parentWindow, document, simulationList[0]).setVisible(true);
 					}
 					


### PR DESCRIPTION
This PR fixes #1409 by removing the instancecount multiplication in getSectionMass. The getComponentMass already takes instancecounts into account.