### PR TITLE
[#1458] Pack component config dialog after inside/outside checkbox change

### DIFF
--- a/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
@@ -372,9 +372,8 @@ public class AppearancePanel extends JPanel {
 			add(customInside, "span 2");
 
 			// Checkbox to set edges the same as inside/outside
-			JPanel edgesPanel = new JPanel(new MigLayout());
 			JLabel edgesText = new JLabel(trans.get("AppearanceCfg.lbl.AppearanceEdges"));
-			edgesPanel.add(edgesText);
+			add(edgesText);
 			String[] options = new String[] {trans.get(tr_outside), trans.get(tr_inside)};
 			JComboBox<String> edgesComboBox = new JComboBox<>(options);
 			if (handler.isEdgesSameAsInside()) {
@@ -383,9 +382,9 @@ public class AppearancePanel extends JPanel {
 			else {
 				edgesComboBox.setSelectedItem(trans.get(tr_outside));
 			}
-			edgesPanel.add(edgesComboBox, "growx");
-			edgesPanel.setToolTipText(trans.get("AppearanceCfg.lbl.ttip.AppearanceEdges"));
-			add(edgesPanel, "span 2, wrap");
+			add(edgesComboBox, "growx, left, wrap");
+			edgesText.setToolTipText(trans.get("AppearanceCfg.lbl.ttip.AppearanceEdges"));
+			edgesComboBox.setToolTipText(trans.get("AppearanceCfg.lbl.ttip.AppearanceEdges"));
 
 			outsideInsidePane = new JTabbedPane();
 			JPanel outsidePanel = new JPanel(new MigLayout("fill", "[150][grow][150][grow]"));

--- a/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
@@ -340,7 +340,7 @@ public class AppearancePanel extends JPanel {
 
 			fDefault.addEnableComponent(combo, false);
 
-			add(combo, "wrap");
+			add(combo, "growx, wrap");
 		}
 
 		add(new JSeparator(SwingConstants.HORIZONTAL), "span, wrap, growx");
@@ -376,14 +376,14 @@ public class AppearancePanel extends JPanel {
 			JLabel edgesText = new JLabel(trans.get("AppearanceCfg.lbl.AppearanceEdges"));
 			edgesPanel.add(edgesText);
 			String[] options = new String[] {trans.get(tr_outside), trans.get(tr_inside)};
-			JComboBox edgesComboBox = new JComboBox(options);
+			JComboBox<String> edgesComboBox = new JComboBox<>(options);
 			if (handler.isEdgesSameAsInside()) {
 				edgesComboBox.setSelectedItem(trans.get(tr_inside));
 			}
 			else {
 				edgesComboBox.setSelectedItem(trans.get(tr_outside));
 			}
-			edgesPanel.add(edgesComboBox);
+			edgesPanel.add(edgesComboBox, "growx");
 			edgesPanel.setToolTipText(trans.get("AppearanceCfg.lbl.ttip.AppearanceEdges"));
 			add(edgesPanel, "span 2, wrap");
 

--- a/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
@@ -199,8 +199,7 @@ public class AppearancePanel extends JPanel {
 	}
 
 
-	public AppearancePanel(final OpenRocketDocument document,
-			final RocketComponent c) {
+	public AppearancePanel(final OpenRocketDocument document, final RocketComponent c, final JDialog parent) {
 		super(new MigLayout("fill", "[150][grow][150][grow]"));
 
 		defaultAppearance = DefaultAppearance.getDefaultAppearance(c);
@@ -408,8 +407,6 @@ public class AppearancePanel extends JPanel {
 					handler.setSeparateInsideOutside(customInside.isSelected());
 					edgesText.setEnabled(customInside.isSelected());
 					edgesComboBox.setEnabled(customInside.isSelected());
-					if (e == null) return;	// When e == null, you just want an update of the UI components, not a component change
-					c.fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 					if (customInside.isSelected()) {
 						remove(outsidePanel);
 						outsideInsidePane.insertTab(trans.get(tr_outside), null, outsidePanel,
@@ -421,7 +418,14 @@ public class AppearancePanel extends JPanel {
 						remove(outsideInsidePane);
 						add(outsidePanel, "span 4, growx, wrap");
 					}
-					updateUI();
+					if (parent != null) {
+						parent.pack();
+					} else {
+						updateUI();
+					}
+
+					if (e == null) return;	// When e == null, you just want an update of the UI components, not a component change
+					c.fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 				}
 			});
 

--- a/swing/src/net/sf/openrocket/gui/configdialog/AxialStageConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/AxialStageConfig.java
@@ -1,6 +1,7 @@
 package net.sf.openrocket.gui.configdialog;
 
 import javax.swing.JComboBox;
+import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
@@ -24,8 +25,8 @@ public class AxialStageConfig extends ComponentAssemblyConfig {
 	private static final long serialVersionUID = -944969957186522471L;
 	private static final Translator trans = Application.getTranslator();
 	
-	public AxialStageConfig(OpenRocketDocument document, RocketComponent component) {
-		super(document, component);
+	public AxialStageConfig(OpenRocketDocument document, RocketComponent component, JDialog parent) {
+		super(document, component, parent);
 		
 		// Stage separation config (for non-first stage)
 		if (component.getStageNumber() > 0) {

--- a/swing/src/net/sf/openrocket/gui/configdialog/BodyTubeConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/BodyTubeConfig.java
@@ -2,6 +2,7 @@ package net.sf.openrocket.gui.configdialog;
 
 
 import javax.swing.JCheckBox;
+import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
@@ -29,8 +30,8 @@ public class BodyTubeConfig extends RocketComponentConfig {
 	private final JCheckBox checkAutoOuterRadius;
 	private static final Translator trans = Application.getTranslator();
 
-	public BodyTubeConfig(OpenRocketDocument d, RocketComponent c) {
-		super(d, c);
+	public BodyTubeConfig(OpenRocketDocument d, RocketComponent c, JDialog parent) {
+		super(d, c, parent);
 
 		JPanel panel = new JPanel(new MigLayout("gap rel unrel", "[][65lp::][30lp::][]", ""));
 

--- a/swing/src/net/sf/openrocket/gui/configdialog/BulkheadConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/BulkheadConfig.java
@@ -1,6 +1,7 @@
 package net.sf.openrocket.gui.configdialog;
 
 
+import javax.swing.JDialog;
 import javax.swing.JPanel;
 
 import net.sf.openrocket.document.OpenRocketDocument;
@@ -14,8 +15,8 @@ import net.sf.openrocket.startup.Application;
 public class BulkheadConfig extends RingComponentConfig {
 	private static final Translator trans = Application.getTranslator();
 	
-	public BulkheadConfig(OpenRocketDocument d, RocketComponent c) {
-		super(d, c);
+	public BulkheadConfig(OpenRocketDocument d, RocketComponent c, JDialog parent) {
+		super(d, c, parent);
 		
 		JPanel tab;
 		

--- a/swing/src/net/sf/openrocket/gui/configdialog/CenteringRingConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/CenteringRingConfig.java
@@ -1,6 +1,7 @@
 package net.sf.openrocket.gui.configdialog;
 
 
+import javax.swing.JDialog;
 import javax.swing.JPanel;
 
 import net.sf.openrocket.document.OpenRocketDocument;
@@ -14,8 +15,8 @@ import net.sf.openrocket.startup.Application;
 public class CenteringRingConfig extends RingComponentConfig {
 	private static final Translator trans = Application.getTranslator();
 	
-	public CenteringRingConfig(OpenRocketDocument d, RocketComponent c) {
-		super(d, c);
+	public CenteringRingConfig(OpenRocketDocument d, RocketComponent c, JDialog parent) {
+		super(d, c, parent);
 		
 		JPanel tab;
 		

--- a/swing/src/net/sf/openrocket/gui/configdialog/ComponentAssemblyConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/ComponentAssemblyConfig.java
@@ -2,6 +2,7 @@ package net.sf.openrocket.gui.configdialog;
 
 import javax.swing.ComboBoxModel;
 import javax.swing.JComboBox;
+import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
@@ -36,8 +37,8 @@ public class ComponentAssemblyConfig extends RocketComponentConfig {
 	private static final Translator trans = Application.getTranslator();
 	private final RocketComponent component;
 	
-	public ComponentAssemblyConfig(OpenRocketDocument document, RocketComponent component) {
-		super(document, component);
+	public ComponentAssemblyConfig(OpenRocketDocument document, RocketComponent component, JDialog parent) {
+		super(document, component, parent);
 		this.component = component;
 	
 		// only stages which are actually off-centerline will get the dialog here:

--- a/swing/src/net/sf/openrocket/gui/configdialog/ComponentConfigDialog.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/ComponentConfigDialog.java
@@ -143,14 +143,14 @@ public class ComponentConfigDialog extends JDialog implements ComponentChangeLis
 		List<RocketComponent> listeners = component.getConfigListeners();
 		boolean isSameClass = component.checkAllClassesEqual(listeners);
 		if (!isSameClass) {
-			return new RocketComponentConfig(document, component);
+			return new RocketComponentConfig(document, component, this);
 		}
 
 		Constructor<? extends RocketComponentConfig> constructor =
 				findDialogContentsConstructor(component);
 		if (constructor != null) {
 			try {
-				return constructor.newInstance(document, component);
+				return constructor.newInstance(document, component, this);
 			} catch (InstantiationException | IllegalAccessException e) {
 				throw new BugException("BUG in constructor reflection", e);
 			} catch (InvocationTargetException e) {
@@ -208,7 +208,7 @@ public class ComponentConfigDialog extends JDialog implements ComponentChangeLis
 			try {
 				configclass = Class.forName(configclassname);
 				c = (Constructor<? extends RocketComponentConfig>)
-						configclass.getConstructor(OpenRocketDocument.class, RocketComponent.class);
+						configclass.getConstructor(OpenRocketDocument.class, RocketComponent.class, JDialog.class);
 				return c;
 			} catch (Exception ignore) {
 			}

--- a/swing/src/net/sf/openrocket/gui/configdialog/EllipticalFinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/EllipticalFinSetConfig.java
@@ -5,6 +5,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.EventObject;
 import javax.swing.JComboBox;
+import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSeparator;
@@ -31,8 +32,8 @@ import net.sf.openrocket.unit.UnitGroup;
 public class EllipticalFinSetConfig extends FinSetConfig {
 	private static final Translator trans = Application.getTranslator();
 	
-	public EllipticalFinSetConfig(OpenRocketDocument d, final RocketComponent component) {
-		super(d, component);
+	public EllipticalFinSetConfig(OpenRocketDocument d, final RocketComponent component, JDialog parent) {
+		super(d, component, parent);
 		
 		DoubleModel m;
 		JSpinner spin;

--- a/swing/src/net/sf/openrocket/gui/configdialog/FinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/FinSetConfig.java
@@ -11,6 +11,7 @@ import java.util.List;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
+import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
@@ -52,8 +53,8 @@ public abstract class FinSetConfig extends RocketComponentConfig {
 	
 	private JButton split = null;
 	
-	public FinSetConfig(OpenRocketDocument d, RocketComponent component) {
-		super(d, component);
+	public FinSetConfig(OpenRocketDocument d, RocketComponent component, JDialog parent) {
+		super(d, component, parent);
 		
 		//// Fin tabs and Through-the-wall fin tabs
 		tabbedPane.insertTab(trans.get("FinSetConfig.tab.Fintabs"), null, finTabPanel(),

--- a/swing/src/net/sf/openrocket/gui/configdialog/FreeformFinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/FreeformFinSetConfig.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import javax.swing.JButton;
 import javax.swing.JComboBox;
+import javax.swing.JDialog;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -82,8 +83,8 @@ public class FreeformFinSetConfig extends FinSetConfig {
 	private FinPointFigure figure = null;
 	private ScaleSelector selector;
 	
-	public FreeformFinSetConfig(OpenRocketDocument d, RocketComponent component) {
-		super(d, component);
+	public FreeformFinSetConfig(OpenRocketDocument d, RocketComponent component, JDialog parent) {
+		super(d, component, parent);
 		
 		//// General and General properties
 		tabbedPane.insertTab(trans.get("FreeformFinSetCfg.tab.General"), null, generalPane(), trans.get("FreeformFinSetCfg.tab.ttip.General"), 0);

--- a/swing/src/net/sf/openrocket/gui/configdialog/InnerTubeConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/InnerTubeConfig.java
@@ -21,6 +21,7 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
+import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
@@ -59,8 +60,8 @@ public class InnerTubeConfig extends RocketComponentConfig {
 	private static final Translator trans = Application.getTranslator();
 
 
-	public InnerTubeConfig(OpenRocketDocument d, RocketComponent c) {
-		super(d, c);
+	public InnerTubeConfig(OpenRocketDocument d, RocketComponent c, JDialog parent) {
+		super(d, c, parent);
 
 		//// General and General properties
 		JPanel rightPanel = new JPanel(new MigLayout());

--- a/swing/src/net/sf/openrocket/gui/configdialog/LaunchLugConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/LaunchLugConfig.java
@@ -2,6 +2,7 @@ package net.sf.openrocket.gui.configdialog;
 
 
 import javax.swing.JComboBox;
+import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
@@ -28,8 +29,8 @@ public class LaunchLugConfig extends RocketComponentConfig {
 	
 	private static final Translator trans = Application.getTranslator();
 	
-	public LaunchLugConfig(OpenRocketDocument d, RocketComponent c) {
-		super(d, c);
+	public LaunchLugConfig(OpenRocketDocument d, RocketComponent c, JDialog parent) {
+		super(d, c, parent);
 		
 		JPanel primary = new JPanel(new MigLayout("fill"));
 		

--- a/swing/src/net/sf/openrocket/gui/configdialog/MassComponentConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/MassComponentConfig.java
@@ -6,6 +6,7 @@ import java.awt.event.ActionListener;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
+import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
@@ -31,8 +32,8 @@ import net.sf.openrocket.gui.widgets.SelectColorButton;
 public class MassComponentConfig extends RocketComponentConfig {
 	private static final Translator trans = Application.getTranslator();
 	
-	public MassComponentConfig(OpenRocketDocument d, RocketComponent component) {
-		super(d, component);
+	public MassComponentConfig(OpenRocketDocument d, RocketComponent component, JDialog parent) {
+		super(d, component, parent);
 
 		//// Left side
 		JPanel panel = new JPanel(new MigLayout("gap rel unrel", "[][65lp::][30lp::]", ""));

--- a/swing/src/net/sf/openrocket/gui/configdialog/NoseConeConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/NoseConeConfig.java
@@ -6,6 +6,7 @@ import java.awt.event.ActionListener;
 
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
+import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSlider;
@@ -44,8 +45,8 @@ public class NoseConeConfig extends RocketComponentConfig {
 	// Prepended to the description from NoseCone.DESCRIPTIONS
 	private static final String PREDESC = "<html>";
 	
-	public NoseConeConfig(OpenRocketDocument d, RocketComponent c) {
-		super(d, c);
+	public NoseConeConfig(OpenRocketDocument d, RocketComponent c, JDialog parent) {
+		super(d, c, parent);
 		
 		final JPanel panel = new JPanel(new MigLayout("", "[][65lp::][30lp::]"));
 		

--- a/swing/src/net/sf/openrocket/gui/configdialog/ParachuteConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/ParachuteConfig.java
@@ -8,6 +8,7 @@ import javax.swing.ComboBoxModel;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
+import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
@@ -40,8 +41,8 @@ public class ParachuteConfig extends RecoveryDeviceConfig {
 	private static final long serialVersionUID = 6108892447949958115L;
 	private static final Translator trans = Application.getTranslator();
 	
-	public ParachuteConfig(OpenRocketDocument d, final RocketComponent component) {
-		super(d, component);
+	public ParachuteConfig(OpenRocketDocument d, final RocketComponent component, JDialog parent) {
+		super(d, component, parent);
 		Parachute parachute = (Parachute) component;
 
 		// Left Side

--- a/swing/src/net/sf/openrocket/gui/configdialog/RailButtonConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RailButtonConfig.java
@@ -1,6 +1,7 @@
 package net.sf.openrocket.gui.configdialog;
 
 import javax.swing.JComboBox;
+import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
@@ -26,8 +27,8 @@ public class RailButtonConfig extends RocketComponentConfig {
 	
 	private static final Translator trans = Application.getTranslator();
 	
-	public RailButtonConfig( OpenRocketDocument document, RocketComponent component) {
-		super(document, component);
+	public RailButtonConfig( OpenRocketDocument document, RocketComponent component, JDialog parent) {
+		super(document, component, parent);
 	
 		// For DEBUG purposes
 //		if( component instanceof AxialStage ){

--- a/swing/src/net/sf/openrocket/gui/configdialog/RecoveryDeviceConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RecoveryDeviceConfig.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.JComponent;
+import javax.swing.JDialog;
 
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.rocketcomponent.DeploymentConfiguration.DeployEvent;
@@ -17,8 +18,8 @@ public abstract class RecoveryDeviceConfig extends RocketComponentConfig {
 	
 	protected final List<JComponent> altitudeComponents = new ArrayList<JComponent>();
 	
-	public RecoveryDeviceConfig(OpenRocketDocument d, RocketComponent component) {
-		super(d, component);
+	public RecoveryDeviceConfig(OpenRocketDocument d, RocketComponent component, JDialog parent) {
+		super(d, component, parent);
 	}
 	
 	

--- a/swing/src/net/sf/openrocket/gui/configdialog/RingComponentConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RingComponentConfig.java
@@ -3,6 +3,7 @@ package net.sf.openrocket.gui.configdialog;
 
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
+import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
@@ -27,8 +28,8 @@ import net.sf.openrocket.unit.UnitGroup;
 public class RingComponentConfig extends RocketComponentConfig {
 	private static final Translator trans = Application.getTranslator();
 	
-	public RingComponentConfig(OpenRocketDocument d, RocketComponent component) {
-		super(d, component);
+	public RingComponentConfig(OpenRocketDocument d, RocketComponent component, JDialog parent) {
+		super(d, component, parent);
 	}
 	
 	

--- a/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
@@ -14,6 +14,7 @@ import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
+import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -74,7 +75,7 @@ public class RocketComponentConfig extends JPanel {
 	private boolean allSameType;		// Checks whether all listener components are of the same type as <component>
 	private boolean allMassive;			// Checks whether all listener components, and this component, are massive
 
-	public RocketComponentConfig(OpenRocketDocument document, RocketComponent component) {
+	public RocketComponentConfig(OpenRocketDocument document, RocketComponent component, JDialog parent) {
 		setLayout(new MigLayout("fill, gap 4!, ins panel", "[]:5[]", "[growprio 5]5![fill, grow, growprio 500]5![growprio 5]"));
 
 		this.document = document;
@@ -126,7 +127,7 @@ public class RocketComponentConfig extends JPanel {
 				trans.get("RocketCompCfg.tab.MassandCGoverride"));
 		if (allMassive) {
 			//// Appearance options
-			appearancePanel = new AppearancePanel(document, component);
+			appearancePanel = new AppearancePanel(document, component, parent);
 			tabbedPane.addTab(trans.get("RocketCompCfg.tab.Appearance"), null, appearancePanel,
 					"Appearance Tool Tip");
 		}

--- a/swing/src/net/sf/openrocket/gui/configdialog/RocketConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RocketConfig.java
@@ -6,6 +6,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 
+import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
@@ -28,8 +29,8 @@ public class RocketConfig extends RocketComponentConfig {
 	
 	private final Rocket rocket;
 	
-	public RocketConfig(OpenRocketDocument d, RocketComponent c) {
-		super(d, c);
+	public RocketConfig(OpenRocketDocument d, RocketComponent c, JDialog parent) {
+		super(d, c, parent);
 		
 		rocket = (Rocket) c;
 		

--- a/swing/src/net/sf/openrocket/gui/configdialog/ShockCordConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/ShockCordConfig.java
@@ -27,8 +27,8 @@ import java.awt.event.ActionListener;
 public class ShockCordConfig extends RocketComponentConfig {
 	private static final Translator trans = Application.getTranslator();
 	
-	public ShockCordConfig(OpenRocketDocument d, RocketComponent component) {
-		super(d, component);
+	public ShockCordConfig(OpenRocketDocument d, RocketComponent component, JDialog parent) {
+		super(d, component, parent);
 
 		JLabel label;
 		DoubleModel m;

--- a/swing/src/net/sf/openrocket/gui/configdialog/SleeveConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/SleeveConfig.java
@@ -1,6 +1,7 @@
 package net.sf.openrocket.gui.configdialog;
 
 
+import javax.swing.JDialog;
 import javax.swing.JPanel;
 
 import net.sf.openrocket.document.OpenRocketDocument;
@@ -13,8 +14,8 @@ import net.sf.openrocket.startup.Application;
 public class SleeveConfig extends RingComponentConfig {
 	private static final Translator trans = Application.getTranslator();
 	
-	public SleeveConfig(OpenRocketDocument d, RocketComponent c) {
-		super(d, c);
+	public SleeveConfig(OpenRocketDocument d, RocketComponent c, JDialog parent) {
+		super(d, c, parent);
 		
 		JPanel tab;
 		//// Outer diameter:

--- a/swing/src/net/sf/openrocket/gui/configdialog/StreamerConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/StreamerConfig.java
@@ -7,6 +7,7 @@ import java.awt.event.ActionListener;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
+import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
@@ -36,8 +37,8 @@ public class StreamerConfig extends RecoveryDeviceConfig {
 	private static final long serialVersionUID = -4445736703470494588L;
 	private static final Translator trans = Application.getTranslator();
 	
-	public StreamerConfig(OpenRocketDocument d, final RocketComponent component) {
-		super(d, component);
+	public StreamerConfig(OpenRocketDocument d, final RocketComponent component, JDialog parent) {
+		super(d, component, parent);
 		Streamer streamer = (Streamer) component;
 
 		//	Left side

--- a/swing/src/net/sf/openrocket/gui/configdialog/ThicknessRingComponentConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/ThicknessRingComponentConfig.java
@@ -1,6 +1,7 @@
 package net.sf.openrocket.gui.configdialog;
 
 
+import javax.swing.JDialog;
 import javax.swing.JPanel;
 
 import net.sf.openrocket.document.OpenRocketDocument;
@@ -13,8 +14,8 @@ import net.sf.openrocket.startup.Application;
 public class ThicknessRingComponentConfig extends RingComponentConfig {
 	private static final Translator trans = Application.getTranslator();
 	
-	public ThicknessRingComponentConfig(OpenRocketDocument d, RocketComponent c) {
-		super(d, c);
+	public ThicknessRingComponentConfig(OpenRocketDocument d, RocketComponent c, JDialog parent) {
+		super(d, c, parent);
 		
 		JPanel tab;
 		

--- a/swing/src/net/sf/openrocket/gui/configdialog/TransitionConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/TransitionConfig.java
@@ -6,6 +6,7 @@ import java.awt.event.ActionListener;
 
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
+import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
@@ -46,8 +47,8 @@ public class TransitionConfig extends RocketComponentConfig {
 	private static final String PREDESC = "<html>";
 	
 	
-	public TransitionConfig(OpenRocketDocument d, RocketComponent c) {
-		super(d, c);
+	public TransitionConfig(OpenRocketDocument d, RocketComponent c, JDialog parent) {
+		super(d, c, parent);
 		
 		final JPanel panel = new JPanel(new MigLayout("gap rel unrel, fillx", "[][65lp::][30lp::]", ""));
 

--- a/swing/src/net/sf/openrocket/gui/configdialog/TrapezoidFinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/TrapezoidFinSetConfig.java
@@ -5,6 +5,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.EventObject;
 import javax.swing.JComboBox;
+import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSeparator;
@@ -33,8 +34,8 @@ public class TrapezoidFinSetConfig extends FinSetConfig {
 	private static final long serialVersionUID = -4870745241749769842L;
 	private static final Translator trans = Application.getTranslator();
 	
-	public TrapezoidFinSetConfig(OpenRocketDocument d, final RocketComponent component) {
-		super(d, component);
+	public TrapezoidFinSetConfig(OpenRocketDocument d, final RocketComponent component, JDialog parent) {
+		super(d, component, parent);
 
 		JPanel mainPanel = new JPanel(new MigLayout());
 

--- a/swing/src/net/sf/openrocket/gui/configdialog/TubeFinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/TubeFinSetConfig.java
@@ -6,6 +6,7 @@ import java.awt.event.ActionListener;
 import java.util.EventObject;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
+import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
@@ -29,8 +30,8 @@ public class TubeFinSetConfig extends RocketComponentConfig {
 	private static final long serialVersionUID = 508482875624928676L;
 	private static final Translator trans = Application.getTranslator();
 	
-	public TubeFinSetConfig(OpenRocketDocument d, RocketComponent c) {
-		super(d, c);
+	public TubeFinSetConfig(OpenRocketDocument d, RocketComponent c, JDialog parent) {
+		super(d, c, parent);
 		
 		JPanel primary = new JPanel(new MigLayout("fill"));
 		


### PR DESCRIPTION
This PR fixes #1458 by resizing the component config dialog after changing the inside/outside appearance checkbox.

Demo:

https://user-images.githubusercontent.com/11031519/175384277-221fe612-ab76-4bdd-92dd-7260650a9b84.mov


