### PR TITLE
Fixed flight event labels getting cut off

### DIFF
--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlot.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlot.java
@@ -427,7 +427,8 @@ public class SimulationPlot {
 
 		// Plot the markers
 		if (config.getDomainAxisType() == FlightDataType.TYPE_TIME) {
-			double markerWidth = 0.7;
+			double markerWidth = 0.01 * plot.getDomainAxis().getUpperBound();
+
 			// Domain time is plotted as vertical markers
 			for (int i = 0; i < eventTimes.size(); i++) {
 				double t = eventTimes.get(i);

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlot.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlot.java
@@ -427,7 +427,7 @@ public class SimulationPlot {
 
 		// Plot the markers
 		if (config.getDomainAxisType() == FlightDataType.TYPE_TIME) {
-
+			double markerWidth = 0.7;
 			// Domain time is plotted as vertical markers
 			for (int i = 0; i < eventTimes.size(); i++) {
 				double t = eventTimes.get(i);
@@ -441,6 +441,10 @@ public class SimulationPlot {
 				m.setAlpha(0.7f);
 				m.setLabelFont(new Font("Dialog", Font.PLAIN, 13));
 				plot.addDomainMarker(m);
+
+				if (t > plot.getDomainAxis().getUpperBound() - markerWidth) {
+					plot.setDomainAxis(new PresetNumberAxis(plot.getDomainAxis().getLowerBound(), t + markerWidth));
+				}
 			}
 
 		} else {


### PR DESCRIPTION
Fixes #1622, though I'm not a fan on the magic number, but I couldn't figure out how to determine the text's height as I can't get the font metrics. Any suggestions?

Before Fix:
![not_fixed](https://user-images.githubusercontent.com/8520854/193457293-bca9d3b2-0f0b-4691-9436-48f73ee6fb4f.png)

After Fix:
![fixed](https://user-images.githubusercontent.com/8520854/193457308-9bddc57b-b8a3-4116-a392-c75c8c6b0cb1.png)