### PR TITLE
[#1603] Fix fin set tab height validation + dynamic max slider value

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -309,7 +309,8 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 		}
 		
 		tabHeight = newTabHeight;
-		validateFinTabHeight();
+		double maxTabHeight = getMaxTabHeight();
+		this.tabHeight = Math.min(this.tabHeight,  maxTabHeight);
 		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
 	}
 	
@@ -424,10 +425,14 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 		
 		//System.err.println(String.format("    << Fin Tab Length: %.6f @ %.6f", tabLength, tabOffset));
 	}
-	
-	public void validateFinTabHeight(){
+
+	/**
+	 * Calculates the maximum height that the fin tabs can be, depending on the parent shape.
+	 * @return maximum tab height value
+	 */
+	public double getMaxTabHeight() {
 		// check tab height 
-		if( null != getParent() ){
+		if (null != getParent() ){
 			final Coordinate finFront = this.getFinFront();
 
 			// pulls the parent-body radius at the fin-tab reference point.
@@ -435,11 +440,9 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 			final double xTrail = this.getTabTrailingEdge();
 			
 			final SymmetricComponent sym = (SymmetricComponent)this.parent;
-			final double bodyRadius = MathUtil.min(sym.getRadius(finFront.x + xLead), sym.getRadius(finFront.x + xTrail));
-			
-			// limit the new heights to be no greater than the current body radius.
-			this.tabHeight = Math.min( this.tabHeight,  bodyRadius );
+			return MathUtil.min(sym.getRadius(finFront.x + xLead), sym.getRadius(finFront.x + xTrail));
 		}
+		return Double.MAX_VALUE;
 	}
 	
 	///////////  Calculation methods  //////////

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -428,12 +428,14 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 	public void validateFinTabHeight(){
 		// check tab height 
 		if( null != getParent() ){
+			final Coordinate finFront = this.getFinFront();
+
 			// pulls the parent-body radius at the fin-tab reference point.
 			final double xLead = this.getTabFrontEdge();
 			final double xTrail = this.getTabTrailingEdge();
 			
 			final SymmetricComponent sym = (SymmetricComponent)this.parent;
-			final double bodyRadius = MathUtil.min(sym.getRadius( xLead), sym.getRadius( xTrail));
+			final double bodyRadius = MathUtil.min(sym.getRadius(finFront.x + xLead), sym.getRadius(finFront.x + xTrail));
 			
 			// limit the new heights to be no greater than the current body radius.
 			this.tabHeight = Math.min( this.tabHeight,  bodyRadius );

--- a/swing/src/net/sf/openrocket/gui/configdialog/FinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/FinSetConfig.java
@@ -34,7 +34,6 @@ import net.sf.openrocket.rocketcomponent.CenteringRing;
 import net.sf.openrocket.rocketcomponent.FinSet;
 import net.sf.openrocket.rocketcomponent.FreeformFinSet;
 import net.sf.openrocket.rocketcomponent.InnerTube;
-import net.sf.openrocket.rocketcomponent.RingComponent;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.rocketcomponent.SymmetricComponent;
 import net.sf.openrocket.rocketcomponent.position.AxialMethod;
@@ -156,16 +155,19 @@ public abstract class FinSetConfig extends RocketComponentConfig {
 		JLabel label;
 		DoubleModel length;
 		DoubleModel length2;
+		DoubleModel maxTabHeight;
 		DoubleModel length_2;
 		JSpinner spin;
 		JButton autoCalc;
 		
 		length = new DoubleModel(component, "Length", UnitGroup.UNITS_LENGTH, 0);
+		maxTabHeight = new DoubleModel(component, "MaxTabHeight", 1, UnitGroup.UNITS_LENGTH, 0);
 		length2 = new DoubleModel(component, "Length", 0.5, UnitGroup.UNITS_LENGTH, 0);
 		length_2 = new DoubleModel(component, "Length", -0.5, UnitGroup.UNITS_LENGTH, 0);
 		
 		register(length);
 		register(length2);
+		register(maxTabHeight);
 		register(length_2);
 		
 		////  Tab length
@@ -192,14 +194,14 @@ public abstract class FinSetConfig extends RocketComponentConfig {
 		label.setToolTipText(trans.get("FinSetConfig.ttip.Tabheight"));
 		panel.add(label, "gapleft para");
 		
-		final DoubleModel tabHeightModel = new DoubleModel(component, "TabHeight", UnitGroup.UNITS_LENGTH, 0);
+		final DoubleModel tabHeightModel = new DoubleModel(component, "TabHeight", UnitGroup.UNITS_LENGTH, 0, ((FinSet)component).getMaxTabHeight());
 		component.addChangeListener( tabHeightModel );
 		spin = new JSpinner(tabHeightModel.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		panel.add(spin, "growx");
 		
 		panel.add(new UnitSelector(tabHeightModel), "growx");
-		panel.add(new BasicSlider(tabHeightModel.getSliderModel(DoubleModel.ZERO, length2)),
+		panel.add(new BasicSlider(tabHeightModel.getSliderModel(DoubleModel.ZERO, maxTabHeight)),
 				"w 100lp, growx 5, wrap");
 		
 		////  Tab position:


### PR DESCRIPTION
This PR fixes #1603 by correcting the fin set tab height validation (this also fixes an issue where if the aft diameter was smaller than the fore diameter, the tabs were able to grow over the rocket's centerline and overlap with each other). I also made it so that the slider of the fin tab height now dynamically updates its maximum value (in beta 4 you could still slide the slider even though the height value got clipped e.g. halfway).