### PR TITLE
[#1513] Combine 'Add component' and 'Modify new component' undo action

### DIFF
--- a/swing/src/net/sf/openrocket/gui/configdialog/ComponentConfigDialog.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/ComponentConfigDialog.java
@@ -230,8 +230,9 @@ public class ComponentConfigDialog extends JDialog implements ComponentChangeLis
 	 * @param document		the document to configure.
 	 * @param component		the component to configure.
 	 * @param rememberPreviousTab if true, the previous tab will be remembered and used for the new dialog
+	 * @param includeUndoModify	if true, include a 'Modify component' undo action
 	 */
-	public static void showDialog(Window parent, OpenRocketDocument document, RocketComponent component, boolean rememberPreviousTab) {
+	public static void showDialog(Window parent, OpenRocketDocument document, RocketComponent component, boolean rememberPreviousTab, boolean includeUndoModify) {
 		if (dialog != null) {
 			// Don't remember the previous tab for rockets or stages, because this will leave you in the override tab for
 			// the next component, which is generally not what you want.
@@ -258,11 +259,25 @@ public class ComponentConfigDialog extends JDialog implements ComponentChangeLis
 		dialog.setVisible(true);
 
 		////Modify
-		if (component.getConfigListeners().size() == 0) {
-			document.addUndoPosition(trans.get("ComponentCfgDlg.Modify") + " " + component.getComponentName());
-		} else {
-			document.addUndoPosition(trans.get("ComponentCfgDlg.ModifyComponents"));
+		if (includeUndoModify) {
+			if (component.getConfigListeners().size() == 0) {
+				document.addUndoPosition(trans.get("ComponentCfgDlg.Modify") + " " + component.getComponentName());
+			} else {
+				document.addUndoPosition(trans.get("ComponentCfgDlg.ModifyComponents"));
+			}
 		}
+	}
+
+	/**
+	 * A singleton configuration dialog.  Will create and show a new dialog if one has not
+	 * previously been used, or update the dialog and show it if a previous one exists.
+	 *
+	 * @param document		the document to configure.
+	 * @param component		the component to configure.
+	 * @param rememberPreviousTab if true, the previous tab will be remembered and used for the new dialog
+	 */
+	public static void showDialog(Window parent, OpenRocketDocument document, RocketComponent component, boolean rememberPreviousTab) {
+		ComponentConfigDialog.showDialog(parent, document, component, rememberPreviousTab, true);
 	}
 
 	/**

--- a/swing/src/net/sf/openrocket/gui/main/ComponentAddButtons.java
+++ b/swing/src/net/sf/openrocket/gui/main/ComponentAddButtons.java
@@ -488,7 +488,7 @@ public class ComponentAddButtons extends JPanel implements Scrollable {
 				}
 			}
 			
-			ComponentConfigDialog.showDialog(parent, document, component, false);
+			ComponentConfigDialog.showDialog(parent, document, component, false, false);
 		}
 	}
 	


### PR DESCRIPTION
This PR fixes #1513 by combining the 'Add new component' and the 'Modify component' of that newly added component into a single 'Add new component' undo action. So if you now add a new component, and modify that new component in the edit dialog that popped up when the new component was added, you do not have perform two undo actions to undo adding that new component. (I also wanted this PR up because it will ease the development for issue #960).

Demo (includes first the prior behavior in OR 22.02.beta.04 and then the new behavior from this PR):

https://user-images.githubusercontent.com/11031519/177221365-c8e581c7-5195-4176-8118-fc51cdee1923.mp4

