### PR TITLE
[#1497] Add warning to launch preferences

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -286,6 +286,9 @@ pref.dlg.lbl.DefaultMach = Default Mach Number for C.P. Estimate:
 pref.dlg.ttip.DefaultMach1 = <HTML><b>This setting will take effect the next time you start OpenRocket.</b> <BR>
 pref.dlg.ttip.DefaultMach2 = To change the CP Mach number during this session use Tools->Component Analysis.
 
+pref.dlg.lbl.launchWarning = NOTE: the settings below apply only to newly created simulations.<br>To change the settings for an existing simulation, select that simulation and edit it.
+pref.dlg.lbl.launchWarning.ttip = You would not be the first one to be confused by this :)
+
 pref.dlg.lbl.Positiontoinsert = Position to insert new body components:
 pref.dlg.lbl.PositiontoinsertStages = Position to insert new stages:
 pref.dlg.lbl.Confirmdeletion = Confirm deletion of simulations.

--- a/swing/src/net/sf/openrocket/gui/dialogs/preferences/LaunchPreferencesPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preferences/LaunchPreferencesPanel.java
@@ -1,5 +1,6 @@
 package net.sf.openrocket.gui.dialogs.preferences;
 
+import java.awt.Color;
 import java.awt.LayoutManager;
 
 import javax.swing.BorderFactory;
@@ -16,6 +17,7 @@ import net.sf.openrocket.gui.SpinnerEditor;
 import net.sf.openrocket.gui.adaptors.BooleanModel;
 import net.sf.openrocket.gui.adaptors.DoubleModel;
 import net.sf.openrocket.gui.components.BasicSlider;
+import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.components.UnitSelector;
 import net.sf.openrocket.models.atmosphere.ExtendedISAModel;
 import net.sf.openrocket.simulation.SimulationOptions;
@@ -31,6 +33,14 @@ public class LaunchPreferencesPanel extends PreferencesPanel {
 
 	public LaunchPreferencesPanel() {
 		super(new MigLayout("fillx, ins 30lp n n n"));
+
+		// Warning message
+		StyledLabel warning = new StyledLabel(String.format(
+				"<html>%s</html>", trans.get("pref.dlg.lbl.launchWarning")),
+				0.5f, StyledLabel.Style.BOLD);
+		warning.setFontColor(Color.RED);
+		warning.setToolTipText(trans.get("pref.dlg.lbl.launchWarning.ttip"));
+		add(warning, "spanx, growx 0, gapbottom para, wrap");
 
 		JPanel sub;
 		String tip;


### PR DESCRIPTION
This PR fixes #1487.
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/11031519/175997554-65154bb8-4375-4a54-a424-c4e669284848.png">

I changed the wording at the end a bit since there are multiple ways to edit a simulation (contextual menu, File > Edit, Ctrl/Cmd + E).