### PR TITLE
[#1464] Don't recenter view when editing a component

### DIFF
--- a/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
@@ -406,6 +406,9 @@ public class AppearancePanel extends JPanel {
 				@Override
 				public void actionPerformed(ActionEvent e) {
 					handler.setSeparateInsideOutside(customInside.isSelected());
+					edgesText.setEnabled(customInside.isSelected());
+					edgesComboBox.setEnabled(customInside.isSelected());
+					if (e == null) return;	// When e == null, you just want an update of the UI components, not a component change
 					c.fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 					if (customInside.isSelected()) {
 						remove(outsidePanel);
@@ -418,8 +421,6 @@ public class AppearancePanel extends JPanel {
 						remove(outsideInsidePane);
 						add(outsidePanel, "span 4, growx, wrap");
 					}
-					edgesText.setEnabled(customInside.isSelected());
-					edgesComboBox.setEnabled(customInside.isSelected());
 					updateUI();
 				}
 			});
@@ -438,7 +439,9 @@ public class AppearancePanel extends JPanel {
 					else {
 						return;
 					}
-					c.fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
+					if (e != null) {	// When e == null, you just want an update of the UI components, not a component change
+						c.fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
+					}
 				}
 			});
 

--- a/swing/src/net/sf/openrocket/gui/scalefigure/AbstractScaleFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/AbstractScaleFigure.java
@@ -110,15 +110,17 @@ public abstract class AbstractScaleFigure extends JPanel {
 	 *
 	 * @param newScaleRequest the scale level
 	 * @param newVisibleBounds the visible bounds upon the Figure
+	 * @return true if the scale changed, false if it was already at the requested scale or something went wrong.
 	 */
-	public void scaleTo(final double newScaleRequest, final Dimension newVisibleBounds) {
+	public boolean scaleTo(final double newScaleRequest, final Dimension newVisibleBounds) {
 		if (MathUtil.equals(this.userScale, newScaleRequest, 0.01) &&
 			(visibleBounds_px.width == newVisibleBounds.width) &&
-			(visibleBounds_px.height == newVisibleBounds.height) )
-		{
-			return;}
+			(visibleBounds_px.height == newVisibleBounds.height) ) {
+			return false;
+		}
 		if (Double.isInfinite(newScaleRequest) || Double.isNaN(newScaleRequest) || 0 > newScaleRequest) {
-			return;}
+			return false;
+		}
 
 		this.userScale = MathUtil.clamp( newScaleRequest, MINIMUM_ZOOM, MAXIMUM_ZOOM);
 		this.scale = baseScale * userScale;
@@ -128,16 +130,18 @@ public abstract class AbstractScaleFigure extends JPanel {
 		updateCanvasSize();
 
 		this.fireChangeEvent();
+		return true;
 	}
 	
 	/**
      * Set the scale level to display newBounds
      * 
-     * @param visibleBounds the visible bounds to scale this figure to.  
+     * @param visibleBounds the visible bounds to scale this figure to.
+	 * @return true if the scale changed, false if it was already at the requested scale or something went wrong.
      */
-	public void scaleTo(Dimension visibleBounds) {
+	public boolean scaleTo(Dimension visibleBounds) {
 		if( 0 >= visibleBounds.getWidth() || 0 >= visibleBounds.getHeight())
-			return;
+			return false;
 
 		updateSubjectDimensions();
 
@@ -145,7 +149,7 @@ public abstract class AbstractScaleFigure extends JPanel {
 		final double height_scale = (visibleBounds.height - 2 * borderThickness_px.height) / (subjectBounds_m.getHeight() * baseScale);
 		final double newScale = Math.min(height_scale, width_scale);
 
-		scaleTo(newScale, visibleBounds);
+		return scaleTo(newScale, visibleBounds);
 	}
 	
     /**

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -778,6 +778,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 				@Override
 				public void stateChanged(EventObject e) {
 					if (updateFlightData(sim)) {
+						// TODO HIGH: this gets updated for every sim run; not necessary...
 						updateFigures();
 					}
 				}

--- a/swing/src/net/sf/openrocket/gui/scalefigure/ScaleScrollPane.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/ScaleScrollPane.java
@@ -61,6 +61,7 @@ public class ScaleScrollPane extends JScrollPane
 
 	// is the subject *currently* being fitting
 	protected boolean fit = false;
+	private boolean figureRescaled = false;	// has the figure been rescaled since the last figure.scaleTo()
 
 	// magic number.  I don't know why this number works, but this nudges the figures to zoom correctly.
     // n.b. it is slightly large than the ruler.width + scrollbar.width
@@ -114,7 +115,7 @@ public class ScaleScrollPane extends JScrollPane
 			verticalRuler.updateSize();
 			if(fit) {
 				final java.awt.Dimension calculatedViewSize = new java.awt.Dimension(getWidth() - viewportMarginPx.width, getHeight() - viewportMarginPx.height);
-				figure.scaleTo(calculatedViewSize);
+				figureRescaled = figure.scaleTo(calculatedViewSize);
 			}
 		});
 		figure.addComponentListener(this);
@@ -143,7 +144,7 @@ public class ScaleScrollPane extends JScrollPane
 
 		if (shouldFit) {
 			final Dimension calculatedViewSize = new Dimension(getWidth() - viewportMarginPx.width, getHeight() - viewportMarginPx.height);
-			figure.scaleTo(calculatedViewSize);
+			figureRescaled = figure.scaleTo(calculatedViewSize);
 
 			revalidate();
 		}
@@ -166,7 +167,7 @@ public class ScaleScrollPane extends JScrollPane
 		// if explicitly setting a zoom level, turn off fitting
 		this.fit = false;
 		Dimension view = viewport.getExtentSize();
-		figure.scaleTo(newScale, view);
+		figureRescaled = figure.scaleTo(newScale, view);
 
 		revalidate();
 	}
@@ -253,12 +254,16 @@ public class ScaleScrollPane extends JScrollPane
 	public void componentResized(ComponentEvent e) {
 		if(fit) {
 			final Dimension calculatedViewSize = new Dimension(getWidth() - viewportMarginPx.width, getHeight() - viewportMarginPx.height);
-			figure.scaleTo(calculatedViewSize);
+			figureRescaled = figure.scaleTo(calculatedViewSize);
 
 			final Point zoomPoint = figure.getAutoZoomPoint();
 			final Rectangle zoomRectangle = new Rectangle(zoomPoint.x, zoomPoint.y, viewport.getWidth(), viewport.getHeight() );
 			figure.scrollRectToVisible(zoomRectangle);
 		}else{
+			// Always recenter the viewport if the user has zoomed in or out.
+			if (!figureRescaled) {
+				return;
+			}
 			final Rectangle scrollRectangle = viewport.getViewRect();
 			scrollRectangle.x = (int)(viewCenter_frac.x * figure.getWidth()) - (scrollRectangle.width/2);
 			scrollRectangle.y = (int)(viewCenter_frac.y * figure.getHeight()) - (scrollRectangle.height/2);
@@ -270,6 +275,7 @@ public class ScaleScrollPane extends JScrollPane
 		revalidate();
 		horizontalRuler.updateSize();
 		verticalRuler.updateSize();
+		figureRescaled = false;
 	}
 
 	@Override


### PR DESCRIPTION
This PR fixes #1464 by not recentering the view when you have dragged the rocket view.

Demo:

https://user-images.githubusercontent.com/11031519/174902456-1faa51c6-5cf4-4ef7-8633-67294b51d957.mov


