### PR TITLE
[#1315] Update auto length in MassObject

### DIFF
--- a/core/src/net/sf/openrocket/file/openrocket/savers/MassObjectSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/savers/MassObjectSaver.java
@@ -13,7 +13,7 @@ public class MassObjectSaver extends InternalComponentSaver {
 
 		MassObject mass = (MassObject) c;
 
-		elements.add("<packedlength>" + mass.getLength() + "</packedlength>");
+		elements.add("<packedlength>" + mass.getLengthNoAuto() + "</packedlength>");
 		if (mass.isRadiusAutomatic()) {
 			elements.add("<packedradius>auto " + mass.getRadiusNoAuto() + "</packedradius>");
 		} else {

--- a/core/src/net/sf/openrocket/file/rocksim/export/BasePartDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/BasePartDTO.java
@@ -84,7 +84,7 @@ public abstract class BasePartDTO {
         setKnownCG(ec.getOverrideCGX() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
         setKnownMass(ec.getMass() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
 
-        if (!(ec instanceof FinSet || ec instanceof MassObject)) {
+        if (!(ec instanceof FinSet)) {
             setLen(ec.getLength() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
         }
         setUseKnownCG(ec.isCGOverridden() || ec.isMassOverridden() ? 1 : 0);
@@ -146,10 +146,6 @@ public abstract class BasePartDTO {
             RingComponent rc = (RingComponent)ec;
             setRadialAngle(rc.getRadialDirection());
             setRadialLoc(rc.getRadialPosition() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
-        }
-
-        if (ec instanceof MassObject) {
-            setLen(((MassObject)ec).getLengthNoAuto() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
         }
     }
 

--- a/core/src/net/sf/openrocket/file/rocksim/export/BasePartDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/BasePartDTO.java
@@ -12,6 +12,7 @@ import net.sf.openrocket.file.rocksim.RocksimLocationMode;
 import net.sf.openrocket.file.rocksim.importt.BaseHandler;
 import net.sf.openrocket.rocketcomponent.ExternalComponent;
 import net.sf.openrocket.rocketcomponent.FinSet;
+import net.sf.openrocket.rocketcomponent.MassObject;
 import net.sf.openrocket.rocketcomponent.RecoveryDevice;
 import net.sf.openrocket.rocketcomponent.RingComponent;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
@@ -83,7 +84,7 @@ public abstract class BasePartDTO {
         setKnownCG(ec.getOverrideCGX() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
         setKnownMass(ec.getMass() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
 
-        if (! (ec instanceof FinSet)) {
+        if (!(ec instanceof FinSet || ec instanceof MassObject)) {
             setLen(ec.getLength() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
         }
         setUseKnownCG(ec.isCGOverridden() || ec.isMassOverridden() ? 1 : 0);
@@ -145,6 +146,10 @@ public abstract class BasePartDTO {
             RingComponent rc = (RingComponent)ec;
             setRadialAngle(rc.getRadialDirection());
             setRadialLoc(rc.getRadialPosition() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+        }
+
+        if (ec instanceof MassObject) {
+            setLen(((MassObject)ec).getLengthNoAuto() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
         }
     }
 

--- a/core/src/net/sf/openrocket/rocketcomponent/MassObject.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/MassObject.java
@@ -77,7 +77,10 @@ public abstract class MassObject extends InternalComponent {
 			// Calculate the parachute volume using the auto radius and the new "auto" length, and transform that back
 			// to the non auto radius situation to set this.length (the volume in both situations is the same).
 			double parachuteVolume = Math.pow(getRadius(), 2) * length;		// Math.PI left out, not needed
-			this.length = parachuteVolume / Math.pow(this.radius, 2);
+			double newLength = parachuteVolume / Math.pow(this.radius, 2);
+			if (MathUtil.equals(this.length, newLength))
+				return;
+			this.length = newLength;
 		} else {
 			if (MathUtil.equals(this.length, length)) {
 				return;

--- a/core/src/net/sf/openrocket/rocketcomponent/MassObject.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/MassObject.java
@@ -50,7 +50,21 @@ public abstract class MassObject extends InternalComponent {
 		return false;
 	}
 
-	
+	@Override
+	public double getLength() {
+		if (this.autoRadius) {
+			// Calculate the parachute volume using the non auto radius and the non auto length, and transform that back
+			// to the auto radius situation to get the auto radius length (the volume in both situations is the same).
+			double parachuteVolume = Math.pow(this.radius, 2) * this.length;	// Math.PI left out, not needed
+			return parachuteVolume / Math.pow(getRadius(), 2);
+		}
+		return length;
+	}
+
+	public double getLengthNoAuto() {
+		return length;
+	}
+
 	public void setLength(double length) {
 		for (RocketComponent listener : configListeners) {
 			if (listener instanceof MassObject) {
@@ -59,10 +73,17 @@ public abstract class MassObject extends InternalComponent {
 		}
 
 		length = Math.max(length, 0);
-		if (MathUtil.equals(this.length, length)) {
-			return;
+		if (this.autoRadius) {
+			// Calculate the parachute volume using the auto radius and the new "auto" length, and transform that back
+			// to the non auto radius situation to set this.length (the volume in both situations is the same).
+			double parachuteVolume = Math.pow(getRadius(), 2) * length;		// Math.PI left out, not needed
+			this.length = parachuteVolume / Math.pow(this.radius, 2);
+		} else {
+			if (MathUtil.equals(this.length, length)) {
+				return;
+			}
+			this.length = length;
 		}
-		this.length = length;
 		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
 	}
 	
@@ -114,8 +135,8 @@ public abstract class MassObject extends InternalComponent {
 
 	public void setRadiusAutomatic(boolean auto) {
 		for (RocketComponent listener : configListeners) {
-			if (listener instanceof Parachute) {
-				((Parachute) listener).setRadiusAutomatic(auto);
+			if (listener instanceof MassObject) {
+				((MassObject) listener).setRadiusAutomatic(auto);
 			}
 		}
 
@@ -123,6 +144,10 @@ public abstract class MassObject extends InternalComponent {
 			return;
 
 		autoRadius = auto;
+
+		// Set the length
+		double parachuteVolume = (Math.PI * Math.pow(getRadius(), 2) * length);
+		length = parachuteVolume / (Math.PI * Math.pow(getRadius(), 2));
 
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}

--- a/core/src/net/sf/openrocket/rocketcomponent/Parachute.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Parachute.java
@@ -18,8 +18,6 @@ public class Parachute extends RecoveryDevice {
 	private int lineCount;
 	private final double DEFAULT_LINE_LENGTH = 0.3;
 	private double lineLength;
-	private final double InitialPackedLength = this.length;
-	private final double InitialPackedRadius = this.radius;
 
 	public Parachute() {
 		this.diameter = DEFAULT_DIAMETER;
@@ -213,23 +211,15 @@ public class Parachute extends RecoveryDevice {
 
 		//	//	Set preset parachute packed length
 		if ((preset.has(ComponentPreset.PACKED_LENGTH)) && preset.get(ComponentPreset.PACKED_LENGTH) > 0) {
-			this.PackedLength = preset.get(ComponentPreset.PACKED_LENGTH);
-			length = PackedLength;
-		} else {
-			length = InitialPackedLength;
+			length = preset.get(ComponentPreset.PACKED_LENGTH);
 		}
 		//	// Set preset parachute packed diameter
 		if ((preset.has(ComponentPreset.PACKED_DIAMETER)) && preset.get(ComponentPreset.PACKED_DIAMETER) > 0) {
-			this.PackedDiameter = preset.get(ComponentPreset.PACKED_DIAMETER);
-			radius = PackedDiameter / 2;
-		} else {
-			radius = InitialPackedRadius;
+			radius = preset.get(ComponentPreset.PACKED_DIAMETER) / 2;
 		}
 		//	// Size parachute packed diameter within parent inner diameter
 		if (length > 0 && radius > 0) {
-			double parachuteVolume = (Math.PI * Math.pow(radius, 2) * length);
 			setRadiusAutomatic(true);
-			length = parachuteVolume / (Math.PI * Math.pow(getRadius(), 2));
 		}
 
 		// SUBSTITUTE / ACTIVATE Override Mass Preset

--- a/core/src/net/sf/openrocket/rocketcomponent/RecoveryDevice.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RecoveryDevice.java
@@ -20,9 +20,6 @@ import net.sf.openrocket.util.MathUtil;
  */
 public abstract class RecoveryDevice extends MassObject implements FlightConfigurableComponent {
 	////
-	protected double PackedDiameter;
-	protected double PackedLength;
-	////
 	protected double DragCoefficient;
 	protected double cd = Parachute.DEFAULT_CD;
 	protected boolean cdAutomatic = true;


### PR DESCRIPTION
This PR fixes #1315. New behavior for all mass objects:

- If the 'Auto' checkbox at (packed) diameter is unchecked:
     - No special behavior; you can just edit the diameter and length as you please
- If you then enable the 'Auto' checkbox:
    - The diameter will change to fit the parent component
    - The length will change in such a way that the (packed) volume after enabling the 'Auto' checkbox is the same as the (packed) volume before enabling the checkbox. E.g. if the diameter is 5 cm before, length 5 cm (volume of 98.17 cm^3), enabling the 'Auto' checkbox changes the diameter to 10 cm, and the length to 1.25 cm (volume still 98.17 cm^3)
    - You can still change the length in the auto mode, but this will now change the volume of the (packed) mass object. So let's say the diameter in auto mode was 10 cm and the length 1.25 cm, if you now set the length to 2.5 cm, the volume changes to 196.35 cm^3. If you now disable the auto setting, again, the volume between auto-mode and non auto-mode will be preserved. So after disabling the 'Auto' checkbox, the diameter falls back to 5 cm, and to keep the volume at 196.35 cm^3, the length will be set to 10 cm.
    - When changing the parent diameter, the volume of the mass object will also be preserverd, so the length of the mass object dynamically changes with the (auto) diameter

In short: there is a preservation of the mass object's volume when converting from auto mode to non auto mode and vice versa. There is a preservation of volume when in auto mode and the parent's diameter is altered.

Demo:

https://user-images.githubusercontent.com/11031519/185869289-ef9d5bdf-090a-4593-9176-3b71b1d6a7c4.mp4

