### PR TITLE
Remove redundant updatefigure/repaint calls

### DIFF
--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -819,7 +819,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 			sim.addChangeListener(new StateChangeListener() {
 				@Override
 				public void stateChanged(EventObject e) {
-					if (updateFlightData(sim)) {
+					if (updateFlightData(sim) && sim.getFlightConfigurationId() == document.getSelectedConfiguration().getFlightConfigurationID()) {
 						// TODO HIGH: this gets updated for every sim run; not necessary...
 						updateFigures();
 					}
@@ -972,8 +972,10 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 
 			// Only set the flight data information of the current flight configuration
 			extraText.setCalculatingData(false);
-			figure.repaint();
-			figure3d.repaint();
+			if (!is3d)
+				figure.repaint();
+			else
+				figure3d.repaint();
 			document.fireDocumentChangeEvent(new SimulationChangeEvent(simulation));
 
 			// Run the new simulation after this one has ended
@@ -1002,8 +1004,10 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 			backgroundSimulationWorker = null;
 			extraText.setFlightData(FlightData.NaN_DATA);
 			extraText.setCalculatingData(false);
-			figure.repaint();
-			figure3d.repaint();
+			if (!is3d)
+				figure.repaint();
+			else
+				figure3d.repaint();
 		}
 	}
 


### PR DESCRIPTION
This PR removes some redundant calls to updating the rocket view, thus improving performance very slightly.

It changes 2 instances where both the 2D view and 3D view are updated to only updating the view that is currently active. + it doesn't update the view when the simulation of the current flight configuration has changed (instead of updating the figure for all simulations).