### PR TITLE
[#1423] Make sure zoom combobox can fit 'Fit (100.0%)'

### DIFF
--- a/swing/src/net/sf/openrocket/gui/scalefigure/ScaleSelector.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/ScaleSelector.java
@@ -58,6 +58,8 @@ public class ScaleSelector {
 		// Zoom level selector
 		scaleSelectorCombo = new JComboBox<>(SCALE_LABELS);
 		scaleSelectorCombo.setEditable(true);
+		scaleSelectorCombo.setSelectedItem("Fit (100.0%)");	// Make sure the combobox can fit this text
+		scaleSelectorCombo.setPreferredSize(scaleSelectorCombo.getPreferredSize());
 		setZoomText();
 		scaleSelectorCombo.addActionListener(new ActionListener() {
 			@Override


### PR DESCRIPTION
This PR fixes #1423 by giving the zoom combobox an initial size so that it can fit the text 'Fit (100.0%)' (thus all text in the form of 'Fit (xxx.x%)'.

<img width="1803" alt="image" src="https://user-images.githubusercontent.com/11031519/173073868-381113dc-fffd-4203-be9e-1286ad3d99d1.png">

I tried making the combobox size dynamically based on its content, but was unsuccessful.