### PR TITLE
[fixes #1100] Implement macOS idle application mode after all windows are closed

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -34,6 +34,7 @@ import javax.swing.tree.TreeSelectionModel;
 import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.appearance.DecalImage;
+import net.sf.openrocket.arch.SystemInfo;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.document.OpenRocketDocumentFactory;
 import net.sf.openrocket.document.StorageOptions;
@@ -1687,7 +1688,8 @@ public class BasicFrame extends JFrame {
 		ComponentAnalysisDialog.hideDialog();
 
 		frames.remove(this);
-		if (frames.isEmpty()) {
+		// Don't quit the application on macOS
+		if (frames.isEmpty() && (SystemInfo.getPlatform() != SystemInfo.Platform.MAC_OS)) {
 			log.info("Last frame closed, exiting");
 			System.exit(0);
 		}
@@ -1702,6 +1704,31 @@ public class BasicFrame extends JFrame {
 	public void printAction() {
 		double rotation = rocketpanel.getFigure().getRotation();
 		new PrintDialog(this, document, rotation).setVisible(true);
+	}
+
+	/**
+	 * Opens a new design file or the last design file, if set in the preferences.
+	 * Can be used for reopening the application or opening it the first time.
+	 */
+	public static void reopen() {
+		if (!Application.getPreferences().isAutoOpenLastDesignOnStartupEnabled()) {
+			BasicFrame.newAction();
+		} else {
+			String lastFile = MRUDesignFile.getInstance().getLastEditedDesignFile();
+			if (lastFile != null) {
+				log.info("Opening last design file: " + lastFile);
+				if (!BasicFrame.open(new File(lastFile), null)) {
+					MRUDesignFile.getInstance().removeFile(lastFile);
+					BasicFrame.newAction();
+				}
+				else {
+					MRUDesignFile.getInstance().addFile(lastFile);
+				}
+			}
+			else {
+				BasicFrame.newAction();
+			}
+		}
 	}
 
 

--- a/swing/src/net/sf/openrocket/gui/util/DummyFrameMenuOSX.java
+++ b/swing/src/net/sf/openrocket/gui/util/DummyFrameMenuOSX.java
@@ -1,0 +1,185 @@
+package net.sf.openrocket.gui.util;
+
+import net.sf.openrocket.gui.dialogs.AboutDialog;
+import net.sf.openrocket.gui.dialogs.LicenseDialog;
+import net.sf.openrocket.gui.help.tours.GuidedTourSelectionDialog;
+import net.sf.openrocket.gui.main.BasicFrame;
+import net.sf.openrocket.gui.main.ExampleDesignFileAction;
+import net.sf.openrocket.gui.main.MRUDesignFileAction;
+import net.sf.openrocket.l10n.Translator;
+import net.sf.openrocket.logging.Markers;
+import net.sf.openrocket.startup.Application;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.KeyStroke;
+import java.awt.Color;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+
+/**
+ * This dummy frame will be generated when all design windows are close on macOS.
+ * It serves to maintain and customize the application menu bar when all the BasicFrame windows are closed.
+ *
+ * @author Sibo Van Gool <sibo.vangool@hotmail.com>
+ */
+public class DummyFrameMenuOSX extends JFrame {
+    private static final Translator trans = Application.getTranslator();
+    private static final Logger log = LoggerFactory.getLogger(BasicFrame.class);
+
+    private static DummyFrameMenuOSX dialog;
+
+    private DummyFrameMenuOSX() {
+        createMenu();
+        setUndecorated(true);
+        setBackground(new Color(0, 0, 0, 0));
+        setVisible(true);   // this is needed to show the menu bar
+    }
+
+    public static DummyFrameMenuOSX createDummyDialog() {
+        dialog = new DummyFrameMenuOSX();
+        return dialog;
+    }
+
+    public static DummyFrameMenuOSX getDummyDialog() {
+        return dialog;
+    }
+
+    public static void removeDummyDialog() {
+        if (dialog != null) {
+            dialog.dispose();
+            dialog = null;
+        }
+    }
+
+    private void createMenu() {
+        JMenuBar menubar = new JMenuBar();
+        JMenu menu;
+        JMenuItem item;
+
+        ////  File
+        menu = new JMenu(trans.get("main.menu.file"));
+        menu.setMnemonic(KeyEvent.VK_F);
+        //// File-handling related tasks
+        menu.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.file.desc"));
+        menubar.add(menu);
+
+        //// New
+        item = new JMenuItem(trans.get("main.menu.file.new"), KeyEvent.VK_N);
+        item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, BasicFrame.SHORTCUT_KEY));
+        item.setMnemonic(KeyEvent.VK_N);
+        //// Create a new rocket design
+        item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.file.new.desc"));
+        item.setIcon(Icons.FILE_NEW);
+        item.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                DummyFrameMenuOSX.removeDummyDialog();
+                log.info(Markers.USER_MARKER, "New... selected");
+                BasicFrame.newAction();
+            }
+        });
+        menu.add(item);
+
+        //// Open...
+        item = new JMenuItem(trans.get("main.menu.file.open"), KeyEvent.VK_O);
+        item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, BasicFrame.SHORTCUT_KEY));
+        //// Open a rocket design
+        item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.file.open.desc"));
+        item.setIcon(Icons.FILE_OPEN);
+        item.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                DummyFrameMenuOSX.removeDummyDialog();
+                log.info(Markers.USER_MARKER, "Open... selected");
+                BasicFrame.openAction(DummyFrameMenuOSX.this);
+            }
+        });
+        menu.add(item);
+
+        //// Open Recent...
+        item = new MRUDesignFileAction(trans.get("main.menu.file.openRecent"), this);
+        item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.file.openRecent.desc"));
+        item.setIcon(Icons.FILE_OPEN);
+        menu.add(item);
+
+        //// Open example...
+        item = new ExampleDesignFileAction(trans.get("main.menu.file.openExample"), null);
+        item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.file.openExample.desc"));
+        item.setIcon(Icons.FILE_OPEN_EXAMPLE);
+        menu.add(item);
+
+        menu.addSeparator();
+
+        ////	Quit
+        item = new JMenuItem(trans.get("main.menu.file.quit"), KeyEvent.VK_Q);
+        item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Q, BasicFrame.SHORTCUT_KEY));
+        //// Quit the program
+        item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.file.quit.desc"));
+        item.setIcon(Icons.FILE_QUIT);
+        item.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                log.info(Markers.USER_MARKER, "Quit selected");
+                BasicFrame.quitAction();
+            }
+        });
+        menu.add(item);
+
+
+        ////	Help
+        menu = new JMenu(trans.get("main.menu.help"));
+        menu.setMnemonic(KeyEvent.VK_H);
+        menu.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.help.desc"));
+        menubar.add(menu);
+
+        ////	Guided tours
+        item = new JMenuItem(trans.get("main.menu.help.tours"), KeyEvent.VK_L);
+        item.setIcon(Icons.HELP_TOURS);
+        item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.help.tours.desc"));
+        item.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                log.info(Markers.USER_MARKER, "Guided tours selected");
+                GuidedTourSelectionDialog.showDialog(DummyFrameMenuOSX.this);
+            }
+        });
+        menu.add(item);
+
+        menu.addSeparator();
+
+        ////	License
+        item = new JMenuItem(trans.get("main.menu.help.license"), KeyEvent.VK_L);
+        item.setIcon(Icons.HELP_LICENSE);
+        item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.help.license.desc"));
+        item.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                log.info(Markers.USER_MARKER, "License selected");
+                new LicenseDialog(DummyFrameMenuOSX.this).setVisible(true);
+            }
+        });
+        menu.add(item);
+
+        ////	About
+        item = new JMenuItem(trans.get("main.menu.help.about"), KeyEvent.VK_A);
+        item.setIcon(Icons.HELP_ABOUT);
+        item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.help.about.desc"));
+        item.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                log.info(Markers.USER_MARKER, "About selected");
+                new AboutDialog(DummyFrameMenuOSX.this).setVisible(true);
+            }
+        });
+        menu.add(item);
+
+
+        this.setJMenuBar(menubar);
+    }
+}

--- a/swing/src/net/sf/openrocket/startup/OSXSetup.java
+++ b/swing/src/net/sf/openrocket/startup/OSXSetup.java
@@ -5,6 +5,7 @@ import java.awt.desktop.AboutHandler;
 import java.awt.desktop.OpenFilesHandler;
 import java.awt.desktop.PreferencesHandler;
 import java.awt.desktop.QuitHandler;
+import java.awt.desktop.AppReopenedListener;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +51,11 @@ final class OSXSetup {
 		r.cancelQuit();
 	};
 
+	private static final AppReopenedListener APP_REOPENED_HANDLER = (e) -> {
+		log.info("App re-opened");
+		BasicFrame.reopen();
+	};
+
 	/**
 	 * The handler for the About item in the OSX app menu
 	 */
@@ -92,6 +98,7 @@ final class OSXSetup {
 			osxDesktop.setAboutHandler(ABOUT_HANDLER);
 			osxDesktop.setPreferencesHandler(PREFERENCES_HANDLER);
 			osxDesktop.setQuitHandler(QUIT_HANDLER);
+			osxDesktop.addAppEventListener(APP_REOPENED_HANDLER);
 
 			// Set the dock icon to the largest icon
 			final Image dockIcon = Toolkit.getDefaultToolkit().getImage(

--- a/swing/src/net/sf/openrocket/startup/OSXSetup.java
+++ b/swing/src/net/sf/openrocket/startup/OSXSetup.java
@@ -7,6 +7,7 @@ import java.awt.desktop.PreferencesHandler;
 import java.awt.desktop.QuitHandler;
 import java.awt.desktop.AppReopenedListener;
 
+import net.sf.openrocket.gui.util.DummyFrameMenuOSX;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,8 +53,10 @@ final class OSXSetup {
 	};
 
 	private static final AppReopenedListener APP_REOPENED_HANDLER = (e) -> {
-		log.info("App re-opened");
-		BasicFrame.reopen();
+		if (BasicFrame.isFramesEmpty()) {
+			log.info("App re-opened");
+			BasicFrame.reopen();
+		}
 	};
 
 	/**

--- a/swing/src/net/sf/openrocket/startup/SwingStartup.java
+++ b/swing/src/net/sf/openrocket/startup/SwingStartup.java
@@ -216,7 +216,9 @@ public class SwingStartup {
 		Databases.fakeMethod();
 
 		// Set up the OSX file open handler here so that it can handle files that are opened when OR is not yet running.
-		OSXSetup.setupOSXOpenFileHandler();
+		if (SystemInfo.getPlatform() == Platform.MAC_OS) {
+			OSXSetup.setupOSXOpenFileHandler();
+		}
 		
 		// Starting action (load files or open new document)
 		log.info("Opening main application window");

--- a/swing/src/net/sf/openrocket/startup/SwingStartup.java
+++ b/swing/src/net/sf/openrocket/startup/SwingStartup.java
@@ -220,23 +220,7 @@ public class SwingStartup {
 		// Starting action (load files or open new document)
 		log.info("Opening main application window");
 		if (!handleCommandLine(args)) {
-			if (!Application.getPreferences().isAutoOpenLastDesignOnStartupEnabled()) {
-				BasicFrame.newAction();
-			} else {
-				String lastFile = MRUDesignFile.getInstance().getLastEditedDesignFile();
-				if (lastFile != null) {
-					if (!BasicFrame.open(new File(lastFile), null)) {
-						MRUDesignFile.getInstance().removeFile(lastFile);
-						BasicFrame.newAction();
-					}
-					else {
-						MRUDesignFile.getInstance().addFile(lastFile);
-					}
-				}
-				else {
-					BasicFrame.newAction();
-				}
-			}
+			BasicFrame.reopen();
 		}
 		
 		// Check whether update info has been fetched or whether it needs more time


### PR DESCRIPTION
This PR fixes #1100 by making OR go into idle mode when all the design windows are closed, instead of quitting the application. In idle mode, an alternative menubar is present (that does not contain the edit tab etc.).

Demo:

https://user-images.githubusercontent.com/11031519/174087249-536fd7f6-b924-4899-b953-7e36d16ac627.mp4

Small sidenote: it seems like even in idle mode OR still uses a significant amount or memory, but that's just due to the horrible memory management of OR in general... 
