### PR TITLE
Use absolute value of jerk in calculating time step in BasicLandingStepper, set minimum time step

### DIFF
--- a/core/src/net/sf/openrocket/simulation/AbstractSimulationStepper.java
+++ b/core/src/net/sf/openrocket/simulation/AbstractSimulationStepper.java
@@ -13,6 +13,8 @@ import net.sf.openrocket.util.Quaternion;
 
 public abstract class AbstractSimulationStepper implements SimulationStepper {
 	
+	protected static final double MIN_TIME_STEP = 0.001;
+	
 	/**
 	 * Compute the atmospheric conditions, allowing listeners to override.
 	 * 

--- a/core/src/net/sf/openrocket/simulation/BasicLandingStepper.java
+++ b/core/src/net/sf/openrocket/simulation/BasicLandingStepper.java
@@ -73,10 +73,12 @@ public class BasicLandingStepper extends AbstractSimulationStepper {
 		double timeStep = RECOVERY_TIME_STEP;
 
 		// adjust based on change in acceleration (ie jerk)
-		final double jerk = linearAcceleration.sub(status.getRocketAcceleration()).multiply(1.0/status.getPreviousTimeStep()).length();
+		final double jerk = Math.abs(linearAcceleration.sub(status.getRocketAcceleration()).multiply(1.0/status.getPreviousTimeStep()).length());
 		if (jerk > MathUtil.EPSILON) {
 			timeStep = Math.min(timeStep, 1.0/jerk);
 		}
+		// but don't let it get *too* small
+		timeStep = Math.max(timeStep, MIN_TIME_STEP);
 
 		// Perform Euler integration
 		Coordinate newPosition = status.getRocketPosition().add(status.getRocketVelocity().multiply(timeStep)).

--- a/core/src/net/sf/openrocket/simulation/RK4SimulationStepper.java
+++ b/core/src/net/sf/openrocket/simulation/RK4SimulationStepper.java
@@ -58,9 +58,6 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 	private static final double MAX_ROLL_RATE_CHANGE = 2 * Math.PI / 180;
 	private static final double MAX_PITCH_CHANGE = 4 * Math.PI / 180;
 	
-	private static final double MIN_TIME_STEP = 0.001;
-	
-	
 	private Random random;
 	
 	


### PR DESCRIPTION
If the recovery device deploys before apogee, the change in acceleration is negative so the timestep adjustment for jerk wasn't being applied.  In the event of  a deployment right at motor burnout, this could result in a huge simulated ground hit velocity.

Also, in the event of very large changes in acceleration, the time step could get absurdly small resulting in the simulation quite slowly until the acceleration settled out.