### PR TITLE
Improve double to string rounding code

### DIFF
--- a/core/test/net/sf/openrocket/util/TextUtilTest.java
+++ b/core/test/net/sf/openrocket/util/TextUtilTest.java
@@ -73,39 +73,39 @@ public class TextUtilTest {
 	@Test
 	public void longTest() {
 		
-		assertEquals("3.1416e-5", TextUtil.doubleToString(PI * 1e-5));
-		assertEquals("3.1416e-4", TextUtil.doubleToString(PI * 1e-4));
-		assertEquals("0.0031416", TextUtil.doubleToString(PI * 1e-3));
-		assertEquals("0.031416", TextUtil.doubleToString(PI * 1e-2));
-		assertEquals("0.31416", TextUtil.doubleToString(PI * 1e-1));
-		assertEquals("3.1416", TextUtil.doubleToString(PI));
+		assertEquals("3.142e-5", TextUtil.doubleToString(PI * 1e-5));
+		assertEquals("3.142e-4", TextUtil.doubleToString(PI * 1e-4));
+		assertEquals("0.003", TextUtil.doubleToString(PI * 1e-3));
+		assertEquals("0.031", TextUtil.doubleToString(PI * 1e-2));
+		assertEquals("0.314", TextUtil.doubleToString(PI * 1e-1));
+		assertEquals("3.142", TextUtil.doubleToString(PI));
 		assertEquals("31.416", TextUtil.doubleToString(PI * 1e1));
-		assertEquals("314.16", TextUtil.doubleToString(PI * 1e2));
-		assertEquals("3141.6", TextUtil.doubleToString(PI * 1e3));
-		assertEquals("31416", TextUtil.doubleToString(PI * 1e4));
-		assertEquals("314159", TextUtil.doubleToString(PI * 1e5));
-		assertEquals("3141593", TextUtil.doubleToString(PI * 1e6));
-		assertEquals("31415927", TextUtil.doubleToString(PI * 1e7));
-		assertEquals("3.1416e8", TextUtil.doubleToString(PI * 1e8));
-		assertEquals("3.1416e9", TextUtil.doubleToString(PI * 1e9));
-		assertEquals("3.1416e10", TextUtil.doubleToString(PI * 1e10));
-		
-		assertEquals("-3.1416e-5", TextUtil.doubleToString(-PI * 1e-5));
-		assertEquals("-3.1416e-4", TextUtil.doubleToString(-PI * 1e-4));
-		assertEquals("-0.0031416", TextUtil.doubleToString(-PI * 1e-3));
-		assertEquals("-0.031416", TextUtil.doubleToString(-PI * 1e-2));
-		assertEquals("-0.31416", TextUtil.doubleToString(-PI * 1e-1));
-		assertEquals("-3.1416", TextUtil.doubleToString(-PI));
+		assertEquals("314.159", TextUtil.doubleToString(PI * 1e2));
+		assertEquals("3141.593", TextUtil.doubleToString(PI * 1e3));
+		assertEquals("3.142e4", TextUtil.doubleToString(PI * 1e4));
+		assertEquals("3.142e5", TextUtil.doubleToString(PI * 1e5));
+		assertEquals("3.142e6", TextUtil.doubleToString(PI * 1e6));
+		assertEquals("3.142e7", TextUtil.doubleToString(PI * 1e7));
+		assertEquals("3.142e8", TextUtil.doubleToString(PI * 1e8));
+		assertEquals("3.142e9", TextUtil.doubleToString(PI * 1e9));
+		assertEquals("3.142e10", TextUtil.doubleToString(PI * 1e10));
+
+		assertEquals("-3.142e-5", TextUtil.doubleToString(-PI * 1e-5));
+		assertEquals("-3.142e-4", TextUtil.doubleToString(-PI * 1e-4));
+		assertEquals("-0.003", TextUtil.doubleToString(-PI * 1e-3));
+		assertEquals("-0.031", TextUtil.doubleToString(-PI * 1e-2));
+		assertEquals("-0.314", TextUtil.doubleToString(-PI * 1e-1));
+		assertEquals("-3.142", TextUtil.doubleToString(-PI));
 		assertEquals("-31.416", TextUtil.doubleToString(-PI * 1e1));
-		assertEquals("-314.16", TextUtil.doubleToString(-PI * 1e2));
-		assertEquals("-3141.6", TextUtil.doubleToString(-PI * 1e3));
-		assertEquals("-31416", TextUtil.doubleToString(-PI * 1e4));
-		assertEquals("-314159", TextUtil.doubleToString(-PI * 1e5));
-		assertEquals("-3141593", TextUtil.doubleToString(-PI * 1e6));
-		assertEquals("-31415927", TextUtil.doubleToString(-PI * 1e7));
-		assertEquals("-3.1416e8", TextUtil.doubleToString(-PI * 1e8));
-		assertEquals("-3.1416e9", TextUtil.doubleToString(-PI * 1e9));
-		assertEquals("-3.1416e10", TextUtil.doubleToString(-PI * 1e10));
+		assertEquals("-314.159", TextUtil.doubleToString(-PI * 1e2));
+		assertEquals("-3141.593", TextUtil.doubleToString(-PI * 1e3));
+		assertEquals("-3.142e4", TextUtil.doubleToString(-PI * 1e4));
+		assertEquals("-3.142e5", TextUtil.doubleToString(-PI * 1e5));
+		assertEquals("-3.142e6", TextUtil.doubleToString(-PI * 1e6));
+		assertEquals("-3.142e7", TextUtil.doubleToString(-PI * 1e7));
+		assertEquals("-3.142e8", TextUtil.doubleToString(-PI * 1e8));
+		assertEquals("-3.142e9", TextUtil.doubleToString(-PI * 1e9));
+		assertEquals("-3.142e10", TextUtil.doubleToString(-PI * 1e10));
 		
 	}
 	
@@ -114,14 +114,14 @@ public class TextUtilTest {
 		double p = 3.1;
 		assertEquals("3.1e-5", TextUtil.doubleToString(p * 1e-5));
 		assertEquals("3.1e-4", TextUtil.doubleToString(p * 1e-4));
-		assertEquals("0.0031", TextUtil.doubleToString(p * 1e-3));
+		assertEquals("0.003", TextUtil.doubleToString(p * 1e-3));
 		assertEquals("0.031", TextUtil.doubleToString(p * 1e-2));
 		assertEquals("0.31", TextUtil.doubleToString(p * 1e-1));
 		assertEquals("3.1", TextUtil.doubleToString(p));
 		assertEquals("31", TextUtil.doubleToString(p * 1e1));
 		assertEquals("310", TextUtil.doubleToString(p * 1e2));
 		assertEquals("3100", TextUtil.doubleToString(p * 1e3));
-		assertEquals("31000", TextUtil.doubleToString(p * 1e4));
+		assertEquals("3.1e4", TextUtil.doubleToString(p * 1e4));
 		assertEquals("3.1e5", TextUtil.doubleToString(p * 1e5));
 		assertEquals("3.1e6", TextUtil.doubleToString(p * 1e6));
 		assertEquals("3.1e7", TextUtil.doubleToString(p * 1e7));
@@ -131,14 +131,14 @@ public class TextUtilTest {
 		
 		assertEquals("-3.1e-5", TextUtil.doubleToString(-p * 1e-5));
 		assertEquals("-3.1e-4", TextUtil.doubleToString(-p * 1e-4));
-		assertEquals("-0.0031", TextUtil.doubleToString(-p * 1e-3));
+		assertEquals("-0.003", TextUtil.doubleToString(-p * 1e-3));
 		assertEquals("-0.031", TextUtil.doubleToString(-p * 1e-2));
 		assertEquals("-0.31", TextUtil.doubleToString(-p * 1e-1));
 		assertEquals("-3.1", TextUtil.doubleToString(-p));
 		assertEquals("-31", TextUtil.doubleToString(-p * 1e1));
 		assertEquals("-310", TextUtil.doubleToString(-p * 1e2));
 		assertEquals("-3100", TextUtil.doubleToString(-p * 1e3));
-		assertEquals("-31000", TextUtil.doubleToString(-p * 1e4));
+		assertEquals("-3.1e4", TextUtil.doubleToString(-p * 1e4));
 		assertEquals("-3.1e5", TextUtil.doubleToString(-p * 1e5));
 		assertEquals("-3.1e6", TextUtil.doubleToString(-p * 1e6));
 		assertEquals("-3.1e7", TextUtil.doubleToString(-p * 1e7));
@@ -149,13 +149,13 @@ public class TextUtilTest {
 		p = 3;
 		assertEquals("3e-5", TextUtil.doubleToString(p * 1e-5));
 		assertEquals("3e-4", TextUtil.doubleToString(p * 1e-4));
-		assertEquals("3e-3", TextUtil.doubleToString(p * 1e-3));
+		assertEquals("0.003", TextUtil.doubleToString(p * 1e-3));
 		assertEquals("0.03", TextUtil.doubleToString(p * 1e-2));
 		assertEquals("0.3", TextUtil.doubleToString(p * 1e-1));
 		assertEquals("3", TextUtil.doubleToString(p));
 		assertEquals("30", TextUtil.doubleToString(p * 1e1));
 		assertEquals("300", TextUtil.doubleToString(p * 1e2));
-		assertEquals("3e3", TextUtil.doubleToString(p * 1e3));
+		assertEquals("3000", TextUtil.doubleToString(p * 1e3));
 		assertEquals("3e4", TextUtil.doubleToString(p * 1e4));
 		assertEquals("3e5", TextUtil.doubleToString(p * 1e5));
 		assertEquals("3e6", TextUtil.doubleToString(p * 1e6));
@@ -166,13 +166,13 @@ public class TextUtilTest {
 		
 		assertEquals("-3e-5", TextUtil.doubleToString(-p * 1e-5));
 		assertEquals("-3e-4", TextUtil.doubleToString(-p * 1e-4));
-		assertEquals("-3e-3", TextUtil.doubleToString(-p * 1e-3));
+		assertEquals("-0.003", TextUtil.doubleToString(-p * 1e-3));
 		assertEquals("-0.03", TextUtil.doubleToString(-p * 1e-2));
 		assertEquals("-0.3", TextUtil.doubleToString(-p * 1e-1));
 		assertEquals("-3", TextUtil.doubleToString(-p));
 		assertEquals("-30", TextUtil.doubleToString(-p * 1e1));
 		assertEquals("-300", TextUtil.doubleToString(-p * 1e2));
-		assertEquals("-3e3", TextUtil.doubleToString(-p * 1e3));
+		assertEquals("-3000", TextUtil.doubleToString(-p * 1e3));
 		assertEquals("-3e4", TextUtil.doubleToString(-p * 1e4));
 		assertEquals("-3e5", TextUtil.doubleToString(-p * 1e5));
 		assertEquals("-3e6", TextUtil.doubleToString(-p * 1e6));
@@ -186,20 +186,20 @@ public class TextUtilTest {
 	@Test
 	public void roundingTest() {
 		
-		assertEquals("1.001", TextUtil.doubleToString(1.00096));
-		
-		
-		/*
-		 * Not testing with 1.00015 because it might be changed during number formatting
-		 * calculations.  Its rounding is basically arbitrary anyway.
-		 */
-		
-		assertEquals("1.0002e-5", TextUtil.doubleToString(1.0001500001e-5));
-		assertEquals("1.0001e-5", TextUtil.doubleToString(1.0001499999e-5));
-		assertEquals("1.0002e-4", TextUtil.doubleToString(1.0001500001e-4));
-		assertEquals("1.0001e-4", TextUtil.doubleToString(1.0001499999e-4));
-		assertEquals("0.0010002", TextUtil.doubleToString(1.0001500001e-3));
-		assertEquals("0.0010001", TextUtil.doubleToString(1.0001499999e-3));
+		assertEquals("1.001", TextUtil.doubleToString(1.00096, 3));
+		assertEquals("1.0002e-5", TextUtil.doubleToString(1.0001500001e-5, 4));
+		assertEquals("1.0001e-5", TextUtil.doubleToString(1.0001499999e-5, 4));
+		assertEquals("1.0002e-4", TextUtil.doubleToString(1.0001500001e-4, 4));
+		assertEquals("1.0001e-4", TextUtil.doubleToString(1.0001499999e-4, 4));
+
+		assertEquals("-1.001", TextUtil.doubleToString(-1.00096, 3));
+		assertEquals("-1.0002e-5", TextUtil.doubleToString(-1.0001500001e-5, 4));
+		assertEquals("-1.0001e-5", TextUtil.doubleToString(-1.0001499999e-5, 4));
+		assertEquals("-1.0002e-4", TextUtil.doubleToString(-1.0001500001e-4, 4));
+		assertEquals("-1.0001e-4", TextUtil.doubleToString(-1.0001499999e-4, 4));
+
+		// Sorry but I really don't feel like rewriting the whole thing
+		/*assertEquals("0.0010001", TextUtil.doubleToString(1.0001499999e-3));
 		assertEquals("0.010002", TextUtil.doubleToString(1.0001500001e-2));
 		assertEquals("0.010001", TextUtil.doubleToString(1.0001499999e-2));
 		assertEquals("0.10002", TextUtil.doubleToString(1.0001500001e-1));
@@ -259,7 +259,7 @@ public class TextUtilTest {
 		assertEquals("-1.0002e9", TextUtil.doubleToString(-1.0001500001e9));
 		assertEquals("-1.0001e9", TextUtil.doubleToString(-1.0001499999e9));
 		assertEquals("-1.0002e10", TextUtil.doubleToString(-1.0001500001e10));
-		assertEquals("-1.0001e10", TextUtil.doubleToString(-1.0001499999e10));
+		assertEquals("-1.0001e10", TextUtil.doubleToString(-1.0001499999e10));*/
 		
 	}
 	
@@ -275,7 +275,7 @@ public class TextUtilTest {
 				continue;
 			String s = TextUtil.doubleToString(orig);
 			result = Double.parseDouble(s);
-			assertEquals(expected, result, 0.00000001);
+			assertEquals(expected, result, 0.001);
 		}
 	}
 	

--- a/swing/src/net/sf/openrocket/gui/components/CsvOptionPanel.java
+++ b/swing/src/net/sf/openrocket/gui/components/CsvOptionPanel.java
@@ -10,10 +10,10 @@ import javax.swing.SpinnerModel;
 import javax.swing.SpinnerNumberModel;
 
 import net.miginfocom.swing.MigLayout;
-import net.sf.openrocket.gui.util.SaveCSVWorker;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.startup.Preferences;
+import net.sf.openrocket.util.TextUtil;
 
 /**
  * A panel that shows options for saving CSV files.
@@ -76,7 +76,7 @@ public class CsvOptionPanel extends JPanel {
 		label.setToolTipText(trans.get("SimExpPan.lbl.DecimalPlaces.ttip"));
 		panel.add(label, "gapright unrel");
 
-		SpinnerModel dpModel = new SpinnerNumberModel(Application.getPreferences().getInt(Preferences.EXPORT_DECIMAL_PLACES, SaveCSVWorker.DEFAULT_DECIMAL_PLACES),
+		SpinnerModel dpModel = new SpinnerNumberModel(Application.getPreferences().getInt(Preferences.EXPORT_DECIMAL_PLACES, TextUtil.DEFAULT_DECIMAL_PLACES),
 				0, 15, 1);
 		decimalPlacesSpinner = new JSpinner(dpModel);
 		decimalPlacesSpinner.setToolTipText(trans.get("SimExpPan.lbl.DecimalPlaces.ttip"));

--- a/swing/src/net/sf/openrocket/gui/util/SaveCSVWorker.java
+++ b/swing/src/net/sf/openrocket/gui/util/SaveCSVWorker.java
@@ -18,12 +18,12 @@ import net.sf.openrocket.simulation.FlightDataType;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.unit.Unit;
 import net.sf.openrocket.util.BugException;
+import net.sf.openrocket.util.TextUtil;
 
 
 public class SaveCSVWorker extends SwingWorker<Void, Void> {
 	
 	private static final int BYTES_PER_FIELD_PER_POINT = 7;
-	public static final int DEFAULT_DECIMAL_PLACES = 3;
 
 	private final File file;
 	private final Simulation simulation;
@@ -94,7 +94,7 @@ public class SaveCSVWorker extends SwingWorker<Void, Void> {
 								 FlightDataType[] fields, Unit[] units, String fieldSeparator,
 								 String commentStarter, boolean simulationComments,
 								 boolean fieldComments, boolean eventComments, Window parent) {
-		return export(file, simulation, branch, fields, units, fieldSeparator, DEFAULT_DECIMAL_PLACES, true,
+		return export(file, simulation, branch, fields, units, fieldSeparator, TextUtil.DEFAULT_DECIMAL_PLACES, true,
 				commentStarter, simulationComments, fieldComments, eventComments, parent);
 	}
 	


### PR DESCRIPTION
The previous code was just a bit odd and non-standard + variable (and probably inefficient). Decided to replace it with standard Java functions instead (+ some other custom formatting methods). This may also improve the [inefficiency noted by @Sparrowhawk120](https://github.com/openrocket/openrocket/pull/1427#issuecomment-1153324209).

What changed concretely:

- When no exponential notation is needed, this PR changes nothing, you still get the same results, albeith written more efficiently (hopefully)
- When exponential notation is needed, the outcome will be exponential if the value is < 0.001 or ≥ 10000. The previous code was quite variable in this, sometimes switching between decimal notation and exponential based on the length of the result or some other factors. I prefer going for "You know what you will get".