### PR TITLE
Fixed photo studio save indents

### DIFF
--- a/core/src/net/sf/openrocket/file/openrocket/OpenRocketSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/OpenRocketSaver.java
@@ -428,8 +428,15 @@ public class OpenRocketSaver extends RocketSaver {
 
 	private void savePhotoSettings(Map<String, String> p) throws IOException {
 		log.debug("Saving Photo Settings");
+
+		writeln("<photostudio>");
+		indent++;
+
 		for (String s : PhotoStudioSaver.getElements(p))
 			writeln(s);
+
+		indent--;
+		writeln("</photostudio>");
 	}
 	
 	

--- a/core/src/net/sf/openrocket/file/openrocket/savers/PhotoStudioSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/savers/PhotoStudioSaver.java
@@ -21,8 +21,6 @@ public class PhotoStudioSaver {
 
         if (photoSettings == null || photoSettings.size() == 0) return elements;
 
-        elements.add("<photostudio>");
-
         elements.add("<roll>" + photoSettings.get("roll") + "</roll>");
         elements.add("<yaw>" + photoSettings.get("yaw") + "</yaw>");
         elements.add("<pitch>" + photoSettings.get("pitch") + "</pitch>");
@@ -54,8 +52,6 @@ public class PhotoStudioSaver {
         elements.add("<sparkWeight>" + photoSettings.get("sparkWeight") + "</sparkWeight>");
 
         elements.add("<sky>" + photoSettings.get("sky") + "</sky>");
-
-        elements.add("</photostudio>");
 
         return elements;
     }


### PR DESCRIPTION
Fixes #1714, this approach felt cleaner than keeping the start and end tags in the list and handling those as special cases.