### PR TITLE
[#1227] Fix fin root edge display in 3D view and fin template

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -1244,7 +1244,7 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 		// for anything more complicated, increase the count: 
 		if ((body instanceof Transition) && (((Transition)body).getType() != Shape.CONICAL)) {
 			// the maximum precision to enforce when calculating the areas of fins (especially on curved parent bodies)
-			final double xWidth = 0.005; // width (in meters) of each individual iteration
+			final double xWidth = 0.0025; // width (in meters) of each individual iteration
 			divisionCount = (int) Math.ceil(intervalLength / xWidth);
 			
 			// When creating body curves, don't create more than this many divisions. -- only relevant on very large components
@@ -1271,7 +1271,8 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 			points[lastIndex] = points[lastIndex].setX(body.getLength()).setY(body.getAftRadius());
 		}
 
-		if( 0.0000001 < (Math.abs(xOffset) + Math.abs(yOffset))){
+		// translate the points if needed
+		if ((Math.abs(xOffset) + Math.abs(yOffset)) > 0.0000001) {
 			points = translatePoints(points, xOffset, yOffset);
 		}
 

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -1232,36 +1232,37 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 	 * @return points representing the mount's points
 	 */
 	private Coordinate[] getMountPoints(final double xStart, final double xEnd, final double xOffset, final double yOffset) {
-		if( null == parent){
+		if (parent == null) {
 			return new Coordinate[]{Coordinate.ZERO};
 		}
 
-		// for a simple bodies, one increment is perfectly accurate.
+		// for a simple body, one increment is perfectly accurate.
 		int divisionCount = 1;
-		// cast-assert
 		final SymmetricComponent body = (SymmetricComponent) getParent();
+		final double intervalLength = xEnd - xStart;
 
 		// for anything more complicated, increase the count: 
-		if( ( body instanceof Transition) && ( ((Transition)body).getType() != Shape.CONICAL )){
-			// the maximum precision to enforce when calculating the areas of fins ( especially on curved parent bodies)
-			final double xWidth = 0.005; // width of each individual iteration
-			divisionCount = (int)Math.ceil(  (xEnd - xStart) / xWidth );
+		if ((body instanceof Transition) && (((Transition)body).getType() != Shape.CONICAL)) {
+			// the maximum precision to enforce when calculating the areas of fins (especially on curved parent bodies)
+			final double xWidth = 0.005; // width (in meters) of each individual iteration
+			divisionCount = (int) Math.ceil(intervalLength / xWidth);
 			
 			// When creating body curves, don't create more than this many divisions. -- only relevant on very large components
 			final int maximumBodyDivisionCount = 100;
-			divisionCount = Math.min( maximumBodyDivisionCount, divisionCount);
+			divisionCount = Math.min(maximumBodyDivisionCount, divisionCount);
 		}
-		
-		final double intervalLength = xEnd - xStart;
-		double increment = (intervalLength)/divisionCount;
-				
+
+		// Recalculate the x step increment, now with the (rounded) division count.
+		double xIncrement = intervalLength / divisionCount;
+
+		// Create the points: step through the radius of the parent
 		double xCur = xStart;
 		Coordinate[] points = new Coordinate[divisionCount+1];
-		for( int index = 0; index < points.length; index++){
-			double yCur = body.getRadius( xCur );
-			points[index]=new Coordinate( xCur, yCur);
+		for (int index = 0; index < points.length; index++) {
+			double yCur = body.getRadius(xCur);
+			points[index] = new Coordinate(xCur, yCur);
 			
-			xCur += increment;
+			xCur += xIncrement;
 		}
 
 		// correct last point, if beyond a rounding error from body's end.

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -963,8 +963,10 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 				MathUtil.equals(getTabLength(), 0)){
 			return new Coordinate[]{};
 		}
+
+		Coordinate[] rootPoints = getRootPoints();
 	
-		final int pointCount = 5;
+		final int pointCount = 5 + rootPoints.length;
 		Coordinate[] points = new Coordinate[pointCount];
 		final Coordinate finFront = this.getFinFront();
 		
@@ -987,7 +989,10 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 		points[1] = new Coordinate(xTabFront, yTabBottom );
 		points[2] = new Coordinate(xTabTrail, yTabBottom );
 		points[3] = new Coordinate(xTabTrail, yTabTrail);
-		points[4] = new Coordinate(xTabFront, yTabFront);
+		for (int i = 0; i < rootPoints.length; i++) {
+			points[i + 4] = rootPoints[rootPoints.length - 1 -i];
+		}
+		points[pointCount - 1] = new Coordinate(xTabFront, yTabFront);
 
 		return points;
 	}

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -1009,7 +1009,8 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 	 * but the minor performance hit is not worth the code complexity of dealing with.
 	 */
 	public Coordinate[] getFinPointsWithTab() {
-		return combineCurves(getFinPoints(), getTabPoints());
+		Coordinate[] temp = combineCurves(getFinPoints(), getRootPoints());
+		return combineCurves(temp, getTabPoints());
 	}
 	
 	@Override

--- a/swing/src/net/sf/openrocket/gui/print/PrintableFinSet.java
+++ b/swing/src/net/sf/openrocket/gui/print/PrintableFinSet.java
@@ -48,7 +48,7 @@ public class PrintableFinSet extends AbstractPrintable<FinSet> {
 
         Coordinate[] points = component.getFinPointsWithTab();
 
-        polygon = new GeneralPath(GeneralPath.WIND_EVEN_ODD, points.length);
+        polygon = new GeneralPath(GeneralPath.WIND_NON_ZERO, points.length);
         polygon.moveTo(0, 0);
 
         minX = 0;
@@ -57,8 +57,8 @@ public class PrintableFinSet extends AbstractPrintable<FinSet> {
         int maxY = 0;
 
         for (Coordinate point : points) {
-            final long x = (long)PrintUnit.METERS.toPoints(point.x);
-            final long y = (long)PrintUnit.METERS.toPoints(point.y);
+            final float x = (float) PrintUnit.METERS.toPoints(point.x);
+            final float y = (float) PrintUnit.METERS.toPoints(point.y);
             minX = (int) Math.min(x, minX);
             minY = (int) Math.min(y, minY);
             maxX = (int) Math.max(x, maxX);

--- a/swing/src/net/sf/openrocket/gui/scalefigure/FinPointFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/FinPointFigure.java
@@ -178,14 +178,15 @@ public class FinPointFigure extends AbstractScaleFigure {
 		// vv in fin-frame == draw-frame vv
 		final double xOffset = -xFinStart;
 		final double yOffset = -body.getRadius(xFinStart);
+		final float length_m = (float)( body.getLength());
 
 		Path2D.Double bodyShape = new Path2D.Double();
 		// draw front-cap:
 		bodyShape.moveTo( xOffset, yOffset);
 		bodyShape.lineTo( xOffset, yOffset + body.getForeRadius());
 
-		final float length_m = (float)( body.getLength());
-		Point2D.Double cur = new Point2D.Double ();
+		// draw edge
+		Point2D.Double cur = new Point2D.Double();
 		for( double xBody = xResolution_m ; xBody < length_m;  xBody += xResolution_m ){
 			// xBody is distance from front of parent body
 			cur.x = xOffset + xBody; // offset from origin (front of fin)


### PR DESCRIPTION
This PR fixes #1227. The root edge of a fin set now correctly outlines a transition's shape both in the 3D view and in the fin template export. Besides the fins, the fin tabs also weren't drawn correctly (neither in the 2D view, nor in the 3D view - the fin tab root edge was always just a straight line). This PR solves that issue as well.

Demo (with a transparent transition):

https://user-images.githubusercontent.com/11031519/185255413-d52b3dcc-c1fa-4c30-9025-a2d433d4c4f4.mp4



Fin template export also works with fin tabs:
<img width="753" alt="Screenshot 2022-08-18 at 00 27 28" src="https://user-images.githubusercontent.com/11031519/185255365-d7e96927-d0d7-422d-9ab3-bd4e1f6be7da.png">

