### PR TITLE
When sitting on the ground, advance simulation time to next event time

### DIFF
--- a/core/src/net/sf/openrocket/simulation/GroundStepper.java
+++ b/core/src/net/sf/openrocket/simulation/GroundStepper.java
@@ -20,5 +20,6 @@ public class GroundStepper extends AbstractSimulationStepper {
 	@Override
 	public void step(SimulationStatus status, double timeStep) throws SimulationException {
 		log.trace("step:  position=" + status.getRocketPosition() + ", velocity=" + status.getRocketVelocity());
+		status.setSimulationTime(status.getSimulationTime() + timeStep);
 	}
 }


### PR DESCRIPTION
This addresses the bug @hcraigmiller found while investigating issue #1569 , where simulating a rocket that never cleared the launch rod would go into an infinite loop that would continue until the user killed the simulation.  More generally, it turns out that if there were events in the event queue after ground hit time, the ground stepper would never advance the simulation time to the next event.  This PR modifies the ground stepper to do that.

Design demonstrating the issue and solution:  
[underpowered.zip](https://github.com/openrocket/openrocket/files/9230019/underpowered.zip)

I don't fully understand the bug originally reported in #1569, but it was pretty clearly something else.  So this doesn't fix that issue.
