### PR TITLE
Fixed NPE when scaling when no components are selected

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/DocumentSelectionModel.java
+++ b/swing/src/net/sf/openrocket/gui/main/DocumentSelectionModel.java
@@ -91,7 +91,7 @@ public class DocumentSelectionModel {
 	 * @return	the currently selected rocket components, or <code>null</code>.
 	 */
 	public List<RocketComponent> getSelectedComponents() {
-		if (componentSelection.size() == 0) return Collections.EMPTY_LIST;
+		if (componentSelection.size() == 0) return Collections.emptyList();
 		return componentSelection;
 	}
 	

--- a/swing/src/net/sf/openrocket/gui/main/DocumentSelectionModel.java
+++ b/swing/src/net/sf/openrocket/gui/main/DocumentSelectionModel.java
@@ -2,6 +2,7 @@ package net.sf.openrocket.gui.main;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -90,7 +91,7 @@ public class DocumentSelectionModel {
 	 * @return	the currently selected rocket components, or <code>null</code>.
 	 */
 	public List<RocketComponent> getSelectedComponents() {
-		if (componentSelection.size() == 0) return null;
+		if (componentSelection.size() == 0) return Collections.EMPTY_LIST;
 		return componentSelection;
 	}
 	


### PR DESCRIPTION
Fixes #1713, NPE was thrown when no components were selected and Edit > Scale was used to scale the rocket. This seems to be because `DocumentSelectionModel.getSelectedComponents` returns null if no components are selected, as opposed to an empty list.