### PR TITLE
[#1574] Update PhotoPanel configuration on document change

### DIFF
--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoPanel.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoPanel.java
@@ -99,6 +99,7 @@ public class PhotoPanel extends JPanel implements GLEventListener {
 			@Override
 			public void documentChanged(DocumentChangeEvent event) {
 				log.debug("Repainting on document change");
+				configuration = doc.getSelectedConfiguration();
 				needUpdate = true;
 				PhotoPanel.this.repaint();
 			}
@@ -127,7 +128,7 @@ public class PhotoPanel extends JPanel implements GLEventListener {
 	}
 
 	PhotoPanel(OpenRocketDocument document, PhotoSettings p) {
-    this.p = p;
+    	this.p = p;
 		this.setLayout(new BorderLayout());
 		PhotoPanel.this.configuration = document.getSelectedConfiguration();
 


### PR DESCRIPTION
This PR fixes #1574. Now when you add a new configuration while PhotoStudio is open, that configuration is drawn in PhotoStudio.

Steps to reproduce:
1. Open 'A simple model rocket'
2. Delete all the configurations
3. Open PhotoStudio
4. Add a new configuration and select a motor for it (PhotoStudio should still be open)
5. You can see the motor being rendered in PhotoStudio, which was previously not the case 