### PR TITLE
[Fixes #1426] Revalidate plotExportPanel after button change

### DIFF
--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationEditDialog.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationEditDialog.java
@@ -277,9 +277,11 @@ public class SimulationEditDialog extends JDialog {
 					switch (selectedIndex) {
 					case 0:
 						ok.setText(trans.get("SimulationEditDialog.btn.plot"));
+						plotExportPanel.revalidate();
 						break;
 					case 1:
 						ok.setText(trans.get("SimulationEditDialog.btn.export"));
+						plotExportPanel.revalidate();
 						break;
 					}
 				}


### PR DESCRIPTION
This PR fixes #1426 by revalidating the plotExportPanel after the 'OK' button changes in the export window.

Demo:

https://user-images.githubusercontent.com/11031519/173188535-1aeca469-a9b1-4a8d-97d2-791f451d8196.mov


