### PR TITLE
[#1617] Mark empty stages as inactive

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -64,6 +64,8 @@ RocketPanel.lbl.Stability = Stability:
 RocketPanel.checkbox.ShowCGCP = Show CG/CP
 RocketPanel.checkbox.ShowCGCP.ttip = Disabling this checkbox hides the CG and CP markings in the rocket view.
 RocketPanel.lbl.Stages = Stages:
+RocketPanel.btn.Stages.Toggle.ttip = Toggle this button to activate or deactive the corresponding stage in your design.
+RocketPanel.btn.Stages.NoChildren.ttip = <html>This stages does not have any child components and is therefore marked as inactive.<br>Add components to the stage to activate it.</html>
 RocketPanel.ttip.Rotation = Change the rocket's roll rotation (only affects the rocket view)
 
 ! BasicFrame

--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -64,7 +64,7 @@ RocketPanel.lbl.Stability = Stability:
 RocketPanel.checkbox.ShowCGCP = Show CG/CP
 RocketPanel.checkbox.ShowCGCP.ttip = Disabling this checkbox hides the CG and CP markings in the rocket view.
 RocketPanel.lbl.Stages = Stages:
-RocketPanel.btn.Stages.Toggle.ttip = Toggle this button to activate or deactive the corresponding stage in your design.
+RocketPanel.btn.Stages.Toggle.ttip = Toggle this button to activate or deactivate the corresponding stage in your design.
 RocketPanel.btn.Stages.NoChildren.ttip = <html>This stages does not have any child components and is therefore marked as inactive.<br>Add components to the stage to activate it.</html>
 RocketPanel.ttip.Rotation = Change the rocket's roll rotation (only affects the rocket view)
 

--- a/core/src/net/sf/openrocket/rocketcomponent/AxialStage.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/AxialStage.java
@@ -1,8 +1,5 @@
 package net.sf.openrocket.rocketcomponent;
 
-import java.util.ArrayList;
-import java.util.Collection;
-
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.rocketcomponent.position.AxialMethod;
 import net.sf.openrocket.startup.Application;

--- a/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
@@ -399,7 +399,7 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 	public AxialStage getBottomStage() {
 		AxialStage bottomStage = null;
 		for (StageFlags curFlags : this.stages.values()) {
-			if (curFlags.active) {
+			if (isStageActive(curFlags.stageNumber)) {
 				bottomStage = rocket.getStage( curFlags.stageNumber);
 			}
 		}
@@ -843,7 +843,7 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 		buf.append(String.format(fmt, "#", "?actv", "Name"));
 		for (StageFlags flags : stages.values()) {
 			final int stageNumber = flags.stageNumber;
-			buf.append(String.format(fmt, stageNumber, (flags.active?" on": "off"), rocket.getStage( stageNumber).getName()));
+			buf.append(String.format(fmt, stageNumber, (isStageActive(flags.stageNumber) ?" on": "off"), rocket.getStage( stageNumber).getName()));
 		}
 		buf.append("\n");
 		return buf.toString();

--- a/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
@@ -241,8 +241,10 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 		if( -1 == stageNumber ) {
 			return true;
 		}
-		
-		return stages.get(stageNumber) != null && stages.get(stageNumber).active;
+
+		AxialStage stage = rocket.getStage(stageNumber);
+		return stage != null && stage.getChildCount() > 0 &&
+				stages.get(stageNumber) != null && stages.get(stageNumber).active;
 	}
 
 	public Collection<RocketComponent> getAllComponents() {
@@ -379,12 +381,8 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 		List<AxialStage> activeStages = new ArrayList<>();
 		
 		for (StageFlags flags : this.stages.values()) {
-			if (flags.active) {
-				AxialStage stage = rocket.getStage(flags.stageNumber);
-				if (stage == null) {
-					continue;
-				}
-				activeStages.add(stage);
+			if (isStageActive(flags.stageNumber)) {
+				activeStages.add( rocket.getStage(flags.stageNumber));
 			}
 		}
 		
@@ -392,13 +390,7 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 	}
 
 	public int getActiveStageCount() {
-		int activeCount = 0;
-		for (StageFlags cur : this.stages.values()) {
-			if (cur.active) {
-				activeCount++;
-			}
-		}
-		return activeCount;
+		return getActiveStages().size();
 	}
 	
 	/**

--- a/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java
+++ b/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java
@@ -46,6 +46,26 @@ public class BarrowmanCalculatorTest {
 //			Application.setInjector(injector);
 //		}
 	}
+
+	/**
+	 * Test a completely empty rocket.
+	 */
+	@Test
+	public void testEmptyRocket() {
+		// First test completely empty rocket
+		Rocket rocket = new Rocket();
+		FlightConfiguration config = rocket.getSelectedConfiguration();
+		BarrowmanCalculator calc = new BarrowmanCalculator();
+		FlightConditions conditions = new FlightConditions(config);
+		WarningSet warnings = new WarningSet();
+
+		Coordinate cp_calc = calc.getCP(config, conditions, warnings);
+
+		assertEquals(" Empty rocket CNa value is incorrect:", 0.0, cp_calc.weight , 0.0);
+		assertEquals(" Empty rocket cp x value is incorrect:", 0.0, cp_calc.x , 0.0);
+		assertEquals(" Empty rocket cp y value is incorrect:", 0.0, cp_calc.y , 0.0);
+		assertEquals(" Empty rocket cp z value is incorrect:", 0.0, cp_calc.z , 0.0);
+	}
 	
 	@Test
 	public void testCPSimpleDry() {
@@ -350,5 +370,68 @@ public class BarrowmanCalculatorTest {
 		assertEquals(" Alpha III With Pods rocket cp y value is incorrect:", cpNoPods.y, cpPods.y, EPSILON);
 		assertEquals(" Alpha III With Pods rocket cp z value is incorrect:", cpNoPods.z, cpPods.z, EPSILON);
 		assertEquals(" Alpha III With Pods rocket CNa value is incorrect:", cpPods.weight, cpNoPods.weight - 3.91572, EPSILON);
+	}
+
+	/**
+	 * Tests whether adding extra empty stages has an effect.
+	 */
+	@Test
+	public void testEmptyStages() {
+		// Reference rocket
+		Rocket rocketRef = TestRockets.makeEstesAlphaIII();
+		FlightConfiguration configRef = rocketRef.getSelectedConfiguration();
+		BarrowmanCalculator calcRef = new BarrowmanCalculator();
+		FlightConditions conditionsRef = new FlightConditions(configRef);
+		WarningSet warnings = new WarningSet();
+
+		Coordinate cp_calcRef = calcRef.getCP(configRef, conditionsRef, warnings);
+
+		// First test with adding an empty stage in the front of the design
+		Rocket rocketFront = TestRockets.makeEstesAlphaIII();
+		AxialStage stage1 = new AxialStage();		// To be placed in front of the design
+		rocketFront.addChild(stage1, 0);
+		FlightConfiguration configFront = rocketFront.getSelectedConfiguration();
+		BarrowmanCalculator calcFront = new BarrowmanCalculator();
+		FlightConditions conditionsFront = new FlightConditions(configFront);
+		warnings = new WarningSet();
+
+		Coordinate cp_calcFront = calcFront.getCP(configFront, conditionsFront, warnings);
+
+		assertEquals(" Estes Alpha III with front empty stage CNa value is incorrect:", cp_calcRef.weight, cp_calcFront.weight , EPSILON);
+		assertEquals(" Estes Alpha III with front empty stage cp x value is incorrect:", cp_calcRef.x, cp_calcFront.x , EPSILON);
+		assertEquals(" Estes Alpha III with front empty stage cp y value is incorrect:", cp_calcRef.y, cp_calcFront.y , EPSILON);
+		assertEquals(" Estes Alpha III with front empty stage cp z value is incorrect:", cp_calcRef.z, cp_calcFront.z , EPSILON);
+
+		// Now test with adding an empty stage in the rear of the design
+		Rocket rocketRear = TestRockets.makeEstesAlphaIII();
+		AxialStage stage2 = new AxialStage();		// To be placed in the rear of the design
+		rocketRear.addChild(stage2);
+		FlightConfiguration configRear = rocketRear.getSelectedConfiguration();
+		BarrowmanCalculator calcRear = new BarrowmanCalculator();
+		FlightConditions conditionsRear = new FlightConditions(configRear);
+		warnings = new WarningSet();
+
+		Coordinate cp_calcRear = calcRear.getCP(configRear, conditionsRear, warnings);
+
+		assertEquals(" Estes Alpha III with rear empty stage CNa value is incorrect:", cp_calcRef.weight, cp_calcRear.weight , EPSILON);
+		assertEquals(" Estes Alpha III with rear empty stage cp x value is incorrect:", cp_calcRef.x, cp_calcRear.x , EPSILON);
+		assertEquals(" Estes Alpha III with rear empty stage cp y value is incorrect:", cp_calcRef.y, cp_calcRear.y , EPSILON);
+		assertEquals(" Estes Alpha III with rear empty stage cp z value is incorrect:", cp_calcRef.z, cp_calcRear.z , EPSILON);
+
+		// Test with multiple empty stages
+		Rocket rocketMulti = rocketFront;
+		AxialStage stage3 = new AxialStage();		// To be placed in the rear of the design
+		rocketMulti.addChild(stage3);
+		FlightConfiguration configMulti = rocketMulti.getSelectedConfiguration();
+		BarrowmanCalculator calcMulti = new BarrowmanCalculator();
+		FlightConditions conditionsMulti = new FlightConditions(configMulti);
+		warnings = new WarningSet();
+
+		Coordinate cp_calcMulti = calcMulti.getCP(configMulti, conditionsMulti, warnings);
+
+		assertEquals(" Estes Alpha III with multiple empty stages CNa value is incorrect:", cp_calcRef.weight, cp_calcMulti.weight , EPSILON);
+		assertEquals(" Estes Alpha III with multiple empty stages cp x value is incorrect:", cp_calcRef.x, cp_calcMulti.x , EPSILON);
+		assertEquals(" Estes Alpha III with multiple empty stages cp y value is incorrect:", cp_calcRef.y, cp_calcMulti.y , EPSILON);
+		assertEquals(" Estes Alpha III with multiple empty stages cp z value is incorrect:", cp_calcRef.z, cp_calcMulti.z , EPSILON);
 	}
 }

--- a/swing/src/net/sf/openrocket/gui/components/StageSelector.java
+++ b/swing/src/net/sf/openrocket/gui/components/StageSelector.java
@@ -11,18 +11,21 @@ import javax.swing.JToggleButton;
 
 import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.gui.widgets.SelectColorToggleButton;
+import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.rocketcomponent.AxialStage;
 import net.sf.openrocket.rocketcomponent.BodyTube;
 import net.sf.openrocket.rocketcomponent.ComponentChangeEvent;
 import net.sf.openrocket.rocketcomponent.FlightConfiguration;
 import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
+import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.StateChangeListener;
 
 
 @SuppressWarnings("serial")
 public class StageSelector extends JPanel implements StateChangeListener {
 
+	private static final Translator trans = Application.getTranslator();
 	private final Rocket rocket;
 	
 	private List<JToggleButton> buttons = new ArrayList<JToggleButton>();
@@ -61,9 +64,16 @@ public class StageSelector extends JPanel implements StateChangeListener {
 	
 	private class StageAction extends AbstractAction {
 		private final AxialStage stage;
-		
+
 		public StageAction(final AxialStage stage) {
 			this.stage = stage;
+			if (this.stage.getChildCount() == 0) {
+				putValue(SHORT_DESCRIPTION, trans.get("RocketPanel.btn.Stages.NoChildren.ttip"));
+				setEnabled(false);
+			} else {
+				putValue(SHORT_DESCRIPTION, trans.get("RocketPanel.btn.Stages.Toggle.ttip"));
+			}
+			updateUI();
 		}
 		
 		@Override
@@ -77,6 +87,15 @@ public class StageSelector extends JPanel implements StateChangeListener {
 		
 		@Override
 		public void actionPerformed(ActionEvent e) {
+			// Don't toggle the state if the stage has no children (and is therefore inactive)
+			if (stage.getChildCount() == 0) {
+				putValue(SHORT_DESCRIPTION, trans.get("RocketPanel.btn.Stages.NoChildren.ttip"));
+				setEnabled(false);
+				return;
+			} else {
+				setEnabled(true);
+				putValue(SHORT_DESCRIPTION, trans.get("RocketPanel.btn.Stages.Toggle.ttip"));
+			}
 			rocket.getSelectedConfiguration().toggleStage(stage.getStageNumber());
 			rocket.fireComponentChangeEvent(ComponentChangeEvent.AEROMASS_CHANGE | ComponentChangeEvent.MOTOR_CHANGE );
 		}


### PR DESCRIPTION
This PR fixes #1617 by marking empty stages as inactive. This is reflected in the stage selector buttons as a disabled button, which also indicates to new users that something is wrong with that stage. To make it even more clear, I added a tooltip text for the stage selector buttons for an empty stage: "This stages does not have any child components and is therefore marked as inactive. Add components to the stage to activate it.", and for a non-empty stage: "Toggle this button to activate or deactivate the corresponding stage in your design.".

Demo:


https://user-images.githubusercontent.com/11031519/191367445-6603c486-307b-4e53-a641-b2e16ab2f04b.mp4


