### PR TITLE
[#1676] Treat zero-length SymmetricComponent as tube/disk

### DIFF
--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/SymmetricComponentCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/SymmetricComponentCalc.java
@@ -56,8 +56,13 @@ public class SymmetricComponentCalc extends RocketComponentCalc {
 		SymmetricComponent component = (SymmetricComponent) c;
 
 		length = component.getLength();
-		foreRadius = component.getForeRadius();
-		aftRadius = component.getAftRadius();
+		if (length > 0) {
+			foreRadius = component.getForeRadius();
+			aftRadius = component.getAftRadius();
+		} else {	// If length is zero, the component is a disk, i.e. a zero-length tube, so match the fore and aft diameter
+			final double componentMaxR = Math.max(component.getForeRadius(), component.getAftRadius());
+			foreRadius = aftRadius = componentMaxR;
+		}
 		
 		fineness = length / (2 * Math.abs(aftRadius - foreRadius));
 		fullVolume = component.getFullVolume();

--- a/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
@@ -311,14 +311,16 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 	private void integrate() {
 		double x, r1, r2;
 		double cgx;
-		
+
+		wetArea = 0;
+		planArea = 0;
+		planCenter = 0;
+		fullVolume = 0;
+		volume = 0;
+		cg = Coordinate.NUL;
+
 		// Check length > 0
 		if (length <= 0) {
-			wetArea = 0;
-			planArea = 0;
-			planCenter = 0;
-			volume = 0;
-			cg = Coordinate.NUL;
 			return;
 		}
 		
@@ -329,11 +331,6 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 		final double pi3 = Math.PI / 3.0;
 		r1 = getRadius(0);
 		x = 0;
-		wetArea = 0;
-		planArea = 0;
-		planCenter = 0;
-		fullVolume = 0;
-		volume = 0;
 		cgx = 0;
 		
 		for (int n = 1; n <= DIVISIONS; n++) {
@@ -422,15 +419,18 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 	 */
 	private void integrateInertiaVolume() {
 		double x, r1, r2;
-		
+
+		longitudinalInertia = 0;
+		rotationalInertia = 0;
+
+		if (length <= 0) return;
+
 		final double l = length / DIVISIONS;
 		final double pil = Math.PI * l; // PI * l
 		final double pil3 = Math.PI * l / 3; // PI * l/3
 		
 		r1 = getRadius(0);
 		x = 0;
-		longitudinalInertia = 0;
-		rotationalInertia = 0;
 		
 		double vol = 0;
 		
@@ -489,14 +489,16 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 	 */
 	private void integrateInertiaSurface() {
 		double x, r1, r2;
-		
+
+		longitudinalInertia = 0;
+		rotationalInertia = 0;
+
+		if (length <= 0) return;
+
 		final double l = length / DIVISIONS;
 		
 		r1 = getRadius(0);
 		x = 0;
-		
-		longitudinalInertia = 0;
-		rotationalInertia = 0;
 		
 		double surface = 0;
 		

--- a/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
@@ -493,7 +493,6 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 		final double l = length / DIVISIONS;
 		
 		r1 = getRadius(0);
-		//System.out.println(r1);
 		x = 0;
 		
 		longitudinalInertia = 0;

--- a/core/src/net/sf/openrocket/rocketcomponent/Transition.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Transition.java
@@ -479,7 +479,7 @@ public class Transition extends SymmetricComponent implements InsideColorCompone
 	public double getRadius(double x) {
 		if ( x < 0 )
 			return getForeRadius();
-		if ( x > length)
+		if ( x >= length)
 			return getAftRadius();
 
 		double r1 = getForeRadius();


### PR DESCRIPTION
This PR fixes #1676 by setting the longitudinal and rotational inertia of a SymmetricComponent (transition/nose cone) to zero if the component length is zero. To then have the same behavior as a phantom body tube (the component acts as a disk and can still cause drag), I match the fore and aft radius to the max value of the two when the component length is zero. This is because a zero-length transition is just a disk, and a disk is just a zero-length tube. So matching the fore and aft radius will let the transition behave like a zero-length tube.