### PR TITLE
[#1167] Remove modality for thrust curve import error dialog

### DIFF
--- a/swing/src/net/sf/openrocket/database/MotorDatabaseLoader.java
+++ b/swing/src/net/sf/openrocket/database/MotorDatabaseLoader.java
@@ -153,7 +153,8 @@ public class MotorDatabaseLoader extends AsynchronousDatabaseLoader {
 						"<br>" + trans.get("MotorDbLoaderDlg.message2") + "</p></body></html>";
 				JOptionPane pane = new JOptionPane(message, JOptionPane.WARNING_MESSAGE);
 				JDialog dialog = pane.createDialog(null, trans.get("MotorDbLoaderDlg.title"));
-				dialog.setModalityType(Dialog.ModalityType.DOCUMENT_MODAL);
+				dialog.setModalityType(Dialog.ModalityType.MODELESS);
+				dialog.setAlwaysOnTop(true);
 				dialog.setVisible(true);
 			}
 			f.getV().close();


### PR DESCRIPTION
This PR fixes #1167. I'm not a 100% pleased with this solution, but it's good enough for now. This PR just removes the modality from the thrust curve import error dialog, so instead of the BasicFrame waiting for the error dialog to be closed, the BasicFrame already loads while the error dialog is displaying. You will notice a small delay where the error dialog is blank, while BasicFrame loads, but after that delay (a second or two), both dialogs show up.
<img width="1697" alt="Screenshot 2022-10-14 at 15 43 54" src="https://user-images.githubusercontent.com/11031519/195862111-b2f70a90-d35e-491e-bd88-e0208ed29b71.png">
<img width="1556" alt="Screenshot 2022-10-14 at 15 43 20" src="https://user-images.githubusercontent.com/11031519/195862136-06cf7fae-0705-4192-a0dd-e4341b0dd4d9.png">

Here is a faulty test thrust curve, to fire the import error.
[Quest_A3T.eng.zip](https://github.com/openrocket/openrocket/files/9786887/Quest_A3T.eng.zip)
