### PR TITLE
[#1537] Add additional configuration parameters for rail buttons

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -1052,7 +1052,10 @@ LaunchLugCfg.tab.Generalprop = General properties
 
 ! RailButtonConfig
 RailBtnCfg.lbl.OuterDiam = Outer Diameter:
-RailBtnCfg.lbl.TotalHeight = Total Height
+RailBtnCfg.lbl.InnerDiam = Inner Diameter:
+RailBtnCfg.lbl.TotalHeight = Total Height:
+RailBtnCfg.lbl.BaseHeight = Base Height:
+RailBtnCfg.lbl.FlangeHeight = Flange Height:
 RailBtnCfg.lbl.Angle = Rotation:
 RailBtnCfg.lbl.PosRelativeTo = Position relative to:
 RailBtnCfg.lbl.Plus = plus

--- a/core/src/net/sf/openrocket/file/openrocket/importt/DocumentConfig.java
+++ b/core/src/net/sf/openrocket/file/openrocket/importt/DocumentConfig.java
@@ -190,8 +190,15 @@ class DocumentConfig {
 		setters.put("RailButton:angleoffset",  new AnglePositionSetter() );
 		setters.put("RailButton:height",  new DoubleSetter(
 				Reflection.findMethod( RailButton.class, "setTotalHeight", double.class)));
+		setters.put("RailButton:baseheight",  new DoubleSetter(
+				Reflection.findMethod( RailButton.class, "setBaseHeight", double.class)));
+		setters.put("RailButton:flangeheight",  new DoubleSetter(
+				Reflection.findMethod( RailButton.class, "setFlangeHeight", double.class)));
 		setters.put("RailButton:outerdiameter",  new DoubleSetter(
 				Reflection.findMethod( RailButton.class, "setOuterDiameter", double.class)));
+		setters.put("RailButton:innerdiameter",  new DoubleSetter(
+				Reflection.findMethod( RailButton.class, "setInnerDiameter", double.class)));
+
 			
 		// Transition
 		setters.put("Transition:shape", new EnumSetter<Transition.Shape>(

--- a/core/src/net/sf/openrocket/file/openrocket/savers/RailButtonSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/savers/RailButtonSaver.java
@@ -27,6 +27,7 @@ public class RailButtonSaver extends ExternalComponentSaver {
 
 		emitDouble( elements, "outerdiameter", rb.getOuterDiameter());
 		emitDouble( elements, "height", rb.getTotalHeight());
+		// TODO!!
 		
 	}
 

--- a/core/src/net/sf/openrocket/file/openrocket/savers/RailButtonSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/savers/RailButtonSaver.java
@@ -26,9 +26,10 @@ public class RailButtonSaver extends ExternalComponentSaver {
 		RailButton rb = (RailButton) c;
 
 		emitDouble( elements, "outerdiameter", rb.getOuterDiameter());
+		emitDouble( elements, "innerdiameter", rb.getInnerDiameter());
 		emitDouble( elements, "height", rb.getTotalHeight());
-		// TODO!!
-		
+		emitDouble( elements, "baseheight", rb.getBaseHeight());
+		emitDouble( elements, "flangeheight", rb.getFlangeHeight());
 	}
 
 	

--- a/core/src/net/sf/openrocket/rocketcomponent/LaunchLug.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/LaunchLug.java
@@ -2,10 +2,7 @@ package net.sf.openrocket.rocketcomponent;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.EventObject;
 
-import net.sf.openrocket.appearance.Appearance;
-import net.sf.openrocket.appearance.Decal;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.preset.ComponentPreset;
 import net.sf.openrocket.preset.ComponentPreset.Type;
@@ -14,7 +11,6 @@ import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.BoundingBox;
 import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.MathUtil;
-import net.sf.openrocket.util.StateChangeListener;
 
 
 public class LaunchLug extends Tube implements AnglePositionable, BoxBounded, LineInstanceable, InsideColorComponent {

--- a/core/src/net/sf/openrocket/rocketcomponent/RailButton.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RailButton.java
@@ -40,19 +40,18 @@ public class RailButton extends ExternalComponent implements AnglePositionable, 
 	 *   ^     [[[[[[]]]]]]              flangeHeight
 	 * total     >||||||<=  inner dia     ^
 	 * height     ||||||            v
-	 *   v     [[[[[[]]]]]]        standoff == baseHeight 
+	 *   v     [[[[[[]]]]]]        baseHeight / standoff
 	 *      ==================      ^
 	 *          (body)
 	 *   
 	 */
 	// Note:  the reference point for Rail Button Components is in the center bottom of the button. 
 	protected double outerDiameter_m;
-	protected double totalHeight_m;
 	protected double innerDiameter_m;
+	protected double totalHeight_m;
 	protected double flangeHeight_m;
- 	protected double standoff_m;
-	
-	protected final static double MINIMUM_STANDOFF= 0.001;
+ 	protected double baseHeight_m;
+
 
 	private double radialDistance_m=0;
 	protected static final AngleMethod angleMethod = AngleMethod.RELATIVE;
@@ -66,7 +65,7 @@ public class RailButton extends ExternalComponent implements AnglePositionable, 
 		this.totalHeight_m = 0.0097;
 		this.innerDiameter_m = 0.008;
 		this.flangeHeight_m = 0.002;
-		this.setStandoff( 0.002);
+		this.setBaseHeight(0.002);
 		this.setInstanceSeparation( this.outerDiameter_m * 6);
 		this.setMaterial(Databases.findMaterial(Material.Type.BULK, "Delrin"));
 		super.displayOrder_side = 14;		// Order for displaying the component in the 2D side view
@@ -75,19 +74,19 @@ public class RailButton extends ExternalComponent implements AnglePositionable, 
 	
 	public RailButton( final double od, final double ht ) {
 		this();
-		this.setOuterDiameter( od);
-		this.setTotalHeight( ht);
+		this.setOuterDiameter(od);
+		this.setTotalHeight(ht);
 		super.displayOrder_side = 14;		// Order for displaying the component in the 2D side view
 		super.displayOrder_back = 11;		// Order for displaying the component in the 2D back view
 	}
 	
-	public RailButton( final double od, final double id, final double ht, final double flangeThickness, final double _standoff ) {
+	public RailButton( final double od, final double id, final double ht, final double _flangeHeight, final double _baseHeight ) {
 		super(AxialMethod.MIDDLE);
 		this.outerDiameter_m = od;
 		this.totalHeight_m = ht;
 		this.innerDiameter_m = id;
-		this.flangeHeight_m = flangeThickness;
-		this.setStandoff( _standoff);
+		this.flangeHeight_m = _flangeHeight;
+		this.setBaseHeight(_baseHeight);
 		this.setInstanceSeparation( od*2);
 		this.setMaterial(Databases.findMaterial(Material.Type.BULK, "Delrin"));
 		super.displayOrder_side = 14;		// Order for displaying the component in the 2D side view
@@ -122,12 +121,8 @@ public class RailButton extends ExternalComponent implements AnglePositionable, 
 		return rb1010;
 	}
 	
-	public double getStandoff(){
-		return this.standoff_m;
-	}
-
 	public double getBaseHeight(){
-		return this.getStandoff();
+		return this.baseHeight_m;
 	}
 	
 	public double getOuterDiameter() {
@@ -139,7 +134,7 @@ public class RailButton extends ExternalComponent implements AnglePositionable, 
 	}
 	
 	public double getInnerHeight() {
-		return (this.totalHeight_m - this.flangeHeight_m - this.standoff_m);
+		return (this.totalHeight_m - this.flangeHeight_m - this.baseHeight_m);
 	}
 	
 	public double getTotalHeight() {
@@ -151,14 +146,28 @@ public class RailButton extends ExternalComponent implements AnglePositionable, 
 	}
 	
 	
-	public void setStandoff(double newStandoff){
+	public void setBaseHeight(double newBaseHeight){
 		for (RocketComponent listener : configListeners) {
 			if (listener instanceof RailButton) {
-				((RailButton) listener).setStandoff(newStandoff);
+				((RailButton) listener).setBaseHeight(newBaseHeight);
 			}
 		}
 
-		this.standoff_m = Math.max( newStandoff, RailButton.MINIMUM_STANDOFF );
+		this.baseHeight_m = Math.max(newBaseHeight, 0);
+		this.baseHeight_m = Math.min(this.baseHeight_m, this.totalHeight_m - this.flangeHeight_m);
+		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
+	}
+
+	public void setFlangeHeight(double newFlangeHeight){
+		for (RocketComponent listener : configListeners) {
+			if (listener instanceof RailButton) {
+				((RailButton) listener).setFlangeHeight(newFlangeHeight);
+			}
+		}
+
+		this.flangeHeight_m = Math.max(newFlangeHeight, 0);
+		this.flangeHeight_m = Math.min(this.flangeHeight_m, this.totalHeight_m - this.baseHeight_m);
+		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 
 	public void setInnerDiameter(double newID ){
@@ -168,7 +177,7 @@ public class RailButton extends ExternalComponent implements AnglePositionable, 
 			}
 		}
 
-		this.innerDiameter_m = newID;
+		this.innerDiameter_m = Math.min(newID, this.outerDiameter_m);
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 
@@ -181,6 +190,7 @@ public class RailButton extends ExternalComponent implements AnglePositionable, 
 		}
 
 		this.outerDiameter_m = newOD;
+		setInnerDiameter(this.innerDiameter_m);
 
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
@@ -192,19 +202,8 @@ public class RailButton extends ExternalComponent implements AnglePositionable, 
 			}
 		}
 
-		this.totalHeight_m = newHeight;
+		this.totalHeight_m = Math.max(newHeight, this.flangeHeight_m + this.baseHeight_m);
 
-		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
-	}
-	
-	public void setThickness(double newThickness ) {
-		for (RocketComponent listener : configListeners) {
-			if (listener instanceof RailButton) {
-				((RailButton) listener).setThickness(newThickness);
-			}
-		}
-
-		this.flangeHeight_m = newThickness;
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 	
@@ -252,15 +251,17 @@ public class RailButton extends ExternalComponent implements AnglePositionable, 
 		super.setAxialMethod(position);
 		fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 	}
-	
+
+	@Override
 	public BoundingBox getInstanceBoundingBox(){
 		BoundingBox instanceBounds = new BoundingBox();
 		
-		instanceBounds.update(new Coordinate(0, this.getTotalHeight(), 0));
+		instanceBounds.update(new Coordinate(0, this.totalHeight_m, 0));
+		instanceBounds.update(new Coordinate(0, -this.totalHeight_m, 0));
 		
-		final double r = this.getOuterDiameter();
-		instanceBounds.update(new Coordinate(r,r,0));
-		instanceBounds.update(new Coordinate(-r,-r,0));
+		final double r = this.getOuterDiameter() / 2;
+		instanceBounds.update(new Coordinate(r, 0, r));
+		instanceBounds.update(new Coordinate(-r, 0, -r));
 		
 		return instanceBounds;
 	}
@@ -306,7 +307,7 @@ public class RailButton extends ExternalComponent implements AnglePositionable, 
 	public double getComponentVolume() {
 		final double volOuter = Math.PI*Math.pow( outerDiameter_m/2, 2)*flangeHeight_m;
 		final double volInner = Math.PI*Math.pow( innerDiameter_m/2, 2)*getInnerHeight();
-		final double volStandoff = Math.PI*Math.pow( outerDiameter_m/2, 2)*standoff_m;
+		final double volStandoff = Math.PI*Math.pow( outerDiameter_m/2, 2)* baseHeight_m;
 		return (volOuter+
 				volInner+
 				volStandoff);
@@ -370,12 +371,12 @@ public class RailButton extends ExternalComponent implements AnglePositionable, 
 	
 	@Override
 	public Coordinate getComponentCG() {
-		// Math.PI and density are assumed constant through calculation, and thus may be factored out. 
-		final double volumeFlange = Math.pow( outerDiameter_m/2, 2)*flangeHeight_m;
-		final double volumeInner = Math.pow( innerDiameter_m/2, 2)*(getInnerHeight());
-		final double volumeStandoff = Math.pow( outerDiameter_m/2, 2)*this.standoff_m;
-		final double totalVolume = volumeFlange + volumeInner + volumeStandoff;
-		final double heightCM = (volumeFlange*( this.totalHeight_m-getFlangeHeight()/2) + volumeInner*( this.standoff_m + this.getInnerHeight()/2) + volumeStandoff*(this.standoff_m/2))/totalVolume;
+		// Math.PI and density are assumed constant through calculation, and thus may be factored out.
+		final double volumeBase = Math.pow(outerDiameter_m / 2, 2) * this.baseHeight_m;
+		final double volumeFlange = Math.pow(outerDiameter_m / 2, 2)* this.flangeHeight_m;
+		final double volumeInner = Math.pow(innerDiameter_m / 2, 2)* getInnerHeight();
+		final double totalVolume = volumeFlange + volumeInner + volumeBase;
+		final double heightCM = (volumeFlange*( this.totalHeight_m-getFlangeHeight()/2) + volumeInner*( this.baseHeight_m + this.getInnerHeight()/2) + volumeBase*(this.baseHeight_m /2))/totalVolume;
 
 		if( heightCM > this.totalHeight_m ){
 			throw new BugException(" bug found while computing the CG of a RailButton: "+this.getName()+"\n height of CG: "+heightCM);

--- a/swing/src/net/sf/openrocket/gui/configdialog/RailButtonConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RailButtonConfig.java
@@ -61,15 +61,6 @@ public class RailButtonConfig extends RocketComponentConfig {
 			panel.add(new UnitSelector(IDModel), "growx");
 			panel.add(new BasicSlider(IDModel.getSliderModel(0, 0.001, 0.02)), "w 100lp, wrap para");
 		}
-		{ //// Height
-			panel.add(new JLabel(trans.get("RailBtnCfg.lbl.TotalHeight")));
-			DoubleModel heightModel = new DoubleModel(component, "TotalHeight", UnitGroup.UNITS_LENGTH, 0);
-			JSpinner heightSpinner = new JSpinner(heightModel.getSpinnerModel());
-			heightSpinner.setEditor(new SpinnerEditor(heightSpinner));
-			panel.add(heightSpinner, "growx");
-			panel.add(new UnitSelector(heightModel), "growx");
-			panel.add(new BasicSlider(heightModel.getSliderModel(0, 0.001, 0.02)), "w 100lp, wrap");
-		}
 		{ //// Base Height
 			panel.add(new JLabel(trans.get("RailBtnCfg.lbl.BaseHeight")));
 			DoubleModel heightModel = new DoubleModel(component, "BaseHeight", UnitGroup.UNITS_LENGTH, 0);
@@ -82,6 +73,15 @@ public class RailButtonConfig extends RocketComponentConfig {
 		{ //// Flange Height
 			panel.add(new JLabel(trans.get("RailBtnCfg.lbl.FlangeHeight")));
 			DoubleModel heightModel = new DoubleModel(component, "FlangeHeight", UnitGroup.UNITS_LENGTH, 0);
+			JSpinner heightSpinner = new JSpinner(heightModel.getSpinnerModel());
+			heightSpinner.setEditor(new SpinnerEditor(heightSpinner));
+			panel.add(heightSpinner, "growx");
+			panel.add(new UnitSelector(heightModel), "growx");
+			panel.add(new BasicSlider(heightModel.getSliderModel(0, 0.001, 0.02)), "w 100lp, wrap");
+		}
+		{ //// Height
+			panel.add(new JLabel(trans.get("RailBtnCfg.lbl.TotalHeight")));
+			DoubleModel heightModel = new DoubleModel(component, "TotalHeight", UnitGroup.UNITS_LENGTH, 0);
 			JSpinner heightSpinner = new JSpinner(heightModel.getSpinnerModel());
 			heightSpinner.setEditor(new SpinnerEditor(heightSpinner));
 			panel.add(heightSpinner, "growx");

--- a/swing/src/net/sf/openrocket/gui/configdialog/RailButtonConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RailButtonConfig.java
@@ -29,13 +29,6 @@ public class RailButtonConfig extends RocketComponentConfig {
 	
 	public RailButtonConfig( OpenRocketDocument document, RocketComponent component, JDialog parent) {
 		super(document, component, parent);
-	
-		// For DEBUG purposes
-//		if( component instanceof AxialStage ){
-//			System.err.println(" Dumping AxialStage tree info for devel / debugging.");
-//			System.err.println(component.toDebugTree());
-//		}
-				
 
 		//// General and General properties
 		tabbedPane.insertTab( trans.get("RailBtnCfg.tab.General"), null, buttonTab( (RailButton)component ), trans.get("RailBtnCfg.tab.GeneralProp"), 0);
@@ -59,6 +52,15 @@ public class RailButtonConfig extends RocketComponentConfig {
 			panel.add(new UnitSelector(ODModel), "growx");
 			panel.add(new BasicSlider(ODModel.getSliderModel(0, 0.001, 0.02)), "w 100lp, wrap");
 		}
+		{ //// Inner Diameter
+			panel.add(new JLabel(trans.get("RailBtnCfg.lbl.InnerDiam")));
+			DoubleModel IDModel = new DoubleModel(component, "InnerDiameter", UnitGroup.UNITS_LENGTH, 0);
+			JSpinner IDSpinner = new JSpinner(IDModel.getSpinnerModel());
+			IDSpinner.setEditor(new SpinnerEditor(IDSpinner));
+			panel.add(IDSpinner, "growx");
+			panel.add(new UnitSelector(IDModel), "growx");
+			panel.add(new BasicSlider(IDModel.getSliderModel(0, 0.001, 0.02)), "w 100lp, wrap para");
+		}
 		{ //// Height
 			panel.add(new JLabel(trans.get("RailBtnCfg.lbl.TotalHeight")));
 			DoubleModel heightModel = new DoubleModel(component, "TotalHeight", UnitGroup.UNITS_LENGTH, 0);
@@ -67,6 +69,24 @@ public class RailButtonConfig extends RocketComponentConfig {
 			panel.add(heightSpinner, "growx");
 			panel.add(new UnitSelector(heightModel), "growx");
 			panel.add(new BasicSlider(heightModel.getSliderModel(0, 0.001, 0.02)), "w 100lp, wrap");
+		}
+		{ //// Base Height
+			panel.add(new JLabel(trans.get("RailBtnCfg.lbl.BaseHeight")));
+			DoubleModel heightModel = new DoubleModel(component, "BaseHeight", UnitGroup.UNITS_LENGTH, 0);
+			JSpinner heightSpinner = new JSpinner(heightModel.getSpinnerModel());
+			heightSpinner.setEditor(new SpinnerEditor(heightSpinner));
+			panel.add(heightSpinner, "growx");
+			panel.add(new UnitSelector(heightModel), "growx");
+			panel.add(new BasicSlider(heightModel.getSliderModel(0, 0.001, 0.02)), "w 100lp, wrap");
+		}
+		{ //// Flange Height
+			panel.add(new JLabel(trans.get("RailBtnCfg.lbl.FlangeHeight")));
+			DoubleModel heightModel = new DoubleModel(component, "FlangeHeight", UnitGroup.UNITS_LENGTH, 0);
+			JSpinner heightSpinner = new JSpinner(heightModel.getSpinnerModel());
+			heightSpinner.setEditor(new SpinnerEditor(heightSpinner));
+			panel.add(heightSpinner, "growx");
+			panel.add(new UnitSelector(heightModel), "growx");
+			panel.add(new BasicSlider(heightModel.getSliderModel(0, 0.001, 0.02)), "w 100lp, wrap para");
 		}
 
 		{ //// Angular Position:
@@ -79,14 +99,17 @@ public class RailButtonConfig extends RocketComponentConfig {
 			panel.add(new BasicSlider( angleModel.getSliderModel(-Math.PI, Math.PI)), "w 100lp, wrap");
 		}
 
+		primary.add(panel, "grow, gapright 201p");
+		panel = new JPanel(new MigLayout("gap rel unrel", "[][65lp::][30lp::][]", ""));
+
 		{ //// Position relative to:
 			panel.add(new JLabel(trans.get("RailBtnCfg.lbl.PosRelativeTo")));
-			
+
 			final EnumModel<AxialMethod> methodModel = new EnumModel<AxialMethod>(component, "AxialMethod", AxialMethod.axialOffsetMethods );
 			JComboBox<AxialMethod> relToCombo = new JComboBox<AxialMethod>( methodModel );
 			panel.add( relToCombo, "spanx, growx, wrap");
 		}
-			
+
 		{ //// plus
 			panel.add(new JLabel(trans.get("RailBtnCfg.lbl.Plus")), "right");
 			DoubleModel offsetModel = new DoubleModel(component, "AxialOffset", UnitGroup.UNITS_LENGTH);
@@ -96,17 +119,13 @@ public class RailButtonConfig extends RocketComponentConfig {
 			panel.add(offsetSpinner, "growx");
 			panel.add(new UnitSelector(offsetModel), "growx");
 			panel.add(new BasicSlider(offsetModel.getSliderModel(
-					new DoubleModel(component.getParent(), "Length", -1.0, UnitGroup.UNITS_NONE),
-					new DoubleModel(component.getParent(), "Length"))),
+							new DoubleModel(component.getParent(), "Length", -1.0, UnitGroup.UNITS_NONE),
+							new DoubleModel(component.getParent(), "Length"))),
 					"w 100lp, wrap para");
-			
-		}
 
-		primary.add(panel, "grow, gapright 201p");
-		panel = new JPanel(new MigLayout("gap rel unrel", "[][65lp::][30lp::][]", ""));
-		
+		}
 		//// Instance count
-		panel.add( instanceablePanel(rbc), "span, wrap");
+		panel.add(instanceablePanel(rbc), "span, wrap");
 
 		//// Material
 		panel.add(materialPanel(Material.Type.BULK),"span, wrap");

--- a/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
@@ -353,7 +353,7 @@ public class RocketComponentConfig extends JPanel {
 	}
 	
 	protected JPanel instanceablePanel( Instanceable inst ){
-		JPanel panel = new JPanel( new MigLayout("fill"));
+		JPanel panel = new JPanel( new MigLayout("fill, insets 0") );
 		{ // Instance Count
 			panel.add(new JLabel(trans.get("RocketCompCfg.lbl.InstanceCount")));
 			IntegerModel countModel = new IntegerModel(component, "InstanceCount", 1);

--- a/swing/src/net/sf/openrocket/gui/figure3d/geometry/ComponentRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/geometry/ComponentRenderer.java
@@ -295,26 +295,37 @@ public class ComponentRenderer {
 			final double ir = r.getInnerDiameter() / 2.0;
 			gl.glRotated(r.getAngleOffset()*180/Math.PI -90 , 1, 0, 0);
 			
-			//Inner Diameter
-			glu.gluCylinder(q, ir, ir, r.getTotalHeight(), LOD, 1);
+			// Base Cylinder
+			if (r.getBaseHeight() > 0) {
+				glu.gluCylinder(q, or, or, r.getBaseHeight(), LOD, 1);
+				glu.gluQuadricOrientation(q, GLU.GLU_INSIDE);
+				glu.gluDisk(q, 0, or, LOD, 2);
+				glu.gluQuadricOrientation(q, GLU.GLU_OUTSIDE);
+				gl.glTranslated(0, 0, r.getBaseHeight());
+				glu.gluDisk(q, 0, or, LOD, 2);
+			} else {	// Draw a closing cap if there is no base
+				glu.gluQuadricOrientation(q, GLU.GLU_INSIDE);
+				glu.gluDisk(q, 0, ir, LOD, 2);
+				glu.gluQuadricOrientation(q, GLU.GLU_OUTSIDE);
+				gl.glTranslated(0, 0, r.getBaseHeight());
+			}
+
+			// Inner Cylinder
+			glu.gluCylinder(q, ir, ir, r.getInnerHeight(), LOD, 1);
 			
-			//Bottom Disc
-			glu.gluCylinder(q, or, or, r.getBaseHeight(), LOD, 1);
-			glu.gluQuadricOrientation(q, GLU.GLU_INSIDE);
-			glu.gluDisk(q, 0, or, LOD, 2);
-			glu.gluQuadricOrientation(q, GLU.GLU_OUTSIDE);
-			gl.glTranslated(0,0,r.getBaseHeight());
-			glu.gluDisk(q, 0, or, LOD, 2);
-			
-			
-			//Upper Disc
-			gl.glTranslated(0,0,r.getTotalHeight() - r.getFlangeHeight() * 2.0);
-			glu.gluCylinder(q, or, or, r.getFlangeHeight(), LOD, 1);
-			glu.gluQuadricOrientation(q, GLU.GLU_INSIDE);
-			glu.gluDisk(q, 0, or, LOD, 2);
-			glu.gluQuadricOrientation(q, GLU.GLU_OUTSIDE);
-			gl.glTranslated(0,0,r.getFlangeHeight());
-			glu.gluDisk(q, 0, or, LOD, 2);
+			// Flange Cylinder
+			if (r.getFlangeHeight() > 0) {
+				gl.glTranslated(0, 0, r.getInnerHeight());
+				glu.gluCylinder(q, or, or, r.getFlangeHeight(), LOD, 1);
+				glu.gluQuadricOrientation(q, GLU.GLU_INSIDE);
+				glu.gluDisk(q, 0, or, LOD, 2);
+				glu.gluQuadricOrientation(q, GLU.GLU_OUTSIDE);
+				gl.glTranslated(0, 0, r.getFlangeHeight());
+				glu.gluDisk(q, 0, or, LOD, 2);
+			} else {	// Draw a closing cap if there is no flange
+				gl.glTranslated(0, 0, r.getInnerHeight());
+				glu.gluDisk(q, 0, ir, LOD, 2);
+			}
 
 		}
 	}

--- a/swing/src/net/sf/openrocket/gui/rocketfigure/RailButtonShapes.java
+++ b/swing/src/net/sf/openrocket/gui/rocketfigure/RailButtonShapes.java
@@ -29,7 +29,7 @@ public class RailButtonShapes extends RocketComponentShape {
 	public static RocketComponentShape[] getShapesSide( final RocketComponent component, final Transformation transformation) {
 		final RailButton btn = (RailButton)component;
 
-		final double baseHeight = btn.getStandoff();
+		final double baseHeight = btn.getBaseHeight();
 		final double innerHeight = btn.getInnerHeight();
 		final double flangeHeight = btn.getFlangeHeight();
 		
@@ -53,72 +53,73 @@ public class RailButtonShapes extends RocketComponentShape {
 
 		Path2D.Double path = new Path2D.Double();
 		Path2D.Double pathInvis = new Path2D.Double();	// Path for the invisible triangles
-		{// central pillar
-			final double drawWidth = outerDiameter;
-			final double drawHeight = outerDiameter*sinr;
-			final Point2D.Double center = new Point2D.Double( loc.x, loc.y );
-			Point2D.Double lowerLeft = new Point2D.Double( center.x - outerRadius, center.y-outerRadius*sinr);
-			path.append( new Ellipse2D.Double( lowerLeft.x, lowerLeft.y, drawWidth, drawHeight), false);
-			
-			path.append( new Line2D.Double( lowerLeft.x,  center.y, lowerLeft.x, (center.y+baseHeightcos) ), false);
-			path.append( new Line2D.Double( (center.x+outerRadius),  center.y, (center.x+outerRadius), (center.y+baseHeightcos) ), false);
-			
-			path.append( new Ellipse2D.Double( lowerLeft.x, (lowerLeft.y+baseHeightcos), drawWidth, drawHeight), false);
+		{// base cylinder
+			if (baseHeight > 0) {
+				final double drawWidth = outerDiameter;
+				final double drawHeight = outerDiameter * sinr;
+				final Point2D.Double center = new Point2D.Double(loc.x, loc.y);
+				Point2D.Double lowerLeft = new Point2D.Double(center.x - outerRadius, center.y - outerRadius * sinr);
+				path.append(new Ellipse2D.Double(lowerLeft.x, lowerLeft.y, drawWidth, drawHeight), false);
 
-			// Invisible rectangle
-			double y_invis;
-			if (baseHeightcos >= 0) {
-				y_invis = center.y;
+				path.append(new Line2D.Double(lowerLeft.x, center.y, lowerLeft.x, (center.y + baseHeightcos)), false);
+				path.append(new Line2D.Double((center.x + outerRadius), center.y, (center.x + outerRadius), (center.y + baseHeightcos)), false);
+
+				path.append(new Ellipse2D.Double(lowerLeft.x, (lowerLeft.y + baseHeightcos), drawWidth, drawHeight), false);
+
+				// Invisible rectangle
+				double y_invis;
+				if (baseHeightcos >= 0) {
+					y_invis = center.y;
+				} else {
+					y_invis = center.y + baseHeightcos;
+				}
+				pathInvis.append(new Rectangle2D.Double(center.x - outerRadius, y_invis, drawWidth, Math.abs(baseHeightcos)), false);
 			}
-			else {
-				y_invis = center.y + baseHeightcos;
-			}
-			pathInvis.append(new Rectangle2D.Double(center.x-outerRadius, y_invis, drawWidth, Math.abs(baseHeightcos)), false);
 		}
 		
-		{// inner flange
+		{// inner cylinder
 			final double drawWidth = innerDiameter;
-			final double drawHeight = innerDiameter*sinr;
-			final Point2D.Double center = new Point2D.Double( loc.x, loc.y + baseHeightcos);
-			final Point2D.Double lowerLeft = new Point2D.Double( center.x - innerRadius, center.y-innerRadius*sinr);
-			path.append( new Ellipse2D.Double( lowerLeft.x, lowerLeft.y, drawWidth, drawHeight), false);
-			
-			path.append( new Line2D.Double( lowerLeft.x,  center.y, lowerLeft.x, (center.y+innerHeightcos) ), false);
-			path.append( new Line2D.Double( (center.x+innerRadius),  center.y, (center.x+innerRadius), (center.y+innerHeightcos) ), false);
-			
-			path.append( new Ellipse2D.Double( lowerLeft.x, (lowerLeft.y+innerHeightcos), drawWidth, drawHeight), false);
+			final double drawHeight = innerDiameter * sinr;
+			final Point2D.Double center = new Point2D.Double(loc.x, loc.y + baseHeightcos);
+			final Point2D.Double lowerLeft = new Point2D.Double(center.x - innerRadius, center.y - innerRadius * sinr);
+			path.append(new Ellipse2D.Double(lowerLeft.x, lowerLeft.y, drawWidth, drawHeight), false);
+
+			path.append(new Line2D.Double(lowerLeft.x, center.y, lowerLeft.x, (center.y + innerHeightcos)), false);
+			path.append(new Line2D.Double((center.x + innerRadius), center.y, (center.x + innerRadius), (center.y + innerHeightcos)), false);
+
+			path.append(new Ellipse2D.Double(lowerLeft.x, (lowerLeft.y + innerHeightcos), drawWidth, drawHeight), false);
 
 			// Invisible rectangle
 			double y_invis;
 			if (innerHeightcos >= 0) {
 				y_invis = center.y;
-			}
-			else {
+			} else {
 				y_invis = center.y + innerHeightcos;
 			}
-			pathInvis.append(new Rectangle2D.Double(center.x-innerRadius, y_invis, drawWidth, Math.abs(innerHeightcos)), false);
+			pathInvis.append(new Rectangle2D.Double(center.x - innerRadius, y_invis, drawWidth, Math.abs(innerHeightcos)), false);
 		}
-		{// outer flange
-			final double drawWidth = outerDiameter;
-			final double drawHeight = outerDiameter*sinr;
-			final Point2D.Double center = new Point2D.Double( loc.x, loc.y+baseHeightcos+innerHeightcos);
-			final Point2D.Double lowerLeft = new Point2D.Double( center.x - outerRadius, center.y-outerRadius*sinr);
-			path.append( new Ellipse2D.Double( lowerLeft.x, lowerLeft.y, drawWidth, drawHeight), false);
-			
-			path.append( new Line2D.Double( lowerLeft.x,  center.y, lowerLeft.x, (center.y+flangeHeightcos) ), false);
-			path.append( new Line2D.Double( (center.x+outerRadius),  center.y, (center.x+outerRadius), (center.y+flangeHeightcos) ), false);
-			
-			path.append( new Ellipse2D.Double( lowerLeft.x, (lowerLeft.y+flangeHeightcos), drawWidth, drawHeight), false);
+		{// flange cylinder
+			if (flangeHeight > 0) {
+				final double drawWidth = outerDiameter;
+				final double drawHeight = outerDiameter * sinr;
+				final Point2D.Double center = new Point2D.Double(loc.x, loc.y + baseHeightcos + innerHeightcos);
+				final Point2D.Double lowerLeft = new Point2D.Double(center.x - outerRadius, center.y - outerRadius * sinr);
+				path.append(new Ellipse2D.Double(lowerLeft.x, lowerLeft.y, drawWidth, drawHeight), false);
 
-			// Invisible rectangle
-			double y_invis;
-			if (flangeHeightcos >= 0) {
-				y_invis = center.y;
+				path.append(new Line2D.Double(lowerLeft.x, center.y, lowerLeft.x, (center.y + flangeHeightcos)), false);
+				path.append(new Line2D.Double((center.x + outerRadius), center.y, (center.x + outerRadius), (center.y + flangeHeightcos)), false);
+
+				path.append(new Ellipse2D.Double(lowerLeft.x, (lowerLeft.y + flangeHeightcos), drawWidth, drawHeight), false);
+
+				// Invisible rectangle
+				double y_invis;
+				if (flangeHeightcos >= 0) {
+					y_invis = center.y;
+				} else {
+					y_invis = center.y + flangeHeightcos;
+				}
+				pathInvis.append(new Rectangle2D.Double(center.x - outerRadius, y_invis, drawWidth, Math.abs(flangeHeightcos)), false);
 			}
-			else {
-				y_invis = center.y + flangeHeightcos;
-			}
-			pathInvis.append(new Rectangle2D.Double(center.x-outerRadius, y_invis, drawWidth, Math.abs(flangeHeightcos)), false);
 		}
 
 		RocketComponentShape[] shapes = RocketComponentShape.toArray(new Shape[]{ path }, component);
@@ -136,7 +137,7 @@ public class RailButtonShapes extends RocketComponentShape {
 	public static RocketComponentShape[] getShapesBack( final RocketComponent component, final Transformation transformation) {
 		final RailButton btn = (RailButton)component;
 
-		final double baseHeight = btn.getStandoff();
+		final double baseHeight = btn.getBaseHeight();
 		final double innerHeight = btn.getInnerHeight();
 		final double flangeHeight = btn.getFlangeHeight();
 
@@ -159,7 +160,9 @@ public class RailButtonShapes extends RocketComponentShape {
 		Path2D.Double path = new Path2D.Double();
 
 		// base
-		path.append( getRotatedRectangle( loc.z, loc.y, outerRadius, baseHeight, combined_angle_rad), false );
+		if (baseHeight > 0) {
+			path.append(getRotatedRectangle(loc.z, loc.y, outerRadius, baseHeight, combined_angle_rad), false);
+		}
 		
 		{// inner
 			final double delta_r = baseHeight;
@@ -167,11 +170,13 @@ public class RailButtonShapes extends RocketComponentShape {
 			final double delta_z = delta_r*sinr;
 			path.append( getRotatedRectangle( loc.z+delta_z, loc.y+delta_y, innerRadius, innerHeight, combined_angle_rad), false);
 		}
-		{// outer flange
-			final double delta_r = baseHeight + innerHeight;
-			final double delta_y = delta_r*cosr;
-			final double delta_z = delta_r*sinr;
-			path.append( getRotatedRectangle( loc.z+delta_z, loc.y+delta_y, outerRadius, flangeHeight, combined_angle_rad), false);
+		{// flange
+			if (flangeHeight > 0) {
+				final double delta_r = baseHeight + innerHeight;
+				final double delta_y = delta_r * cosr;
+				final double delta_z = delta_r * sinr;
+				path.append(getRotatedRectangle(loc.z + delta_z, loc.y + delta_y, outerRadius, flangeHeight, combined_angle_rad), false);
+			}
 		}
 
 		return RocketComponentShape.toArray( new Shape[]{ path }, component);


### PR DESCRIPTION
This PR fixes #1537 by adding the following configuration parameters for a rail button:
- Inner diameter (controls the diameter of the middle part of the rail button)
- Base height (controls the height of the cylinder closest to its parent component)
- Flange height (controls the height of the cylinder furthest away from its parent component)

Demo:

https://user-images.githubusercontent.com/11031519/179631165-a1f6ed63-e0ae-4549-bb4c-79dcbbdc168c.mp4

