### PR TITLE
[#1480] Pre-check diameter filters in component preset chooser

### DIFF
--- a/core/src/net/sf/openrocket/startup/Preferences.java
+++ b/core/src/net/sf/openrocket/startup/Preferences.java
@@ -63,6 +63,9 @@ public abstract class Preferences implements ChangeSource {
 	public static final String MOTOR_DIAMETER_FILTER = "MotorDiameterMatch";
 	public static final String MOTOR_HIDE_SIMILAR = "MotorHideSimilar";
 	public static final String MOTOR_HIDE_UNAVAILABLE = "MotorHideUnavailable";
+
+	public static final String MATCH_FORE_DIAMETER = "MatchForeDiameter";
+	public static final String MATCH_AFT_DIAMETER = "MatchAftDiameter";
 	
 	// Node names
 	public static final String PREFERRED_THRUST_CURVE_MOTOR_NODE = "preferredThrustCurveMotors";
@@ -488,6 +491,44 @@ public abstract class Preferences implements ChangeSource {
 	 */
 	public final boolean isShowMarkers() {
 		return this.getBoolean(SHOW_MARKERS, false);
+	}
+
+	/**
+	 * Set whether the component preset chooser dialog should filter by fore diameter when the window is opened.
+	 * @param enabled 	true if the fore diameter filter should be enabled,
+	 * 					false if it should be disabled.
+	 */
+	public final void setMatchForeDiameter(boolean enabled) {
+		this.putBoolean(MATCH_FORE_DIAMETER, enabled);
+	}
+
+	/**
+	 * Answer if the component preset chooser dialog should filter by fore diameter when the window is opened.
+	 *
+	 * @return 	true if the fore diameter filter should be enabled,
+	 * 			false if it should be disabled.
+	 */
+	public final boolean isMatchForeDiameter() {
+		return this.getBoolean(MATCH_FORE_DIAMETER, true);
+	}
+
+	/**
+	 * Set whether the component preset chooser dialog should filter by aft diameter when the window is opened.
+	 * @param enabled 	true if the aft diameter filter should be enabled,
+	 * 					false if it should be disabled.
+	 */
+	public final void setMatchAftDiameter(boolean enabled) {
+		this.putBoolean(MATCH_AFT_DIAMETER, enabled);
+	}
+
+	/**
+	 * Answer if the component preset chooser dialog should filter by aft diameter when the window is opened.
+	 *
+	 * @return 	true if the aft diameter filter should be enabled,
+	 * 			false if it should be disabled.
+	 */
+	public final boolean isMatchAftDiameter() {
+		return this.getBoolean(MATCH_AFT_DIAMETER, true);
 	}
 
 	/**

--- a/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
@@ -222,6 +222,7 @@ public class ComponentPresetChooserDialog extends JDialog {
 			foreDiameterFilterCheckBox = new JCheckBox(trans.get("ComponentPresetChooserDialog.checkbox.filterForeDiameter"));
 			final SymmetricComponent prevSym = curSym.getPreviousSymmetricComponent();
 			if (prevSym != null && foreDiameterColumnIndex >= 0) {
+				foreDiameterFilterCheckBox.setSelected(true);
 				foreDiameterFilter = new ComponentPresetRowFilter(prevSym.getAftRadius() * 2.0, foreDiameterColumnIndex);
 				panel.add(foreDiameterFilterCheckBox, "wrap");
 				foreDiameterFilterCheckBox.addItemListener(new ItemListener() {
@@ -238,6 +239,7 @@ public class ComponentPresetChooserDialog extends JDialog {
 			aftDiameterFilterCheckBox = new JCheckBox(trans.get("ComponentPresetChooserDialog.checkbox.filterAftDiameter"));
 			final SymmetricComponent nextSym = curSym.getNextSymmetricComponent();
 			if (nextSym != null && aftDiameterColumnIndex >= 0) {
+				aftDiameterFilterCheckBox.setSelected(true);
 				aftDiameterFilter = new ComponentPresetRowFilter(nextSym.getForeRadius() * 2.0, aftDiameterColumnIndex);
 				panel.add(aftDiameterFilterCheckBox, "wrap");
 				aftDiameterFilterCheckBox.addItemListener(new ItemListener() {

--- a/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
@@ -26,6 +26,7 @@ import javax.swing.table.TableModel;
 
 import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.SwingPreferences;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.preset.ComponentPreset;
 import net.sf.openrocket.preset.TypedKey;
@@ -42,6 +43,8 @@ import net.sf.openrocket.gui.widgets.SelectColorButton;
 public class ComponentPresetChooserDialog extends JDialog {
 	
 	private static final Translator trans = Application.getTranslator();
+	
+	private final SwingPreferences preferences = (SwingPreferences) Application.getPreferences();
 	
 	private final RocketComponent component;
 	
@@ -222,13 +225,14 @@ public class ComponentPresetChooserDialog extends JDialog {
 			foreDiameterFilterCheckBox = new JCheckBox(trans.get("ComponentPresetChooserDialog.checkbox.filterForeDiameter"));
 			final SymmetricComponent prevSym = curSym.getPreviousSymmetricComponent();
 			if (prevSym != null && foreDiameterColumnIndex >= 0) {
-				foreDiameterFilterCheckBox.setSelected(true);
+				foreDiameterFilterCheckBox.setSelected(preferences.isMatchForeDiameter());
 				foreDiameterFilter = new ComponentPresetRowFilter(prevSym.getAftRadius() * 2.0, foreDiameterColumnIndex);
 				panel.add(foreDiameterFilterCheckBox, "wrap");
 				foreDiameterFilterCheckBox.addItemListener(new ItemListener() {
 					@Override
 					public void itemStateChanged(ItemEvent e) {
 						updateFilters();
+						preferences.setMatchForeDiameter(foreDiameterFilterCheckBox.isSelected());
 					}
 				});
 			}
@@ -239,13 +243,14 @@ public class ComponentPresetChooserDialog extends JDialog {
 			aftDiameterFilterCheckBox = new JCheckBox(trans.get("ComponentPresetChooserDialog.checkbox.filterAftDiameter"));
 			final SymmetricComponent nextSym = curSym.getNextSymmetricComponent();
 			if (nextSym != null && aftDiameterColumnIndex >= 0) {
-				aftDiameterFilterCheckBox.setSelected(true);
+				aftDiameterFilterCheckBox.setSelected(preferences.isMatchAftDiameter());
 				aftDiameterFilter = new ComponentPresetRowFilter(nextSym.getForeRadius() * 2.0, aftDiameterColumnIndex);
 				panel.add(aftDiameterFilterCheckBox, "wrap");
 				aftDiameterFilterCheckBox.addItemListener(new ItemListener() {
 					@Override
 					public void itemStateChanged(ItemEvent e) {
 						updateFilters();
+						preferences.setMatchAftDiameter(aftDiameterFilterCheckBox.isSelected());
 					}
 				});
 			}


### PR DESCRIPTION
This PR solves #1480 in which it was requested to automatically check the "Match fore diameter" and "Match aft diameter" options in the component preset chooser window. This was done by adding a line for each option which selects the JCheckbox after checking if the option is applicable but before adding the checkbox to the pane.