### PR TITLE
[#1510] Don't update flight configuration from simulation edit

### DIFF
--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationEditDialog.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationEditDialog.java
@@ -151,7 +151,7 @@ public class SimulationEditDialog extends JDialog {
 			
 			final Rocket rkt = document.getRocket();
 			final FlightConfiguration config = rkt.getFlightConfiguration(simulationList[0].getFlightConfigurationId());
-			final ConfigurationComboBox configComboBox = new ConfigurationComboBox(rkt);
+			final ConfigurationComboBox configComboBox = new ConfigurationComboBox(rkt, false);
 			configComboBox.setSelectedItem(config);
 			
 			//// Select the motor configuration to use.


### PR DESCRIPTION
This PR fixes #1510 by not updating the rocket's selected flight configuration when changing the flight configuration in a simulation's edit dialog.