### PR TITLE
[Fixes #1422] Add sliders to pods/booster config + fix radius offset not updating with radius method

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -952,10 +952,10 @@ StageConfig.tab.Separation.ttip = Stage separation options
 StageConfig.separation.lbl.title = Select when this stage separates:
 StageConfig.separation.lbl.plus = plus
 StageConfig.separation.lbl.seconds = seconds
-StageConfig.parallel.radius = Radial Distance
-StageConfig.parallel.angle = Angle
-StageConfig.parallel.count = Number of Copies
-StageConfig.parallel.offset = Offset Value
+StageConfig.parallel.radius = Radial Distance:
+StageConfig.parallel.angle = Angle:
+StageConfig.parallel.count = Number of Copies:
+StageConfig.parallel.plus = plus
 
 !EllipticalFinSetConfig
 EllipticalFinSetCfg.Nbroffins = Number of fins:
@@ -1481,20 +1481,18 @@ Shape.Haackseries.desc2 = The Haack series <i>nose cones</i> are designed to min
 
 
 ! RocketComponent
-RocketComponent.Position.Method.Axial.Label = Radius Positioning Method
 RocketComponent.Position.Method.Axial.ABSOLUTE = Tip of the nose cone
 RocketComponent.Position.Method.Axial.AFTER =  After the sibling component
 RocketComponent.Position.Method.Axial.BOTTOM = Bottom of the parent component
 RocketComponent.Position.Method.Axial.MIDDLE =  Middle of the parent component
 RocketComponent.Position.Method.Axial.TOP = Top of the parent component
 
-RocketComponent.Position.Method.Radius.Label = Radius Positioning Method
-RocketComponent.Position.Method.Radius.FREE = Position relative to the component's center 
-RocketComponent.Position.Method.Radius.SURFACE = Position on the target component surface (without offset)
-RocketComponent.Position.Method.Radius.RELATIVE = Position relative to the component surface
-RocketComponent.Position.Method.Radius.COAXIAL = Position on the same axis as the target component
+RocketComponent.Position.Method.Radius.Label = Radius relative to:
+RocketComponent.Position.Method.Radius.FREE = Center of the parent component
+RocketComponent.Position.Method.Radius.SURFACE = Surface of the parent component (without offset)
+RocketComponent.Position.Method.Radius.RELATIVE = Surface of the parent component
+RocketComponent.Position.Method.Radius.COAXIAL = Same axis as the target component
 
-RocketComponent.Position.Method.Angle.Label = Angle Positioning Method
 RocketComponent.Position.Method.Angle.RELATIVE = Relative to the parent component
 RocketComponent.Position.Method.Angle.FIXED = Angle is fixed.
 RocketComponent.Position.Method.Angle.MIRROR_XY = Mirror relative to the rocket's x-y plane

--- a/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
@@ -424,7 +424,7 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 
 		this.stages.clear();
 		for (AxialStage curStage : this.rocket.getStageList()) {
-			
+			if (curStage == null) continue;
 			StageFlags flagsToAdd = new StageFlags( curStage.getStageNumber(), true);
 			this.stages.put(curStage.getStageNumber(), flagsToAdd);
 		}

--- a/core/src/net/sf/openrocket/rocketcomponent/PodSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/PodSet.java
@@ -26,7 +26,7 @@ public class PodSet extends ComponentAssembly implements RingInstanceable {
 	protected double angleSeparation = Math.PI;
 	// angle to the first pod
 	protected double angleOffset_rad = 0;
-	 
+
 	protected RadiusMethod radiusMethod = RadiusMethod.RELATIVE;
 	protected double radiusOffset_m = 0;
 	
@@ -225,19 +225,22 @@ public class PodSet extends ComponentAssembly implements RingInstanceable {
 		}
 
 		mutex.verify();
-		if( this.radiusMethod.clampToZero() ) {
+
+		if (radius_m == this.radiusOffset_m) return;
+
+		if (this.radiusMethod.clampToZero()) {
 			this.radiusOffset_m = 0.0;
-		}else {
+		} else {
 			this.radiusOffset_m = radius_m;
 		}
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
-	
+
 	@Override
 	public RadiusMethod getRadiusMethod() {
 		return this.radiusMethod;
 	}
-	
+
 	@Override
 	public void setRadiusMethod(RadiusMethod newMethod ) {
 		for (RocketComponent listener : configListeners) {
@@ -246,11 +249,13 @@ public class PodSet extends ComponentAssembly implements RingInstanceable {
 			}
 		}
 
+		if (newMethod == this.radiusMethod) return;
+
 		mutex.verify();
-		this.radiusMethod = newMethod;
-		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
+		double radius = this.radiusMethod.getRadius(getParent(), this, this.radiusOffset_m);	// Radius from the parent's center
+		setRadius(newMethod, radius);
 	}
-	
+
 	@Override
 	public void setRadius(RadiusMethod requestMethod, double requestRadius ) {
 		for (RocketComponent listener : configListeners) {
@@ -260,16 +265,15 @@ public class PodSet extends ComponentAssembly implements RingInstanceable {
 		}
 
 		mutex.verify();
-		
-		RadiusMethod newMethod = requestMethod; 
+
 		double newRadius = requestRadius;
-		
+
 		if( this.radiusMethod.clampToZero() ) {
 			newRadius = 0.;
 		}
-		
-		this.radiusMethod = newMethod;
-		this.radiusOffset_m = newRadius;
+
+		this.radiusMethod = requestMethod;
+		this.radiusOffset_m =  this.radiusMethod.getAsOffset(getParent(), this, newRadius);
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 

--- a/core/src/net/sf/openrocket/rocketcomponent/position/RadiusMethod.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/position/RadiusMethod.java
@@ -16,6 +16,11 @@ public enum RadiusMethod implements DistanceMethod {
 		public double getRadius( final RocketComponent parentComponent, final RocketComponent thisComponent, final double requestedOffset ){
 			return 0.;
 		}
+
+		@Override
+		public double getAsOffset(final RocketComponent parentComponent, final RocketComponent thisComponent, double radius) {
+			return 0;
+		}
 	},
 	
 	FREE(Application.getTranslator().get("RocketComponent.Position.Method.Radius.FREE") ){
@@ -25,6 +30,11 @@ public enum RadiusMethod implements DistanceMethod {
 		@Override
 		public double getRadius( final RocketComponent parentComponent, final RocketComponent thisComponent, final double requestedOffset ){
 			return requestedOffset;
+		}
+
+		@Override
+		public double getAsOffset(final RocketComponent parentComponent, final RocketComponent thisComponent, double radius) {
+			return radius;
 		}
 	},
 	
@@ -43,6 +53,18 @@ public enum RadiusMethod implements DistanceMethod {
 			}
 			return radius;
 		}
+
+		@Override
+		public double getAsOffset(final RocketComponent parentComponent, final RocketComponent thisComponent, double radius) {
+			double offset = radius;
+			if (parentComponent instanceof BodyTube) {
+				offset -= ((BodyTube)parentComponent).getOuterRadius();
+			}
+			if (thisComponent instanceof RadiusPositionable) {
+				offset -= ((RadiusPositionable)thisComponent).getBoundingRadius();
+			}
+			return offset;
+		}
 	},
 
 	// Defines placement relative to the outside of the target component
@@ -60,10 +82,15 @@ public enum RadiusMethod implements DistanceMethod {
 			}
 			return radius;
 		}
+
+		@Override
+		public double getAsOffset(RocketComponent parentComponent, RocketComponent thisComponent, double radius) {
+			return 0;
+		}
 	};
 
 	public static final RadiusMethod[] choices(){
-		return new RadiusMethod[]{ RadiusMethod.FREE, RadiusMethod.RELATIVE }; 
+		return new RadiusMethod[]{ RadiusMethod.FREE, RadiusMethod.RELATIVE };
 	}
 	
 	public final String description;
@@ -82,5 +109,15 @@ public enum RadiusMethod implements DistanceMethod {
 	@Override
 	public boolean clampToZero() { return true; }
 	
-	public abstract double getRadius( final RocketComponent parentComponent, final RocketComponent thisComponent, final double requestedOffset );
+	public abstract double getRadius(final RocketComponent parentComponent, final RocketComponent thisComponent, final double requestedOffset );
+
+	/**
+	 * Returns the radius offset argument (starting from the center of its parent) as an offset value for this
+	 * RadiusMethod.
+	 * @param parentComponent parent of this component
+	 * @param thisComponent the component for which the offset is requested
+	 * @param radius the radius offset argument
+	 * @return the offset value of this RadiusMethod that yields the given radius
+	 */
+	public abstract double getAsOffset(final RocketComponent parentComponent, final RocketComponent thisComponent, final double radius);
 }

--- a/core/test/net/sf/openrocket/rocketcomponent/ParallelStageTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/ParallelStageTest.java
@@ -251,7 +251,7 @@ public class ParallelStageTest extends BaseTestCase {
 		// vv function under test
 		parallelBoosterStage.setAxialOffset( AxialMethod.BOTTOM, 0.0 );
 		final double targetRadiusOffset = 0.01;
-		parallelBoosterStage.setRadius( RadiusMethod.RELATIVE, targetRadiusOffset );
+		parallelBoosterStage.setRadius( RadiusMethod.RELATIVE, RadiusMethod.RELATIVE.getRadius(parallelBoosterStage.getParent(), parallelBoosterStage, targetRadiusOffset));
 		// ^^ function under test
 
 		assertFalse(RadiusMethod.RELATIVE.clampToZero());

--- a/swing/src/net/sf/openrocket/gui/adaptors/DoubleModel.java
+++ b/swing/src/net/sf/openrocket/gui/adaptors/DoubleModel.java
@@ -207,6 +207,19 @@ public class DoubleModel implements StateChangeListener, ChangeSource, Invalidat
 			
 			quad2 = quad1 = quad0 = 0; // Not used
 		}
+
+		public ValueSliderModel(double min, DoubleModel max) {
+			this.islinear = true;
+			linearPosition = 1.0;
+
+			this.min = new DoubleModel(min);
+			this.mid = max; // Never use exponential scale
+			this.max = max;
+
+			max.addChangeListener(this);
+
+			quad2 = quad1 = quad0 = 0; // Not used
+		}
 		
 		
 		
@@ -424,6 +437,10 @@ public class DoubleModel implements StateChangeListener, ChangeSource, Invalidat
 	}
 	
 	public BoundedRangeModel getSliderModel(double min, double max) {
+		return new ValueSliderModel(min, max);
+	}
+
+	public BoundedRangeModel getSliderModel(double min, DoubleModel max) {
 		return new ValueSliderModel(min, max);
 	}
 	


### PR DESCRIPTION
This PR fixes #1422 by adding sliders to the config dialog:
![Screenshot 2022-06-11 at 01 19 50](https://user-images.githubusercontent.com/11031519/173162080-2ef2ab21-2a16-4a21-8d98-ae5444e8faf4.jpg)

I also changed the labels to make it more consistent with the rest of the program, as can be seen on the previous screenshots.

While working on this issue, I also notices that the radius offset was unresponsive to changes to the radius method (or well, it just reacted in a faulty way), which this PR also fixes:

Previous behavior:

https://user-images.githubusercontent.com/11031519/173162266-0a223a0b-2076-40b5-82e1-f1988932a820.mov

New behavior:

https://user-images.githubusercontent.com/11031519/173162332-981196d8-9b1d-485d-82fe-baec43e25032.mov

All the mentioned behaviors work both for pod sets and boosters.

Here is a [jar file](https://github.com/openrocket/openrocket/suites/6887416517/artifacts/266800683) for testing.