### PR TITLE
[#1723] Import MassObject length with NoAuto

### DIFF
--- a/core/src/net/sf/openrocket/file/openrocket/importt/DocumentConfig.java
+++ b/core/src/net/sf/openrocket/file/openrocket/importt/DocumentConfig.java
@@ -374,7 +374,7 @@ class DocumentConfig {
 		
 		// MassObject
 		setters.put("MassObject:packedlength", new DoubleSetter(
-				Reflection.findMethod(MassObject.class, "setLength", double.class)));
+				Reflection.findMethod(MassObject.class, "setLengthNoAuto", double.class)));
 		setters.put("MassObject:packedradius", new DoubleSetter(
 				Reflection.findMethod(MassObject.class, "setRadius", double.class),
 				"auto", " ",

--- a/core/src/net/sf/openrocket/rocketcomponent/MassObject.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/MassObject.java
@@ -248,8 +248,8 @@ public abstract class MassObject extends InternalComponent {
 	@Override
 	public final Collection<Coordinate> getComponentBounds() {
 		Collection<Coordinate> c = new ArrayList<Coordinate>();
-		addBound(c, 0, radius);
-		addBound(c, length, radius);
+		addBound(c, 0, getRadius());
+		addBound(c, getLength(), getRadius());
 		return c;
 	}
 	


### PR DESCRIPTION
This PR fixes #1723. The issue was that the MassObject length was saved with the NoAuto parameter, but that during import the normal length was set, instead of LengthNoAuto.