### PR TITLE
If we don't have any events left in the queue, shouldn't advance time

### DIFF
--- a/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
+++ b/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
@@ -130,8 +130,8 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 				double oldAlt = currentStatus.getRocketPosition().z;
 				
 				if (SimulationListenerHelper.firePreStep(currentStatus)) {
-					// Step at most to the next event
-					double maxStepTime = Double.MAX_VALUE;
+					// Step at most to the next event.  If there is no next event, don't step time
+					double maxStepTime = 0.0;
 					FlightEvent nextEvent = currentStatus.getEventQueue().peek();
 					if (nextEvent != null) {
 						maxStepTime = MathUtil.max(nextEvent.getTime() - currentStatus.getSimulationTime(), 0.001);


### PR DESCRIPTION
Fixes #1575.
