### PR TITLE
Use last BasicFrame as parent in macOS OpenFileHandler

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -139,6 +139,8 @@ public class BasicFrame extends JFrame {
 
 	private SimulationPanel simulationPanel;
 
+	public static BasicFrame lastFrameInstance = null;		// Latest BasicFrame that was created
+
 
 	/**
 	 * Sole constructor.  Creates a new frame based on the supplied document
@@ -152,6 +154,7 @@ public class BasicFrame extends JFrame {
 		this.document = document;
 		this.rocket = document.getRocket();
 		this.rocket.getSelectedConfiguration().setAllStages();
+		BasicFrame.lastFrameInstance = this;
 
 		//	Create the component tree selection model that will be used
 		componentSelectionModel = new DefaultTreeSelectionModel();

--- a/swing/src/net/sf/openrocket/startup/OSXSetup.java
+++ b/swing/src/net/sf/openrocket/startup/OSXSetup.java
@@ -38,7 +38,7 @@ final class OSXSetup {
 	 */
 	public static final OpenFilesHandler OPEN_FILE_HANDLER = (e) -> {
 		log.info("Opening file from association: " + e.getFiles().get(0));
-		BasicFrame.open(e.getFiles().get(0), null);
+		BasicFrame.open(e.getFiles().get(0), BasicFrame.lastFrameInstance);
 	};
 	
 	/**

--- a/swing/src/net/sf/openrocket/startup/SwingStartup.java
+++ b/swing/src/net/sf/openrocket/startup/SwingStartup.java
@@ -85,8 +85,6 @@ public class SwingStartup {
 		SwingUtilities.invokeAndWait(new Runnable() {
 			@Override
 			public void run() {
-				// Set up the OSX file open handler here so that it can handle files that are opened when OR is not yet running.
-				OSXSetup.setupOSXOpenFileHandler();
 				runner.runInEDT(args);
 			}
 		});
@@ -216,6 +214,9 @@ public class SwingStartup {
 		((SwingPreferences) Application.getPreferences()).loadDefaultUnits();
 		
 		Databases.fakeMethod();
+
+		// Set up the OSX file open handler here so that it can handle files that are opened when OR is not yet running.
+		OSXSetup.setupOSXOpenFileHandler();
 		
 		// Starting action (load files or open new document)
 		log.info("Opening main application window");


### PR DESCRIPTION
One final PR to fix an issue in the macOS file association. This PR ensures that a design file opened by the macOS file association replaces an already open (replaceable) design file.