### PR TITLE
[#1694] Update rocket figure after unit change

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/preferences/PreferencesDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preferences/PreferencesDialog.java
@@ -14,6 +14,7 @@ import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
 
 import net.miginfocom.swing.MigLayout;
+import net.sf.openrocket.gui.main.BasicFrame;
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.gui.util.SwingPreferences;
 import net.sf.openrocket.l10n.Translator;
@@ -33,7 +34,7 @@ public class PreferencesDialog extends JDialog {
 	private final SwingPreferences preferences = (SwingPreferences) Application
 			.getPreferences();
 
-	private PreferencesDialog(Window parent) {
+	private PreferencesDialog(BasicFrame parent) {
 		// // Preferences
 		super(parent, trans.get("pref.dlg.title.Preferences"),
 				Dialog.ModalityType.APPLICATION_MODAL);
@@ -93,6 +94,11 @@ public class PreferencesDialog extends JDialog {
 			@Override
 			public void windowClosed(WindowEvent e) {
 				preferences.storeDefaultUnits();
+				// Make sure unit change applies to the rocket figure
+				if (parent != null) {
+					parent.getRocketPanel().updateExtras();
+					parent.getRocketPanel().updateFigures();
+				}
 			}
 		});
 
@@ -103,7 +109,7 @@ public class PreferencesDialog extends JDialog {
 
 	private static PreferencesDialog dialog = null;
 
-	public static void showPreferences(Window parent) {
+	public static void showPreferences(BasicFrame parent) {
 		if (dialog != null) {
 			dialog.dispose();
 		}

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketPanel.java
@@ -686,7 +686,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 	 */
 	private WarningSet warnings = new WarningSet();
 
-	private void updateExtras() {
+	public void updateExtras() {
 		Coordinate cp, cg;
 		double cgx = Double.NaN;
 		double cgy = Double.NaN;

--- a/swing/src/net/sf/openrocket/startup/OSXSetup.java
+++ b/swing/src/net/sf/openrocket/startup/OSXSetup.java
@@ -67,12 +67,12 @@ final class OSXSetup {
 	/**
 	 * The handler for the About item in the OSX app menu
 	 */
-	private static final AboutHandler ABOUT_HANDLER = a -> new AboutDialog(null).setVisible(true);
+	private static final AboutHandler ABOUT_HANDLER = a -> new AboutDialog(BasicFrame.lastFrameInstance).setVisible(true);
 
 	/**
 	 * The handler for the Preferences item in the OSX app menu
 	 */
-	private static final PreferencesHandler PREFERENCES_HANDLER = p -> PreferencesDialog.showPreferences(null);
+	private static final PreferencesHandler PREFERENCES_HANDLER = p -> PreferencesDialog.showPreferences(BasicFrame.lastFrameInstance);
 
 	/**
 	 * Sets up the Application's Icon, Name, Menu and some menu item handlers


### PR DESCRIPTION
This PR fixes #1694. If you change the units in the preference dialog, and close the dialog, the units in the rocket view should get updated.

Note: the units for the stability info and flight info are not updated in the 3D view, see issue #1771.