### PR TITLE
[#1646] Increase fin root resolution

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -33,7 +33,7 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 	 * Maximum number of root points in the root geometry.
 	 */
 	private static final int MAX_ROOT_DIVISIONS = 100;
-	private static final int MAX_ROOT_DIVISIONS_LOW_RES = 20;
+	private static final int MAX_ROOT_DIVISIONS_LOW_RES = 15;
 
     public void setOverrideMass() {
     }

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -1073,11 +1073,12 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 		// for anything more complicated, increase the count:
 		if ((body instanceof Transition) && (((Transition)body).getType() != Shape.CONICAL)) {
 			// the maximum precision to enforce when calculating the areas of fins (especially on curved parent bodies)
-			final double xWidth = 0.005; // width (in meters) of each individual iteration
+			final double xWidth = 0.0025; // width (in meters) of each individual iteration
 			divisionCount = (int) Math.ceil(intervalLength / xWidth);
 
 			// When creating body curves, don't create more than this many divisions. -- only relevant on very large components
-			final int maximumBodyDivisionCount = 100;
+			// a too high division count will cause the 3D render to have invisible faces because it can't deal with the geometry.
+			final int maximumBodyDivisionCount = 20;
 			divisionCount = Math.min(maximumBodyDivisionCount, divisionCount);
 		}
 

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -966,6 +966,22 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 	 *
 	 * @return points representing the fin-root points, relative to ( x: fin-front, y: centerline ) i.e. relto: fin Component reference point
 	 */
+	public Coordinate[] getRootPoints(final int maximumBodyDivisionCount) {
+		if( null == parent){
+			return new Coordinate[]{Coordinate.ZERO};
+		}
+
+		final Coordinate finLead = getFinFront();
+		final double xFinEnd = finLead.x + getLength();
+
+		return getMountPoints( finLead.x, xFinEnd, -finLead.x, -finLead.y, maximumBodyDivisionCount);
+	}
+
+	/**
+	 * used to get body points for the profile design view
+	 *
+	 * @return points representing the fin-root points, relative to ( x: fin-front, y: centerline ) i.e. relto: fin Component reference point
+	 */
 	public Coordinate[] getRootPoints(){
 		if( null == parent){
 			return new Coordinate[]{Coordinate.ZERO};
@@ -982,6 +998,16 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 	 */
 	public Coordinate[] getFinPointsWithRoot() {
 		return combineCurves(getFinPoints(), getRootPoints());
+	}
+
+	/**
+	 * Return a list of coordinates defining the geometry of a single fin, including the parent's body points .
+	 *
+	 * This low res version is for 3D rendering, as a too high resolution would cause clipping and invisible fin faces.
+	 * This should at one point be solved by rendering the fin faces using triangulation, instead of how it's currently implemented.
+	 */
+	public Coordinate[] getFinPointsWithLowResRoot() {
+		return combineCurves(getFinPoints(), getRootPoints(20));
 	}
 
 	/**
@@ -1060,7 +1086,8 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 	 *
 	 * @return points representing the mount's points
 	 */
-	private Coordinate[] getMountPoints(final double xStart, final double xEnd, final double xOffset, final double yOffset) {
+	private Coordinate[] getMountPoints(final double xStart, final double xEnd, final double xOffset, final double yOffset,
+										final int maximumBodyDivisionCount) {
 		if (parent == null) {
 			return new Coordinate[]{Coordinate.ZERO};
 		}
@@ -1078,7 +1105,6 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 
 			// When creating body curves, don't create more than this many divisions. -- only relevant on very large components
 			// a too high division count will cause the 3D render to have invisible faces because it can't deal with the geometry.
-			final int maximumBodyDivisionCount = 20;
 			divisionCount = Math.min(maximumBodyDivisionCount, divisionCount);
 		}
 
@@ -1107,6 +1133,10 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 		}
 
 		return points;
+	}
+
+	private Coordinate[] getMountPoints(final double xStart, final double xEnd, final double xOffset, final double yOffset) {
+		return getMountPoints(xStart, xEnd, xOffset, yOffset, 100);
 	}
 	
 	@Override

--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -1073,7 +1073,7 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 		// for anything more complicated, increase the count:
 		if ((body instanceof Transition) && (((Transition)body).getType() != Shape.CONICAL)) {
 			// the maximum precision to enforce when calculating the areas of fins (especially on curved parent bodies)
-			final double xWidth = 0.0025; // width (in meters) of each individual iteration
+			final double xWidth = 0.005; // width (in meters) of each individual iteration
 			divisionCount = (int) Math.ceil(intervalLength / xWidth);
 
 			// When creating body curves, don't create more than this many divisions. -- only relevant on very large components

--- a/swing/src/net/sf/openrocket/gui/figure3d/geometry/FinRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/geometry/FinRenderer.java
@@ -34,7 +34,7 @@ public class FinRenderer {
 		gl.glTranslated(-bounds.min.x, -bounds.min.y - finSet.getBodyRadius(), 0);
 		gl.glMatrixMode(GLMatrixFunc.GL_MODELVIEW);
 
-		Coordinate[] finPoints = finSet.getFinPointsWithRoot();
+		Coordinate[] finPoints = finSet.getFinPointsWithLowResRoot();
 		Coordinate[] tabPoints = finSet.getTabPoints();
 
 		{

--- a/swing/src/net/sf/openrocket/gui/figure3d/geometry/FinRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/geometry/FinRenderer.java
@@ -34,8 +34,9 @@ public class FinRenderer {
 		gl.glTranslated(-bounds.min.x, -bounds.min.y - finSet.getBodyRadius(), 0);
 		gl.glMatrixMode(GLMatrixFunc.GL_MODELVIEW);
 
-		Coordinate finPoints[] = finSet.getFinPointsWithRoot();
-		Coordinate tabPoints[] = finSet.getTabPoints();
+		Coordinate[] finPoints = finSet.getFinPointsWithRoot();
+		Coordinate[] tabPoints = finSet.getTabPoints();
+
 		{
 		    gl.glPushMatrix();
             

--- a/swing/src/net/sf/openrocket/gui/figure3d/geometry/FinRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/geometry/FinRenderer.java
@@ -35,7 +35,7 @@ public class FinRenderer {
 		gl.glMatrixMode(GLMatrixFunc.GL_MODELVIEW);
 
 		Coordinate[] finPoints = finSet.getFinPointsWithLowResRoot();
-		Coordinate[] tabPoints = finSet.getTabPoints();
+		Coordinate[] tabPoints = finSet.getTabPointsLowRes();
 
 		{
 		    gl.glPushMatrix();


### PR DESCRIPTION
This PR fixes #1646. Turns out the fin root points resolution of 2.5 mm was too small. Increasing it to 5 mm appears to have solved the issue.

So fin template export will be **slightly** less smooth (see discussion [here](https://github.com/openrocket/openrocket/pull/1598#issuecomment-1218776893)).