### PR TITLE
Add no-junit-report unit test targets in root

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -44,14 +44,25 @@
 	
 	<target name="unittest" depends="unittest-core, unittest-swing">
 	</target>
+
+    <target name="unittest-no-junit-report" depends="unittest-core, unittest-swing">
+    </target>
 	
 	<target name="unittest-core" depends="jar-core">
 		<ant dir="core" target="unittest" inheritAll="false" />
 	</target>
+
+    <target name="unittest-core-no-junit-report" depends="jar-core">
+        <ant dir="core" target="unittest" inheritAll="false" />
+    </target>
 	
 	<target name="unittest-swing" depends="jar-swing">
-		<ant dir="swing" target="unittest" inheritAll="false" />
+		<ant dir="swing" target="unittest-no-junit-report" inheritAll="false" />
 	</target>
+
+    <target name="unittest-swing-no-junit-report" depends="jar-swing">
+        <ant dir="swing" target="unittest-no-junit-report" inheritAll="false" />
+    </target>
 
     <!-- CHECK -->
     <target name="check" depends="checktodo,checkascii"/>


### PR DESCRIPTION
This PR adds targets in the root build file for running no-junit-report unit tests, which means that unit tests errors are shown in an output stream, e.g. your console, instead of the typical `index.html` JUnit report file.

Those no-junit-report already existed in the core and swing module, but not in the root build file.