### PR TITLE
[#1561] Such a stupid bug....

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/MotorChooserDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/MotorChooserDialog.java
@@ -91,7 +91,7 @@ public class MotorChooserDialog extends JDialog implements CloseableDialog {
 		// Set the closeable dialog after all initialization
 		selectionPanel.setCloseableDialog(this);
 
-		GUIUtil.setDisposableDialogOptions(this, cancelButton);
+		GUIUtil.setWindowIcons(this);
 	}
 	
 	public void setMotorMountAndConfig( FlightConfigurationId _fcid, MotorMount _mount ) {


### PR DESCRIPTION
As the title dictates, very stupid bug. When implementing the window icon in #1447, I recycled some code from another window that has the window icon. So instead of using `GUIUtil.setDisposableDialogOptions`, `GUIUtil.setWindowIcons` should be used. This PR fixes #1561 and fixes #1554.