### PR TITLE
[#1574] Fix motor flame lighting when no motor

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
@@ -305,6 +305,9 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 		
 		while (!toProcess.isEmpty()) {
 			RocketComponent comp = toProcess.poll();
+			if (comp == null) {
+				continue;
+			}
 			
 			toReturn.add(comp);
 			for (RocketComponent child : comp.getChildren()) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/DebugLogDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/DebugLogDialog.java
@@ -381,7 +381,7 @@ public class DebugLogDialog extends JDialog {
 		});
 		
 		GUIUtil.setDisposableDialogOptions(this, close);
-		setLocationRelativeTo(null);
+		setLocationRelativeTo(parent);
 		followBox.requestFocus();
 	}
 	

--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoPanel.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoPanel.java
@@ -393,7 +393,7 @@ public class PhotoPanel extends JPanel implements GLEventListener {
 
 		gl.glTranslated(dx - p.getAdvance(), 0, 0);
 
-		if (p.isFlame()) {
+		if (p.isFlame() && configuration.hasMotors()) {
 			convertColor(p.getFlameColor(), color);
 
 			gl.glLightfv(GLLightingFunc.GL_LIGHT2, GLLightingFunc.GL_AMBIENT,


### PR DESCRIPTION
This PR fixes part of #1574, namely now there will no more flame lighting when the rocket has no motors.

The other part of #1574 that needs to be fixed is while PhotoStudio is active, and you add a new configuration with a motor, that motor is not drawn in PhotoStudio. Only if you close PhotoStudio and reopen it, the motor becomes visible. I will not handle a fix for that in this PR.