### PR TITLE
[#1440] Add all context drags to component drag

### DIFF
--- a/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
+++ b/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
@@ -390,6 +390,7 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 			}
 			
 			// iterate across component instances
+			double componentFrictionCDTotal = 0;		// Total friction drag of the component
 			final ArrayList<InstanceContext> contextList = entry.getValue();
 			for(InstanceContext context: contextList ) {
 				double componentFrictionCD = calcMap.get(c).calculateFrictionCD(conditions, componentCf, warningSet);
@@ -411,9 +412,11 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 					otherFrictionCD += componentFrictionCD;
 				}
 
-				if (map != null) {
-					map.get(c).setFrictionCD(componentFrictionCD);
-				}
+				componentFrictionCDTotal += componentFrictionCD;
+			}
+
+			if (map != null) {
+				map.get(c).setFrictionCD(componentFrictionCDTotal);
 			}
 		}
 		
@@ -590,17 +593,17 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 				continue;
 
 			// iterate across component instances
+			double pressureCDTotal = 0;		// Total pressure drag for this component
 			final ArrayList<InstanceContext> contextList = entry.getValue();
 			for(InstanceContext context: contextList ) {
 
 				// Pressure drag
-				double cd = calcMap.get(c).calculatePressureCD(conditions, stagnation, base,
+				double pressureCD = calcMap.get(c).calculatePressureCD(conditions, stagnation, base,
 															   warningSet);
-				total += cd;
-				
-				if (forceMap != null) {
-					forceMap.get(c).setPressureCD(cd);
-				}
+				pressureCDTotal += pressureCD;
+
+				// Total pressure drag of the rocket
+				total += pressureCD;
 				
 				if(c.isCDOverridden())
 					continue;					
@@ -616,14 +619,15 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 					
 					if (radius < s.getForeRadius()) {
 						double area = Math.PI * (pow2(s.getForeRadius()) - pow2(radius));
-						cd = stagnation * area / conditions.getRefArea();
-						total += cd;
-						
-						if (forceMap != null) {
-							forceMap.get(c).setPressureCD(forceMap.get(c).getPressureCD() + cd);
-						}
+						pressureCD = stagnation * area / conditions.getRefArea();
+						pressureCDTotal += pressureCD;
+						total += pressureCD;
 					}
 				}
+			}
+
+			if (forceMap != null) {
+				forceMap.get(c).setPressureCD(pressureCDTotal);
 			}
 		}
 		
@@ -678,10 +682,10 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 				
 				if (radius > s.getForeRadius()) {
 					double area = Math.PI * (pow2(radius) - pow2(s.getForeRadius()));
-					double cd = base * area / conditions.getRefArea();
-					total += cd;
+					double baseCD = base * area / conditions.getRefArea();
+					total += baseCD;
 					if ((map != null) && (prevComponent != null)) {
-						map.get(prevComponent).setBaseCD(cd);
+						map.get(prevComponent).setBaseCD(baseCD);
 					}
 				}
 				
@@ -691,10 +695,10 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 				final SymmetricComponent n = s.getNextSymmetricComponent();
 				if ((n == null) || !configuration.isStageActive(n.getStageNumber())) {
 					double area = Math.PI * pow2(s.getAftRadius());
-					double cd = base * area / conditions.getRefArea();
-					total += cd;
+					double baseCD = base * area / conditions.getRefArea();
+					total += baseCD;
 					if (map != null) {
-						map.get(s).setBaseCD(cd);
+						map.get(s).setBaseCD(baseCD);
 					}
 				}
 			}


### PR DESCRIPTION
This PR fixes #1440 by including all context drags to the component drag (for friction and pressure CD) instead of simply setting the component drag to the last context's drag.

FinSets should now display the correct CD:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/11031519/176681004-e4c53b50-43b7-43eb-967b-6f020e04c658.png">
