### PR TITLE
[#1305] Bigger default preset window size + remember column width

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/EditDecalDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/EditDecalDialog.java
@@ -163,9 +163,11 @@ public class EditDecalDialog extends JDialog {
 		panel.add(cancelButton, "tag cancel");
 		
 		this.add(panel);
-		
-		GUIUtil.rememberWindowSize(this);
+
 		GUIUtil.setDisposableDialogOptions(this, okButton);
+		GUIUtil.rememberWindowSize(this);
+		this.setLocationByPlatform(true);
+		GUIUtil.rememberWindowPosition(this);
 		
 	}
 	

--- a/swing/src/net/sf/openrocket/gui/dialogs/optimization/OptimizationPlotDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/optimization/OptimizationPlotDialog.java
@@ -116,6 +116,8 @@ public class OptimizationPlotDialog extends JDialog {
 		
 		GUIUtil.setDisposableDialogOptions(this, close);
 		GUIUtil.rememberWindowSize(this);
+		this.setLocationByPlatform(true);
+		GUIUtil.rememberWindowPosition(this);
 	}
 	
 	

--- a/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
@@ -2,6 +2,7 @@ package net.sf.openrocket.gui.dialogs.preset;
 
 
 import java.awt.Dialog;
+import java.awt.Dimension;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -77,7 +78,11 @@ public class ComponentPresetChooserDialog extends JDialog {
 		this.component = component;
 		this.presetType = component.getPresetType();
 		this.presets = Application.getComponentPresetDao().listForType(component.getPresetType());
-		
+
+		if (owner.getParent() != null) {
+			this.setPreferredSize(new Dimension((int)(0.7 * owner.getParent().getWidth()), (int) (0.7 * owner.getParent().getHeight())));
+			this.setLocationRelativeTo(owner.getParent());
+		}
 		List<TypedKey<?>> displayedColumnKeys = Arrays.asList(component.getPresetType().getDisplayedColumns());
 		
 		{
@@ -138,7 +143,7 @@ public class ComponentPresetChooserDialog extends JDialog {
 		// need to create componentSelectionTable before filter checkboxes,
 		// but add to panel after
 		componentSelectionTable = new ComponentPresetTable(presetType, presets, displayedColumnKeys);
-		//		GUIUtil.setAutomaticColumnTableWidths(componentSelectionTable, 20);
+		GUIUtil.setAutomaticColumnTableWidths(componentSelectionTable, 20);
 		int w = componentSelectionTable.getRowHeight() + 4;
 		XTableColumnModel tm = componentSelectionTable.getXColumnModel();
 		//TableColumn tc = componentSelectionTable.getColumnModel().getColumn(0);
@@ -151,7 +156,7 @@ public class ComponentPresetChooserDialog extends JDialog {
 		
 		JScrollPane scrollpane = new JScrollPane();
 		scrollpane.setViewportView(componentSelectionTable);
-		panel.add(scrollpane, "grow, width 700lp, height 300lp, pushy, spanx, wrap rel");
+		panel.add(scrollpane, "grow, pushy, spanx, wrap rel");
 		
 		panel.add(new StyledLabel(String.format("<html>%s %s</html>", Chars.UP_ARROW, trans.get("lbl.favorites")), -1), "spanx, gapleft 5px, wrap para");
 		
@@ -167,9 +172,12 @@ public class ComponentPresetChooserDialog extends JDialog {
 		panel.add(closeButton, "spanx, right, tag close");
 		
 		this.add(panel);
-		
-		GUIUtil.rememberWindowSize(this);
+
 		GUIUtil.setDisposableDialogOptions(this, closeButton);
+		GUIUtil.rememberWindowSize(this);
+		this.setLocationByPlatform(true);
+		GUIUtil.rememberWindowPosition(this);
+		GUIUtil.rememberTableColumnWidths(componentSelectionTable, "Presets" + component.getClass().getCanonicalName());
 
 		updateFilters();
 	}

--- a/swing/src/net/sf/openrocket/gui/help/tours/SlideShowDialog.java
+++ b/swing/src/net/sf/openrocket/gui/help/tours/SlideShowDialog.java
@@ -94,8 +94,9 @@ public class SlideShowDialog extends JDialog {
 		addKeyActions();
 		GUIUtil.setDisposableDialogOptions(this, nextButton);
 		nextButton.grabFocus();
-		GUIUtil.rememberWindowPosition(this);
 		GUIUtil.rememberWindowSize(this);
+		this.setLocationByPlatform(true);
+		GUIUtil.rememberWindowPosition(this);
 		//		this.setAlwaysOnTop(true);
 	}
 	

--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -241,6 +241,7 @@ public class BasicFrame extends JFrame {
 		GUIUtil.rememberWindowSize(this);
 
 		this.setLocationByPlatform(true);
+		GUIUtil.rememberWindowPosition(this);
 
 		GUIUtil.setWindowIcons(this);
 

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
@@ -168,6 +168,8 @@ public class SimulationPlotDialog extends JDialog {
 		
 		GUIUtil.setDisposableDialogOptions(this, button);
 		GUIUtil.rememberWindowSize(this);
+		this.setLocationByPlatform(true);
+		GUIUtil.rememberWindowPosition(this);
 	}
 
 	private boolean doPngExport(ChartPanel chartPanel, JFreeChart chart){

--- a/swing/src/net/sf/openrocket/gui/util/GUIUtil.java
+++ b/swing/src/net/sf/openrocket/gui/util/GUIUtil.java
@@ -13,12 +13,14 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -52,9 +54,11 @@ import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.border.TitledBorder;
 import javax.swing.event.ChangeListener;
+import javax.swing.event.TableColumnModelListener;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableColumnModel;
 import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
 import javax.swing.tree.DefaultMutableTreeNode;
@@ -65,6 +69,7 @@ import javax.swing.tree.TreeSelectionModel;
 
 import net.sf.openrocket.gui.Resettable;
 import net.sf.openrocket.logging.Markers;
+import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.BugException;
 import net.sf.openrocket.util.Invalidatable;
@@ -346,6 +351,33 @@ public class GUIUtil {
 				window.setSize(dim);
 			}
 		}
+	}
+
+	public static void rememberTableColumnWidths(final JTable table, String keyName) {
+		final String key = keyName == null ? table.getClass().getName() : keyName;
+		for (int i = 0; i < table.getColumnCount(); i++) {
+			final int column = i;
+			table.getColumnModel().getColumn(i).addPropertyChangeListener(new PropertyChangeListener() {
+				@Override
+				public void propertyChange(PropertyChangeEvent evt) {
+					if (evt.getPropertyName().equals("width")) {
+						log.debug("Storing width of " + table.getName() + "-" + table.getColumnName(column) + ": " + table.getColumnModel().getColumn(column).getWidth());
+						((SwingPreferences) Application.getPreferences()).setTableColumnWidth(
+								key, column, table.getColumnModel().getColumn(column).getWidth());
+					}
+				}
+			});
+
+			final Integer width = ((SwingPreferences) Application.getPreferences()).getTableColumnWidth(
+					key, column);
+			if (width != null) {
+				table.getColumnModel().getColumn(column).setPreferredWidth(width);
+			}
+		}
+	}
+
+	public static void rememberTableColumnWidths(final JTable table) {
+		rememberTableColumnWidths(table, null);
 	}
 	
 	

--- a/swing/src/net/sf/openrocket/gui/util/SwingPreferences.java
+++ b/swing/src/net/sf/openrocket/gui/util/SwingPreferences.java
@@ -401,6 +401,34 @@ public class SwingPreferences extends net.sf.openrocket.startup.Preferences {
 		PREFNODE.node("windows").put("size." + c.getCanonicalName(), "max");
 		storeVersion();
 	}
+
+	public Integer getTableColumnWidth(String keyName, int columnIdx) {
+		String pref = PREFNODE.node("tables").get(
+				"cw." + keyName + "." + columnIdx, null);
+		if (pref == null)
+			return null;
+
+
+		try {
+			return Integer.parseInt(pref);
+		} catch (NumberFormatException e) {
+			return null;
+		}
+	}
+
+	public Integer getTableColumnWidth(Class<?> c, int columnIdx) {
+		return getTableColumnWidth(c.getCanonicalName(), columnIdx);
+	}
+
+	public void setTableColumnWidth(String keyName, int columnIdx, Integer width) {
+		PREFNODE.node("tables").put(
+				"cw." + keyName + "." + columnIdx, width.toString());
+		storeVersion();
+	}
+
+	public void setTableColumnWidth(Class<?> c, int columnIdx, Integer width) {
+		setTableColumnWidth(c.getCanonicalName(), columnIdx, width);
+	}
 	
 	/**
 	 * this class returns a java.awt.Color object for the specified key.


### PR DESCRIPTION
This PR fixes #1305 by adding the following changes to the preset dialog UI:
- By default larger window size (based on the size of BasicFrame - the main OR window)
- Rememberance of window size and location
     - The window size and location is the same for the preset dialogs accross all component types. If you change the dialog size in the body tube preset dialog, then that same window size will be used for the nose cone preset dialog. Seems like the most reasonable approach to me.
- Rememberance of column widths
     - This is custom for each different preset dialog. Changing e.g. the width of the second column in the body tube dialog does not alter the second column width in the nose cone preset dialog.

Demo:

https://user-images.githubusercontent.com/11031519/184496917-b7e5f9e1-91c6-465c-a3a9-adc6f6eebb78.mp4

