### PR TITLE
[#1441] Increase component analysis drag characteristics precision to 3 decimals

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
@@ -674,7 +674,7 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 
 				// A drag coefficient
 				double cd = (Double) value;
-				this.setText(String.format("%.2f (%.0f%%)", cd, 100 * cd / totalCD));
+				this.setText(String.format("%.3f (%.0f%%)", cd, 100 * cd / totalCD));
 
 				float r = (float) (cd / 1.5);
 


### PR DESCRIPTION
This PR somewhat fixes PR #1441 by increasing the component analysis drag characteristics precision to 3 decimals instead of the previous 2 decimals.