### PR TITLE
[#1244] Reset component appearance after reset to default

### DIFF
--- a/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
@@ -432,12 +432,12 @@ public class AppearancePanel extends JPanel {
 		BooleanModel mDefault;
 		if (!insideBuilder) {
 			builder = ab;
-			mDefault = new BooleanModel(c.getAppearance() == null);
+			mDefault = new BooleanModel(c.getAppearance() == null || defaultAppearance.equals(c.getAppearance()));
 		}
 		else if (c instanceof InsideColorComponent) {
 			builder = insideAb;
-			mDefault = new BooleanModel(
-					((InsideColorComponent)c).getInsideColorComponentHandler().getInsideAppearance() == null);
+			Appearance appearance = ((InsideColorComponent)c).getInsideColorComponentHandler().getInsideAppearance();
+			mDefault = new BooleanModel(appearance == null || defaultAppearance.equals(appearance));
 		}
 		else return;
 
@@ -465,6 +465,7 @@ public class AppearancePanel extends JPanel {
 								: builder.getAppearance();
 					}
 					builder.setAppearance(defaultAppearance);
+					c.setAppearance(null);
 				} else {
 					if (!insideBuilder)
 						builder.setAppearance(previousUserSelectedAppearance);


### PR DESCRIPTION
This PR fixes #1244 by resetting the component appearance when the 'reset to default' checkbox gets checked.