### PR TITLE
[#1490] Select recovery device/stage after config panel select

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -19,6 +19,7 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -300,23 +301,28 @@ public class BasicFrame extends JFrame {
 		componentSelectionModel.addTreeSelectionListener(new TreeSelectionListener() {
 			@Override
 			public void valueChanged(TreeSelectionEvent e) {
-				TreePath selPath = e.getNewLeadSelectionPath();
-				if (selPath == null) return;
-				RocketComponent c = (RocketComponent) selPath.getLastPathComponent();
+				if (tree == null || tree.getSelectionPaths() == null || tree.getSelectionPaths().length == 0
+						|| rocketpanel == null) return;
 
-				if (c instanceof AxialStage || c instanceof Rocket || c instanceof PodSet) {
-					if (rocketpanel == null) return;
-
-					List<RocketComponent> children = new LinkedList<>();
-					for (RocketComponent child : c) {
-						children.add(child);
+				// Get all the components that need to be selected = currently selected components + children of stages/boosters/podsets
+				List<RocketComponent> children = new ArrayList<>(Arrays.asList(rocketpanel.getFigure().getSelection()));
+				for (TreePath p : tree.getSelectionPaths()) {
+					if (p != null) {
+						RocketComponent c = (RocketComponent) p.getLastPathComponent();
+						if (c instanceof AxialStage || c instanceof Rocket || c instanceof PodSet) {
+							Iterator<RocketComponent> iter = c.iterator(false);
+							while (iter.hasNext()) {
+								RocketComponent child = iter.next();
+								children.add(child);
+							}
+						}
 					}
+				}
 
-					// Select all the child components
-					if (rocketpanel.getFigure() != null && rocketpanel.getFigure3d() != null) {
-						rocketpanel.getFigure().setSelection(children.toArray(new RocketComponent[0]));
-						rocketpanel.getFigure3d().setSelection(children.toArray(new RocketComponent[0]));
-					}
+				// Select all the child components
+				if (rocketpanel.getFigure() != null && rocketpanel.getFigure3d() != null) {
+					rocketpanel.getFigure().setSelection(children.toArray(new RocketComponent[0]));
+					rocketpanel.getFigure3d().setSelection(children.toArray(new RocketComponent[0]));
 				}
 			}
 		});

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
@@ -1,9 +1,12 @@
 package net.sf.openrocket.gui.main.flightconfigpanel;
 
 import java.awt.event.ActionEvent;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.AbstractAction;
@@ -162,6 +165,30 @@ public class RecoveryConfigurationPanel extends FlightConfigurablePanel<Recovery
 		return recoveryTable;
 	}
 
+	@Override
+	protected void installTableListener() {
+		super.installTableListener();
+
+		table.getColumnModel().getSelectionModel().addListSelectionListener(new ListSelectionListener() {
+			@Override
+			public void valueChanged(ListSelectionEvent e) {
+				updateComponentSelection(e);
+			}
+		});
+
+		table.addFocusListener(new FocusListener() {
+			@Override
+			public void focusGained(FocusEvent e) {
+				updateComponentSelection(new ListSelectionEvent(this, 0, 0, false));
+			}
+
+			@Override
+			public void focusLost(FocusEvent e) {
+
+			}
+		});
+	}
+
 	public void selectDeployment() {
 		List<RecoveryDevice> devices = getSelectedComponents();
 		List<FlightConfigurationId> fcIds = getSelectedConfigurationIds();
@@ -237,6 +264,16 @@ public class RecoveryConfigurationPanel extends FlightConfigurablePanel<Recovery
 
 	private void doPopupFull(MouseEvent e) {
 		popupMenuFull.show(e.getComponent(), e.getX(), e.getY());
+	}
+
+	public void updateComponentSelection(ListSelectionEvent e) {
+		if (e.getValueIsAdjusting()) {
+			return;
+		}
+		List<RocketComponent> components = new ArrayList<>(getSelectedComponents());
+		if (components.size() == 0) return;
+
+		flightConfigurationPanel.setSelectedComponents(components);
 	}
 
 	public void updateButtonState() {

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
@@ -267,7 +267,7 @@ public class RecoveryConfigurationPanel extends FlightConfigurablePanel<Recovery
 	}
 
 	public void updateComponentSelection(ListSelectionEvent e) {
-		if (e.getValueIsAdjusting()) {
+		if (e.getValueIsAdjusting() || getSelectedComponents() == null) {
 			return;
 		}
 		List<RocketComponent> components = new ArrayList<>(getSelectedComponents());

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
@@ -1,9 +1,12 @@
 package net.sf.openrocket.gui.main.flightconfigpanel;
 
 import java.awt.event.ActionEvent;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.AbstractAction;
@@ -27,6 +30,7 @@ import net.sf.openrocket.rocketcomponent.AxialStage;
 import net.sf.openrocket.rocketcomponent.ComponentChangeEvent;
 import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
 import net.sf.openrocket.rocketcomponent.Rocket;
+import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.rocketcomponent.StageSeparationConfiguration;
 import net.sf.openrocket.rocketcomponent.StageSeparationConfiguration.SeparationEvent;
 import net.sf.openrocket.startup.Application;
@@ -170,6 +174,30 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialS
 		return separationTable;
 	}
 
+	@Override
+	protected void installTableListener() {
+		super.installTableListener();
+
+		table.getColumnModel().getSelectionModel().addListSelectionListener(new ListSelectionListener() {
+			@Override
+			public void valueChanged(ListSelectionEvent e) {
+				updateComponentSelection(e);
+			}
+		});
+
+		table.addFocusListener(new FocusListener() {
+			@Override
+			public void focusGained(FocusEvent e) {
+				updateComponentSelection(new ListSelectionEvent(this, 0, 0, false));
+			}
+
+			@Override
+			public void focusLost(FocusEvent e) {
+
+			}
+		});
+	}
+
 	public void selectSeparation() {
 		List<AxialStage> stages = getSelectedComponents();
 		List<FlightConfigurationId> fcIds = getSelectedConfigurationIds();
@@ -246,6 +274,16 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialS
 
 	private void doPopupFull(MouseEvent e) {
 		popupMenuFull.show(e.getComponent(), e.getX(), e.getY());
+	}
+
+	public void updateComponentSelection(ListSelectionEvent e) {
+		if (e.getValueIsAdjusting()) {
+			return;
+		}
+		List<RocketComponent> components = new ArrayList<>(getSelectedComponents());
+		if (components.size() == 0) return;
+
+		flightConfigurationPanel.setSelectedComponents(components);
 	}
 
 	public void updateButtonState() {

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
@@ -277,7 +277,7 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialS
 	}
 
 	public void updateComponentSelection(ListSelectionEvent e) {
-		if (e.getValueIsAdjusting()) {
+		if (e.getValueIsAdjusting() || getSelectedComponents() == null) {
 			return;
 		}
 		List<RocketComponent> components = new ArrayList<>(getSelectedComponents());


### PR DESCRIPTION
This PR fixes #1490 and selects the recovery device/stage in the design view corresponding to the selected recovery device/stage in the recovery/stage configuration table.

Demo:

https://user-images.githubusercontent.com/11031519/176032271-54db5047-31dd-43cf-aced-6637013454bd.mov

This PR also fixes o an issue with #1494 where selecting multiple stages had no effect on the design view.
