### PR TITLE
Refactor to remove deprecation warning for newInstance

### DIFF
--- a/core/src/net/sf/openrocket/document/Simulation.java
+++ b/core/src/net/sf/openrocket/document/Simulation.java
@@ -1,5 +1,6 @@
 package net.sf.openrocket.document;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.EventListener;
 import java.util.EventObject;
 import java.util.List;
@@ -350,13 +351,15 @@ public class Simulation implements ChangeSource, Cloneable {
 			SimulationEngine simulator;
 			
 			try {
-				simulator = simulationEngineClass.newInstance();
+				simulator = simulationEngineClass.getConstructor().newInstance();
 			} catch (InstantiationException e) {
 				throw new IllegalStateException("Cannot instantiate simulator.", e);
 			} catch (IllegalAccessException e) {
 				throw new IllegalStateException("Cannot access simulator instance?! BUG!", e);
+			} catch (InvocationTargetException | NoSuchMethodException e) {
+				throw new RuntimeException(e);
 			}
-			
+
 			SimulationConditions simulationConditions = options.toSimulationConditions();
 			simulationConditions.setSimulation(this);
 			for (SimulationListener l : additionalListeners) {


### PR DESCRIPTION
During work on [Issue 1507](https://github.com/openrocket/openrocket/pull/1507), noticed that the simulation construction was using a deprecated newInstance method.  Per the comments on the method, moved it to using the defaultConstructor's newInstance method.