### PR TITLE
Initialize OSX OpenFileHandler in invokeAndWait

### DIFF
--- a/swing/src/net/sf/openrocket/startup/OSXSetup.java
+++ b/swing/src/net/sf/openrocket/startup/OSXSetup.java
@@ -6,6 +6,7 @@ import java.awt.desktop.OpenFilesEvent;
 import java.awt.desktop.OpenFilesHandler;
 import java.awt.desktop.PreferencesHandler;
 import java.awt.desktop.QuitHandler;
+import java.lang.reflect.InvocationTargetException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,7 +93,6 @@ final class OSXSetup {
 			
 			// Set handlers
 			osxDesktop.setAboutHandler(ABOUT_HANDLER);
-			osxDesktop.setOpenFileHandler(OPEN_FILE_HANDLER);
 			osxDesktop.setPreferencesHandler(PREFERENCES_HANDLER);
 			osxDesktop.setQuitHandler(QUIT_HANDLER);
 
@@ -113,6 +113,22 @@ final class OSXSetup {
 			// so at worst case log an error and continue
 			log.warn("Error setting up OSX UI:", t);
 		}
+	}
+
+	/**
+	 * Sets up the open file handler, which handles file association on macOS.
+	 */
+	public static void setupOSXOpenFileHandler() {
+		if (SystemInfo.getPlatform() != Platform.MAC_OS) {
+			log.warn("Attempting to set up OSX file handler on non-MAC_OS");
+		}
+		final Desktop osxDesktop = Desktop.getDesktop();
+		if (osxDesktop == null) {
+			// Application is null: Something is wrong, give up on OS setup
+			throw new NullPointerException("com.apple.eawt.Application.getApplication() returned NULL. "
+					+ "Aborting OSX UI Setup.");
+		}
+		osxDesktop.setOpenFileHandler(OPEN_FILE_HANDLER);
 	}
 
 }

--- a/swing/src/net/sf/openrocket/startup/OSXSetup.java
+++ b/swing/src/net/sf/openrocket/startup/OSXSetup.java
@@ -2,11 +2,9 @@ package net.sf.openrocket.startup;
 
 import java.awt.*;
 import java.awt.desktop.AboutHandler;
-import java.awt.desktop.OpenFilesEvent;
 import java.awt.desktop.OpenFilesHandler;
 import java.awt.desktop.PreferencesHandler;
 import java.awt.desktop.QuitHandler;
-import java.lang.reflect.InvocationTargetException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,7 +14,6 @@ import net.sf.openrocket.arch.SystemInfo.Platform;
 import net.sf.openrocket.gui.dialogs.AboutDialog;
 import net.sf.openrocket.gui.dialogs.preferences.PreferencesDialog;
 import net.sf.openrocket.gui.main.BasicFrame;
-import net.sf.openrocket.gui.main.MRUDesignFile;
 
 import javax.swing.*;
 

--- a/swing/src/net/sf/openrocket/startup/SwingStartup.java
+++ b/swing/src/net/sf/openrocket/startup/SwingStartup.java
@@ -85,6 +85,8 @@ public class SwingStartup {
 		SwingUtilities.invokeAndWait(new Runnable() {
 			@Override
 			public void run() {
+				// Set up the OSX file open handler here so that it can handle files that are opened when OR is not yet running.
+				OSXSetup.setupOSXOpenFileHandler();
 				runner.runInEDT(args);
 			}
 		});


### PR DESCRIPTION
This PR fixes a small bug in the maOS file association that when you tried to open a design file when OR was not yet running, that upon startup you got a RuntimeException error because BasicFrame was not yet loaded. Moving the OpenFileHandler inside the invokeAndWait fixes the issue.