### PR TITLE
Add unit tests for MassObject auto radius

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/MassObject.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/MassObject.java
@@ -53,10 +53,10 @@ public abstract class MassObject extends InternalComponent {
 	@Override
 	public double getLength() {
 		if (this.autoRadius) {
-			// Calculate the parachute volume using the non auto radius and the non auto length, and transform that back
+			// Calculate the volume using the non auto radius and the non auto length, and transform that back
 			// to the auto radius situation to get the auto radius length (the volume in both situations is the same).
-			double parachuteVolume = Math.pow(this.radius, 2) * this.length;	// Math.PI left out, not needed
-			return parachuteVolume / Math.pow(getRadius(), 2);
+			double volume = Math.pow(this.radius, 2) * this.length;	// Math.PI left out, not needed
+			return volume / Math.pow(getRadius(), 2);
 		}
 		return length;
 	}
@@ -93,10 +93,10 @@ public abstract class MassObject extends InternalComponent {
 
 		length = Math.max(length, 0);
 		if (this.autoRadius) {
-			// Calculate the parachute volume using the auto radius and the new "auto" length, and transform that back
+			// Calculate the volume using the auto radius and the new "auto" length, and transform that back
 			// to the non auto radius situation to set this.length (the volume in both situations is the same).
-			double parachuteVolume = Math.pow(getRadius(), 2) * length;		// Math.PI left out, not needed
-			double newLength = parachuteVolume / Math.pow(this.radius, 2);
+			double volume = Math.pow(getRadius(), 2) * length;		// Math.PI left out, not needed
+			double newLength = volume / Math.pow(this.radius, 2);
 			if (MathUtil.equals(this.length, newLength))
 				return;
 			this.length = newLength;
@@ -168,8 +168,8 @@ public abstract class MassObject extends InternalComponent {
 		autoRadius = auto;
 
 		// Set the length
-		double parachuteVolume = (Math.PI * Math.pow(getRadius(), 2) * length);
-		length = parachuteVolume / (Math.PI * Math.pow(getRadius(), 2));
+		double volume = (Math.PI * Math.pow(getRadius(), 2) * length);
+		length = volume / (Math.PI * Math.pow(getRadius(), 2));
 
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}

--- a/core/test/net/sf/openrocket/rocketcomponent/MassObjectTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/MassObjectTest.java
@@ -1,0 +1,86 @@
+package net.sf.openrocket.rocketcomponent;
+
+import net.sf.openrocket.util.BaseTestCase.BaseTestCase;
+import net.sf.openrocket.util.MathUtil;
+import org.junit.Test;
+import org.junit.Assert;
+
+public class MassObjectTest extends BaseTestCase {
+    @Test
+    public void testAutoRadius() {
+        MassObject sc = new ShockCord();
+        MassObject mc = new MassComponent();
+        MassObject pc = new Parachute();
+        MassObject st = new Streamer();
+        MassObject[] massObjects = {sc, mc, pc, st};
+
+        for (MassObject mo : massObjects) {
+            // Test no auto
+            mo.setRadiusAutomatic(false);
+            mo.setRadius(0.1);
+            mo.setLength(0.1);
+            Assert.assertEquals(String.format(" No auto %s incorrect radius", mo.getClass().getName()),
+                    0.1, mo.getRadius(), MathUtil.EPSILON);
+            Assert.assertEquals(String.format(" No auto %s incorrect no auto radius", mo.getClass().getName()),
+                    0.1, mo.getRadiusNoAuto(),MathUtil.EPSILON);
+            Assert.assertEquals(String.format(" No auto %s incorrect length", mo.getClass().getName()),
+                    0.1, mo.getLength(), MathUtil.EPSILON);
+            Assert.assertEquals(String.format(" No auto %s incorrect no auto length", mo.getClass().getName()),
+                    0.1, mo.getLengthNoAuto(), MathUtil.EPSILON);
+
+            mo.setLengthNoAuto(0.1);
+            Assert.assertEquals(String.format(" No auto 2 %s incorrect length", mo.getClass().getName()),
+                    0.1, mo.getLength(), MathUtil.EPSILON);
+            Assert.assertEquals(String.format(" No auto 2 %s incorrect no auto length", mo.getClass().getName()),
+                    0.1, mo.getLengthNoAuto(), MathUtil.EPSILON);
+
+            // Test auto
+            BodyTube parent = new BodyTube();
+            parent.setOuterRadius(0.05);
+            parent.setInnerRadius(0.05);
+            parent.addChild(mo);
+            mo.setRadiusAutomatic(true);
+            Assert.assertEquals(String.format(" Auto 1 %s incorrect radius", mo.getClass().getName()),
+                    0.05, mo.getRadius(), MathUtil.EPSILON);
+            Assert.assertEquals(String.format(" Auto 1 %s incorrect no auto radius", mo.getClass().getName()),
+                    0.1, mo.getRadiusNoAuto(), MathUtil.EPSILON);
+            Assert.assertEquals(String.format(" Auto 1 %s incorrect length", mo.getClass().getName()),
+                    0.4, mo.getLength(), MathUtil.EPSILON);
+            Assert.assertEquals(String.format(" Auto 1 %s incorrect no auto length", mo.getClass().getName()),
+                    0.1, mo.getLengthNoAuto(), MathUtil.EPSILON);
+
+            parent.setOuterRadius(0.1);
+            parent.setInnerRadius(0.1);
+            Assert.assertEquals(String.format(" Auto 2 %s incorrect radius", mo.getClass().getName()),
+                    0.1, mo.getRadius(), MathUtil.EPSILON);
+            Assert.assertEquals(String.format(" Auto 2 %s incorrect no auto radius", mo.getClass().getName()),
+                    0.1, mo.getRadiusNoAuto(), MathUtil.EPSILON);
+            Assert.assertEquals(String.format(" Auto 2 %s incorrect length", mo.getClass().getName()),
+                    0.1, mo.getLength(), MathUtil.EPSILON);
+            Assert.assertEquals(String.format(" Auto 2 %s incorrect no auto length", mo.getClass().getName()),
+                    0.1, mo.getLengthNoAuto(), MathUtil.EPSILON);
+
+            parent.setOuterRadius(0.075);
+            parent.setInnerRadius(0.075);
+            mo.setLength(0.075);
+            Assert.assertEquals(String.format(" Auto 3 %s incorrect radius", mo.getClass().getName()),
+                    0.075, mo.getRadius(), MathUtil.EPSILON);
+            Assert.assertEquals(String.format(" Auto 3 %s incorrect no auto radius", mo.getClass().getName()),
+                    0.1, mo.getRadiusNoAuto(), MathUtil.EPSILON);
+            Assert.assertEquals(String.format(" Auto 3 %s incorrect length", mo.getClass().getName()),
+                    0.075, mo.getLength(), MathUtil.EPSILON);
+            Assert.assertEquals(String.format(" Auto 3 %s incorrect no auto length", mo.getClass().getName()),
+                    0.0422, mo.getLengthNoAuto(), 0.001);
+
+            mo.setLengthNoAuto(0.05);
+            Assert.assertEquals(String.format(" Auto 4 %s incorrect radius", mo.getClass().getName()),
+                    0.075, mo.getRadius(), MathUtil.EPSILON);
+            Assert.assertEquals(String.format(" Auto 4 %s incorrect no auto radius", mo.getClass().getName()),
+                    0.1, mo.getRadiusNoAuto(), MathUtil.EPSILON);
+            Assert.assertEquals(String.format(" Auto 4 %s incorrect length", mo.getClass().getName()),
+                    0.0889, mo.getLength(), 0.001);
+            Assert.assertEquals(String.format(" Auto 4 %s incorrect no auto length", mo.getClass().getName()),
+                    0.05, mo.getLengthNoAuto(), MathUtil.EPSILON);
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes #1725 and adds unit tests for MassObject auto radius.