### PR TITLE
[#1454] Fix stackoverflow error

### DIFF
--- a/core/src/net/sf/openrocket/appearance/AppearanceBuilder.java
+++ b/core/src/net/sf/openrocket/appearance/AppearanceBuilder.java
@@ -555,7 +555,7 @@ public class AppearanceBuilder extends AbstractChangeSource {
 	 * @return true if listener was successfully added, false if not
 	 */
 	public boolean addConfigListener(RocketComponent component, AppearanceBuilder ab) {
-		if (component == null || ab == null) {
+		if (component == null || ab == null || configListeners.values().contains(ab) || ab == this) {
 			return false;
 		}
 		configListeners.put(component, ab);

--- a/core/src/net/sf/openrocket/rocketcomponent/BodyTube.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/BodyTube.java
@@ -31,7 +31,7 @@ public class BodyTube extends SymmetricComponent implements BoxBounded, MotorMou
 	
 	private MotorConfigurationSet motors;
 
-	private final InsideColorComponentHandler insideColorComponentHandler = new InsideColorComponentHandler(this);
+	private InsideColorComponentHandler insideColorComponentHandler = new InsideColorComponentHandler(this);
 	
 	public BodyTube() {
 		this(8 * DEFAULT_RADIUS, DEFAULT_RADIUS);
@@ -519,6 +519,11 @@ public class BodyTube extends SymmetricComponent implements BoxBounded, MotorMou
 	@Override
 	public InsideColorComponentHandler getInsideColorComponentHandler() {
 		return this.insideColorComponentHandler;
+	}
+
+	@Override
+	public void setInsideColorComponentHandler(InsideColorComponentHandler handler) {
+		this.insideColorComponentHandler = handler;
 	}
 
 	@Override

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -123,7 +123,7 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 	private double totalVolume = Double.NaN;
 	private Coordinate centerOfMass = Coordinate.NaN;
 
-	private final InsideColorComponentHandler insideColorComponentHandler = new InsideColorComponentHandler(this);
+	private InsideColorComponentHandler insideColorComponentHandler = new InsideColorComponentHandler(this);
 	
 	/**
 	 * New FinSet with given number of fins and given base rotation angle.
@@ -1368,5 +1368,10 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 	@Override
 	public InsideColorComponentHandler getInsideColorComponentHandler() {
 		return this.insideColorComponentHandler;
+	}
+
+	@Override
+	public void setInsideColorComponentHandler(InsideColorComponentHandler handler) {
+		this.insideColorComponentHandler = handler;
 	}
 }

--- a/core/src/net/sf/openrocket/rocketcomponent/InsideColorComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/InsideColorComponent.java
@@ -22,4 +22,6 @@ public interface InsideColorComponent {
      * @return the InsideColorComponentHandler
      */
     InsideColorComponentHandler getInsideColorComponentHandler();
+
+    void setInsideColorComponentHandler(InsideColorComponentHandler handler);
 }

--- a/core/src/net/sf/openrocket/rocketcomponent/LaunchLug.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/LaunchLug.java
@@ -30,7 +30,7 @@ public class LaunchLug extends Tube implements AnglePositionable, BoxBounded, Li
 	private int instanceCount = 1;
 	private double instanceSeparation = 0; // front-front along the positive rocket axis. i.e. [1,0,0];
 
-	private final InsideColorComponentHandler insideColorComponentHandler = new InsideColorComponentHandler(this);
+	private InsideColorComponentHandler insideColorComponentHandler = new InsideColorComponentHandler(this);
 	
 	public LaunchLug() {
 		super(AxialMethod.MIDDLE);
@@ -332,5 +332,10 @@ public class LaunchLug extends Tube implements AnglePositionable, BoxBounded, Li
 	@Override
 	public InsideColorComponentHandler getInsideColorComponentHandler() {
 		return this.insideColorComponentHandler;
+	}
+
+	@Override
+	public void setInsideColorComponentHandler(InsideColorComponentHandler handler) {
+		this.insideColorComponentHandler = handler;
 	}
 }

--- a/core/src/net/sf/openrocket/rocketcomponent/NoseCone.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/NoseCone.java
@@ -20,7 +20,7 @@ import java.util.EventObject;
 public class NoseCone extends Transition implements InsideColorComponent {
 	private static final Translator trans = Application.getTranslator();
 
-	private final InsideColorComponentHandler insideColorComponentHandler = new InsideColorComponentHandler(this);
+	private InsideColorComponentHandler insideColorComponentHandler = new InsideColorComponentHandler(this);
 	
 	/********* Constructors **********/
 	public NoseCone() {
@@ -154,5 +154,10 @@ public class NoseCone extends Transition implements InsideColorComponent {
 	@Override
 	public InsideColorComponentHandler getInsideColorComponentHandler() {
 		return this.insideColorComponentHandler;
+	}
+
+	@Override
+	public void setInsideColorComponentHandler(InsideColorComponentHandler handler) {
+		this.insideColorComponentHandler = handler;
 	}
 }

--- a/core/src/net/sf/openrocket/rocketcomponent/Transition.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Transition.java
@@ -44,7 +44,7 @@ public class Transition extends SymmetricComponent implements InsideColorCompone
 	// Used to cache the clip length
 	private double clipLength = -1;
 
-	private final InsideColorComponentHandler insideColorComponentHandler = new InsideColorComponentHandler(this);
+	private InsideColorComponentHandler insideColorComponentHandler = new InsideColorComponentHandler(this);
 
 	public Transition() {
 		super();
@@ -730,6 +730,11 @@ public class Transition extends SymmetricComponent implements InsideColorCompone
 	@Override
 	public InsideColorComponentHandler getInsideColorComponentHandler() {
 		return this.insideColorComponentHandler;
+	}
+
+	@Override
+	public void setInsideColorComponentHandler(InsideColorComponentHandler handler) {
+		this.insideColorComponentHandler = handler;
 	}
 
 	/**

--- a/core/src/net/sf/openrocket/rocketcomponent/TubeFinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/TubeFinSet.java
@@ -28,7 +28,7 @@ public class TubeFinSet extends Tube implements AxialPositionable, BoxBounded, R
 	private AngleMethod angleMethod = AngleMethod.FIXED;
 	protected RadiusMethod radiusMethod = RadiusMethod.RELATIVE;
 
-	private final InsideColorComponentHandler insideColorComponentHandler = new InsideColorComponentHandler(this);
+	private InsideColorComponentHandler insideColorComponentHandler = new InsideColorComponentHandler(this);
 	
 	/**
 	 * Rotation angle of the first fin.  Zero corresponds to the positive y-axis.
@@ -522,5 +522,10 @@ public class TubeFinSet extends Tube implements AxialPositionable, BoxBounded, R
 	@Override
 	public InsideColorComponentHandler getInsideColorComponentHandler() {
 		return this.insideColorComponentHandler;
+	}
+
+	@Override
+	public void setInsideColorComponentHandler(InsideColorComponentHandler handler) {
+		this.insideColorComponentHandler = handler;
 	}
 }

--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -345,6 +345,7 @@ public class BasicFrame extends JFrame {
 				c.clearConfigListeners();
 				for (int i = 1; i < paths.length; i++) {
 					RocketComponent listener = (RocketComponent) paths[i].getLastPathComponent();
+					listener.clearConfigListeners();
 					c.addConfigListener(listener);
 				}
 				ComponentConfigDialog.showDialog(BasicFrame.this, BasicFrame.this.document, c);

--- a/swing/src/net/sf/openrocket/gui/main/RocketActions.java
+++ b/swing/src/net/sf/openrocket/gui/main/RocketActions.java
@@ -791,7 +791,8 @@ public class RocketActions {
 			Simulation[] sims = selectionModel.getSelectedSimulations();
 
 			if (isCopyable(components)) {
-				ComponentConfigDialog.disposeDialog();
+				if (ComponentConfigDialog.isDialogVisible())
+					ComponentConfigDialog.disposeDialog();
 
 				List<RocketComponent> copiedComponents = copyComponentsMaintainParent(components);
 				OpenRocketClipboard.setClipboard(copiedComponents);
@@ -885,7 +886,9 @@ public class RocketActions {
 				RocketComponent component = components.get(0);
 				if (components.size() > 1) {
 					for (int i = 1; i < components.size(); i++) {
-						component.addConfigListener(components.get(i));
+						RocketComponent listener = components.get(i);
+						listener.clearConfigListeners();	// Make sure all the listeners are cleared (should not be possible, but just in case)
+						component.addConfigListener(listener);
 					}
 				}
 				ComponentConfigDialog.showDialog(parentFrame, document, component);


### PR DESCRIPTION
This PR fixes #1454. The problem was that when cloning a RocketComponent, the InsideColorComponentHandler of the new component wasn't cloned as well, causing the program to go in an endless loop when editing the inside color, because the component's listener also had the same InsideColorComponentHandler. Additionally, the configListeners should not be cloned from the previous component, as that would also lead to a stackoverlow error.