### PR TITLE
[#1592] Update recovery altitude slider state

### DIFF
--- a/swing/src/net/sf/openrocket/gui/configdialog/ParachuteConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/ParachuteConfig.java
@@ -3,6 +3,8 @@ package net.sf.openrocket.gui.configdialog;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 
 import javax.swing.ComboBoxModel;
 import javax.swing.JButton;
@@ -221,6 +223,12 @@ public class ParachuteConfig extends RecoveryDeviceConfig {
 			//	This is the bottom stage:  Restrict deployment options.
 			eventCombo.removeItem( DeployEvent.LOWER_STAGE_SEPARATION );
 		}
+		eventCombo.addItemListener(new ItemListener() {
+			@Override
+			public void itemStateChanged(ItemEvent e) {
+				updateFields();
+			}
+		});
 		panel.add(eventCombo, "spanx 3, growx, wrap");
 		
 		// ... and delay

--- a/swing/src/net/sf/openrocket/gui/configdialog/RecoveryDeviceConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RecoveryDeviceConfig.java
@@ -28,7 +28,7 @@ public abstract class RecoveryDeviceConfig extends RocketComponentConfig {
 	public void updateFields() {
 		super.updateFields();
 		
-		if (altitudeComponents == null)
+		if (altitudeComponents == null || altitudeComponents.size() == 0)
 			return;
 		
 		boolean enabled = (((RecoveryDevice) component).getDeploymentConfigurations().getDefault().getDeployEvent() == DeployEvent.ALTITUDE);

--- a/swing/src/net/sf/openrocket/gui/configdialog/StreamerConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/StreamerConfig.java
@@ -3,6 +3,8 @@ package net.sf.openrocket.gui.configdialog;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
@@ -204,6 +206,12 @@ public class StreamerConfig extends RecoveryDeviceConfig {
 			//	This is the bottom stage.  restrict deployment options.
 			eventCombo.removeItem( DeployEvent.LOWER_STAGE_SEPARATION );
 		}
+		eventCombo.addItemListener(new ItemListener() {
+			@Override
+			public void itemStateChanged(ItemEvent e) {
+				updateFields();
+			}
+		});
 		panel.add( eventCombo, "spanx 3, growx, wrap");
 		
 		// ... and delay


### PR DESCRIPTION
This PR fixes #1592 and updates the altitude widgets enable/disable state in the parachute and streamer config dialog, when the 'Deploys at' setting is changed.