### PR TITLE
[#1662] Fix scaling of pod axial offset + fix ThicknessRingComponent scaling down

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/PodSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/PodSet.java
@@ -1,15 +1,11 @@
 package net.sf.openrocket.rocketcomponent;
 
-import java.util.ArrayList;
-import java.util.Collection;
 
-import jdk.jshell.spi.ExecutionControl;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.rocketcomponent.position.AngleMethod;
 import net.sf.openrocket.rocketcomponent.position.AxialMethod;
 import net.sf.openrocket.rocketcomponent.position.RadiusMethod;
 import net.sf.openrocket.startup.Application;
-import net.sf.openrocket.util.BoundingBox;
 import net.sf.openrocket.util.BugException;
 import net.sf.openrocket.util.Coordinate;
 

--- a/core/src/net/sf/openrocket/rocketcomponent/PodSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/PodSet.java
@@ -8,6 +8,7 @@ import net.sf.openrocket.rocketcomponent.position.RadiusMethod;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.BugException;
 import net.sf.openrocket.util.Coordinate;
+import net.sf.openrocket.util.MathUtil;
 
 public class PodSet extends ComponentAssembly implements RingInstanceable {
 	
@@ -120,7 +121,7 @@ public class PodSet extends ComponentAssembly implements RingInstanceable {
 	
 	@Override
 	public double getAxialOffset() {
-		double returnValue = Double.NaN;
+		double returnValue;
 		
 		if (this.isAfter()){
 			// remember the implicit (this instanceof Stage)
@@ -129,7 +130,7 @@ public class PodSet extends ComponentAssembly implements RingInstanceable {
 			returnValue = super.getAxialOffset(this.axialMethod);
 		}
 		
-		if (0.000001 > Math.abs(returnValue)) {
+		if (MathUtil.EPSILON > Math.abs(returnValue)) {
 			returnValue = 0.0;
 		}
 		

--- a/swing/src/net/sf/openrocket/gui/dialogs/ScaleDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/ScaleDialog.java
@@ -133,7 +133,6 @@ public class ScaleDialog extends JDialog {
 		list = new ArrayList<>(1);
 		list.add(new MassObjectScaler());
 		SCALERS_NO_OFFSET.put(MassObject.class, list);
-		//addScaler(MassObject.class, "LengthNoAuto", SCALERS_NO_OFFSET);
 		addScaler(MassObject.class, "Radius", "isRadiusAutomatic", SCALERS_NO_OFFSET);
 		addScaler(MassObject.class, "RadialPosition", SCALERS_OFFSET);
 		
@@ -158,8 +157,9 @@ public class ScaleDialog extends JDialog {
 		addScaler(RingComponent.class, "RadialPosition", SCALERS_OFFSET);
 		
 		// ThicknessRingComponent
-		addScaler(ThicknessRingComponent.class, "OuterRadius", "isOuterRadiusAutomatic", SCALERS_NO_OFFSET);
-		addScaler(ThicknessRingComponent.class, "Thickness", SCALERS_NO_OFFSET);
+		list = new ArrayList<>(1);
+		list.add(new ThicknessRingComponentScaler());
+		SCALERS_NO_OFFSET.put(ThicknessRingComponent.class, list);
 		
 		// InnerTube
 		addScaler(InnerTube.class, "MotorOverhang", SCALERS_NO_OFFSET);
@@ -769,8 +769,28 @@ public class ScaleDialog extends JDialog {
 
 	}
 
-	private static class RailButtonScaler implements Scaler {
+	private static class ThicknessRingComponentScaler implements Scaler {
+		@Override
+		public void scale(RocketComponent component, double multiplier, boolean scaleMass) {
+			final Map<Class<? extends RocketComponent>, List<Scaler>> scalers = new HashMap<>();
+			// We need to specify this particular order, otherwise scale the inner/outer radius may clip the dimensions of the other outer/inner radius
+			if (multiplier >= 1) {			// Scale up
+				addScaler(ThicknessRingComponent.class, "OuterRadius", "isOuterRadiusAutomatic", scalers);
+				addScaler(ThicknessRingComponent.class, "Thickness", scalers);
+			} else {						// Scale down
+				addScaler(ThicknessRingComponent.class, "Thickness", scalers);
+				addScaler(ThicknessRingComponent.class, "OuterRadius", "isOuterRadiusAutomatic", scalers);
+			}
 
+			for (List<Scaler> foo : scalers.values()) {
+				for (Scaler s : foo) {
+					s.scale(component, multiplier, scaleMass);
+				}
+			}
+		}
+	}
+
+	private static class RailButtonScaler implements Scaler {
 		@Override
 		public void scale(RocketComponent component, double multiplier, boolean scaleMass) {
 			final Map<Class<? extends RocketComponent>, List<Scaler>> scalers = new HashMap<>();
@@ -795,7 +815,6 @@ public class ScaleDialog extends JDialog {
 				}
 			}
 		}
-
 	}
 	
 }


### PR DESCRIPTION
This PR fixes #1662. The issue was in the scaling order, whereby the parent component of the pod was scaled first, and then the pod (and its offset). This caused the parent reference length for the axial offset to change first, and the scaled axial offset to be calculated incorrectly. This PR first does all the component offset scalings, and only then the component dimension scalings.

I also noticed the same issue as #1653, but for ThicknessRingComponents (e.g. TubeCoupler), which this PR fixes.