### PR TITLE
Increase error margin for DisableStageTest

### DIFF
--- a/core/test/net/sf/openrocket/simulation/DisableStageTest.java
+++ b/core/test/net/sf/openrocket/simulation/DisableStageTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
  * @author Sibo Van Gool <sibo.vangool@hotmail.com>
  */
 public class DisableStageTest extends BaseTestCase {
-    private final double delta = 0.025;  // 2.5 % error margin (simulations are not exact)
+    private final double delta = 0.05;  // 5 % error margin (simulations are not exact)
 
     /**
      * Tests that the simulation results are correct when a single stage is deactivated and re-activated.


### PR DESCRIPTION
I thought the DisableStageTest was stable after #1610, but I'm still getting sporadic unit test failures (although much less than before #1610). So I'm gonna increase the error margin from 2.5% to 5%, which is still reasonable.