### PR TITLE
[#1743] Better background color for optimization plot

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/optimization/OptimizationPlotDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/optimization/OptimizationPlotDialog.java
@@ -95,6 +95,14 @@ public class OptimizationPlotDialog extends JDialog {
 			throw new IllegalArgumentException("Invalid dimensionality, dim=" + modifiers.size());
 		}
 		chart.setBorder(BorderFactory.createLineBorder(Color.BLACK));
+		Color backgroundColor = new Color(240, 240, 240);
+		chart.getChart().setBackgroundPaint(backgroundColor);
+		if (chart.getChart().getLegend() != null) {
+			chart.getChart().getLegend().setBackgroundPaint(Color.WHITE);
+		}
+		chart.getChart().getXYPlot().setBackgroundPaint(Color.WHITE);
+		chart.getChart().getXYPlot().setRangeGridlinePaint(Color.lightGray);
+		chart.getChart().getXYPlot().setDomainGridlinePaint(Color.lightGray);
 		panel.add(chart, "span, grow, wrap para");
 		
 


### PR DESCRIPTION
This PR fixes #1743. New plots:
<img width="1168" alt="Screenshot 2022-10-15 at 16 43 21" src="https://user-images.githubusercontent.com/11031519/195992512-4bc7f692-916c-4b7c-a89f-d7b839a16853.png">
<img width="1168" alt="Screenshot 2022-10-15 at 16 43 07" src="https://user-images.githubusercontent.com/11031519/195992524-7414bfcd-7cec-4de7-a064-34edd34b5584.png">
