### PR TITLE
Improve sampling for SimulationRunDialog

### DIFF
--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationRunDialog.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationRunDialog.java
@@ -270,6 +270,7 @@ public class SimulationRunDialog extends JDialog {
 		private final int index;
 		private final double burnoutTimeEstimate;
 		private volatile double burnoutVelocity;
+		private volatile double apogeeAltitude;
 
 		private final CustomExpressionSimulationListener exprListener;
 
@@ -368,13 +369,14 @@ public class SimulationRunDialog extends JDialog {
 			// Past apogee, switch to landing
 			if (simulationStage == -1 && status.getRocketVelocity().z < 0) {
 				simulationStage++;
-				log.debug("CHANGING to simulationStage " + simulationStage + ", apogee=" + simulationMaxAltitude[index]);
+				apogeeAltitude = MathUtil.max(simulationMaxAltitude[index], 1);
+				log.debug("CHANGING to simulationStage " + simulationStage + ", apogee=" + apogeeAltitude);
 			}
 
 			// >= 0 Landing. z-position from apogee to zero
 			// TODO: MEDIUM: several stages
-			log.debug("simulationStage landing (" + simulationStage + "):  alt=" + status.getRocketPosition().z + "  apogee=" + simulationMaxAltitude[index]);
-			setSimulationProgress(MathUtil.map(status.getRocketPosition().z, simulationMaxAltitude[index], 0, APOGEE_PROGRESS, 1.0));
+			log.debug("simulationStage landing (" + simulationStage + "):  alt=" + status.getRocketPosition().z + "  apogee=" + apogeeAltitude);
+			setSimulationProgress(MathUtil.map(status.getRocketPosition().z, apogeeAltitude, 0, APOGEE_PROGRESS, 1.0));
 			updateProgress();
 		}
 


### PR DESCRIPTION
It turned out there were two (more) issues:

1. The simulation ran so fast the rocket was on the ground before the first progress update happened.  Since the SimulationStatus was simply being published, this meant that all of the entries in the publish queue were references to the same status, and all the samples before it were effectively lost. Publishing a copy of the SimulationStatus fixes this.

2. Since vertical velocity is slightly less than 0 when apogee is detected, the max altitude code wasn't picking up on the apogee event. Looking for either positive z velocity or actual increase in altitude fixes this (we still need to also update if z velocity is positive so we reset after "false apogees" caused by things like calculating optimal recovery delay).

It also turned out the apogeeAltitude variable wasn't quite redundant; it included a call to MathUtil.max() to make sure the recorded apogee couldn't be 0 (though, as the original bug report shows, there were pathological conditions under which that didn't work).  So that variable is back in "just in case".

Fixes #1728 (for real this time, I hope!)