### PR TITLE
[Fixes #753] Update ScaleScrollPane size when rocket changes

### DIFF
--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -219,6 +219,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 			public void stateChanged(EventObject e) {
 				updateExtras();
 				updateFigures();
+				scrollPane.componentResized(null);	// Triggers a resize so that when the rocket becomes smaller, the scrollPane updates its size
 			}
 		});
 


### PR DESCRIPTION
This PR fixes #753 where the rocket view did not resize when the rocket became shorter. The ScaleScrollPane componentResized just gets triggered whenever the rocket changes (may be not very efficient when parts of the rocket change that do not affect the rocket compound size, but shouldn't be too bad, there is a check somewhere deep that checks whether the bounds actually changed before updating the rocket view).

New behavior:

https://user-images.githubusercontent.com/11031519/173206868-33f05ccc-1a33-4594-83ea-103529209090.mov


Here is a [jar file](https://github.com/openrocket/openrocket/suites/6893520699/artifacts/267268666) for testing.