### PR TITLE
Don't explicitly save smokeAlpha in photostudio .ork

### DIFF
--- a/core/src/net/sf/openrocket/file/openrocket/savers/PhotoStudioSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/savers/PhotoStudioSaver.java
@@ -43,7 +43,6 @@ public class PhotoStudioSaver {
         emitColor("flameColor", elements, photoSettings.get("flameColor"));
         elements.add("<smoke>" + photoSettings.get("smoke") + "</smoke>");
         emitColor("smokeColor", elements, photoSettings.get("smokeColor"));
-        elements.add("<smokeOpacity>" + photoSettings.get("smokeOpacity") + "</smokeOpacity>");
         elements.add("<sparks>" + photoSettings.get("sparks") + "</sparks>");
         elements.add("<exhaustScale>" + photoSettings.get("exhaustScale") + "</exhaustScale>");
         elements.add("<flameAspectRatio>" + photoSettings.get("flameAspectRatio") + "</flameAspectRatio>");

--- a/swing/src/net/sf/openrocket/file/photo/PhotoStudioGetter.java
+++ b/swing/src/net/sf/openrocket/file/photo/PhotoStudioGetter.java
@@ -135,11 +135,6 @@ public class PhotoStudioGetter {
             p.setSmokeColor(smokeColor);
             return;
         }
-        if ("smokeOpacity".equals(element)) {
-            double smokeOpacity = Double.parseDouble(content);
-            p.setSmokeOpacity(smokeOpacity);
-            return;
-        }
         if ("sparks".equals(element)) {
             boolean sparks = Boolean.parseBoolean(content);
             p.setSparks(sparks);

--- a/swing/src/net/sf/openrocket/file/photo/PhotoStudioSetter.java
+++ b/swing/src/net/sf/openrocket/file/photo/PhotoStudioSetter.java
@@ -41,7 +41,6 @@ public class PhotoStudioSetter {
         photoSettings.put("flameColor", getColor(p.getFlameColor()));
         photoSettings.put("smoke", String.valueOf(p.isSmoke()));
         photoSettings.put("smokeColor", getColor(p.getSmokeColor()));
-        photoSettings.put("smokeOpacity", String.valueOf(p.getSmokeOpacity()));
         photoSettings.put("sparks", String.valueOf(p.isSparks()));
         photoSettings.put("exhaustScale", String.valueOf(p.getExhaustScale()));
         photoSettings.put("flameAspectRatio", String.valueOf(p.getFlameAspectRatio()));

--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettings.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettings.java
@@ -31,7 +31,6 @@ public class PhotoSettings extends AbstractChangeSource implements FlameSettings
 	private Color flameColor = new Color(255, 100, 50);
 	private boolean smoke = false;
 	private Color smokeColor = new Color(230, 230, 230, 102);
-	private double smokeOpacity = 0.4;
 	private boolean sparks = false;
 	private double exhaustScale = 1.0;
 	private double flameAspectRatio = 1.0;
@@ -204,18 +203,22 @@ public class PhotoSettings extends AbstractChangeSource implements FlameSettings
 	}
 	
 	public void setSmokeColor(Color smokeColor) {
-		smokeColor.setAlpha(this.smokeColor.getAlpha());
 		this.smokeColor = smokeColor;
 		fireChangeEvent();
 	}
-	
-	public double getSmokeAlpha() {
-		return smokeColor.getAlpha() / 255f;
-	}
+
 	
 	public void setSmokeAlpha(double alpha) {
 		smokeColor.setAlpha((int) (alpha * 255));
 		fireChangeEvent();
+	}
+
+	public double getSmokeOpacity() {
+		return smokeColor.getAlpha() / 255f;
+	}
+
+	public void setSmokeOpacity(double smokeOpacity) {
+		setSmokeAlpha(smokeOpacity);
 	}
 	
 	public boolean isSparks() {
@@ -270,14 +273,5 @@ public class PhotoSettings extends AbstractChangeSource implements FlameSettings
 	public void setSparkWeight(double sparkWeight) {
 		this.sparkWeight = sparkWeight;
 		fireChangeEvent();
-	}
-
-	public double getSmokeOpacity() {
-		return smokeOpacity;
-	}
-
-	public void setSmokeOpacity(double smokeOpacity) {
-		this.smokeOpacity = smokeOpacity;
-		setSmokeAlpha(smokeOpacity);
 	}
 }

--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/exhaust/FlameRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/exhaust/FlameRenderer.java
@@ -152,8 +152,6 @@ public final class FlameRenderer {
 
 		public Color getSmokeColor();
 
-		public double getSmokeAlpha();
-
 		public double getFlameAspectRatio();
 
 		public boolean isSparks();


### PR DESCRIPTION
This PR fixes the bug reported on [TRF](https://www.rocketryforum.com/threads/announcement-openrocket-version-22-02-public-beta-5-is-now-available.171295/post-2328000) where opening PhotoStudio could throw an exception. The issue was that smokeOpacity in the .ork file was saved as 2.0, which was the converted to an alpha value of 510. Don't ask me why that happened, but it was either way redundant for a smokeOpacity field in the .ork file, since the alpha value was already stored in smokeColor. So this PR simply removes the smokeOpacity field in the .ork file.