### PR TITLE
[#1465] Include xmin in sideview canvas origin calculation

### DIFF
--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketFigure.java
@@ -486,7 +486,7 @@ public class RocketFigure extends AbstractScaleFigure {
 			
 			originLocation_px = new Point(newOriginX, newOriginY);
 		}else if (currentViewType == RocketPanel.VIEW_TYPE.SideView){
-			final int newOriginX = mid_x - (subjectWidth / 2);
+			final int newOriginX = mid_x - (subjectWidth / 2) - (int)(subjectBounds_m.getMinX() * scale);
 			final int newOriginY = Math.max(getHeight(), subjectHeight + 2*borderThickness_px.height )/ 2;
 			originLocation_px = new Point(newOriginX, newOriginY);
 		}


### PR DESCRIPTION
This PR fixes #1465 by including the rocket's xmin position into its sideview origin calculation. For normal rockets, xmin should equal 0, thus nothing should have changed for them. For rockets where some of its child components reach further to the left than their parent component, xmin becomes smaller than zero, which should then also be included in the origin calculation. The design file from #1465 was an example of the child components reaching further to the left. A body tube contained a pod set that was positioned to the left of its parent body tube. Another way of recreating the issue from #1465 is by opening 'A simple model rocket' and moving the launch lug all the way to the left.

<img width="1736" alt="image" src="https://user-images.githubusercontent.com/11031519/174503145-57b4b6d7-a980-4040-b4be-7ba9f6d92272.png">
