### PR TITLE
[#411] Improvements to scale dialog

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/ScaleDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/ScaleDialog.java
@@ -193,6 +193,7 @@ public class ScaleDialog extends JDialog {
 	
 	
 	private final DoubleModel multiplier = new DoubleModel(1.0, UnitGroup.UNITS_RELATIVE, SCALE_MIN, SCALE_MAX);
+	private UnitSelector multiplierUnit;
 	private final DoubleModel fromField = new DoubleModel(0, UnitGroup.UNITS_LENGTH, 0);
 	private final DoubleModel toField = new DoubleModel(0, UnitGroup.UNITS_LENGTH, 0);
 	
@@ -384,9 +385,9 @@ public class ScaleDialog extends JDialog {
 		spin.setToolTipText(tip);
 		panel.add(spin, "w :30lp:65lp");
 		
-		UnitSelector unit = new UnitSelector(multiplier);
-		unit.setToolTipText(tip);
-		panel.add(unit, "w 30lp");
+		multiplierUnit = new UnitSelector(multiplier);
+		multiplierUnit.setToolTipText(tip);
+		panel.add(multiplierUnit, "w 30lp");
 		BasicSlider slider = new BasicSlider(multiplier.getSliderModel(0.25, 1.0, 4.0));
 		slider.setToolTipText(tip);
 		panel.add(slider, "w 100lp, growx, wrap para");
@@ -402,8 +403,8 @@ public class ScaleDialog extends JDialog {
 		spin.setEditor(new SpinnerEditor(spin));
 		spin.setToolTipText(tip);
 		panel.add(spin, "span, split, w :30lp:65lp");
-		
-		unit = new UnitSelector(fromField);
+
+		UnitSelector unit = new UnitSelector(fromField);
 		unit.setToolTipText(tip);
 		panel.add(unit, "w 30lp");
 		
@@ -481,7 +482,11 @@ public class ScaleDialog extends JDialog {
 	private void doScale() {
 		double mul = multiplier.getValue();
 		if (!(SCALE_MIN <= mul && mul <= SCALE_MAX)) {
-			Application.getExceptionHandler().handleErrorCondition("Illegal multiplier value, mul=" + mul);
+			if (multiplierUnit == null) {
+				Application.getExceptionHandler().handleErrorCondition("Illegal multiplier value, mul=" + mul);
+			} else {
+				Application.getExceptionHandler().handleErrorCondition("Illegal multiplier value, mul=" + multiplierUnit.getSelectedUnit().toStringUnit(mul));
+			}
 			return;
 		}
 		

--- a/swing/src/net/sf/openrocket/gui/dialogs/ScaleDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/ScaleDialog.java
@@ -383,7 +383,7 @@ public class ScaleDialog extends JDialog {
 		JSpinner spin = new JSpinner(multiplier.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		spin.setToolTipText(tip);
-		panel.add(spin, "w :30lp:65lp");
+		panel.add(spin, "wmin 40lp, growx 1000");
 		
 		multiplierUnit = new UnitSelector(multiplier);
 		multiplierUnit.setToolTipText(tip);
@@ -402,7 +402,7 @@ public class ScaleDialog extends JDialog {
 		spin = new JSpinner(fromField.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		spin.setToolTipText(tip);
-		panel.add(spin, "span, split, w :30lp:65lp");
+		panel.add(spin, "span, split, wmin 40lp, growx 1000");
 
 		UnitSelector unit = new UnitSelector(fromField);
 		unit.setToolTipText(tip);
@@ -415,7 +415,7 @@ public class ScaleDialog extends JDialog {
 		spin = new JSpinner(toField.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		spin.setToolTipText(tip);
-		panel.add(spin, "w :30lp:65lp");
+		panel.add(spin, "wmin 40lp, growx 1000");
 		
 		unit = new UnitSelector(toField);
 		unit.setToolTipText(tip);


### PR DESCRIPTION
This PR fixes #411 by displaying the scale dialog error message in terms of the currently selected unit + the spinner widgets now have a larger width.