### PR TITLE
Fixed error on using DampingMoment simulation listener

### DIFF
--- a/core/src/net/sf/openrocket/simulation/listeners/example/DampingMoment.java
+++ b/core/src/net/sf/openrocket/simulation/listeners/example/DampingMoment.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import net.sf.openrocket.aerodynamics.AerodynamicCalculator;
 import net.sf.openrocket.aerodynamics.AerodynamicForces;
 import net.sf.openrocket.aerodynamics.FlightConditions;
+import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.motor.MotorConfiguration;
 import net.sf.openrocket.rocketcomponent.FlightConfiguration;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
@@ -85,7 +86,7 @@ public class DampingMoment extends AbstractSimulationListener {
 		AerodynamicCalculator aerocalc = status.getSimulationConditions().getAerodynamicCalculator();
 		
 		// Must go through each component ...
-		Map<RocketComponent, AerodynamicForces> forces = aerocalc.getForceAnalysis(status.getConfiguration(), flightConditions, null);
+		Map<RocketComponent, AerodynamicForces> forces = aerocalc.getForceAnalysis(status.getConfiguration(), flightConditions, new WarningSet());
 		for (Map.Entry<RocketComponent, AerodynamicForces> entry : forces.entrySet()) {
 			
 			RocketComponent comp = entry.getKey();

--- a/core/src/net/sf/openrocket/simulation/listeners/example/DampingMoment.java
+++ b/core/src/net/sf/openrocket/simulation/listeners/example/DampingMoment.java
@@ -86,7 +86,7 @@ public class DampingMoment extends AbstractSimulationListener {
 		AerodynamicCalculator aerocalc = status.getSimulationConditions().getAerodynamicCalculator();
 		
 		// Must go through each component ...
-		Map<RocketComponent, AerodynamicForces> forces = aerocalc.getForceAnalysis(status.getConfiguration(), flightConditions, new WarningSet());
+		Map<RocketComponent, AerodynamicForces> forces = aerocalc.getForceAnalysis(status.getConfiguration(), flightConditions, status.getWarnings());
 		for (Map.Entry<RocketComponent, AerodynamicForces> entry : forces.entrySet()) {
 			
 			RocketComponent comp = entry.getKey();


### PR DESCRIPTION
When attempting to run a simulation with the DampingMoment simulation listener added an exception is thrown and the variable is not computed.

It seems that AerodynamicCalculator.getForceAnalysis was modified to take in a WarningSet argument, however, for the DampingMoment listener, this was given as null, causing the error.