### PR TITLE
[#1487] Fix configuration referencing after loadFrom rocket

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
@@ -390,10 +390,12 @@ public class Rocket extends ComponentAssembly {
 		this.stageMap = r.stageMap;		
 
 		// these flight configurations need to reference the _this_ Rocket:
+		this.configSet.reset();
 		this.configSet.setDefault(new FlightConfiguration(this));
 		for (FlightConfigurationId key : r.configSet.map.keySet()) {
 			this.configSet.set(key, new FlightConfiguration(this, key));
 		}
+		this.selectedConfiguration = this.configSet.get(r.getSelectedConfiguration().getId());
 
 		this.perfectFinish = r.perfectFinish;
 		

--- a/swing/src/net/sf/openrocket/gui/figureelements/RocketInfo.java
+++ b/swing/src/net/sf/openrocket/gui/figureelements/RocketInfo.java
@@ -41,7 +41,7 @@ public class RocketInfo implements FigureElement {
 	private final Caret cpCaret = new CPCaret(0,0);
 	private final Caret cgCaret = new CGCaret(0,0);
 	
-	private final UnitGroup stabilityUnits;
+	private UnitGroup stabilityUnits;
 	
 	private FlightConfiguration configuration;
 	private double cg = 0, cp = 0;
@@ -459,5 +459,6 @@ public class RocketInfo implements FigureElement {
 	
 	public void setCurrentConfig(FlightConfiguration newConfig) {
 		this.configuration = newConfig;
+		this.stabilityUnits = UnitGroup.stabilityUnits(newConfig);
 	}
 }

--- a/swing/test/net/sf/openrocket/IntegrationTest.java
+++ b/swing/test/net/sf/openrocket/IntegrationTest.java
@@ -71,7 +71,7 @@ public class IntegrationTest {
 	private Action undoAction, redoAction;
 	
 	private AerodynamicCalculator aeroCalc = new BarrowmanCalculator();
-	private FlightConfiguration config;
+	private FlightConfigurationId fcid;
 	private FlightConditions conditions;
 	private String massComponentID = null;
 	
@@ -112,14 +112,12 @@ public class IntegrationTest {
 		
 		undoAction = UndoRedoAction.newUndoAction(document);
 		redoAction = UndoRedoAction.newRedoAction(document);
-        FlightConfigurationId fcid = document.getSimulation(0).getFlightConfigurationId();
-		config = document.getRocket().getFlightConfiguration(fcid);
+        fcid = document.getSimulation(0).getFlightConfigurationId();
+		FlightConfiguration config = document.getRocket().getFlightConfiguration(fcid);
 		conditions = new FlightConditions(config);
 		
 		// Test undo state
 		checkUndoState(null, null);
-		
-		InnerTube mmt = (InnerTube)config.getRocket().getChild(0).getChild(1).getChild(2);
 		 
 		// Compute cg+cp + altitude
 	    //   double cgx, double mass, double cpx, double cna)
@@ -330,6 +328,7 @@ public class IntegrationTest {
 	}
 	
 	private void checkCgCp(double cgx, double mass, double cpx, double cna) {
+		FlightConfiguration config = document.getRocket().getFlightConfiguration(fcid);
 		final RigidBody launchData = MassCalculator.calculateLaunch(config);
 		final Coordinate cg = launchData.getCenterOfMass();
 		assertEquals(cgx, cg.x, 0.001);


### PR DESCRIPTION
This PR fixes #1487 by updating the selected configuration of a rocket in the loadFrom method (called after an undo action). There was then still an issue that when updating the figures, a NullPointerException was thrown because RocketInfo still used an old configuration, which is solved by updating stabilityUnits in RocketInfo when the configuration is changed.