### PR TITLE
[#1758] Bump GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,18 +14,18 @@ jobs:
 
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Setup JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'adopt'
       - name: Ant build
         run: ant -noinput -buildfile build.xml clean check jar unittest
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: openrocket_build_${{ github.run_number }}
           path: ${{github.workspace}}/swing/build/jar/OpenRocket.jar


### PR DESCRIPTION
This PR fixes #1758 and bumps the GitHub actions versions to v3 instead of v2, which I think support Node.js 16, but will have to check after creating this PR and verifying the GitHub build.