### PR TITLE
[#1687] Save stage activeness to design file

### DIFF
--- a/core/src/net/sf/openrocket/document/OpenRocketDocumentFactory.java
+++ b/core/src/net/sf/openrocket/document/OpenRocketDocumentFactory.java
@@ -15,6 +15,7 @@ public class OpenRocketDocumentFactory {
 		//// Sustainer
 		stage.setName(trans.get("BasicFrame.StageName.Sustainer"));
 		rocket.addChild(stage);
+		rocket.getSelectedConfiguration().setAllStages();
 		OpenRocketDocument doc = new OpenRocketDocument(rocket);
 		doc.setSaved(true);
 		return doc;

--- a/core/src/net/sf/openrocket/file/openrocket/importt/OpenRocketLoader.java
+++ b/core/src/net/sf/openrocket/file/openrocket/importt/OpenRocketLoader.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
+import net.sf.openrocket.rocketcomponent.FlightConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.InputSource;
@@ -53,7 +54,10 @@ public class OpenRocketLoader extends AbstractRocketLoader {
 			throw new RocketLoadException("Malformed XML in input.", e);
 		}
 		
-		doc.getSelectedConfiguration().setAllStages();
+		// load the stage activeness
+		for (FlightConfiguration config : doc.getRocket().getFlightConfigurations()) {
+			config.applyPreloadedStageActiveness();
+		}
 		
 		// Deduce suitable time skip
 		double timeSkip = StorageOptions.SIMULATION_DATA_NONE;

--- a/core/src/net/sf/openrocket/file/openrocket/savers/RocketSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/savers/RocketSaver.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import net.sf.openrocket.file.openrocket.OpenRocketSaver;
+import net.sf.openrocket.rocketcomponent.AxialStage;
 import net.sf.openrocket.rocketcomponent.FlightConfiguration;
 import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
 import net.sf.openrocket.rocketcomponent.ReferenceType;
@@ -53,15 +55,23 @@ public class RocketSaver extends RocketComponentSaver {
 			if ( rocket.getSelectedConfiguration().equals( flightConfig )){
 				str += " default=\"true\"";
 			}
-			
+
+			// close motorconfiguration opening tag
+			str += ">";
+			elements.add(str);
+
+			// flight configuration name
 			if (flightConfig.isNameOverridden()){
-				str += "><name>" + net.sf.openrocket.util.TextUtil.escapeXML(flightConfig.getNameRaw())
-						+ "</name></motorconfiguration>";
-			} else {
-				str += "/>";
+				elements.add(OpenRocketSaver.INDENT + "<name>" + net.sf.openrocket.util.TextUtil.escapeXML(flightConfig.getNameRaw())
+						+ "</name>");
+			}
+			// stage activeness
+			for (AxialStage stage : rocket.getStageList()) {
+				elements.add(OpenRocketSaver.INDENT + "<stage number=\"" + stage.getStageNumber() + "\"" +
+						" active=\"" + flightConfig.isStageActive(stage.getStageNumber()) + "\"/>");
 			}
 
-			elements.add(str);
+			elements.add("</motorconfiguration>");
 		}
 		
 		// Reference diameter

--- a/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
@@ -752,23 +752,23 @@ public class Rocket extends ComponentAssembly {
 	 * Return a flight configuration.  If the supplied id does not have a specific instance, the default is returned.  
 	 *
 	 * @param fcid the flight configuration id
-	 * @return	FlightConfiguration instance 
+	 * @return	FlightConfiguration instance
 	 */
-	public FlightConfigurationId createFlightConfiguration( final FlightConfigurationId fcid) {
+	public FlightConfiguration createFlightConfiguration( final FlightConfigurationId fcid) {
 		checkState();
 
         if( null == fcid ){
             // fall-through to the default case:
             // ...creating a FlightConfiguration( null ) just allocates a fresh new FCID
 		}else if( fcid.hasError() ){
-			return configSet.getDefault().getFlightConfigurationID();
+			return configSet.getDefault();
 		}else if( configSet.containsId(fcid)){
-			return fcid;
+			return configSet.get(fcid);
 		}
         FlightConfiguration nextConfig = new FlightConfiguration(this, fcid);
         this.configSet.set(nextConfig.getId(), nextConfig);
         fireComponentChangeEvent(ComponentChangeEvent.TREE_CHANGE);
-        return nextConfig.getFlightConfigurationID();
+        return nextConfig;
 	}
 
 	/**

--- a/core/src/net/sf/openrocket/util/TestRockets.java
+++ b/core/src/net/sf/openrocket/util/TestRockets.java
@@ -1625,6 +1625,14 @@ public class TestRockets {
 			
 		return document;
 	}
+
+	public static OpenRocketDocument makeTestRocket_v108_withDisabledStage() {
+		Rocket rocket = makeFalcon9Heavy();
+		rocket.getSelectedConfiguration()._setStageActive(0, false, false);
+		OpenRocketDocument document = OpenRocketDocumentFactory.createDocumentFromRocket(rocket);
+
+		return document;
+	}
 	
 	/*
 	 * Create a new test rocket for testing OpenRocketSaver.estimateFileSize()

--- a/core/src/net/sf/openrocket/util/TestRockets.java
+++ b/core/src/net/sf/openrocket/util/TestRockets.java
@@ -941,7 +941,7 @@ public class TestRockets {
 		Rocket rocket = new Rocket();
 		rocket.setName("Falcon9H Scale Rocket");
 
-		FlightConfigurationId selFCID = rocket.createFlightConfiguration( new FlightConfigurationId( FALCON_9H_FCID_1 ));
+		FlightConfigurationId selFCID = rocket.createFlightConfiguration( new FlightConfigurationId( FALCON_9H_FCID_1 )).getFlightConfigurationID();
         rocket.setSelectedConfiguration(selFCID);
 
 		// ====== Payload Stage ======

--- a/core/test/net/sf/openrocket/file/openrocket/OpenRocketSaverTest.java
+++ b/core/test/net/sf/openrocket/file/openrocket/OpenRocketSaverTest.java
@@ -2,6 +2,8 @@ package net.sf.openrocket.file.openrocket;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -19,6 +21,7 @@ import net.sf.openrocket.database.ComponentPresetDatabase;
 import net.sf.openrocket.database.motor.MotorDatabase;
 import net.sf.openrocket.database.motor.ThrustCurveMotorSetDatabase;
 import net.sf.openrocket.document.OpenRocketDocument;
+import net.sf.openrocket.document.OpenRocketDocumentFactory;
 import net.sf.openrocket.document.StorageOptions;
 import net.sf.openrocket.file.GeneralRocketLoader;
 import net.sf.openrocket.file.RocketLoadException;
@@ -29,6 +32,10 @@ import net.sf.openrocket.motor.Manufacturer;
 import net.sf.openrocket.motor.Motor;
 import net.sf.openrocket.motor.ThrustCurveMotor;
 import net.sf.openrocket.plugin.PluginModule;
+import net.sf.openrocket.rocketcomponent.BodyTube;
+import net.sf.openrocket.rocketcomponent.FlightConfiguration;
+import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
+import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.simulation.extension.impl.ScriptingExtension;
 import net.sf.openrocket.simulation.extension.impl.ScriptingUtil;
 import net.sf.openrocket.startup.Application;
@@ -138,6 +145,77 @@ public class OpenRocketSaverTest {
 			OpenRocketDocument rocketDocLoaded = loadRocket(file.getPath());
 			assertNotNull(rocketDocLoaded);
 		}
+	}
+
+	@Test
+	public void testSaveStageActiveness() {
+		OpenRocketDocument rocketDoc = TestRockets.makeTestRocket_v108_withDisabledStage();
+		StorageOptions options = new StorageOptions();
+		options.setSimulationTimeSkip(0.05);
+
+		// Save rockets, load, validate
+		File file = saveRocket(rocketDoc, options);
+		OpenRocketDocument rocketDocLoaded = loadRocket(file.getPath());
+
+		// Check that the stages activeness is saved
+		FlightConfiguration config = rocketDocLoaded.getRocket().getSelectedConfiguration();
+		assertFalse(" selected config, stage 0 should have been disabled after saving", config.isStageActive(0));
+		assertTrue(" selected config, stage 1 should have been enabled after saving", config.isStageActive(1));
+		assertTrue(" selected config, stage 2 should have been enabled after saving", config.isStageActive(2));
+
+		// Disable second stage
+		config._setStageActive(1, false, false);
+		file = saveRocket(rocketDocLoaded, options);
+		rocketDocLoaded = loadRocket(file.getPath());
+		config = rocketDocLoaded.getRocket().getSelectedConfiguration();
+		assertFalse(" selected config, stage 0 should have been disabled after saving", config.isStageActive(0));
+		assertFalse(" selected config, stage 1 should have been disabled after saving", config.isStageActive(1));
+		assertTrue(" selected config, stage 2 should have been enabled after saving", config.isStageActive(2));
+
+		// Re-enable first stage
+		config._setStageActive(0, true, false);
+		file = saveRocket(rocketDocLoaded, options);
+		rocketDocLoaded = loadRocket(file.getPath());
+		config = rocketDocLoaded.getRocket().getSelectedConfiguration();
+		assertTrue(" selected config, stage 0 should have been enabled after saving", config.isStageActive(0));
+		assertFalse(" selected config, stage 1 should have been disabled after saving", config.isStageActive(1));
+		assertTrue(" selected config, stage 2 should have been enabled after saving", config.isStageActive(2));
+
+		// Check that other configurations are not affected
+		FlightConfiguration extraConfig = rocketDocLoaded.getRocket().createFlightConfiguration(TestRockets.TEST_FCID_0);
+		extraConfig.setAllStages();
+		file = saveRocket(rocketDocLoaded, options);
+		rocketDocLoaded = loadRocket(file.getPath());
+		config = rocketDocLoaded.getRocket().getSelectedConfiguration();
+		extraConfig = rocketDocLoaded.getRocket().getFlightConfiguration(TestRockets.TEST_FCID_0);
+		assertTrue(" selected config, stage 0 should have been enabled after saving", config.isStageActive(0));
+		assertFalse(" selected config, stage 1 should have been disabled after saving", config.isStageActive(1));
+		assertTrue(" selected config, stage 2 should have been enabled after saving", config.isStageActive(2));
+		assertTrue(" extra config, stage 0 should have been enabled after saving", extraConfig.isStageActive(0));
+		assertTrue(" extra config, stage 1 should have been enabled after saving", extraConfig.isStageActive(1));
+		assertTrue(" extra config, stage 2 should have been enabled after saving", extraConfig.isStageActive(2));
+
+		// Disable a stage in the extra config, and an extra one in the selected config
+		extraConfig._setStageActive(0, false, false);
+		config._setStageActive(2, false, false);
+		file = saveRocket(rocketDocLoaded, options);
+		rocketDocLoaded = loadRocket(file.getPath());
+		config = rocketDocLoaded.getRocket().getSelectedConfiguration();
+		extraConfig = rocketDocLoaded.getRocket().getFlightConfiguration(TestRockets.TEST_FCID_0);
+		assertTrue(" selected config, stage 0 should have been enabled after saving", config.isStageActive(0));
+		assertFalse(" selected config, stage 1 should have been disabled after saving", config.isStageActive(1));
+		assertFalse(" selected config, stage 2 should have been disabled after saving", config.isStageActive(2));
+		assertFalse(" extra config, stage 0 should have been disabled after saving", extraConfig.isStageActive(0));
+		assertTrue(" extra config, stage 1 should have been enabled after saving", extraConfig.isStageActive(1));
+		assertTrue(" extra config, stage 2 should have been enabled after saving", extraConfig.isStageActive(2));
+
+		// Test an empty rocket with no configurations
+		OpenRocketDocument document = OpenRocketDocumentFactory.createNewRocket();
+		file = saveRocket(document, options);
+		rocketDocLoaded = loadRocket(file.getPath());
+		rocketDocLoaded.getRocket().getStage(0).addChild(new BodyTube());		// Add a child, otherwise the stage is always marked inactive
+		config = rocketDocLoaded.getRocket().getSelectedConfiguration();
+		assertTrue(" empty rocket, selected config, stage 0 should have been enabled after saving", config.isStageActive(0));
 	}
 	
 	@Test

--- a/core/test/net/sf/openrocket/file/openrocket/OpenRocketSaverTest.java
+++ b/core/test/net/sf/openrocket/file/openrocket/OpenRocketSaverTest.java
@@ -126,6 +126,7 @@ public class OpenRocketSaverTest {
 		rocketDocs.add(TestRockets.makeTestRocket_v106_withStageSeparationConfig());
 		rocketDocs.add(TestRockets.makeTestRocket_v107_withSimulationExtension(SIMULATION_EXTENSION_SCRIPT));
         rocketDocs.add(TestRockets.makeTestRocket_v108_withBoosters());
+		rocketDocs.add(TestRockets.makeTestRocket_v108_withDisabledStage());
 		rocketDocs.add(TestRockets.makeTestRocket_for_estimateFileSize());
 		
 		StorageOptions options = new StorageOptions();

--- a/core/test/net/sf/openrocket/rocketcomponent/AxialStageTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/AxialStageTest.java
@@ -16,7 +16,7 @@ public class AxialStageTest extends BaseTestCase {
     public void testDisableStage() {
         final Rocket rocket = TestRockets.makeFalcon9Heavy();
         final FlightConfiguration config = rocket.getSelectedConfiguration();
-        final FlightConfigurationId fcid = rocket.createFlightConfiguration(new FlightConfigurationId());
+        final FlightConfigurationId fcid = rocket.createFlightConfiguration(new FlightConfigurationId()).getFlightConfigurationID();
         final FlightConfiguration config2 = rocket.getFlightConfiguration(fcid);
 
         // Disable the payload stage
@@ -106,7 +106,7 @@ public class AxialStageTest extends BaseTestCase {
     public void testDisableStageAndMove() {
         final Rocket rocket = TestRockets.makeFalcon9Heavy();
         final FlightConfiguration config = rocket.getSelectedConfiguration();
-        final FlightConfigurationId fcid = rocket.createFlightConfiguration(new FlightConfigurationId());
+        final FlightConfigurationId fcid = rocket.createFlightConfiguration(new FlightConfigurationId()).getFlightConfigurationID();
         final FlightConfiguration config2 = rocket.getFlightConfiguration(fcid);
 
         // Disable the payload stage
@@ -173,7 +173,7 @@ public class AxialStageTest extends BaseTestCase {
     public void testDisableStageAndCopy() {
         final Rocket rocket = TestRockets.makeFalcon9Heavy();
         final FlightConfiguration config = rocket.getSelectedConfiguration();
-        final FlightConfigurationId fcid = rocket.createFlightConfiguration(new FlightConfigurationId());
+        final FlightConfigurationId fcid = rocket.createFlightConfiguration(new FlightConfigurationId()).getFlightConfigurationID();
         final FlightConfiguration config2 = rocket.getFlightConfiguration(fcid);
 
         // Disable the core stage

--- a/fileformat.txt
+++ b/fileformat.txt
@@ -57,6 +57,7 @@ The following file format versions exist:
       Transitions, Inner Tubes, Launch Lugs, and Fins.
       Added PhotoStudio settings saving (<photostudio>)
       Added override CD parameter (<overridecd>)
+      Added stage activeness remembrance (<stage> under <motorconfiguration>)
       Separated <overridesubcomponents> into individual parameters for mass, CG, and CD.
       Rename <fincount> to <instancecount> (<fincount> remains for backward compatibility)
       Rename <position> to <axialoffset> (<position> remains for backward compatibility)

--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -154,7 +154,6 @@ public class BasicFrame extends JFrame {
 
 		this.document = document;
 		this.rocket = document.getRocket();
-		this.rocket.getSelectedConfiguration().setAllStages();
 		BasicFrame.lastFrameInstance = this;
 
 		//	Create the component tree selection model that will be used


### PR DESCRIPTION
This PR fixes #1687 and adds stage activeness saving in the design file.

Example beginning of a saved file:
```XML
<?xml version='1.0' encoding='utf-8'?>
<openrocket version="1.8" creator="OpenRocket 22.02.beta.05">
  <rocket>
    <name>Three-staged rocket</name>
    <axialoffset method="absolute">0.0</axialoffset>
    <position type="absolute">0.0</position>
    <designer>Sampo Niskanen</designer>
    <motorconfiguration configid="da326836-0959-4c94-bcd5-49dee07235a4">
      <stage number="0" active="true"/>
      <stage number="1" active="true"/>
      <stage number="2" active="true"/>
    </motorconfiguration>
    <motorconfiguration configid="05896b5a-71a7-48ac-b7ae-eadeb267975b">
      <name>Hi, I have a name :)</name>
      <stage number="0" active="true"/>
      <stage number="1" active="false"/>
      <stage number="2" active="true"/>
    </motorconfiguration>
    <motorconfiguration configid="b13e8ca2-f54d-4ca8-9b23-06c6c9eb237a" default="true">
      <stage number="0" active="false"/>
      <stage number="1" active="true"/>
      <stage number="2" active="false"/>
    </motorconfiguration>
    <referencetype>maximum</referencetype>

    <subcomponents>
      <stage>
        <name>Sustainer</name>
```