### PR TITLE
[#1489] Visually select child components of selected rocket/stage/podset

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -74,6 +74,7 @@ import net.sf.openrocket.logging.Markers;
 import net.sf.openrocket.rocketcomponent.AxialStage;
 import net.sf.openrocket.rocketcomponent.ComponentChangeEvent;
 import net.sf.openrocket.rocketcomponent.ComponentChangeListener;
+import net.sf.openrocket.rocketcomponent.PodSet;
 import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.startup.Application;
@@ -294,7 +295,30 @@ public class BasicFrame extends JFrame {
 		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_O, SHORTCUT_KEY), null);
 		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_N, SHORTCUT_KEY), null);
 
+		// Visually select all child components of a stage/rocket/podset when it is selected
+		componentSelectionModel.addTreeSelectionListener(new TreeSelectionListener() {
+			@Override
+			public void valueChanged(TreeSelectionEvent e) {
+				TreePath selPath = e.getNewLeadSelectionPath();
+				if (selPath == null) return;
+				RocketComponent c = (RocketComponent) selPath.getLastPathComponent();
 
+				if (c instanceof AxialStage || c instanceof Rocket || c instanceof PodSet) {
+					if (rocketpanel == null) return;
+
+					List<RocketComponent> children = new LinkedList<>();
+					for (RocketComponent child : c) {
+						children.add(child);
+					}
+
+					// Select all the child components
+					if (rocketpanel.getFigure() != null && rocketpanel.getFigure3d() != null) {
+						rocketpanel.getFigure().setSelection(children.toArray(new RocketComponent[0]));
+						rocketpanel.getFigure3d().setSelection(children.toArray(new RocketComponent[0]));
+					}
+				}
+			}
+		});
 
 		// Double-click opens config dialog
 		MouseListener ml = new MouseAdapter() {

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -421,6 +421,10 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		return figure;
 	}
 
+	public RocketFigure3d getFigure3d() {
+		return figure3d;
+	}
+
 	public AerodynamicCalculator getAerodynamicCalculator() {
 		return aerodynamicCalculator;
 	}


### PR DESCRIPTION
This PR fixes #1489 by visually selecting all children of a selected rocket, stage/booster or podset. It only visually selects the components, meaning that if you click the edit button, only the stage/rocket/podset will be edited, not the children (because only the stage/rocket/podset is selected in the componenttree). Right-clicking in the design view will also visually deselect all the components and then (single-component) select the component that is right-clicked upon.

Again, a lot of words, here's a demo:

https://user-images.githubusercontent.com/11031519/175839367-3a5a42dd-982f-4b41-afa9-c8c76fb4de94.mp4


Also works in the 3D view: 

https://user-images.githubusercontent.com/11031519/175839502-8664f74d-19dd-4533-9345-315139b759fe.mp4

