### PR TITLE
Fix pressed icon size of IconButton

### DIFF
--- a/swing/src/net/sf/openrocket/gui/widgets/IconButton.java
+++ b/swing/src/net/sf/openrocket/gui/widgets/IconButton.java
@@ -39,6 +39,13 @@ public class IconButton extends SelectColorButton {
     }
 
     @Override
+    public void setIcon(Icon defaultIcon) {
+        super.setIcon(defaultIcon);
+        // There is a bug where the normal override of the pressed icon does not work, so we have to assign it here.
+        setPressedIcon(Icons.getScaledIcon(defaultIcon, ICON_SCALE));
+    }
+
+    @Override
     public Icon getIcon() {
         return Icons.getScaledIcon(super.getIcon(), IconButton.ICON_SCALE);
     }


### PR DESCRIPTION
This PR fixes an issue in the icon buttons where pressing/holding down a button caused the button icon to jump back to its original size, instead of the intended reduced size. Probably a macOS thing...

Previous behavior:

https://user-images.githubusercontent.com/11031519/186762344-44288224-0127-491b-8107-c05d3669d92a.mov

New behavior:

https://user-images.githubusercontent.com/11031519/186762448-744e053c-9195-4674-b352-74231c480de9.mov
