### PR TITLE
[#236] Limit simulation time step to 0.01 s

### DIFF
--- a/swing/src/net/sf/openrocket/gui/adaptors/DoubleModel.java
+++ b/swing/src/net/sf/openrocket/gui/adaptors/DoubleModel.java
@@ -773,6 +773,14 @@ public class DoubleModel implements StateChangeListener, ChangeSource, Invalidat
 	 */
 	public void setValue(double v) {
 		checkState(true);
+
+		if (v > maxValue) {
+			log.debug("Clipping value " + v + " to maximum " + maxValue + " for " + this);
+			v = maxValue;
+		} else if (v < minValue) {
+			log.debug("Clipping value " + v + " to minimum " + minValue + " for " + this);
+			v = minValue;
+		}
 		
 		log.debug("Setting value " + v + " for " + this);
 		if (setMethod == null) {

--- a/swing/src/net/sf/openrocket/gui/adaptors/DoubleModel.java
+++ b/swing/src/net/sf/openrocket/gui/adaptors/DoubleModel.java
@@ -774,12 +774,10 @@ public class DoubleModel implements StateChangeListener, ChangeSource, Invalidat
 	public void setValue(double v) {
 		checkState(true);
 
-		if (v > maxValue) {
-			log.debug("Clipping value " + v + " to maximum " + maxValue + " for " + this);
-			v = maxValue;
-		} else if (v < minValue) {
-			log.debug("Clipping value " + v + " to minimum " + minValue + " for " + this);
-			v = minValue;
+		double clampedValue = MathUtil.clamp(v, minValue, maxValue);
+		if (clampedValue != v) {
+			log.debug("Clamped value " + v + " to " + clampedValue + " for " + this);
+			v = clampedValue;
 		}
 		
 		log.debug("Setting value " + v + " for " + this);

--- a/swing/src/net/sf/openrocket/gui/dialogs/preferences/SimulationPreferencesPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preferences/SimulationPreferencesPanel.java
@@ -135,7 +135,7 @@ public class SimulationPreferencesPanel extends PreferencesPanel {
 		subsub.add(label, "gapright para");
 
 		DoubleModel m_ts = new DoubleModel(preferences, "TimeStep", UnitGroup.UNITS_TIME_STEP,
-				0, 1);
+				0.01, 1);
 
 		spin = new JSpinner(m_ts.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
@@ -145,7 +145,7 @@ public class SimulationPreferencesPanel extends PreferencesPanel {
 		unit = new UnitSelector(m_ts);
 		unit.setToolTipText(tip);
 		subsub.add(unit, "");
-		slider = new BasicSlider(m_ts.getSliderModel(0, 0.2));
+		slider = new BasicSlider(m_ts.getSliderModel(0.01, 0.2));
 		slider.setToolTipText(tip);
 		subsub.add(slider, "w 100");
 

--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationOptionsPanel.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationOptionsPanel.java
@@ -143,7 +143,7 @@ class SimulationOptionsPanel extends JPanel {
 		subsub.add(label, "gapright para");
 		
 		m = new DoubleModel(conditions, "TimeStep", UnitGroup.UNITS_TIME_STEP,
-				0, 1);
+				0.01, 1);
 		
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
@@ -153,7 +153,7 @@ class SimulationOptionsPanel extends JPanel {
 		unit = new UnitSelector(m);
 		unit.setToolTipText(tip);
 		subsub.add(unit, "");
-		slider = new BasicSlider(m.getSliderModel(0, 0.2));
+		slider = new BasicSlider(m.getSliderModel(0.01, 0.2));
 		slider.setToolTipText(tip);
 		subsub.add(slider, "w 100");
 		


### PR DESCRIPTION
This PR fixes #236 and limits the simulation time step setting to 0.01 s.

Although this is a simple PR, I did implement something that **needs testing** of whether it doesn't brake other stuff in the program. I added a check to `setValue` in `DoubleModel.java` that clips the set value to the model's maximum and minimum value. I must say I was surprised that this wasn't implemented already. The effect of this operation should be that when you type a numerical value in a spinner box and hit enter, that if that value was larger than the DoubleModel's maxValue, that the set value will be clipped to maxValue. Same goes for minValue in the other direction.