### PR TITLE
[#1470] Move component config dialog to center if outside parent's monitor

### DIFF
--- a/swing/src/net/sf/openrocket/gui/configdialog/ComponentConfigDialog.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/ComponentConfigDialog.java
@@ -1,11 +1,15 @@
 package net.sf.openrocket.gui.configdialog;
 
 
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.Rectangle;
 import java.awt.Window;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.swing.JDialog;
@@ -13,6 +17,7 @@ import javax.swing.JDialog;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.gui.util.SwingPreferences;
+import net.sf.openrocket.gui.util.WindowLocationUtil;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.rocketcomponent.AxialStage;
 import net.sf.openrocket.rocketcomponent.ComponentChangeEvent;
@@ -256,6 +261,7 @@ public class ComponentConfigDialog extends JDialog implements ComponentChangeLis
 
 		dialog = new ComponentConfigDialog(parent, document, component);
 		dialog.setVisible(true);
+		WindowLocationUtil.moveIfOutsideOfParentMonitor(dialog, parent);
 
 		////Modify
 		if (component.getConfigListeners().size() == 0) {

--- a/swing/src/net/sf/openrocket/gui/util/WindowLocationUtil.java
+++ b/swing/src/net/sf/openrocket/gui/util/WindowLocationUtil.java
@@ -1,0 +1,74 @@
+package net.sf.openrocket.gui.util;
+
+import java.awt.GraphicsDevice;
+import java.awt.Window;
+
+/**
+ * Helper class for setting the location of a Swing window. E.g. to check when the window is outside the screen and
+ * recenter it if so.
+ *
+ * @author Sibo Van Gool <sibo.vangool@hotmail.com>
+ */
+public abstract class WindowLocationUtil {
+    /**
+     * Sets the location of the window, but don't go outside the screen.
+     * @param window the window to move
+     * @param x the target x position on the screen
+     * @param y the target y position on the screen
+     */
+    public static void setLocationWithinScreen(Window window, int x, int y) {
+        java.awt.Dimension screenSize = java.awt.Toolkit.getDefaultToolkit().getScreenSize();
+        java.awt.Dimension windowSize = window.getSize();
+        int screenWidth = screenSize.width;
+        int screenHeight = screenSize.height;
+        int windowWidth = windowSize.width;
+        int windowHeight = windowSize.height;
+        int xPos = x;
+        int yPos = y;
+        if (xPos + windowWidth > screenWidth) {
+            xPos = screenWidth - windowWidth;
+        }
+        if (yPos + windowHeight > screenHeight) {
+            yPos = screenHeight - windowHeight;
+        }
+        window.setLocation(xPos, yPos);
+    }
+
+    /**
+     * Moves the window to the center of the screen if its location is outside the boundary of the screen.
+     * @param window window to move
+     */
+    public static void moveIfOutsideOfMonitor(Window window) {
+        GraphicsDevice currentDevice = window.getGraphicsConfiguration().getDevice();
+        if (currentDevice != null && window.isVisible() &&
+                !currentDevice.getDefaultConfiguration().getBounds().contains(window.getLocationOnScreen())) {
+            int width = currentDevice.getDefaultConfiguration().getBounds().width;
+            int height = currentDevice.getDefaultConfiguration().getBounds().height;
+            window.setLocation(
+                    ((width / 2) - (window.getSize().width / 2)) + currentDevice.getDefaultConfiguration().getBounds().x,
+                    ((height / 2) - (window.getSize().height / 2)) + currentDevice.getDefaultConfiguration().getBounds().y
+            );
+        }
+    }
+
+    /**
+     * Moves the window to the center of the screen if it is on another monitor as the parent window, or if its location
+     * is outside the boundary of the parent's monitor screen.
+     * @param window window to move
+     * @param parent parent window
+     */
+    public static void moveIfOutsideOfParentMonitor(Window window, Window parent) {
+        GraphicsDevice parentDevice = parent.getGraphicsConfiguration().getDevice();
+        GraphicsDevice currentDevice = window.getGraphicsConfiguration().getDevice();
+        if (parentDevice != null && (currentDevice == null || currentDevice != parentDevice ||
+                (window.isVisible() && !parentDevice.getDefaultConfiguration().getBounds().contains(
+                        window.getLocationOnScreen())))) {
+            int width = parentDevice.getDefaultConfiguration().getBounds().width;
+            int height = parentDevice.getDefaultConfiguration().getBounds().height;
+            window.setLocation(
+                    ((width / 2) - (window.getSize().width / 2)) + parentDevice.getDefaultConfiguration().getBounds().x,
+                    ((height / 2) - (window.getSize().height / 2)) + parentDevice.getDefaultConfiguration().getBounds().y
+            );
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes #1470 by moving a component config dialog to the center of its parent's screen (the main OR window) when the config dialog is initially located on another monitor as the parent, or if its location is outside of the visible region of the screen.

Steps to reproduce:
1. Open a blank design file
2. Create a body tube; the body tube config dialog will pop up
3. Move the config dialog to a second monitor
4. Close the config dialog
5. Edit the body tube
6. The config dialog should now be centered on the screen of the monitor that the main OR window is opened in

So note: it's still perfectly possible to move the edit dialog on another monitor, but it will reset its position if close and reopen the config dialog.