### PR TITLE
[#1549] Ctrl/Cmd + A select all shortcut in simulation table and component tree

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -418,18 +418,18 @@ public class BasicFrame extends JFrame {
 		button = new SelectColorButton(actions.getMoveDownAction());
 		panel.add(button, "sizegroup buttons, aligny 0%");
 
-		button = new SelectColorButton(actions.getEditAction());
-		button.setIcon(null);
+		button = new SelectColorButton();
+		RocketActions.tieActionToButtonNoIcon(button, actions.getEditAction());
 		button.setMnemonic(0);
 		panel.add(button, "sizegroup buttons, gaptop 20%");
 
-		button = new SelectColorButton(actions.getDuplicateAction());
-		button.setIcon(null);
+		button = new SelectColorButton();
+		RocketActions.tieActionToButtonNoIcon(button, actions.getDuplicateAction());
 		button.setMnemonic(0);
 		panel.add(button, "sizegroup buttons");
 
-		button = new SelectColorButton(actions.getDeleteAction());
-		button.setIcon(null);
+		button = new SelectColorButton();
+		RocketActions.tieActionToButtonNoIcon(button, actions.getDeleteAction());
 		button.setMnemonic(0);
 		panel.add(button, "sizegroup buttons");
 

--- a/swing/src/net/sf/openrocket/gui/main/RocketActions.java
+++ b/swing/src/net/sf/openrocket/gui/main/RocketActions.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
+import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -189,6 +190,35 @@ public class RocketActions {
 		return moveDownAction;
 	}
 
+	/**
+	 * Tie an action to a JButton, without using the icon or text of the action for the button.
+	 *
+	 * For any smartass that wants to know why you don't just initialize the JButton with the action and then set the
+	 * icon to null and set the button text: this causes a bug where the text of the icon becomes much smaller than is intended.
+	 *
+	 * @param button button to tie the action to
+	 * @param action action to tie to the button
+	 * @param text text to display on the button
+	 */
+	public static void tieActionToButtonNoIcon(JButton button, Action action, String text) {
+		button.setAction(action);
+		button.setIcon(null);
+		button.setText(text);
+	}
+
+	/**
+	 * Tie an action to a JButton, without using the icon of the action for the button.
+	 *
+	 * For any smartass that wants to know why you don't just initialize the JButton with the action and then set the
+	 * icon to null: this causes a bug where the text of the icon becomes much smaller than is intended.
+	 *
+	 * @param button button to tie the action to
+	 * @param action action to tie to the button
+	 */
+	public static void tieActionToButtonNoIcon(JButton button, Action action) {
+		button.setAction(action);
+		button.setIcon(null);
+	}
 	
 	
 	////////  Helper methods for the actions

--- a/swing/src/net/sf/openrocket/gui/main/SimulationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/SimulationPanel.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 
 import javax.swing.AbstractAction;
+import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
@@ -31,6 +32,7 @@ import javax.swing.JTable;
 import javax.swing.KeyStroke;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.DefaultTableCellRenderer;
@@ -433,16 +435,7 @@ public class SimulationPanel extends JPanel {
 		// Override processKeyBinding so that the JTable does not catch
 		// key bindings used in menu accelerators
 		simulationTable = new ColumnTable(simulationTableModel) {
-
 			private static final long serialVersionUID = -5799340181229735630L;
-
-			@Override
-			protected boolean processKeyBinding(KeyStroke ks,
-					KeyEvent e,
-					int condition,
-					boolean pressed) {
-				return false;
-			}
 		};
 		ColumnTableRowSorter simulationTableSorter = new ColumnTableRowSorter(simulationTableModel);
 		simulationTable.setRowSorter(simulationTableSorter);

--- a/swing/src/net/sf/openrocket/gui/main/SimulationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/SimulationPanel.java
@@ -496,11 +496,14 @@ public class SimulationPanel extends JPanel {
 		});
 
 		simulationTable.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
-			private int previousRow = -1;
+			private int previousSelectedRow = -1;
+			private int previousSelectedRowCount = 0;
 			public void valueChanged(ListSelectionEvent event) {
-				if (simulationTable.getSelectedRow() != previousRow) {
+				if ((simulationTable.getSelectedRow() != previousSelectedRow) ||
+						(simulationTable.getSelectedRowCount() != previousSelectedRowCount)) {
 					updateButtonStates();
-					previousRow = simulationTable.getSelectedRow();
+					previousSelectedRow = simulationTable.getSelectedRow();
+					previousSelectedRowCount = simulationTable.getSelectedRowCount();
 				}
 			}
 		});
@@ -699,10 +702,11 @@ public class SimulationPanel extends JPanel {
 		} else {
 			if (selection.length > 1) {
 				plotButton.setEnabled(false);
+				editButton.setEnabled(false);
 			} else {
 				plotButton.setEnabled(true);
+				editButton.setEnabled(true);
 			}
-			editButton.setEnabled(true);
 			runButton.setEnabled(true);
 			deleteButton.setEnabled(true);
 		}

--- a/swing/src/net/sf/openrocket/gui/main/SimulationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/SimulationPanel.java
@@ -10,7 +10,6 @@ import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -19,7 +18,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 
 import javax.swing.AbstractAction;
-import javax.swing.Action;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
@@ -123,31 +121,31 @@ public class SimulationPanel extends JPanel {
 
 		//// New simulation button
 		JButton newButton = new SelectColorButton();
-		tieActionToButtonNoIcon(newButton, newSimulationAction, trans.get("simpanel.but.newsimulation"));
+		RocketActions.tieActionToButtonNoIcon(newButton, newSimulationAction, trans.get("simpanel.but.newsimulation"));
 		newButton.setToolTipText(trans.get("simpanel.but.ttip.newsimulation"));
 		this.add(newButton, "skip 1, gapright para");
 
 		//// Edit simulation button
 		editButton = new SelectColorButton();
-		tieActionToButtonNoIcon(editButton, editSimulationAction, trans.get("simpanel.but.editsimulation"));
+		RocketActions.tieActionToButtonNoIcon(editButton, editSimulationAction, trans.get("simpanel.but.editsimulation"));
 		editButton.setToolTipText(trans.get("simpanel.but.ttip.editsim"));
 		this.add(editButton, "gapright para");
 
 		//// Run simulations
 		runButton = new SelectColorButton();
-		tieActionToButtonNoIcon(runButton, runSimulationAction, trans.get("simpanel.but.runsimulations"));
+		RocketActions.tieActionToButtonNoIcon(runButton, runSimulationAction, trans.get("simpanel.but.runsimulations"));
 		runButton.setToolTipText(trans.get("simpanel.but.ttip.runsimu"));
 		this.add(runButton, "gapright para");
 
 		//// Delete simulations button
 		deleteButton = new SelectColorButton();
-		tieActionToButtonNoIcon(deleteButton, deleteSimulationAction, trans.get("simpanel.but.deletesimulations"));
+		RocketActions.tieActionToButtonNoIcon(deleteButton, deleteSimulationAction, trans.get("simpanel.but.deletesimulations"));
 		deleteButton.setToolTipText(trans.get("simpanel.but.ttip.deletesim"));
 		this.add(deleteButton, "gapright para");
 
 		//// Plot / export button
 		plotButton = new SelectColorButton();
-		tieActionToButtonNoIcon(plotButton, plotSimulationAction, trans.get("simpanel.but.plotexport"));
+		RocketActions.tieActionToButtonNoIcon(plotButton, plotSimulationAction, trans.get("simpanel.but.plotexport"));
 		this.add(plotButton, "wrap para");
 
 
@@ -745,12 +743,6 @@ public class SimulationPanel extends JPanel {
 				break;
 			simulationTable.addRowSelectionInterval(row, row);
 		}
-	}
-
-	private void tieActionToButtonNoIcon(JButton button, Action action, String text) {
-		button.setAction(action);
-		button.setIcon(null);
-		button.setText(text);
 	}
 
 	private abstract static class SimulationAction extends AbstractAction {

--- a/swing/src/net/sf/openrocket/gui/main/SimulationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/SimulationPanel.java
@@ -151,255 +151,7 @@ public class SimulationPanel extends JPanel {
 
 
 		////////  The simulation table
-
-		simulationTableModel = new ColumnTableModel(
-
-				////  Status and warning column
-				new Column("") {
-					private JLabel label = null;
-
-					@Override
-					public Object getValueAt(int row) {
-						if (row < 0 || row >= document.getSimulationCount())
-							return null;
-
-						// Initialize the label
-						if (label == null) {
-							label = new StyledLabel(2f);
-							label.setIconTextGap(1);
-							//							label.setFont(label.getFont().deriveFont(Font.BOLD));
-						}
-
-						// Set simulation status icon
-						Simulation.Status status = document.getSimulation(row).getStatus();
-						label.setIcon(Icons.SIMULATION_STATUS_ICON_MAP.get(status));
-
-
-						// Set warning marker
-						if (status == Simulation.Status.NOT_SIMULATED ||
-								status == Simulation.Status.EXTERNAL) {
-
-							label.setText("");
-
-						} else {
-
-							WarningSet w = document.getSimulation(row).getSimulatedWarnings();
-							if (w == null) {
-								label.setText("");
-							} else if (w.isEmpty()) {
-								label.setForeground(OK_COLOR);
-								label.setText(OK_TEXT);
-							} else {
-								label.setForeground(WARNING_COLOR);
-								label.setText(WARNING_TEXT);
-							}
-						}
-
-						return label;
-					}
-
-					@Override
-					public int getExactWidth() {
-						return 36;
-					}
-
-					@Override
-					public Class<?> getColumnClass() {
-						return JLabel.class;
-					}
-				},
-
-				//// Simulation name
-				//// Name
-				new Column(trans.get("simpanel.col.Name")) {
-					@Override
-					public Object getValueAt(int row) {
-						if (row < 0 || row >= document.getSimulationCount())
-							return null;
-						return document.getSimulation(row).getName();
-					}
-
-					@Override
-					public int getDefaultWidth() {
-						return 125;
-					}
-
-					@Override
-					public Comparator<String> getComparator() {
-						return new AlphanumComparator();
-					}
-				},
-
-				//// Simulation configuration
-				new Column(trans.get("simpanel.col.Configuration")) {
-					@Override
-					public Object getValueAt(int row) {
-						if (row < 0 || row >= document.getSimulationCount()){
-							return null;
-						}
-
-						Rocket rkt = document.getRocket();
-						FlightConfigurationId fcid = document.getSimulation(row).getId();
-						return descriptor.format( rkt, fcid);
-					}
-
-					@Override
-					public int getDefaultWidth() {
-						return 125;
-					}
-				},
-
-				//// Launch rod velocity
-				new ValueColumn(trans.get("simpanel.col.Velocityoffrod"), UnitGroup.UNITS_VELOCITY) {
-					@Override
-					public Double valueAt(int row) {
-						if (row < 0 || row >= document.getSimulationCount())
-							return null;
-
-						FlightData data = document.getSimulation(row).getSimulatedData();
-						if (data == null)
-							return null;
-
-						return data.getLaunchRodVelocity();
-					}
-
-				},
-
-				//// Apogee
-				new ValueColumn(trans.get("simpanel.col.Apogee"), UnitGroup.UNITS_DISTANCE) {
-					@Override
-					public Double valueAt(int row) {
-						if (row < 0 || row >= document.getSimulationCount())
-							return null;
-
-						FlightData data = document.getSimulation(row).getSimulatedData();
-						if (data == null)
-							return null;
-
-						return data.getMaxAltitude();
-					}
-				},
-
-				//// Velocity at deployment
-				new ValueColumn(trans.get("simpanel.col.Velocityatdeploy"), UnitGroup.UNITS_VELOCITY) {
-					@Override
-					public Double valueAt(int row) {
-						if (row < 0 || row >= document.getSimulationCount())
-							return null;
-
-						FlightData data = document.getSimulation(row).getSimulatedData();
-						if (data == null)
-							return null;
-
-						return data.getDeploymentVelocity();
-					}
-				},
-
-				//// Deployment Time from Apogee
-				new ValueColumn(trans.get("simpanel.col.OptimumCoastTime"),
-						trans.get("simpanel.col.OptimumCoastTime.ttip"),
-						UnitGroup.UNITS_SHORT_TIME) {
-					@Override
-					public Double valueAt(int row) {
-						if (row < 0 || row >= document.getSimulationCount())
-							return null;
-
-						FlightData data = document.getSimulation(row).getSimulatedData();
-						if (data == null || data.getBranchCount() == 0)
-							return null;
-
-						double val = data.getBranch(0).getOptimumDelay();
-						if ( Double.isNaN(val) ) {
-							return null;
-						}
-						return val;
-					}
-				},
-
-				//// Maximum velocity
-				new ValueColumn(trans.get("simpanel.col.Maxvelocity"), UnitGroup.UNITS_VELOCITY) {
-					@Override
-					public Double valueAt(int row) {
-						if (row < 0 || row >= document.getSimulationCount())
-							return null;
-
-						FlightData data = document.getSimulation(row).getSimulatedData();
-						if (data == null)
-							return null;
-
-						return data.getMaxVelocity();
-					}
-				},
-
-				//// Maximum acceleration
-				new ValueColumn(trans.get("simpanel.col.Maxacceleration"), UnitGroup.UNITS_ACCELERATION) {
-					@Override
-					public Double valueAt(int row) {
-						if (row < 0 || row >= document.getSimulationCount())
-							return null;
-
-						FlightData data = document.getSimulation(row).getSimulatedData();
-						if (data == null)
-							return null;
-
-						return data.getMaxAcceleration();
-					}
-				},
-
-				//// Time to apogee
-				new ValueColumn(trans.get("simpanel.col.Timetoapogee"), UnitGroup.UNITS_FLIGHT_TIME) {
-					@Override
-					public Double valueAt(int row) {
-						if (row < 0 || row >= document.getSimulationCount())
-							return null;
-
-						FlightData data = document.getSimulation(row).getSimulatedData();
-						if (data == null)
-							return null;
-
-						return data.getTimeToApogee();
-					}
-				},
-
-				//// Flight time
-				new ValueColumn(trans.get("simpanel.col.Flighttime"), UnitGroup.UNITS_FLIGHT_TIME) {
-					@Override
-					public Double valueAt(int row) {
-						if (row < 0 || row >= document.getSimulationCount())
-							return null;
-
-						FlightData data = document.getSimulation(row).getSimulatedData();
-						if (data == null)
-							return null;
-
-						return data.getFlightTime();
-					}
-				},
-
-				//// Ground hit velocity
-				new ValueColumn(trans.get("simpanel.col.Groundhitvelocity"), UnitGroup.UNITS_VELOCITY) {
-					@Override
-					public Double valueAt(int row) {
-						if (row < 0 || row >= document.getSimulationCount())
-							return null;
-
-						FlightData data = document.getSimulation(row).getSimulatedData();
-						if (data == null)
-							return null;
-
-						return data.getGroundHitVelocity();
-					}
-				}
-
-				) {
-
-				private static final long serialVersionUID = 8686456963492628476L;
-
-			@Override
-			public int getRowCount() {
-				return document.getSimulationCount();
-			}
-		};
+		simulationTableModel = new SimulationTableModel();
 
 		// Override processKeyBinding so that the JTable does not catch
 		// key bindings used in menu accelerators
@@ -971,6 +723,254 @@ public class SimulationPanel extends JPanel {
 
 			return tip;
 		}
+	}
 
+	private class SimulationTableModel extends ColumnTableModel {
+		private static final long serialVersionUID = 8686456963492628476L;
+
+		public SimulationTableModel() {
+			super(
+					////  Status and warning column
+					new Column("") {
+						private JLabel label = null;
+
+						@Override
+						public Object getValueAt(int row) {
+							if (row < 0 || row >= document.getSimulationCount())
+								return null;
+
+							// Initialize the label
+							if (label == null) {
+								label = new StyledLabel(2f);
+								label.setIconTextGap(1);
+								//							label.setFont(label.getFont().deriveFont(Font.BOLD));
+							}
+
+							// Set simulation status icon
+							Simulation.Status status = document.getSimulation(row).getStatus();
+							label.setIcon(Icons.SIMULATION_STATUS_ICON_MAP.get(status));
+
+
+							// Set warning marker
+							if (status == Simulation.Status.NOT_SIMULATED ||
+									status == Simulation.Status.EXTERNAL) {
+
+								label.setText("");
+
+							} else {
+
+								WarningSet w = document.getSimulation(row).getSimulatedWarnings();
+								if (w == null) {
+									label.setText("");
+								} else if (w.isEmpty()) {
+									label.setForeground(OK_COLOR);
+									label.setText(OK_TEXT);
+								} else {
+									label.setForeground(WARNING_COLOR);
+									label.setText(WARNING_TEXT);
+								}
+							}
+
+							return label;
+						}
+
+						@Override
+						public int getExactWidth() {
+							return 36;
+						}
+
+						@Override
+						public Class<?> getColumnClass() {
+							return JLabel.class;
+						}
+					},
+
+					//// Simulation name
+					//// Name
+					new Column(trans.get("simpanel.col.Name")) {
+						@Override
+						public Object getValueAt(int row) {
+							if (row < 0 || row >= document.getSimulationCount())
+								return null;
+							return document.getSimulation(row).getName();
+						}
+
+						@Override
+						public int getDefaultWidth() {
+							return 125;
+						}
+
+						@Override
+						public Comparator<String> getComparator() {
+							return new AlphanumComparator();
+						}
+					},
+
+					//// Simulation configuration
+					new Column(trans.get("simpanel.col.Configuration")) {
+						@Override
+						public Object getValueAt(int row) {
+							if (row < 0 || row >= document.getSimulationCount()) {
+								return null;
+							}
+
+							Rocket rkt = document.getRocket();
+							FlightConfigurationId fcid = document.getSimulation(row).getId();
+							return descriptor.format(rkt, fcid);
+						}
+
+						@Override
+						public int getDefaultWidth() {
+							return 125;
+						}
+					},
+
+					//// Launch rod velocity
+					new ValueColumn(trans.get("simpanel.col.Velocityoffrod"), UnitGroup.UNITS_VELOCITY) {
+						@Override
+						public Double valueAt(int row) {
+							if (row < 0 || row >= document.getSimulationCount())
+								return null;
+
+							FlightData data = document.getSimulation(row).getSimulatedData();
+							if (data == null)
+								return null;
+
+							return data.getLaunchRodVelocity();
+						}
+
+					},
+
+					//// Apogee
+					new ValueColumn(trans.get("simpanel.col.Apogee"), UnitGroup.UNITS_DISTANCE) {
+						@Override
+						public Double valueAt(int row) {
+							if (row < 0 || row >= document.getSimulationCount())
+								return null;
+
+							FlightData data = document.getSimulation(row).getSimulatedData();
+							if (data == null)
+								return null;
+
+							return data.getMaxAltitude();
+						}
+					},
+
+					//// Velocity at deployment
+					new ValueColumn(trans.get("simpanel.col.Velocityatdeploy"), UnitGroup.UNITS_VELOCITY) {
+						@Override
+						public Double valueAt(int row) {
+							if (row < 0 || row >= document.getSimulationCount())
+								return null;
+
+							FlightData data = document.getSimulation(row).getSimulatedData();
+							if (data == null)
+								return null;
+
+							return data.getDeploymentVelocity();
+						}
+					},
+
+					//// Deployment Time from Apogee
+					new ValueColumn(trans.get("simpanel.col.OptimumCoastTime"),
+							trans.get("simpanel.col.OptimumCoastTime.ttip"), UnitGroup.UNITS_SHORT_TIME) {
+						@Override
+						public Double valueAt(int row) {
+							if (row < 0 || row >= document.getSimulationCount())
+								return null;
+
+							FlightData data = document.getSimulation(row).getSimulatedData();
+							if (data == null || data.getBranchCount() == 0)
+								return null;
+
+							double val = data.getBranch(0).getOptimumDelay();
+							if (Double.isNaN(val)) {
+								return null;
+							}
+							return val;
+						}
+					},
+
+					//// Maximum velocity
+					new ValueColumn(trans.get("simpanel.col.Maxvelocity"), UnitGroup.UNITS_VELOCITY) {
+						@Override
+						public Double valueAt(int row) {
+							if (row < 0 || row >= document.getSimulationCount())
+								return null;
+
+							FlightData data = document.getSimulation(row).getSimulatedData();
+							if (data == null)
+								return null;
+
+							return data.getMaxVelocity();
+						}
+					},
+
+					//// Maximum acceleration
+					new ValueColumn(trans.get("simpanel.col.Maxacceleration"), UnitGroup.UNITS_ACCELERATION) {
+						@Override
+						public Double valueAt(int row) {
+							if (row < 0 || row >= document.getSimulationCount())
+								return null;
+
+							FlightData data = document.getSimulation(row).getSimulatedData();
+							if (data == null)
+								return null;
+
+							return data.getMaxAcceleration();
+						}
+					},
+
+					//// Time to apogee
+					new ValueColumn(trans.get("simpanel.col.Timetoapogee"), UnitGroup.UNITS_FLIGHT_TIME) {
+						@Override
+						public Double valueAt(int row) {
+							if (row < 0 || row >= document.getSimulationCount())
+								return null;
+
+							FlightData data = document.getSimulation(row).getSimulatedData();
+							if (data == null)
+								return null;
+
+							return data.getTimeToApogee();
+						}
+					},
+
+					//// Flight time
+					new ValueColumn(trans.get("simpanel.col.Flighttime"), UnitGroup.UNITS_FLIGHT_TIME) {
+						@Override
+						public Double valueAt(int row) {
+							if (row < 0 || row >= document.getSimulationCount())
+								return null;
+
+							FlightData data = document.getSimulation(row).getSimulatedData();
+							if (data == null)
+								return null;
+
+							return data.getFlightTime();
+						}
+					},
+
+					//// Ground hit velocity
+					new ValueColumn(trans.get("simpanel.col.Groundhitvelocity"), UnitGroup.UNITS_VELOCITY) {
+						@Override
+						public Double valueAt(int row) {
+							if (row < 0 || row >= document.getSimulationCount())
+								return null;
+
+							FlightData data = document.getSimulation(row).getSimulatedData();
+							if (data == null)
+								return null;
+
+							return data.getGroundHitVelocity();
+						}
+					}
+			);
+		}
+
+		@Override
+		public int getRowCount() {
+			return document.getSimulationCount();
+		}
 	}
 }

--- a/swing/src/net/sf/openrocket/gui/main/componenttree/ComponentTree.java
+++ b/swing/src/net/sf/openrocket/gui/main/componenttree/ComponentTree.java
@@ -6,6 +6,9 @@ import javax.swing.ToolTipManager;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.gui.components.BasicTree;
 
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+
 
 @SuppressWarnings("serial")
 public class ComponentTree extends BasicTree {
@@ -13,7 +16,21 @@ public class ComponentTree extends BasicTree {
 	public ComponentTree(OpenRocketDocument document) {
 		super();
 		this.setModel(new ComponentTreeModel(document.getRocket(), this));
-		
+
+		addKeyListener(new KeyListener() {
+			@Override
+			public void keyTyped(KeyEvent e) { }
+
+			@Override
+			public void keyPressed(KeyEvent e) {
+				if ((e.getKeyCode() == KeyEvent.VK_A) && ((e.getModifiersEx() & KeyEvent.META_DOWN_MASK) != 0)) {
+					setSelectionInterval(1, getRowCount());		// Don't select the rocket (row 0)
+				}
+			}
+
+			@Override
+			public void keyReleased(KeyEvent e) { }
+		});
 		this.setCellRenderer(new ComponentTreeRenderer());
 		
 		this.setDragEnabled(true);


### PR DESCRIPTION
This PR fixes #1549 and allows all elements of the simulation table to be selected with the ctrl/cmd + A command. The same shortcut also works in the component tree, where all components are selected, except for the rocket.

I also noticed a bug in the simulation table where if you select e.g. row 1, then row 2, the plot button was disabled, as should be, but if you would then deselect row 1, then the button's status did not re-enable. This is fixed now in this PR. I also disabled the 'Edit simulation' when multiple simulations are selected. The 'plot' and 'edit' context menu items are now also disabled when multiple simulations are selected.

While working on the previous bug, I also noticed that the 'Edit', 'Delete' and 'Duplicate' button in the home screen (next to the component tree) had a smaller text than the move up/down buttons above. I think this was only macOS specific, but in any case this PR fixes that.