### PR TITLE
[#1742] Highlight text white if in selection

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/optimization/SimulationModifierTree.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/optimization/SimulationModifierTree.java
@@ -6,6 +6,7 @@ import java.awt.Font;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
 
 import javax.swing.JTree;
 import javax.swing.ToolTipManager;
@@ -175,7 +176,12 @@ public class SimulationModifierTree extends BasicTree {
 				if (selectedModifiers.contains(object)) {
 					setForeground(Color.GRAY);
 				} else {
-					setForeground(Color.BLACK);
+					if (tree.getSelectionRows() != null &&
+							IntStream.of(tree.getSelectionRows()).anyMatch(r -> r == row)) {
+						setForeground(Color.WHITE);
+					} else {
+						setForeground(Color.BLACK);
+					}
 				}
 				setFont(modifierFont);
 				setText(((SimulationModifier) object).getName());


### PR DESCRIPTION
This PR fixes #1742. (text is grey if the parameter is already in the optimization list)
<img width="1316" alt="image" src="https://user-images.githubusercontent.com/11031519/195988221-d094d597-82bd-491f-ad86-dfcd4d1d1e84.png">
