### PR TITLE
Mark the snap grade as stable

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: openrocket
 adopt-info: openrocket
-grade: devel
+grade: stable
 summary: A free, fully featured model rocket simulator.
 description: |
   OpenRocket is a free, fully featured model rocket simulator that allows you
@@ -77,6 +77,7 @@ parts:
     prime:
       - -usr/lib/jvm/java-*/lib/security/cacerts
       - -usr/lib/jvm/java-*/jre/lib/security/cacerts
+      - -usr/lib/jvm/java-*/lib/security/blacklisted.certs
 
   launcher:
     plugin: dump


### PR DESCRIPTION
The grade of the snap is marked as devel, which is great while the
app is being developed but means that the snap is not eligible to be
published to candidate or stable release channels. This change marks
the snap grade as stable to allow it to be released.

Additionally, the automatic snap publishing that happens for each
commit pushed to the unstable branch has been failing to release
the snap revisions due to a symlink introduced in the openjdk package
for which leaves a dangling symlink certs. The blacklisted.certs
should be now contained in blocked.certs so we add that to the list
of files to remove when being primed (final preparation for snap
packaging).

Fixes #1384

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>