### PR TITLE
[#1321] Externalize tube coupler children on RockSim export

### DIFF
--- a/core/resources/l10n/messages_es.properties
+++ b/core/resources/l10n/messages_es.properties
@@ -1638,7 +1638,7 @@ pref.dlg.PrefChoiseSelector1            = Preguntar siempre
 pref.dlg.PrefChoiseSelector2            = Insertar en medio
 pref.dlg.PrefChoiseSelector3            = A\u00f1adir al final
 pref.dlg.RASPfiles                      = Ficheros de motor RASP (*.eng)
-pref.dlg.RockSimfiles                   = Ficheros de motor Rocksim (*.rse)
+pref.dlg.RockSimfiles                   = Ficheros de motor RockSim (*.rse)
 pref.dlg.ZIParchives                    = Archivos ZIP (*.zip)
 ! Preference dialog
 pref.dlg.but.add                        = Agregar

--- a/core/src/net/sf/openrocket/file/GeneralRocketLoader.java
+++ b/core/src/net/sf/openrocket/file/GeneralRocketLoader.java
@@ -16,7 +16,7 @@ import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.document.OpenRocketDocumentFactory;
 import net.sf.openrocket.file.openrocket.importt.OpenRocketLoader;
-import net.sf.openrocket.file.rocksim.importt.RocksimLoader;
+import net.sf.openrocket.file.rocksim.importt.RockSimLoader;
 import net.sf.openrocket.util.ArrayUtils;
 import net.sf.openrocket.util.TextUtil;
 
@@ -41,7 +41,7 @@ public class GeneralRocketLoader {
 	
 	private final OpenRocketLoader openRocketLoader = new OpenRocketLoader();
 	
-	private final RocksimLoader rocksimLoader = new RocksimLoader();
+	private final RockSimLoader rocksimLoader = new RockSimLoader();
 	
 	private final File baseFile;
 	private final URL jarURL;

--- a/core/src/net/sf/openrocket/file/GeneralRocketSaver.java
+++ b/core/src/net/sf/openrocket/file/GeneralRocketSaver.java
@@ -19,7 +19,7 @@ import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.document.StorageOptions;
 import net.sf.openrocket.document.StorageOptions.FileType;
 import net.sf.openrocket.file.openrocket.OpenRocketSaver;
-import net.sf.openrocket.file.rocksim.export.RocksimSaver;
+import net.sf.openrocket.file.rocksim.export.RockSimSaver;
 import net.sf.openrocket.rocketcomponent.InsideColorComponent;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.util.DecalNotFoundException;
@@ -143,7 +143,7 @@ public class GeneralRocketSaver {
 	 */
 	public long estimateFileSize(OpenRocketDocument doc, StorageOptions options) {
 		if (options.getFileType() == StorageOptions.FileType.ROCKSIM) {
-			return new RocksimSaver().estimateFileSize(doc, options);
+			return new RockSimSaver().estimateFileSize(doc, options);
 		} else {
 			return new OpenRocketSaver().estimateFileSize(doc, options);
 		}
@@ -233,7 +233,7 @@ public class GeneralRocketSaver {
 			throws IOException {
 		
 		if (options.getFileType() == StorageOptions.FileType.ROCKSIM) {
-			new RocksimSaver().save(output, document, options);
+			new RockSimSaver().save(output, document, options);
 		} else {
 			new OpenRocketSaver().save(output, document, options);
 		}

--- a/core/src/net/sf/openrocket/file/TipShapeCode.java
+++ b/core/src/net/sf/openrocket/file/TipShapeCode.java
@@ -7,9 +7,9 @@ import net.sf.openrocket.rocketcomponent.FinSet;
 public final class TipShapeCode {
 
     /**
-     * Convert a Rocksim tip shape to an OpenRocket CrossSection.
+     * Convert a RockSim tip shape to an OpenRocket CrossSection.
      *
-     * @param tipShape the tip shape code from Rocksim
+     * @param tipShape the tip shape code from RockSim
      *
      * @return a CrossSection instance
      */

--- a/core/src/net/sf/openrocket/file/rocksim/RockSimCommonConstants.java
+++ b/core/src/net/sf/openrocket/file/rocksim/RockSimCommonConstants.java
@@ -2,7 +2,7 @@ package net.sf.openrocket.file.rocksim;
 
 /**
  */
-public class RocksimCommonConstants {
+public class RockSimCommonConstants {
 
     public static final String SHAPE_CODE = "ShapeCode";
     public static final String CONSTRUCTION_TYPE = "ConstructionType";
@@ -88,27 +88,27 @@ public class RocksimCommonConstants {
     public static final String MAX_TUBES_ALLOWED = "MaxTubesAllowed";
 
     /**
-     * Length conversion.  Rocksim is in millimeters, OpenRocket in meters.
+     * Length conversion.  RockSim is in millimeters, OpenRocket in meters.
      */
     public static final int ROCKSIM_TO_OPENROCKET_LENGTH = 1000;
     /**
-     * Mass conversion.  Rocksim is in grams, OpenRocket in kilograms.
+     * Mass conversion.  RockSim is in grams, OpenRocket in kilograms.
      */
     public static final int ROCKSIM_TO_OPENROCKET_MASS = 1000;
     /**
-     * Bulk Density conversion.  Rocksim is in kilograms/cubic meter, OpenRocket in kilograms/cubic meter.
+     * Bulk Density conversion.  RockSim is in kilograms/cubic meter, OpenRocket in kilograms/cubic meter.
      */
     public static final int ROCKSIM_TO_OPENROCKET_BULK_DENSITY = 1;
     /**
-     * Surface Density conversion.  Rocksim is in grams/sq centimeter, OpenRocket in kilograms/sq meter.  1000/(100*100) = 1/10
+     * Surface Density conversion.  RockSim is in grams/sq centimeter, OpenRocket in kilograms/sq meter.  1000/(100*100) = 1/10
      */
     public static final double ROCKSIM_TO_OPENROCKET_SURFACE_DENSITY = 1/10d;
     /**
-     * Line Density conversion.  Rocksim is in kilograms/meter, OpenRocket in kilograms/meter.
+     * Line Density conversion.  RockSim is in kilograms/meter, OpenRocket in kilograms/meter.
      */
     public static final int ROCKSIM_TO_OPENROCKET_LINE_DENSITY = 1;
     /**
-     * Radius conversion.  Rocksim is always in diameters, OpenRocket mostly in radius.
+     * Radius conversion.  RockSim is always in diameters, OpenRocket mostly in radius.
      */
     public static final int ROCKSIM_TO_OPENROCKET_RADIUS = 2 * ROCKSIM_TO_OPENROCKET_LENGTH;
 }

--- a/core/src/net/sf/openrocket/file/rocksim/RockSimDensityType.java
+++ b/core/src/net/sf/openrocket/file/rocksim/RockSimDensityType.java
@@ -1,19 +1,19 @@
 /*
- * RocksimDensityType.java
+ * RockSimDensityType.java
  */
 package net.sf.openrocket.file.rocksim;
 
 import net.sf.openrocket.material.Material;
 
 /**
- * Models the nose cone shape of a rocket.  Maps from Rocksim's notion to OpenRocket's.
+ * Models the nose cone shape of a rocket.  Maps from RockSim's notion to OpenRocket's.
  */
-public enum RocksimDensityType {
-    ROCKSIM_BULK   (0, RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_BULK_DENSITY),
-    ROCKSIM_SURFACE(1, RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_SURFACE_DENSITY),
-    ROCKSIM_LINE   (2, RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LINE_DENSITY);
+public enum RockSimDensityType {
+    ROCKSIM_BULK   (0, RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_BULK_DENSITY),
+    ROCKSIM_SURFACE(1, RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_SURFACE_DENSITY),
+    ROCKSIM_LINE   (2, RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LINE_DENSITY);
 
-    /** The Rocksim enumeration value. Sent in XML. */
+    /** The RockSim enumeration value. Sent in XML. */
     private final int ordinal;
 
     /** The corresponding OpenRocket shape. */
@@ -22,16 +22,16 @@ public enum RocksimDensityType {
     /**
      * Constructor.
      *
-     * @param idx            the Rocksim shape code
+     * @param idx            the RockSim shape code
      * @param theConversion  the numerical conversion ratio to OpenRocket
      */
-    private RocksimDensityType(int idx, double theConversion) {
+    private RockSimDensityType(int idx, double theConversion) {
         ordinal = idx;
         conversion = theConversion;
     }
 
     /**
-     * Get the OpenRocket shape that corresponds to the Rocksim value.
+     * Get the OpenRocket shape that corresponds to the RockSim value.
      *
      * @return a conversion
      */
@@ -40,14 +40,14 @@ public enum RocksimDensityType {
     }
 
     /**
-     * Lookup an instance of this enum based upon the Rocksim code.
+     * Lookup an instance of this enum based upon the RockSim code.
      *
-     * @param rocksimDensityType  the Rocksim code (from XML)
+     * @param rocksimDensityType  the RockSim code (from XML)
      * @return an instance of this enum
      */
-    public static RocksimDensityType fromCode(int rocksimDensityType) {
-        RocksimDensityType[] values = values();
-        for (RocksimDensityType value : values) {
+    public static RockSimDensityType fromCode(int rocksimDensityType) {
+        RockSimDensityType[] values = values();
+        for (RockSimDensityType value : values) {
             if (value.ordinal == rocksimDensityType) {
                 return value;
             }
@@ -60,7 +60,7 @@ public enum RocksimDensityType {
      *
      * @param type  the OR type
      *
-     * @return  the Rocksim XML value
+     * @return  the RockSim XML value
      */
     public static int toCode(Material.Type type) {
         if (type.equals(Material.Type.BULK)) {

--- a/core/src/net/sf/openrocket/file/rocksim/RockSimFinishCode.java
+++ b/core/src/net/sf/openrocket/file/rocksim/RockSimFinishCode.java
@@ -1,5 +1,5 @@
 /*
- * RocksimFinishCode.java
+ * RockSimFinishCode.java
  */
 package net.sf.openrocket.file.rocksim;
 
@@ -8,13 +8,13 @@ import net.sf.openrocket.rocketcomponent.ExternalComponent;
 /**
  * Models the finish of a component.
  */
-public enum RocksimFinishCode {
+public enum RockSimFinishCode {
     POLISHED(0, ExternalComponent.Finish.POLISHED),
     GLOSS(1, ExternalComponent.Finish.SMOOTH),
     MATT(2, ExternalComponent.Finish.NORMAL),
     UNFINISHED(3, ExternalComponent.Finish.UNFINISHED);
 
-    /** The Rocksim code (from XML). */
+    /** The RockSim code (from XML). */
     private final int ordinal;
     
     /** The corresponding OpenRocket finish. */
@@ -23,10 +23,10 @@ public enum RocksimFinishCode {
     /**
      * Constructor.
      * 
-     * @param idx   the Rocksim enum value
+     * @param idx   the RockSim enum value
      * @param theFinish  the OpenRocket finish
      */
-    private RocksimFinishCode(int idx, ExternalComponent.Finish theFinish) {
+    private RockSimFinishCode(int idx, ExternalComponent.Finish theFinish) {
         ordinal = idx;
         finish = theFinish;
     }
@@ -41,15 +41,15 @@ public enum RocksimFinishCode {
     }
 
     /**
-     * Lookup an instance of this enum from a Rocksim value.
+     * Lookup an instance of this enum from a RockSim value.
      * 
-     * @param rocksimFinishCode  the Rocksim value
+     * @param rocksimFinishCode  the RockSim value
      * 
      * @return an instance of this enum; Defaults to MATT
      */
-    public static RocksimFinishCode fromCode(int rocksimFinishCode) {
-        RocksimFinishCode[] values = values();
-        for (RocksimFinishCode value : values) {
+    public static RockSimFinishCode fromCode(int rocksimFinishCode) {
+        RockSimFinishCode[] values = values();
+        for (RockSimFinishCode value : values) {
             if (value.ordinal == rocksimFinishCode) {
                 return value;
             }
@@ -62,7 +62,7 @@ public enum RocksimFinishCode {
      *
      * @param type  the OR type
      *
-     * @return  the Rocksim XML value
+     * @return  the RockSim XML value
      */
     public static int toCode(ExternalComponent.Finish type) {
         if (type.equals(ExternalComponent.Finish.UNFINISHED)) {

--- a/core/src/net/sf/openrocket/file/rocksim/RockSimLocationMode.java
+++ b/core/src/net/sf/openrocket/file/rocksim/RockSimLocationMode.java
@@ -1,19 +1,19 @@
 /*
- * RocksimLocationMode.java
+ * RockSimLocationMode.java
  */
 package net.sf.openrocket.file.rocksim;
 
 import net.sf.openrocket.rocketcomponent.position.AxialMethod;
 
 /**
- * Models the relative position of parts on a rocket.  Maps from Rocksim's notion to OpenRocket's.
+ * Models the relative position of parts on a rocket.  Maps from RockSim's notion to OpenRocket's.
  */
-public enum RocksimLocationMode {
+public enum RockSimLocationMode {
     FRONT_OF_OWNING_PART (0, AxialMethod.TOP),
     FROM_TIP_OF_NOSE     (1, AxialMethod.ABSOLUTE),
     BACK_OF_OWNING_PART  (2, AxialMethod.BOTTOM);
 
-    /** The value Rocksim uses internally (and in the XML file). */
+    /** The value RockSim uses internally (and in the XML file). */
     private final int ordinal;
     
     /** The OpenRocket position equivalent. */
@@ -25,7 +25,7 @@ public enum RocksimLocationMode {
      * @param idx   the rocksim enum value
      * @param theOpenRocketPosition  the corresponding OpenRocket position
      */
-    RocksimLocationMode(int idx, AxialMethod theOpenRocketPosition) {
+    RockSimLocationMode(int idx, AxialMethod theOpenRocketPosition) {
         ordinal = idx;
         position = theOpenRocketPosition;
     }
@@ -46,9 +46,9 @@ public enum RocksimLocationMode {
      * 
      * @return an instance of this enum
      */
-    public static RocksimLocationMode fromCode(int rocksimCode) {
-        RocksimLocationMode[] values = values();
-        for (RocksimLocationMode value : values) {
+    public static RockSimLocationMode fromCode(int rocksimCode) {
+        RockSimLocationMode[] values = values();
+        for (RockSimLocationMode value : values) {
             if (value.ordinal == rocksimCode) {
                 return value;
             }

--- a/core/src/net/sf/openrocket/file/rocksim/RockSimNoseConeCode.java
+++ b/core/src/net/sf/openrocket/file/rocksim/RockSimNoseConeCode.java
@@ -1,5 +1,5 @@
 /*
- * RocksimNoseConeCode.java
+ * RockSimNoseConeCode.java
  */
 package net.sf.openrocket.file.rocksim;
 
@@ -9,19 +9,19 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Models the nose cone shape of a rocket.  Maps from Rocksim's notion to OpenRocket's.
+ * Models the nose cone shape of a rocket.  Maps from RockSim's notion to OpenRocket's.
  */
-public enum RocksimNoseConeCode {
+public enum RockSimNoseConeCode {
     CONICAL(0, Transition.Shape.CONICAL, "Conic", "Cone"),
     OGIVE(1, Transition.Shape.OGIVE),
-    PARABOLIC(2, Transition.Shape.ELLIPSOID),  //Rocksim' PARABOLIC most closely resembles an ELLIPSOID in OpenRocket
+    PARABOLIC(2, Transition.Shape.ELLIPSOID),  //RockSim' PARABOLIC most closely resembles an ELLIPSOID in OpenRocket
     ELLIPTICAL(3, Transition.Shape.ELLIPSOID),
     POWER_SERIES(4, Transition.Shape.POWER),
     PARABOLIC_SERIES(5, Transition.Shape.PARABOLIC),
     HAACK(6, Transition.Shape.HAACK);
 
     /**
-     * The Rocksim enumeration value. Sent in XML.
+     * The RockSim enumeration value. Sent in XML.
      */
     private final int ordinal;
 
@@ -38,11 +38,11 @@ public enum RocksimNoseConeCode {
     /**
      * Constructor.
      *
-     * @param idx           the Rocksim shape code
+     * @param idx           the RockSim shape code
      * @param aShape        the corresponding OpenRocket shape
      * @param theShapeNames an array of alternate names
      */
-    private RocksimNoseConeCode(int idx, Transition.Shape aShape, String... theShapeNames) {
+    private RockSimNoseConeCode(int idx, Transition.Shape aShape, String... theShapeNames) {
         ordinal = idx;
         shape = aShape;
         shapeNames.add(this.name().toLowerCase());
@@ -54,7 +54,7 @@ public enum RocksimNoseConeCode {
     }
 
     /**
-     * Get the OpenRocket shape that corresponds to the Rocksim shape.
+     * Get the OpenRocket shape that corresponds to the RockSim shape.
      *
      * @return a shape
      */
@@ -63,14 +63,14 @@ public enum RocksimNoseConeCode {
     }
 
     /**
-     * Lookup an instance of this enum based upon the Rocksim code.
+     * Lookup an instance of this enum based upon the RockSim code.
      *
-     * @param rocksimShapeCode the Rocksim code (from XML)
+     * @param rocksimShapeCode the RockSim code (from XML)
      * @return an instance of this enum
      */
-    public static RocksimNoseConeCode fromCode(int rocksimShapeCode) {
-        RocksimNoseConeCode[] values = values();
-        for (RocksimNoseConeCode value : values) {
+    public static RockSimNoseConeCode fromCode(int rocksimShapeCode) {
+        RockSimNoseConeCode[] values = values();
+        for (RockSimNoseConeCode value : values) {
             if (value.ordinal == rocksimShapeCode) {
                 return value;
             }
@@ -79,14 +79,14 @@ public enum RocksimNoseConeCode {
     }
 
     /**
-     * Lookup an ordinal value for the Rocksim code.
+     * Lookup an ordinal value for the RockSim code.
      *
      * @param type the OR Shape
-     * @return the Rocksim code
+     * @return the RockSim code
      */
     public static int toCode(Transition.Shape type) {
-        RocksimNoseConeCode[] values = values();
-        for (RocksimNoseConeCode value : values) {
+        RockSimNoseConeCode[] values = values();
+        for (RockSimNoseConeCode value : values) {
             if (value.shape.equals(type)) {
                 if (value.ordinal == 2) {
                     return 3;
@@ -103,9 +103,9 @@ public enum RocksimNoseConeCode {
      * @param theName the name of the shape; case does not matter
      * @return the corresponding enum instance; defaults to PARABOLIC if not found.
      */
-    public static RocksimNoseConeCode fromShapeName(String theName) {
-        RocksimNoseConeCode[] values = values();
-        for (RocksimNoseConeCode value : values) {
+    public static RockSimNoseConeCode fromShapeName(String theName) {
+        RockSimNoseConeCode[] values = values();
+        for (RockSimNoseConeCode value : values) {
             if (value.shapeNames.contains(theName.toLowerCase())) {
                 return value;
             }
@@ -120,7 +120,7 @@ public enum RocksimNoseConeCode {
      * @param nameOrOrdinalString the shape number or shape name
      * @return an instance of this enum; defaults to PARABOLIC if not found
      */
-    public static RocksimNoseConeCode fromShapeNameOrCode(String nameOrOrdinalString) {
+    public static RockSimNoseConeCode fromShapeNameOrCode(String nameOrOrdinalString) {
         try {
             return fromCode(Integer.parseInt(nameOrOrdinalString));
         }

--- a/core/src/net/sf/openrocket/file/rocksim/export/AbstractTransitionDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/AbstractTransitionDTO.java
@@ -80,27 +80,27 @@ public class AbstractTransitionDTO extends BasePartDTO implements AttachablePart
         for (int i = 0; i < children.size(); i++) {
             RocketComponent rocketComponents = children.get(i);
             if (rocketComponents instanceof InnerTube) {
-                attachedParts.add(new InnerBodyTubeDTO((InnerTube) rocketComponents, this));
+                addAttachedPart(new InnerBodyTubeDTO((InnerTube) rocketComponents, this));
             } else if (rocketComponents instanceof BodyTube) {
-                attachedParts.add(new BodyTubeDTO((BodyTube) rocketComponents));
+                addAttachedPart(new BodyTubeDTO((BodyTube) rocketComponents));
             } else if (rocketComponents instanceof Transition) {
-                attachedParts.add(new TransitionDTO((Transition) rocketComponents));
+                addAttachedPart(new TransitionDTO((Transition) rocketComponents));
             } else if (rocketComponents instanceof EngineBlock) {
-                attachedParts.add(new EngineBlockDTO((EngineBlock) rocketComponents));
+                addAttachedPart(new EngineBlockDTO((EngineBlock) rocketComponents));
             } else if (rocketComponents instanceof TubeCoupler) {
-                attachedParts.add(new TubeCouplerDTO((TubeCoupler) rocketComponents));
+                addAttachedPart(new TubeCouplerDTO((TubeCoupler) rocketComponents, this));
             } else if (rocketComponents instanceof CenteringRing) {
-                attachedParts.add(new CenteringRingDTO((CenteringRing) rocketComponents));
+                addAttachedPart(new CenteringRingDTO((CenteringRing) rocketComponents));
             } else if (rocketComponents instanceof Bulkhead) {
-                attachedParts.add(new BulkheadDTO((Bulkhead) rocketComponents));
+                addAttachedPart(new BulkheadDTO((Bulkhead) rocketComponents));
             } else if (rocketComponents instanceof Parachute) {
-                attachedParts.add(new ParachuteDTO((Parachute) rocketComponents));
+                addAttachedPart(new ParachuteDTO((Parachute) rocketComponents));
             } else if (rocketComponents instanceof MassObject) {
-                attachedParts.add(new MassObjectDTO((MassObject) rocketComponents));
+                addAttachedPart(new MassObjectDTO((MassObject) rocketComponents));
             } else if (rocketComponents instanceof FreeformFinSet) {
-                attachedParts.add(new CustomFinSetDTO((FreeformFinSet) rocketComponents));
+                addAttachedPart(new CustomFinSetDTO((FreeformFinSet) rocketComponents));
             } else if (rocketComponents instanceof FinSet) {
-                attachedParts.add(new FinSetDTO((FinSet) rocketComponents));
+                addAttachedPart(new FinSetDTO((FinSet) rocketComponents));
             }
         }
     }
@@ -139,7 +139,9 @@ public class AbstractTransitionDTO extends BasePartDTO implements AttachablePart
 
     @Override
     public void addAttachedPart(BasePartDTO part) {
-        attachedParts.add(part);
+        if (!attachedParts.contains(part)) {
+            attachedParts.add(part);
+        }
     }
 
     @Override

--- a/core/src/net/sf/openrocket/file/rocksim/export/AbstractTransitionDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/AbstractTransitionDTO.java
@@ -1,7 +1,7 @@
 package net.sf.openrocket.file.rocksim.export;
 
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
-import net.sf.openrocket.file.rocksim.RocksimNoseConeCode;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimNoseConeCode;
 import net.sf.openrocket.rocketcomponent.BodyTube;
 import net.sf.openrocket.rocketcomponent.Bulkhead;
 import net.sf.openrocket.rocketcomponent.CenteringRing;
@@ -26,30 +26,30 @@ import java.util.List;
 
 /**
  * A common ancestor class for nose cones and transitions.  This class is responsible for adapting an OpenRocket
- * Transition to a Rocksim Transition.
+ * Transition to a RockSim Transition.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 public class AbstractTransitionDTO extends BasePartDTO implements AttachableParts {
 
-    @XmlElement(name = RocksimCommonConstants.SHAPE_CODE)
+    @XmlElement(name = RockSimCommonConstants.SHAPE_CODE)
     private int shapeCode = 1;
-    @XmlElement(name = RocksimCommonConstants.CONSTRUCTION_TYPE)
+    @XmlElement(name = RockSimCommonConstants.CONSTRUCTION_TYPE)
     private int constructionType = 1;
-    @XmlElement(name = RocksimCommonConstants.WALL_THICKNESS)
+    @XmlElement(name = RockSimCommonConstants.WALL_THICKNESS)
     private double wallThickness = 0d;
-    @XmlElement(name = RocksimCommonConstants.SHAPE_PARAMETER)
+    @XmlElement(name = RockSimCommonConstants.SHAPE_PARAMETER)
     private double shapeParameter = 0d;
 
-    @XmlElementWrapper(name = RocksimCommonConstants.ATTACHED_PARTS)
+    @XmlElementWrapper(name = RockSimCommonConstants.ATTACHED_PARTS)
     @XmlElementRefs({
-            @XmlElementRef(name = RocksimCommonConstants.BODY_TUBE, type = BodyTubeDTO.class),
-            @XmlElementRef(name = RocksimCommonConstants.BODY_TUBE, type = InnerBodyTubeDTO.class),
-            @XmlElementRef(name = RocksimCommonConstants.FIN_SET, type = FinSetDTO.class),
-            @XmlElementRef(name = RocksimCommonConstants.CUSTOM_FIN_SET, type = CustomFinSetDTO.class),
-            @XmlElementRef(name = RocksimCommonConstants.RING, type = CenteringRingDTO.class),
-            @XmlElementRef(name = RocksimCommonConstants.STREAMER, type = StreamerDTO.class),
-            @XmlElementRef(name = RocksimCommonConstants.PARACHUTE, type = ParachuteDTO.class),
-            @XmlElementRef(name = RocksimCommonConstants.MASS_OBJECT, type = MassObjectDTO.class)})
+            @XmlElementRef(name = RockSimCommonConstants.BODY_TUBE, type = BodyTubeDTO.class),
+            @XmlElementRef(name = RockSimCommonConstants.BODY_TUBE, type = InnerBodyTubeDTO.class),
+            @XmlElementRef(name = RockSimCommonConstants.FIN_SET, type = FinSetDTO.class),
+            @XmlElementRef(name = RockSimCommonConstants.CUSTOM_FIN_SET, type = CustomFinSetDTO.class),
+            @XmlElementRef(name = RockSimCommonConstants.RING, type = CenteringRingDTO.class),
+            @XmlElementRef(name = RockSimCommonConstants.STREAMER, type = StreamerDTO.class),
+            @XmlElementRef(name = RockSimCommonConstants.PARACHUTE, type = ParachuteDTO.class),
+            @XmlElementRef(name = RockSimCommonConstants.MASS_OBJECT, type = MassObjectDTO.class)})
     List<BasePartDTO> attachedParts = new ArrayList<BasePartDTO>();
 
     /**
@@ -66,7 +66,7 @@ public class AbstractTransitionDTO extends BasePartDTO implements AttachablePart
     protected AbstractTransitionDTO(Transition nc) {
         super(nc);
         setConstructionType(nc.isFilled() ? 0 : 1);
-        setShapeCode(RocksimNoseConeCode.toCode(nc.getType()));
+        setShapeCode(RockSimNoseConeCode.toCode(nc.getType()));
 
         if (Transition.Shape.POWER.equals(nc.getType()) ||
                 Transition.Shape.HAACK.equals(nc.getType()) ||
@@ -74,7 +74,7 @@ public class AbstractTransitionDTO extends BasePartDTO implements AttachablePart
             setShapeParameter(nc.getShapeParameter());
         }
 
-        setWallThickness(nc.getThickness() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+        setWallThickness(nc.getThickness() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 
         List<RocketComponent> children = nc.getChildren();
         for (int i = 0; i < children.size(); i++) {

--- a/core/src/net/sf/openrocket/file/rocksim/export/AttachableParts.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/AttachableParts.java
@@ -1,9 +1,9 @@
 package net.sf.openrocket.file.rocksim.export;
 
 /**
- * An interface that defines methods for attaching and detaching child components.  Rocksim has a special
+ * An interface that defines methods for attaching and detaching child components.  RockSim has a special
  * XML element that acts as a container, called <pre><AttachedParts></AttachedParts></pre>.  Implementors of
- * this interface are those Rocksim DTO classes that support the attached parts element.
+ * this interface are those RockSim DTO classes that support the attached parts element.
  */
 public interface AttachableParts {
     /**

--- a/core/src/net/sf/openrocket/file/rocksim/export/BasePartDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/BasePartDTO.java
@@ -5,14 +5,13 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
-import net.sf.openrocket.file.rocksim.RocksimDensityType;
-import net.sf.openrocket.file.rocksim.RocksimFinishCode;
-import net.sf.openrocket.file.rocksim.RocksimLocationMode;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimDensityType;
+import net.sf.openrocket.file.rocksim.RockSimFinishCode;
+import net.sf.openrocket.file.rocksim.RockSimLocationMode;
 import net.sf.openrocket.file.rocksim.importt.BaseHandler;
 import net.sf.openrocket.rocketcomponent.ExternalComponent;
 import net.sf.openrocket.rocketcomponent.FinSet;
-import net.sf.openrocket.rocketcomponent.MassObject;
 import net.sf.openrocket.rocketcomponent.RecoveryDevice;
 import net.sf.openrocket.rocketcomponent.RingComponent;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
@@ -20,49 +19,49 @@ import net.sf.openrocket.rocketcomponent.StructuralComponent;
 import net.sf.openrocket.rocketcomponent.position.AxialMethod;
 
 /**
- * The base class for all OpenRocket to Rocksim conversions.
+ * The base class for all OpenRocket to RockSim conversions.
  */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
 public abstract class BasePartDTO {
 
     /**
-     * The very important Rocksim serial number.  Each component needs one.  This is not multi-thread safe.  Trying
+     * The very important RockSim serial number.  Each component needs one.  This is not multi-thread safe.  Trying
      * to save multiple files at the same time will have unpredictable results with respect to the serial numbering.
      */
     private static int currentSerialNumber = 1;
 
-    @XmlElement(name = RocksimCommonConstants.KNOWN_MASS)
+    @XmlElement(name = RockSimCommonConstants.KNOWN_MASS)
     private double knownMass = 0d;
-    @XmlElement(name = RocksimCommonConstants.DENSITY)
+    @XmlElement(name = RockSimCommonConstants.DENSITY)
     private double density = 0d;
-    @XmlElement(name = RocksimCommonConstants.MATERIAL)
+    @XmlElement(name = RockSimCommonConstants.MATERIAL)
     private String material = "";
-    @XmlElement(name = RocksimCommonConstants.NAME)
+    @XmlElement(name = RockSimCommonConstants.NAME)
     private String name = "";
-    @XmlElement(name = RocksimCommonConstants.KNOWN_CG)
+    @XmlElement(name = RockSimCommonConstants.KNOWN_CG)
     private double knownCG = 0;
-    @XmlElement(name = RocksimCommonConstants.USE_KNOWN_CG)
+    @XmlElement(name = RockSimCommonConstants.USE_KNOWN_CG)
     private int useKnownCG = 1;
-    @XmlElement(name = RocksimCommonConstants.XB)
+    @XmlElement(name = RockSimCommonConstants.XB)
     private double xb = 0;
-    @XmlElement(name = RocksimCommonConstants.CALC_MASS)
+    @XmlElement(name = RockSimCommonConstants.CALC_MASS)
     private double calcMass = 0d;
-    @XmlElement(name = RocksimCommonConstants.CALC_CG)
+    @XmlElement(name = RockSimCommonConstants.CALC_CG)
     private double calcCG = 0d;
-    @XmlElement(name = RocksimCommonConstants.DENSITY_TYPE)
+    @XmlElement(name = RockSimCommonConstants.DENSITY_TYPE)
     private int densityType = 0;
-    @XmlElement(name = RocksimCommonConstants.RADIAL_LOC)
+    @XmlElement(name = RockSimCommonConstants.RADIAL_LOC)
     private double radialLoc = 0;
-    @XmlElement(name = RocksimCommonConstants.RADIAL_ANGLE)
+    @XmlElement(name = RockSimCommonConstants.RADIAL_ANGLE)
     private double radialAngle = 0;
-    @XmlElement(name = RocksimCommonConstants.LOCATION_MODE)
+    @XmlElement(name = RockSimCommonConstants.LOCATION_MODE)
     private int locationMode = 0;
-    @XmlElement(name = RocksimCommonConstants.LEN, required = false, nillable = false)
+    @XmlElement(name = RockSimCommonConstants.LEN, required = false, nillable = false)
     private double len = 0d;
-    @XmlElement(name = RocksimCommonConstants.FINISH_CODE)
+    @XmlElement(name = RockSimCommonConstants.FINISH_CODE)
     private int finishCode = 0;
-    @XmlElement(name = RocksimCommonConstants.SERIAL_NUMBER)
+    @XmlElement(name = RockSimCommonConstants.SERIAL_NUMBER)
     private int serialNumber = -1;
 
     /**
@@ -79,50 +78,50 @@ public abstract class BasePartDTO {
      */
     protected BasePartDTO(RocketComponent ec) {
         serialNumber = currentSerialNumber++;
-        setCalcCG(ec.getCG().x * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
-        setCalcMass(ec.getComponentMass() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
-        setKnownCG(ec.getOverrideCGX() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
-        setKnownMass(ec.getMass() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
+        setCalcCG(ec.getCG().x * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+        setCalcMass(ec.getComponentMass() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
+        setKnownCG(ec.getOverrideCGX() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+        setKnownMass(ec.getMass() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
 
         if (!(ec instanceof FinSet)) {
-            setLen(ec.getLength() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+            setLen(ec.getLength() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
         }
         setUseKnownCG(ec.isCGOverridden() || ec.isMassOverridden() ? 1 : 0);
         setName(ec.getName());
 
-        setXb(ec.getAxialOffset() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+        setXb(ec.getAxialOffset() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 
         //When the relative position is BOTTOM, the position location of the bottom edge of the component is +
         //to the right of the bottom of the parent, and - to the left.
-        //But in Rocksim, it's + to the left and - to the right
+        //But in RockSim, it's + to the left and - to the right
         if (ec.getAxialMethod().equals(AxialMethod.BOTTOM)) {
-            setXb((-1 * ec.getAxialOffset()) * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+            setXb((-1 * ec.getAxialOffset()) * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
         }
         else if (ec.getAxialMethod().equals(AxialMethod.MIDDLE)) {
             //Mapped to TOP, so adjust accordingly
-            setXb((ec.getAxialOffset() + (ec.getParent().getLength() - ec.getLength()) /2)* RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+            setXb((ec.getAxialOffset() + (ec.getParent().getLength() - ec.getLength()) /2)* RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
         }
 
         if (ec instanceof ExternalComponent) {
             ExternalComponent comp = (ExternalComponent) ec;
-            setLocationMode(RocksimLocationMode.toCode(comp.getAxialMethod()));
+            setLocationMode(RockSimLocationMode.toCode(comp.getAxialMethod()));
 
-            setDensity(comp.getMaterial().getDensity() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_BULK_DENSITY);
-            setDensityType(RocksimDensityType.toCode(comp.getMaterial().getType()));
+            setDensity(comp.getMaterial().getDensity() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_BULK_DENSITY);
+            setDensityType(RockSimDensityType.toCode(comp.getMaterial().getType()));
             String compMaterial = comp.getMaterial().getName();
             if (compMaterial.startsWith(BaseHandler.ROCKSIM_MATERIAL_PREFIX)) {
                 compMaterial = compMaterial.substring(BaseHandler.ROCKSIM_MATERIAL_PREFIX.length());
             }
             setMaterial(compMaterial);
 
-            setFinishCode(RocksimFinishCode.toCode(comp.getFinish()));
+            setFinishCode(RockSimFinishCode.toCode(comp.getFinish()));
         }
         else if (ec instanceof StructuralComponent) {
             StructuralComponent comp = (StructuralComponent) ec;
 
-            setLocationMode(RocksimLocationMode.toCode(comp.getAxialMethod()));
-            setDensity(comp.getMaterial().getDensity() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_BULK_DENSITY);
-            setDensityType(RocksimDensityType.toCode(comp.getMaterial().getType()));
+            setLocationMode(RockSimLocationMode.toCode(comp.getAxialMethod()));
+            setDensity(comp.getMaterial().getDensity() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_BULK_DENSITY);
+            setDensityType(RockSimDensityType.toCode(comp.getMaterial().getType()));
             String compMaterial = comp.getMaterial().getName();
             if (compMaterial.startsWith(BaseHandler.ROCKSIM_MATERIAL_PREFIX)) {
                 compMaterial = compMaterial.substring(BaseHandler.ROCKSIM_MATERIAL_PREFIX.length());
@@ -132,9 +131,9 @@ public abstract class BasePartDTO {
         else if (ec instanceof RecoveryDevice) {
             RecoveryDevice comp = (RecoveryDevice) ec;
 
-            setLocationMode(RocksimLocationMode.toCode(comp.getAxialMethod()));
-            setDensity(comp.getMaterial().getDensity() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_SURFACE_DENSITY);
-            setDensityType(RocksimDensityType.toCode(comp.getMaterial().getType()));
+            setLocationMode(RockSimLocationMode.toCode(comp.getAxialMethod()));
+            setDensity(comp.getMaterial().getDensity() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_SURFACE_DENSITY);
+            setDensityType(RockSimDensityType.toCode(comp.getMaterial().getType()));
             String compMaterial = comp.getMaterial().getName();
             if (compMaterial.startsWith(BaseHandler.ROCKSIM_MATERIAL_PREFIX)) {
                 compMaterial = compMaterial.substring(BaseHandler.ROCKSIM_MATERIAL_PREFIX.length());
@@ -145,7 +144,7 @@ public abstract class BasePartDTO {
         if (ec instanceof RingComponent) {
             RingComponent rc = (RingComponent)ec;
             setRadialAngle(rc.getRadialDirection());
-            setRadialLoc(rc.getRadialPosition() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+            setRadialLoc(rc.getRadialPosition() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
         }
     }
 

--- a/core/src/net/sf/openrocket/file/rocksim/export/BodyTubeDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/BodyTubeDTO.java
@@ -97,34 +97,34 @@ public class BodyTubeDTO extends BasePartDTO implements AttachableParts {
                 final InnerBodyTubeDTO innerBodyTubeDTO = new InnerBodyTubeDTO(innerTube, this);
                 //Only add the inner tube if it is NOT a cluster.
                 if (innerTube.getInstanceCount() == 1) {
-                    attachedParts.add(innerBodyTubeDTO);
+                    addAttachedPart(innerBodyTubeDTO);
                 }
             } else if (rocketComponents instanceof BodyTube) {
-                attachedParts.add(new BodyTubeDTO((BodyTube) rocketComponents));
+                addAttachedPart(new BodyTubeDTO((BodyTube) rocketComponents));
             } else if (rocketComponents instanceof Transition) {
-                attachedParts.add(new TransitionDTO((Transition) rocketComponents));
+                addAttachedPart(new TransitionDTO((Transition) rocketComponents));
             } else if (rocketComponents instanceof EngineBlock) {
-                attachedParts.add(new EngineBlockDTO((EngineBlock) rocketComponents));
+                addAttachedPart(new EngineBlockDTO((EngineBlock) rocketComponents));
             } else if (rocketComponents instanceof TubeCoupler) {
-                attachedParts.add(new TubeCouplerDTO((TubeCoupler) rocketComponents));
+                addAttachedPart(new TubeCouplerDTO((TubeCoupler) rocketComponents, this));
             } else if (rocketComponents instanceof CenteringRing) {
-                attachedParts.add(new CenteringRingDTO((CenteringRing) rocketComponents));
+                addAttachedPart(new CenteringRingDTO((CenteringRing) rocketComponents));
             } else if (rocketComponents instanceof Bulkhead) {
-                attachedParts.add(new BulkheadDTO((Bulkhead) rocketComponents));
+                addAttachedPart(new BulkheadDTO((Bulkhead) rocketComponents));
             } else if (rocketComponents instanceof LaunchLug) {
-                attachedParts.add(new LaunchLugDTO((LaunchLug) rocketComponents));
+                addAttachedPart(new LaunchLugDTO((LaunchLug) rocketComponents));
             } else if (rocketComponents instanceof Streamer) {
-                attachedParts.add(new StreamerDTO((Streamer) rocketComponents));
+                addAttachedPart(new StreamerDTO((Streamer) rocketComponents));
             } else if (rocketComponents instanceof Parachute) {
-                attachedParts.add(new ParachuteDTO((Parachute) rocketComponents));
+                addAttachedPart(new ParachuteDTO((Parachute) rocketComponents));
             } else if (rocketComponents instanceof MassObject) {
-                attachedParts.add(new MassObjectDTO((MassObject) rocketComponents));
+                addAttachedPart(new MassObjectDTO((MassObject) rocketComponents));
             } else if (rocketComponents instanceof FreeformFinSet) {
-                attachedParts.add(new CustomFinSetDTO((FreeformFinSet) rocketComponents));
+                addAttachedPart(new CustomFinSetDTO((FreeformFinSet) rocketComponents));
             } else if (rocketComponents instanceof FinSet) {
-                attachedParts.add(new FinSetDTO((FinSet) rocketComponents));
+                addAttachedPart(new FinSetDTO((FinSet) rocketComponents));
             } else if (rocketComponents instanceof TubeFinSet) {
-                attachedParts.add(new TubeFinSetDTO((TubeFinSet) rocketComponents));
+                addAttachedPart(new TubeFinSetDTO((TubeFinSet) rocketComponents));
             }
         }
     }
@@ -199,8 +199,10 @@ public class BodyTubeDTO extends BasePartDTO implements AttachableParts {
     }
 
     @Override
-    public void addAttachedPart(BasePartDTO thePart) {
-        attachedParts.add(thePart);
+    public void addAttachedPart(BasePartDTO part) {
+        if (!attachedParts.contains(part)) {
+            attachedParts.add(part);
+        }
     }
 
     @Override

--- a/core/src/net/sf/openrocket/file/rocksim/export/BodyTubeDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/BodyTubeDTO.java
@@ -1,6 +1,6 @@
 package net.sf.openrocket.file.rocksim.export;
 
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.rocketcomponent.BodyTube;
 import net.sf.openrocket.rocketcomponent.Bulkhead;
 import net.sf.openrocket.rocketcomponent.CenteringRing;
@@ -28,36 +28,36 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Models the XML element for a Rocksim body tube.
+ * Models the XML element for a RockSim body tube.
  */
-@XmlRootElement(name = RocksimCommonConstants.BODY_TUBE)
+@XmlRootElement(name = RockSimCommonConstants.BODY_TUBE)
 @XmlAccessorType(XmlAccessType.FIELD)
 public class BodyTubeDTO extends BasePartDTO implements AttachableParts {
 
-    @XmlElement(name = RocksimCommonConstants.OD)
+    @XmlElement(name = RockSimCommonConstants.OD)
     private double od = 0d;
-    @XmlElement(name = RocksimCommonConstants.ID)
+    @XmlElement(name = RockSimCommonConstants.ID)
     private double id = 0d;
-    @XmlElement(name = RocksimCommonConstants.IS_MOTOR_MOUNT)
+    @XmlElement(name = RockSimCommonConstants.IS_MOTOR_MOUNT)
     private int isMotorMount = 0;
-    @XmlElement(name = RocksimCommonConstants.MOTOR_DIA)
+    @XmlElement(name = RockSimCommonConstants.MOTOR_DIA)
     private double motorDia = 0d;
-    @XmlElement(name = RocksimCommonConstants.ENGINE_OVERHANG)
+    @XmlElement(name = RockSimCommonConstants.ENGINE_OVERHANG)
     private double engineOverhang = 0d;
-    @XmlElement(name = RocksimCommonConstants.IS_INSIDE_TUBE)
+    @XmlElement(name = RockSimCommonConstants.IS_INSIDE_TUBE)
     private int isInsideTube = 0;
-    @XmlElementWrapper(name = RocksimCommonConstants.ATTACHED_PARTS)
+    @XmlElementWrapper(name = RockSimCommonConstants.ATTACHED_PARTS)
     @XmlElementRefs({
-            @XmlElementRef(name = RocksimCommonConstants.BODY_TUBE, type = BodyTubeDTO.class),
-            @XmlElementRef(name = RocksimCommonConstants.BODY_TUBE, type = InnerBodyTubeDTO.class),
-            @XmlElementRef(name = RocksimCommonConstants.RING, type = CenteringRingDTO.class),
-            @XmlElementRef(name = RocksimCommonConstants.LAUNCH_LUG, type = LaunchLugDTO.class),
-            @XmlElementRef(name = RocksimCommonConstants.FIN_SET, type = FinSetDTO.class),
-            @XmlElementRef(name = RocksimCommonConstants.CUSTOM_FIN_SET, type = CustomFinSetDTO.class),
-            @XmlElementRef(name = RocksimCommonConstants.TUBE_FIN_SET, type = TubeFinSetDTO.class),
-            @XmlElementRef(name = RocksimCommonConstants.STREAMER, type = StreamerDTO.class),
-            @XmlElementRef(name = RocksimCommonConstants.PARACHUTE, type = ParachuteDTO.class),
-            @XmlElementRef(name = RocksimCommonConstants.MASS_OBJECT, type = MassObjectDTO.class)})
+            @XmlElementRef(name = RockSimCommonConstants.BODY_TUBE, type = BodyTubeDTO.class),
+            @XmlElementRef(name = RockSimCommonConstants.BODY_TUBE, type = InnerBodyTubeDTO.class),
+            @XmlElementRef(name = RockSimCommonConstants.RING, type = CenteringRingDTO.class),
+            @XmlElementRef(name = RockSimCommonConstants.LAUNCH_LUG, type = LaunchLugDTO.class),
+            @XmlElementRef(name = RockSimCommonConstants.FIN_SET, type = FinSetDTO.class),
+            @XmlElementRef(name = RockSimCommonConstants.CUSTOM_FIN_SET, type = CustomFinSetDTO.class),
+            @XmlElementRef(name = RockSimCommonConstants.TUBE_FIN_SET, type = TubeFinSetDTO.class),
+            @XmlElementRef(name = RockSimCommonConstants.STREAMER, type = StreamerDTO.class),
+            @XmlElementRef(name = RockSimCommonConstants.PARACHUTE, type = ParachuteDTO.class),
+            @XmlElementRef(name = RockSimCommonConstants.MASS_OBJECT, type = MassObjectDTO.class)})
     List<BasePartDTO> attachedParts = new ArrayList<BasePartDTO>();
 
     /**
@@ -83,10 +83,10 @@ public class BodyTubeDTO extends BasePartDTO implements AttachableParts {
     protected BodyTubeDTO(BodyTube theORBodyTube) {
         super(theORBodyTube);
 
-        setEngineOverhang(theORBodyTube.getMotorOverhang() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
-        setID(theORBodyTube.getInnerRadius() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
-        setOD(theORBodyTube.getOuterRadius() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
-        setMotorDia((theORBodyTube.getMotorMountDiameter() / 2) * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+        setEngineOverhang(theORBodyTube.getMotorOverhang() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+        setID(theORBodyTube.getInnerRadius() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+        setOD(theORBodyTube.getOuterRadius() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+        setMotorDia((theORBodyTube.getMotorMountDiameter() / 2) * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
         setMotorMount(theORBodyTube.isMotorMount());
 
         List<RocketComponent> children = theORBodyTube.getChildren();

--- a/core/src/net/sf/openrocket/file/rocksim/export/BulkheadDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/BulkheadDTO.java
@@ -1,6 +1,6 @@
 package net.sf.openrocket.file.rocksim.export;
 
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.rocketcomponent.Bulkhead;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -8,9 +8,9 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
- * Conversion of an OR Bulkhead to an Rocksim Bulkhead.  Bulkheads are represented as Rings in Rocksim.
+ * Conversion of an OR Bulkhead to an RockSim Bulkhead.  Bulkheads are represented as Rings in RockSim.
  */
-@XmlRootElement(name = RocksimCommonConstants.RING)
+@XmlRootElement(name = RockSimCommonConstants.RING)
 @XmlAccessorType(XmlAccessType.FIELD)
 public class BulkheadDTO extends CenteringRingDTO {
 

--- a/core/src/net/sf/openrocket/file/rocksim/export/CenteringRingDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/CenteringRingDTO.java
@@ -1,6 +1,6 @@
 package net.sf.openrocket.file.rocksim.export;
 
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.rocketcomponent.RadiusRingComponent;
 import net.sf.openrocket.rocketcomponent.ThicknessRingComponent;
 
@@ -11,9 +11,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
 /**
- * Centering ring conversion from OR to Rocksim.
+ * Centering ring conversion from OR to RockSim.
  */
-@XmlRootElement(name = RocksimCommonConstants.RING)
+@XmlRootElement(name = RockSimCommonConstants.RING)
 @XmlAccessorType(XmlAccessType.FIELD)
 public class CenteringRingDTO extends BasePartDTO {
 
@@ -33,13 +33,13 @@ public class CenteringRingDTO extends BasePartDTO {
         }
     }
 
-    @XmlElement(name = RocksimCommonConstants.OD)
+    @XmlElement(name = RockSimCommonConstants.OD)
     private double od = 0d;
-    @XmlElement(name = RocksimCommonConstants.ID)
+    @XmlElement(name = RockSimCommonConstants.ID)
     private double id = 0d;
-    @XmlElement(name = RocksimCommonConstants.USAGE_CODE)
+    @XmlElement(name = RockSimCommonConstants.USAGE_CODE)
     private int usageCode = UsageCode.CenteringRing.ordinal;
-    @XmlElement(name = RocksimCommonConstants.AUTO_SIZE)
+    @XmlElement(name = RockSimCommonConstants.AUTO_SIZE)
     private int autoSize = 0;
 
     /**
@@ -55,8 +55,8 @@ public class CenteringRingDTO extends BasePartDTO {
      */
     public CenteringRingDTO(RadiusRingComponent theORRadiusRing) {
         super(theORRadiusRing);
-        setId(theORRadiusRing.getInnerRadius()* RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
-        setOd(theORRadiusRing.getOuterRadius()* RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+        setId(theORRadiusRing.getInnerRadius()* RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+        setOd(theORRadiusRing.getOuterRadius()* RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
     }
 
     /**
@@ -66,8 +66,8 @@ public class CenteringRingDTO extends BasePartDTO {
      */
     public CenteringRingDTO(ThicknessRingComponent theORThicknessRing) {
         super(theORThicknessRing);
-        setId(theORThicknessRing.getInnerRadius()* RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
-        setOd(theORThicknessRing.getOuterRadius()* RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+        setId(theORThicknessRing.getInnerRadius()* RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+        setOd(theORThicknessRing.getOuterRadius()* RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
     }
 
     public double getOd() {

--- a/core/src/net/sf/openrocket/file/rocksim/export/CustomFinSetDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/CustomFinSetDTO.java
@@ -1,6 +1,6 @@
 package net.sf.openrocket.file.rocksim.export;
 
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.rocketcomponent.FreeformFinSet;
 import net.sf.openrocket.util.Coordinate;
 
@@ -11,11 +11,11 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /**
  */
-@XmlRootElement(name = RocksimCommonConstants.CUSTOM_FIN_SET)
+@XmlRootElement(name = RockSimCommonConstants.CUSTOM_FIN_SET)
 @XmlAccessorType(XmlAccessType.FIELD)
 public class CustomFinSetDTO extends FinSetDTO {
 
-    @XmlElement(name = RocksimCommonConstants.POINT_LIST)
+    @XmlElement(name = RockSimCommonConstants.POINT_LIST)
     private String pointList = "";
 
     /**
@@ -38,11 +38,11 @@ public class CustomFinSetDTO extends FinSetDTO {
     private String convertFreeFormPoints(Coordinate[] points) {
         StringBuilder sb = new StringBuilder();
 
-        //Reverse the order for Rocksim
+        //Reverse the order for RockSim
         for (int i = points.length - 1; i >= 0; i--) {
             Coordinate point = points[i];
-            sb.append(point.x * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH).append(",")
-                    .append(point.y * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH).append("|");
+            sb.append(point.x * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH).append(",")
+                    .append(point.y * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH).append("|");
         }
         return sb.toString();
     }

--- a/core/src/net/sf/openrocket/file/rocksim/export/FinSetDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/FinSetDTO.java
@@ -1,7 +1,7 @@
 package net.sf.openrocket.file.rocksim.export;
 
 import net.sf.openrocket.file.TipShapeCode;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.rocketcomponent.EllipticalFinSet;
 import net.sf.openrocket.rocketcomponent.FinSet;
 import net.sf.openrocket.rocketcomponent.FreeformFinSet;
@@ -15,35 +15,35 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * This class models XML elements for Rocksim finsets.
  */
-@XmlRootElement(name = RocksimCommonConstants.FIN_SET)
+@XmlRootElement(name = RockSimCommonConstants.FIN_SET)
 @XmlAccessorType(XmlAccessType.FIELD)
 public class FinSetDTO extends BasePartDTO {
 
-    @XmlElement(name = RocksimCommonConstants.FIN_COUNT)
+    @XmlElement(name = RockSimCommonConstants.FIN_COUNT)
     private int finCount = 0;
-    @XmlElement(name = RocksimCommonConstants.ROOT_CHORD)
+    @XmlElement(name = RockSimCommonConstants.ROOT_CHORD)
     private double rootChord = 0d;
-    @XmlElement(name = RocksimCommonConstants.TIP_CHORD)
+    @XmlElement(name = RockSimCommonConstants.TIP_CHORD)
     private double tipChord = 0d;
-    @XmlElement(name = RocksimCommonConstants.SEMI_SPAN)
+    @XmlElement(name = RockSimCommonConstants.SEMI_SPAN)
     private double semiSpan = 0d;
-    @XmlElement(name = RocksimCommonConstants.SWEEP_DISTANCE)
+    @XmlElement(name = RockSimCommonConstants.SWEEP_DISTANCE)
     private double sweepDistance = 0d;
-    @XmlElement(name = RocksimCommonConstants.THICKNESS)
+    @XmlElement(name = RockSimCommonConstants.THICKNESS)
     private double thickness = 0d;
-    @XmlElement(name = RocksimCommonConstants.SHAPE_CODE)
+    @XmlElement(name = RockSimCommonConstants.SHAPE_CODE)
     private int shapeCode = 0;
-    @XmlElement(name = RocksimCommonConstants.TIP_SHAPE_CODE)
+    @XmlElement(name = RockSimCommonConstants.TIP_SHAPE_CODE)
     private int tipShapeCode = 0;
-    @XmlElement(name = RocksimCommonConstants.TAB_LENGTH)
+    @XmlElement(name = RockSimCommonConstants.TAB_LENGTH)
     private double tabLength = 0d;
-    @XmlElement(name = RocksimCommonConstants.TAB_DEPTH)
+    @XmlElement(name = RockSimCommonConstants.TAB_DEPTH)
     private double tabDepth = 0d;
-    @XmlElement(name = RocksimCommonConstants.TAB_OFFSET)
+    @XmlElement(name = RockSimCommonConstants.TAB_OFFSET)
     private double tabOffset = 0d;
-    @XmlElement(name = RocksimCommonConstants.SWEEP_MODE)
+    @XmlElement(name = RockSimCommonConstants.SWEEP_MODE)
     private int sweepMode = 1;
-    @XmlElement(name = RocksimCommonConstants.CANT_ANGLE)
+    @XmlElement(name = RockSimCommonConstants.CANT_ANGLE)
     private double cantAngle = 0d;
 
     /**
@@ -62,26 +62,26 @@ public class FinSetDTO extends BasePartDTO {
 
         setFinCount(theORFinSet.getFinCount());
         setCantAngle(theORFinSet.getCantAngle());
-        setTabDepth(theORFinSet.getTabHeight() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
-        setTabLength(theORFinSet.getTabLength() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
-        setTabOffset(theORFinSet.getTabOffset() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
-        setThickness(theORFinSet.getThickness() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+        setTabDepth(theORFinSet.getTabHeight() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+        setTabLength(theORFinSet.getTabLength() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+        setTabOffset(theORFinSet.getTabOffset() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+        setThickness(theORFinSet.getThickness() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 
         setRadialAngle(theORFinSet.getBaseRotation());
         setTipShapeCode(TipShapeCode.convertTipShapeCode(theORFinSet.getCrossSection()));
         if (theORFinSet instanceof TrapezoidFinSet) {
             TrapezoidFinSet tfs = (TrapezoidFinSet) theORFinSet;
             setShapeCode(0);
-            setRootChord(theORFinSet.getLength() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
-            setSemiSpan(tfs.getHeight() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
-            setTipChord(tfs.getTipChord() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
-            setSweepDistance(tfs.getSweep() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+            setRootChord(theORFinSet.getLength() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+            setSemiSpan(tfs.getHeight() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+            setTipChord(tfs.getTipChord() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+            setSweepDistance(tfs.getSweep() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
         }
         else if (theORFinSet instanceof EllipticalFinSet) {
             EllipticalFinSet efs = (EllipticalFinSet) theORFinSet;
             setShapeCode(1);
-            setRootChord(theORFinSet.getLength() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
-            setSemiSpan(efs.getHeight() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+            setRootChord(theORFinSet.getLength() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+            setSemiSpan(efs.getHeight() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
         }
         else if (theORFinSet instanceof FreeformFinSet) {
             setShapeCode(2);

--- a/core/src/net/sf/openrocket/file/rocksim/export/InnerBodyTubeDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/InnerBodyTubeDTO.java
@@ -63,26 +63,26 @@ public class InnerBodyTubeDTO extends BodyTubeDTO implements AttachableParts {
 				//to the list of attached parts.  If it is a cluster, then it is handled specially outside of this
 				//loop.
 				if (innerTube.getInstanceCount() == 1) {
-					attachedParts.add(new InnerBodyTubeDTO(innerTube, this));
+					addAttachedPart(new InnerBodyTubeDTO(innerTube, this));
 				}
 			} else if (rocketComponents instanceof BodyTube) {
-				attachedParts.add(new BodyTubeDTO((BodyTube) rocketComponents));
+				addAttachedPart(new BodyTubeDTO((BodyTube) rocketComponents));
 			} else if (rocketComponents instanceof Transition) {
-				attachedParts.add(new TransitionDTO((Transition) rocketComponents));
+				addAttachedPart(new TransitionDTO((Transition) rocketComponents));
 			} else if (rocketComponents instanceof EngineBlock) {
-				attachedParts.add(new EngineBlockDTO((EngineBlock) rocketComponents));
+				addAttachedPart(new EngineBlockDTO((EngineBlock) rocketComponents));
 			} else if (rocketComponents instanceof TubeCoupler) {
-				attachedParts.add(new TubeCouplerDTO((TubeCoupler) rocketComponents));
+				addAttachedPart(new TubeCouplerDTO((TubeCoupler) rocketComponents));
 			} else if (rocketComponents instanceof CenteringRing) {
-				attachedParts.add(new CenteringRingDTO((CenteringRing) rocketComponents));
+				addAttachedPart(new CenteringRingDTO((CenteringRing) rocketComponents));
 			} else if (rocketComponents instanceof Bulkhead) {
-				attachedParts.add(new BulkheadDTO((Bulkhead) rocketComponents));
+				addAttachedPart(new BulkheadDTO((Bulkhead) rocketComponents));
 			} else if (rocketComponents instanceof Streamer) {
-				attachedParts.add(new StreamerDTO((Streamer) rocketComponents));
+				addAttachedPart(new StreamerDTO((Streamer) rocketComponents));
 			} else if (rocketComponents instanceof Parachute) {
-				attachedParts.add(new ParachuteDTO((Parachute) rocketComponents));
+				addAttachedPart(new ParachuteDTO((Parachute) rocketComponents));
 			} else if (rocketComponents instanceof MassObject) {
-				attachedParts.add(new MassObjectDTO((MassObject) rocketComponents));
+				addAttachedPart(new MassObjectDTO((MassObject) rocketComponents));
 			}
 		}
 		//Do the cluster.  For now this splits the cluster into separate tubes, which is how Rocksim represents it.
@@ -119,7 +119,9 @@ public class InnerBodyTubeDTO extends BodyTubeDTO implements AttachableParts {
 	
 	@Override
 	public void addAttachedPart(BasePartDTO part) {
-		attachedParts.add(part);
+		if (!attachedParts.contains(part)) {
+			attachedParts.add(part);
+		}
 	}
 	
 	@Override

--- a/core/src/net/sf/openrocket/file/rocksim/export/InnerBodyTubeDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/InnerBodyTubeDTO.java
@@ -6,7 +6,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.rocketcomponent.BodyTube;
 import net.sf.openrocket.rocketcomponent.Bulkhead;
 import net.sf.openrocket.rocketcomponent.CenteringRing;
@@ -23,7 +23,7 @@ import net.sf.openrocket.util.Coordinate;
 /**
  * This class models the XML element for a Rocksim inside tube.
  */
-@XmlRootElement(name = RocksimCommonConstants.BODY_TUBE)
+@XmlRootElement(name = RockSimCommonConstants.BODY_TUBE)
 @XmlAccessorType(XmlAccessType.FIELD)
 public class InnerBodyTubeDTO extends BodyTubeDTO implements AttachableParts {
 	
@@ -45,14 +45,14 @@ public class InnerBodyTubeDTO extends BodyTubeDTO implements AttachableParts {
 	 */
 	public InnerBodyTubeDTO(InnerTube bt, AttachableParts parent) {
 		super(bt);
-		setEngineOverhang(bt.getMotorOverhang() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
-		setID(bt.getInnerRadius() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
-		setOD(bt.getOuterRadius() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
-		setMotorDia((bt.getMotorMountDiameter() / 2) * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+		setEngineOverhang(bt.getMotorOverhang() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+		setID(bt.getInnerRadius() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+		setOD(bt.getOuterRadius() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+		setMotorDia((bt.getMotorMountDiameter() / 2) * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
 		setMotorMount(bt.isMotorMount());
 		setInsideTube(true);
 		setRadialAngle(bt.getRadialDirection());
-		setRadialLoc(bt.getRadialPosition() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+		setRadialLoc(bt.getRadialPosition() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 		
 		List<RocketComponent> children = bt.getChildren();
 		for (int i = 0; i < children.size(); i++) {

--- a/core/src/net/sf/openrocket/file/rocksim/export/LaunchLugDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/LaunchLugDTO.java
@@ -5,19 +5,19 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.rocketcomponent.LaunchLug;
 
 /**
  * This class models an XML element for a Rocksim LaunchLug.
  */
-@XmlRootElement(name = RocksimCommonConstants.LAUNCH_LUG)
+@XmlRootElement(name = RockSimCommonConstants.LAUNCH_LUG)
 @XmlAccessorType(XmlAccessType.FIELD)
 public class LaunchLugDTO extends BasePartDTO {
 
-    @XmlElement(name = RocksimCommonConstants.OD)
+    @XmlElement(name = RockSimCommonConstants.OD)
     private double od = 0d;
-    @XmlElement(name = RocksimCommonConstants.ID)
+    @XmlElement(name = RockSimCommonConstants.ID)
     private double id = 0d;
 
     /**
@@ -33,8 +33,8 @@ public class LaunchLugDTO extends BasePartDTO {
      */
     public LaunchLugDTO(LaunchLug theORLaunchLug) {
         super(theORLaunchLug);
-        setId(theORLaunchLug.getInnerRadius() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
-        setOd(theORLaunchLug.getOuterRadius() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+        setId(theORLaunchLug.getInnerRadius() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+        setOd(theORLaunchLug.getOuterRadius() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
         setRadialAngle(theORLaunchLug.getAngleOffset());
     }
 

--- a/core/src/net/sf/openrocket/file/rocksim/export/MassObjectDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/MassObjectDTO.java
@@ -1,6 +1,6 @@
 package net.sf.openrocket.file.rocksim.export;
 
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.rocketcomponent.MassObject;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -11,11 +11,11 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * Class that models a Rocksim MassObject.
  */
-@XmlRootElement(name = RocksimCommonConstants.MASS_OBJECT)
+@XmlRootElement(name = RockSimCommonConstants.MASS_OBJECT)
 @XmlAccessorType(XmlAccessType.FIELD)
 public class MassObjectDTO extends BasePartDTO{
 
-    @XmlElement(name = RocksimCommonConstants.TYPE_CODE)
+    @XmlElement(name = RockSimCommonConstants.TYPE_CODE)
     private final int typeCode = 0;
 
     /**
@@ -32,7 +32,7 @@ public class MassObjectDTO extends BasePartDTO{
     public MassObjectDTO(MassObject mo) {
         super(mo);
         setRadialAngle(mo.getRadialDirection());
-        setRadialLoc(mo.getRadialPosition() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+        setRadialLoc(mo.getRadialPosition() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
         setCalcMass(0d);
         setCalcCG(0d);
         setKnownCG(getXb());

--- a/core/src/net/sf/openrocket/file/rocksim/export/NoseConeDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/NoseConeDTO.java
@@ -1,6 +1,6 @@
 package net.sf.openrocket.file.rocksim.export;
 
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.rocketcomponent.NoseCone;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -9,18 +9,18 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
- * This class models a Rocksim XML Element for a nose cone.
+ * This class models a RockSim XML Element for a nose cone.
  */
-@XmlRootElement(name = RocksimCommonConstants.NOSE_CONE)
+@XmlRootElement(name = RockSimCommonConstants.NOSE_CONE)
 @XmlAccessorType(XmlAccessType.FIELD)
 public class NoseConeDTO extends AbstractTransitionDTO {
 
 
-    @XmlElement(name = RocksimCommonConstants.BASE_DIA)
+    @XmlElement(name = RockSimCommonConstants.BASE_DIA)
     private double baseDia = 0d;
-    @XmlElement(name = RocksimCommonConstants.SHOULDER_LEN)
+    @XmlElement(name = RockSimCommonConstants.SHOULDER_LEN)
     private double shoulderLen = 0d;
-    @XmlElement(name = RocksimCommonConstants.SHOULDER_OD)
+    @XmlElement(name = RockSimCommonConstants.SHOULDER_OD)
     private double shoulderOD = 0d;
 
     /**
@@ -36,9 +36,9 @@ public class NoseConeDTO extends AbstractTransitionDTO {
      */
     public NoseConeDTO(NoseCone nc) {
         super(nc);
-        setBaseDia(nc.getAftRadius() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
-        setShoulderLen(nc.getAftShoulderLength() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
-        setShoulderOD(nc.getAftShoulderRadius() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+        setBaseDia(nc.getAftRadius() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+        setShoulderLen(nc.getAftShoulderLength() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+        setShoulderOD(nc.getAftShoulderRadius() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
     }
 
     public double getBaseDia() {

--- a/core/src/net/sf/openrocket/file/rocksim/export/ParachuteDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/ParachuteDTO.java
@@ -1,6 +1,6 @@
 package net.sf.openrocket.file.rocksim.export;
 
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.file.rocksim.importt.BaseHandler;
 import net.sf.openrocket.rocketcomponent.Parachute;
 
@@ -11,25 +11,25 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /**
  */
-@XmlRootElement(name = RocksimCommonConstants.PARACHUTE)
+@XmlRootElement(name = RockSimCommonConstants.PARACHUTE)
 @XmlAccessorType(XmlAccessType.FIELD)
 public class ParachuteDTO extends BasePartDTO {
 
-    @XmlElement(name = RocksimCommonConstants.DIAMETER)
+    @XmlElement(name = RockSimCommonConstants.DIAMETER)
     private double dia = 0d;
-    @XmlElement(name = RocksimCommonConstants.SHROUD_LINE_COUNT)
+    @XmlElement(name = RockSimCommonConstants.SHROUD_LINE_COUNT)
     private int ShroudLineCount = 0;
-    @XmlElement(name = RocksimCommonConstants.THICKNESS)
+    @XmlElement(name = RockSimCommonConstants.THICKNESS)
     private double thickness = 0d;
-    @XmlElement(name = RocksimCommonConstants.SHROUD_LINE_LEN)
+    @XmlElement(name = RockSimCommonConstants.SHROUD_LINE_LEN)
     private double shroudLineLen = 0d;
-    @XmlElement(name = RocksimCommonConstants.CHUTE_COUNT)
+    @XmlElement(name = RockSimCommonConstants.CHUTE_COUNT)
     private int chuteCount = 1;
-    @XmlElement(name = RocksimCommonConstants.SHROUD_LINE_MASS_PER_MM)
+    @XmlElement(name = RockSimCommonConstants.SHROUD_LINE_MASS_PER_MM)
     private double shroudLineMassPerMM = 0d;
-    @XmlElement(name = RocksimCommonConstants.SHROUD_LINE_MATERIAL)
+    @XmlElement(name = RockSimCommonConstants.SHROUD_LINE_MATERIAL)
     private String shroudLineMaterial = "";
-    @XmlElement(name = RocksimCommonConstants.DRAG_COEFFICIENT)
+    @XmlElement(name = RockSimCommonConstants.DRAG_COEFFICIENT)
     private double dragCoefficient = 0.75d;
 
     /**
@@ -47,13 +47,13 @@ public class ParachuteDTO extends BasePartDTO {
         super(theORParachute);
         
         setChuteCount(1);
-        setDia(theORParachute.getDiameter() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+        setDia(theORParachute.getDiameter() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
         setDragCoefficient(theORParachute.getCD());
         setShroudLineCount(theORParachute.getLineCount());
-        setShroudLineLen(theORParachute.getLineLength() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+        setShroudLineLen(theORParachute.getLineLength() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 
         String material = theORParachute.getLineMaterial().getName();
-        setShroudLineMassPerMM(theORParachute.getLineMaterial().getDensity() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LINE_DENSITY);
+        setShroudLineMassPerMM(theORParachute.getLineMaterial().getDensity() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LINE_DENSITY);
 
         if (material.startsWith(BaseHandler.ROCKSIM_MATERIAL_PREFIX)) {
             material = material.substring(BaseHandler.ROCKSIM_MATERIAL_PREFIX.length());

--- a/core/src/net/sf/openrocket/file/rocksim/export/RockSimDesignDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/RockSimDesignDTO.java
@@ -1,6 +1,6 @@
 package net.sf.openrocket.file.rocksim.export;
 
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -10,15 +10,15 @@ import javax.xml.bind.annotation.XmlElement;
  * High-level placeholder element for Rocksim.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-public class RocksimDesignDTO {
+public class RockSimDesignDTO {
 
-    @XmlElement(name = RocksimCommonConstants.ROCKET_DESIGN)
+    @XmlElement(name = RockSimCommonConstants.ROCKET_DESIGN)
     private RocketDesignDTO design;
 
     /**
      * Constructor.
      */
-    public RocksimDesignDTO() {
+    public RockSimDesignDTO() {
     }
 
     /**

--- a/core/src/net/sf/openrocket/file/rocksim/export/RockSimDocumentDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/RockSimDocumentDTO.java
@@ -1,6 +1,6 @@
 package net.sf.openrocket.file.rocksim.export;
 
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -10,28 +10,28 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * The top level Rocksim document.
  */
-@XmlRootElement(name = RocksimCommonConstants.ROCK_SIM_DOCUMENT)
+@XmlRootElement(name = RockSimCommonConstants.ROCK_SIM_DOCUMENT)
 @XmlAccessorType(XmlAccessType.FIELD)
-public class RocksimDocumentDTO {
+public class RockSimDocumentDTO {
 
-    @XmlElement(name = RocksimCommonConstants.FILE_VERSION)
+    @XmlElement(name = RockSimCommonConstants.FILE_VERSION)
     private final String version = "4";
 
-    @XmlElement(name = RocksimCommonConstants.DESIGN_INFORMATION)
-    private RocksimDesignDTO design;
+    @XmlElement(name = RockSimCommonConstants.DESIGN_INFORMATION)
+    private RockSimDesignDTO design;
 
     /**
      * Constructor.
      */
-    public RocksimDocumentDTO() {
+    public RockSimDocumentDTO() {
     }
 
     /**
      * Get the subordinate design DTO.
      *
-     * @return  the RocksimDesignDTO
+     * @return  the RockSimDesignDTO
      */
-    public RocksimDesignDTO getDesign() {
+    public RockSimDesignDTO getDesign() {
         return design;
     }
 
@@ -40,7 +40,7 @@ public class RocksimDocumentDTO {
      *
      * @param theDesign
      */
-    public void setDesign(RocksimDesignDTO theDesign) {
+    public void setDesign(RockSimDesignDTO theDesign) {
         this.design = theDesign;
     }
 

--- a/core/src/net/sf/openrocket/file/rocksim/export/RockSimSaver.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/RockSimSaver.java
@@ -16,7 +16,7 @@ import org.slf4j.LoggerFactory;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.document.StorageOptions;
 import net.sf.openrocket.file.RocketSaver;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.masscalc.MassCalculator;
 import net.sf.openrocket.masscalc.RigidBody;
 import net.sf.openrocket.rocketcomponent.AxialStage;
@@ -26,12 +26,12 @@ import net.sf.openrocket.rocketcomponent.Rocket;
 /**
  * This class is responsible for converting an OpenRocket design to a Rocksim design.
  */
-public class RocksimSaver extends RocketSaver {
+public class RockSimSaver extends RocketSaver {
 	
 	/**
 	 * The logger.
 	 */
-	private static final Logger log = LoggerFactory.getLogger(RocksimSaver.class);
+	private static final Logger log = LoggerFactory.getLogger(RockSimSaver.class);
 	
 	/**
 	 * This method marshals an OpenRocketDocument (OR design) to Rocksim-compliant XML.
@@ -39,19 +39,19 @@ public class RocksimSaver extends RocketSaver {
 	 * @param doc the OR design
 	 * @return Rocksim-compliant XML
 	 */
-	public String marshalToRocksim(OpenRocketDocument doc) {
+	public String marshalToRockSim(OpenRocketDocument doc) {
 		
 		try {
-			JAXBContext binder = JAXBContext.newInstance(RocksimDocumentDTO.class);
+			JAXBContext binder = JAXBContext.newInstance(RockSimDocumentDTO.class);
 			Marshaller marshaller = binder.createMarshaller();
 			marshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
 			marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
 			StringWriter sw = new StringWriter();
 			
-			marshaller.marshal(toRocksimDocumentDTO(doc), sw);
+			marshaller.marshal(toRockSimDocumentDTO(doc), sw);
 			return sw.toString();
 		} catch (Exception e) {
-			log.error("Could not marshall a design to Rocksim format. " + e.getMessage());
+			log.error("Could not marshall a design to RockSim format. " + e.getMessage());
 		}
 		
 		return null;
@@ -62,13 +62,13 @@ public class RocksimSaver extends RocketSaver {
 		log.info("Saving .rkt file");
 		
 		BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(dest, StandardCharsets.UTF_8));
-		writer.write(marshalToRocksim(doc));
+		writer.write(marshalToRockSim(doc));
 		writer.flush();
 	}
 	
 	@Override
 	public long estimateFileSize(OpenRocketDocument doc, StorageOptions options) {
-		return marshalToRocksim(doc).length();
+		return marshalToRockSim(doc).length();
 	}
 	
 	/**
@@ -77,16 +77,16 @@ public class RocksimSaver extends RocketSaver {
 	 * @param doc the OR design
 	 * @return a corresponding Rocksim representation
 	 */
-	private RocksimDocumentDTO toRocksimDocumentDTO(OpenRocketDocument doc) {
-		RocksimDocumentDTO rsd = new RocksimDocumentDTO();
+	private RockSimDocumentDTO toRockSimDocumentDTO(OpenRocketDocument doc) {
+		RockSimDocumentDTO rsd = new RockSimDocumentDTO();
 		
-		rsd.setDesign(toRocksimDesignDTO(doc.getRocket()));
+		rsd.setDesign(toRockSimDesignDTO(doc.getRocket()));
 		
 		return rsd;
 	}
 	
-	private RocksimDesignDTO toRocksimDesignDTO(Rocket rocket) {
-		RocksimDesignDTO result = new RocksimDesignDTO();
+	private RockSimDesignDTO toRockSimDesignDTO(Rocket rocket) {
+		RockSimDesignDTO result = new RockSimDesignDTO();
 		result.setDesign(toRocketDesignDTO(rocket));
 		return result;
 	}
@@ -96,7 +96,7 @@ public class RocksimSaver extends RocketSaver {
 		
 		final FlightConfiguration configuration = rocket.getEmptyConfiguration();
 		final RigidBody spentData = MassCalculator.calculateStructure( configuration);
-		final double cg = spentData.cm.x *RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
+		final double cg = spentData.cm.x * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
 
 		int stageCount = rocket.getStageCount();
 		if (stageCount == 3) {

--- a/core/src/net/sf/openrocket/file/rocksim/export/StageDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/StageDTO.java
@@ -1,6 +1,6 @@
 package net.sf.openrocket.file.rocksim.export;
 
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.rocketcomponent.BodyTube;
 import net.sf.openrocket.rocketcomponent.NoseCone;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
@@ -21,9 +21,9 @@ import java.util.List;
 public class StageDTO {
 
     @XmlElementRefs({
-            @XmlElementRef(name = RocksimCommonConstants.BODY_TUBE, type = BodyTubeDTO.class),
-            @XmlElementRef(name = RocksimCommonConstants.NOSE_CONE, type = NoseConeDTO.class),
-            @XmlElementRef(name = RocksimCommonConstants.TRANSITION, type = TransitionDTO.class)
+            @XmlElementRef(name = RockSimCommonConstants.BODY_TUBE, type = BodyTubeDTO.class),
+            @XmlElementRef(name = RockSimCommonConstants.NOSE_CONE, type = NoseConeDTO.class),
+            @XmlElementRef(name = RockSimCommonConstants.TRANSITION, type = TransitionDTO.class)
     })
     private final List<BasePartDTO> externalPart = new ArrayList<BasePartDTO>();
 
@@ -44,31 +44,31 @@ public class StageDTO {
 
         if (stageNumber == 3) {
             if (theORStage.isMassOverridden()) {
-                design.setStage3Mass(theORStage.getMass() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
+                design.setStage3Mass(theORStage.getMass() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
                 design.setUseKnownMass(1);
             }
             if (theORStage.isCGOverridden()) {
-                design.setStage3CG(theORStage.getOverrideCGX() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+                design.setStage3CG(theORStage.getOverrideCGX() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
             }
         }
         
         if (stageNumber == 2) {
             if (theORStage.isMassOverridden()) {
-                design.setStage2Mass(theORStage.getMass() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
+                design.setStage2Mass(theORStage.getMass() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
                 design.setUseKnownMass(1);
             }
             if (theORStage.isCGOverridden()) {
-                design.setStage2CGAlone(theORStage.getOverrideCGX() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+                design.setStage2CGAlone(theORStage.getOverrideCGX() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
             }
         }
 
         if (stageNumber == 1) {
             if (theORStage.isMassOverridden()) {
-                design.setStage1Mass(theORStage.getMass() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
+                design.setStage1Mass(theORStage.getMass() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
                 design.setUseKnownMass(1);
             }
             if (theORStage.isCGOverridden()) {
-                design.setStage1CGAlone(theORStage.getOverrideCGX() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+                design.setStage1CGAlone(theORStage.getOverrideCGX() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
             }
         }
 

--- a/core/src/net/sf/openrocket/file/rocksim/export/StreamerDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/StreamerDTO.java
@@ -1,6 +1,6 @@
 package net.sf.openrocket.file.rocksim.export;
 
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.rocketcomponent.Streamer;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -11,13 +11,13 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * This class models a Rocksim XML element for a streamer.
  */
-@XmlRootElement(name = RocksimCommonConstants.STREAMER)
+@XmlRootElement(name = RockSimCommonConstants.STREAMER)
 @XmlAccessorType(XmlAccessType.FIELD)
 public class StreamerDTO extends BasePartDTO {
 
-    @XmlElement(name = RocksimCommonConstants.WIDTH)
+    @XmlElement(name = RockSimCommonConstants.WIDTH)
         private double width = 0d;
-        @XmlElement(name = RocksimCommonConstants.DRAG_COEFFICIENT)
+        @XmlElement(name = RockSimCommonConstants.DRAG_COEFFICIENT)
         private double dragCoefficient = 0.75d;
 
     /**
@@ -33,7 +33,7 @@ public class StreamerDTO extends BasePartDTO {
      */
     public StreamerDTO(Streamer theORStreamer) {
         super(theORStreamer);
-        setWidth(theORStreamer.getStripWidth() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+        setWidth(theORStreamer.getStripWidth() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
         setDragCoefficient(theORStreamer.getCD());
     }
 

--- a/core/src/net/sf/openrocket/file/rocksim/export/TransitionDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/TransitionDTO.java
@@ -1,6 +1,6 @@
 package net.sf.openrocket.file.rocksim.export;
 
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.rocketcomponent.Transition;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -11,22 +11,22 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * This class models a transition XML element in Rocksim file format.
  */
-@XmlRootElement(name = RocksimCommonConstants.TRANSITION)
+@XmlRootElement(name = RockSimCommonConstants.TRANSITION)
 @XmlAccessorType(XmlAccessType.FIELD)
 public class TransitionDTO extends AbstractTransitionDTO {
 
 
-    @XmlElement(name = RocksimCommonConstants.FRONT_SHOULDER_LEN)
+    @XmlElement(name = RockSimCommonConstants.FRONT_SHOULDER_LEN)
     private double frontShoulderLen = 0d;
-    @XmlElement(name = RocksimCommonConstants.REAR_SHOULDER_LEN)
+    @XmlElement(name = RockSimCommonConstants.REAR_SHOULDER_LEN)
     private double rearShoulderLen = 0d;
-    @XmlElement(name = RocksimCommonConstants.FRONT_SHOULDER_DIA)
+    @XmlElement(name = RockSimCommonConstants.FRONT_SHOULDER_DIA)
     private double frontShoulderDia = 0d;
-    @XmlElement(name = RocksimCommonConstants.REAR_SHOULDER_DIA)
+    @XmlElement(name = RockSimCommonConstants.REAR_SHOULDER_DIA)
     private double rearShoulderDia = 0d;
-    @XmlElement(name = RocksimCommonConstants.FRONT_DIA)
+    @XmlElement(name = RockSimCommonConstants.FRONT_DIA)
     private double frontDia = 0d;
-    @XmlElement(name = RocksimCommonConstants.REAR_DIA)
+    @XmlElement(name = RockSimCommonConstants.REAR_DIA)
     private double rearDia = 0d;
 
     /**
@@ -43,12 +43,12 @@ public class TransitionDTO extends AbstractTransitionDTO {
      */
     public TransitionDTO(Transition theORTransition) {
         super(theORTransition);
-        setFrontDia(theORTransition.getForeRadius() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
-        setRearDia(theORTransition.getAftRadius() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
-        setFrontShoulderDia(theORTransition.getForeShoulderRadius() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
-        setFrontShoulderLen(theORTransition.getForeShoulderLength() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
-        setRearShoulderDia(theORTransition.getAftShoulderRadius() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
-        setRearShoulderLen(theORTransition.getAftShoulderLength() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+        setFrontDia(theORTransition.getForeRadius() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+        setRearDia(theORTransition.getAftRadius() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+        setFrontShoulderDia(theORTransition.getForeShoulderRadius() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+        setFrontShoulderLen(theORTransition.getForeShoulderLength() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+        setRearShoulderDia(theORTransition.getAftShoulderRadius() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+        setRearShoulderLen(theORTransition.getAftShoulderLength() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 
 
     }

--- a/core/src/net/sf/openrocket/file/rocksim/export/TubeCouplerDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/TubeCouplerDTO.java
@@ -1,11 +1,26 @@
 package net.sf.openrocket.file.rocksim.export;
 
 import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
+import net.sf.openrocket.rocketcomponent.BodyTube;
+import net.sf.openrocket.rocketcomponent.Bulkhead;
+import net.sf.openrocket.rocketcomponent.CenteringRing;
+import net.sf.openrocket.rocketcomponent.EngineBlock;
+import net.sf.openrocket.rocketcomponent.FinSet;
+import net.sf.openrocket.rocketcomponent.FreeformFinSet;
+import net.sf.openrocket.rocketcomponent.InnerTube;
+import net.sf.openrocket.rocketcomponent.MassObject;
+import net.sf.openrocket.rocketcomponent.Parachute;
+import net.sf.openrocket.rocketcomponent.RocketComponent;
+import net.sf.openrocket.rocketcomponent.Streamer;
+import net.sf.openrocket.rocketcomponent.Transition;
 import net.sf.openrocket.rocketcomponent.TubeCoupler;
+import net.sf.openrocket.rocketcomponent.position.AxialMethod;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Conversion DTO for a TubeCoupler.  TubeCoupler's are represented as Rings in Rocksim.
@@ -22,5 +37,43 @@ public class TubeCouplerDTO extends CenteringRingDTO {
     public TubeCouplerDTO(TubeCoupler tc) {
         super(tc);
         setUsageCode(UsageCode.TubeCoupler);
+    }
+
+    /**
+     * Full copy constructor.
+     *
+     * @param tc     the corresponding OR tube coupler
+     * @param parent the attached parts (subcomponents in RockSim speak) of the TubeCoupler's parent.  This instance
+     *               is a member of those attached parts, as well as all sibling components.  This is passed in the
+     *               event that the tube coupler is a cluster.  In that situation this instance will be removed and
+     *               individual instances for each cluster member will be added.
+     */
+    public TubeCouplerDTO(TubeCoupler tc, AttachableParts parent) {
+        super(tc);
+        setUsageCode(UsageCode.TubeCoupler);
+
+        // Add this component first, then the children
+        parent.addAttachedPart(this);
+
+        for (RocketComponent component : tc.getChildren()) {
+            component.setAxialMethod(AxialMethod.ABSOLUTE);
+            if (component instanceof InnerTube) {
+                parent.addAttachedPart(new InnerBodyTubeDTO((InnerTube) component, parent));
+            } else if (component instanceof EngineBlock) {
+                parent.addAttachedPart(new EngineBlockDTO((EngineBlock) component));
+            } else if (component instanceof TubeCoupler) {
+                new TubeCouplerDTO((TubeCoupler) component, parent);
+            } else if (component instanceof CenteringRing) {
+                parent.addAttachedPart(new CenteringRingDTO((CenteringRing) component));
+            } else if (component instanceof Bulkhead) {
+                parent.addAttachedPart(new BulkheadDTO((Bulkhead) component));
+            } else if (component instanceof Parachute) {
+                parent.addAttachedPart(new ParachuteDTO((Parachute) component));
+            } else if (component instanceof Streamer) {
+                parent.addAttachedPart(new StreamerDTO((Streamer) component));
+            } else if (component instanceof MassObject) {
+                parent.addAttachedPart(new MassObjectDTO((MassObject) component));
+            }
+        }
     }
 }

--- a/core/src/net/sf/openrocket/file/rocksim/export/TubeCouplerDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/TubeCouplerDTO.java
@@ -1,6 +1,6 @@
 package net.sf.openrocket.file.rocksim.export;
 
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.rocketcomponent.TubeCoupler;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -10,7 +10,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * Conversion DTO for a TubeCoupler.  TubeCoupler's are represented as Rings in Rocksim.
  */
-@XmlRootElement(name = RocksimCommonConstants.RING)
+@XmlRootElement(name = RockSimCommonConstants.RING)
 @XmlAccessorType(XmlAccessType.FIELD)
 public class TubeCouplerDTO extends CenteringRingDTO {
 

--- a/core/src/net/sf/openrocket/file/rocksim/export/TubeFinSetDTO.java
+++ b/core/src/net/sf/openrocket/file/rocksim/export/TubeFinSetDTO.java
@@ -1,6 +1,6 @@
 package net.sf.openrocket.file.rocksim.export;
 
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.rocketcomponent.TubeFinSet;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -11,17 +11,17 @@ import javax.xml.bind.annotation.XmlRootElement;
 /**
  * This class models an XML element for a Rocksim TubeFinSet.
  */
-@XmlRootElement(name = RocksimCommonConstants.TUBE_FIN_SET)
+@XmlRootElement(name = RockSimCommonConstants.TUBE_FIN_SET)
 @XmlAccessorType(XmlAccessType.FIELD)
 public class TubeFinSetDTO extends BasePartDTO {
 
-    @XmlElement(name = RocksimCommonConstants.OD)
+    @XmlElement(name = RockSimCommonConstants.OD)
     private double od = 0d;
-    @XmlElement(name = RocksimCommonConstants.ID)
+    @XmlElement(name = RockSimCommonConstants.ID)
     private double id = 0d;
-    @XmlElement(name = RocksimCommonConstants.TUBE_COUNT)
+    @XmlElement(name = RockSimCommonConstants.TUBE_COUNT)
     private int tubeCount = 0;
-    @XmlElement(name = RocksimCommonConstants.MAX_TUBES_ALLOWED)
+    @XmlElement(name = RockSimCommonConstants.MAX_TUBES_ALLOWED)
     private int maxTubeCount = 0;
 
     /**
@@ -37,8 +37,8 @@ public class TubeFinSetDTO extends BasePartDTO {
      */
     public TubeFinSetDTO(TubeFinSet theORTubeFinSet) {
         super(theORTubeFinSet);
-        setId(theORTubeFinSet.getInnerRadius() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
-        setOd(theORTubeFinSet.getOuterRadius() * RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+        setId(theORTubeFinSet.getInnerRadius() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+        setOd(theORTubeFinSet.getOuterRadius() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
         setRadialAngle(theORTubeFinSet.getBaseRotation());
         setTubeCount(theORTubeFinSet.getFinCount());
     }

--- a/core/src/net/sf/openrocket/file/rocksim/importt/AttachedPartsHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/AttachedPartsHandler.java
@@ -5,7 +5,7 @@ package net.sf.openrocket.file.rocksim.importt;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.DocumentLoadingContext;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.file.simplesax.AbstractElementHandler;
 import net.sf.openrocket.file.simplesax.ElementHandler;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
@@ -46,43 +46,43 @@ class AttachedPartsHandler extends AbstractElementHandler {
 
     @Override
 	public ElementHandler openElement(String element, HashMap<String, String> attributes, WarningSet warnings) {
-		if (RocksimCommonConstants.FIN_SET.equals(element)) {
+		if (RockSimCommonConstants.FIN_SET.equals(element)) {
 			return new FinSetHandler(context, component);
 		}
-		if (RocksimCommonConstants.CUSTOM_FIN_SET.equals(element)) {
+		if (RockSimCommonConstants.CUSTOM_FIN_SET.equals(element)) {
 			return new FinSetHandler(context, component);
 		}
-		if (RocksimCommonConstants.LAUNCH_LUG.equals(element)) {
+		if (RockSimCommonConstants.LAUNCH_LUG.equals(element)) {
 			return new LaunchLugHandler(context, component, warnings);
 		}
-		if (RocksimCommonConstants.PARACHUTE.equals(element)) {
+		if (RockSimCommonConstants.PARACHUTE.equals(element)) {
 			return new ParachuteHandler(context, component, warnings);
 		}
-		if (RocksimCommonConstants.STREAMER.equals(element)) {
+		if (RockSimCommonConstants.STREAMER.equals(element)) {
 			return new StreamerHandler(context, component, warnings);
 		}
-		if (RocksimCommonConstants.MASS_OBJECT.equals(element)) {
+		if (RockSimCommonConstants.MASS_OBJECT.equals(element)) {
 			return new MassObjectHandler(context, component, warnings);
 		}
-		if (RocksimCommonConstants.RING.equals(element)) {
+		if (RockSimCommonConstants.RING.equals(element)) {
 			return new RingHandler(context, component, warnings);
 		}
-		if (RocksimCommonConstants.BODY_TUBE.equals(element)) {
+		if (RockSimCommonConstants.BODY_TUBE.equals(element)) {
 			return new InnerBodyTubeHandler(context, component, warnings);
 		}
-		if (RocksimCommonConstants.TRANSITION.equals(element)) {
+		if (RockSimCommonConstants.TRANSITION.equals(element)) {
 			return new TransitionHandler(context, component, warnings);
 		}
-		if (RocksimCommonConstants.SUBASSEMBLY.equals(element)) {
+		if (RockSimCommonConstants.SUBASSEMBLY.equals(element)) {
 			return new SubAssemblyHandler(context, component);
 		}
-		if (RocksimCommonConstants.TUBE_FIN_SET.equals(element)) {
+		if (RockSimCommonConstants.TUBE_FIN_SET.equals(element)) {
 			return new TubeFinSetHandler(context, component, warnings);
 		}
-		if (RocksimCommonConstants.RING_TAIL.equals(element)) {
+		if (RockSimCommonConstants.RING_TAIL.equals(element)) {
 			warnings.add("Ring tails are not currently supported. Ignoring.");
 		}
-		if (RocksimCommonConstants.EXTERNAL_POD.equals(element)) {
+		if (RockSimCommonConstants.EXTERNAL_POD.equals(element)) {
 			warnings.add("Pods are not currently supported. Ignoring.");
 		}
 		return null;

--- a/core/src/net/sf/openrocket/file/rocksim/importt/BaseHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/BaseHandler.java
@@ -10,8 +10,8 @@ import java.util.HashMap;
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.database.Databases;
 import net.sf.openrocket.file.DocumentLoadingContext;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
-import net.sf.openrocket.file.rocksim.RocksimDensityType;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimDensityType;
 import net.sf.openrocket.file.simplesax.AbstractElementHandler;
 import net.sf.openrocket.material.Material;
 import net.sf.openrocket.rocketcomponent.ExternalComponent;
@@ -46,7 +46,7 @@ public abstract class BaseHandler<C extends RocketComponent> extends AbstractEle
 	/**
 	 * The internal Rocksim density type.
 	 */
-	private RocksimDensityType densityType = RocksimDensityType.ROCKSIM_BULK;
+	private RockSimDensityType densityType = RockSimDensityType.ROCKSIM_BULK;
 	
 	/**
 	 * The material name.
@@ -77,24 +77,24 @@ public abstract class BaseHandler<C extends RocketComponent> extends AbstractEle
 			throws SAXException {
 		final C component = getComponent();
 		try {
-			if (RocksimCommonConstants.NAME.equals(element)) {
+			if (RockSimCommonConstants.NAME.equals(element)) {
 				component.setName(content);
 			}
-			if (RocksimCommonConstants.KNOWN_MASS.equals(element)) {
-				mass = Math.max(0d, Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
+			if (RockSimCommonConstants.KNOWN_MASS.equals(element)) {
+				mass = Math.max(0d, Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
 			}
-			if (RocksimCommonConstants.DENSITY.equals(element)) {
+			if (RockSimCommonConstants.DENSITY.equals(element)) {
 				density = Math.max(0d, Double.parseDouble(content));
 			}
-			if (RocksimCommonConstants.KNOWN_CG.equals(element)) {
-				cg = Math.max(0d, Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+			if (RockSimCommonConstants.KNOWN_CG.equals(element)) {
+				cg = Math.max(0d, Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 			}
-			if (RocksimCommonConstants.USE_KNOWN_CG.equals(element)) { //Rocksim sets UseKnownCG to true to control the override of both cg and mass
+			if (RockSimCommonConstants.USE_KNOWN_CG.equals(element)) { //Rocksim sets UseKnownCG to true to control the override of both cg and mass
 				boolean override = "1".equals(content);
 				setOverride(component, override, mass, cg);
 			}
-			if (RocksimCommonConstants.DENSITY_TYPE.equals(element)) {
-				densityType = RocksimDensityType.fromCode(Integer.parseInt(content));
+			if (RockSimCommonConstants.DENSITY_TYPE.equals(element)) {
+				densityType = RockSimDensityType.fromCode(Integer.parseInt(content));
 			}
 			
 			appearanceBuilder.processElement(element, content, warnings);
@@ -141,7 +141,7 @@ public abstract class BaseHandler<C extends RocketComponent> extends AbstractEle
 	 *
 	 * @return a value in OpenRocket SURFACE density units
 	 */
-	protected double computeDensity(RocksimDensityType type, double rawDensity) {
+	protected double computeDensity(RockSimDensityType type, double rawDensity) {
 		return rawDensity / type.asOpenRocket();
 	}
 	
@@ -219,7 +219,7 @@ public abstract class BaseHandler<C extends RocketComponent> extends AbstractEle
 	 *
 	 * @return a Rocksim density type
 	 */
-	protected RocksimDensityType getDensityType() {
+	protected RockSimDensityType getDensityType() {
 		return densityType;
 	}
 	

--- a/core/src/net/sf/openrocket/file/rocksim/importt/BodyTubeHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/BodyTubeHandler.java
@@ -9,8 +9,8 @@ import org.xml.sax.SAXException;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.DocumentLoadingContext;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
-import net.sf.openrocket.file.rocksim.RocksimFinishCode;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimFinishCode;
 import net.sf.openrocket.file.simplesax.ElementHandler;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
 import net.sf.openrocket.material.Material;
@@ -46,7 +46,7 @@ class BodyTubeHandler extends BaseHandler<BodyTube> {
 	
 	@Override
 	public ElementHandler openElement(String element, HashMap<String, String> attributes, WarningSet warnings) {
-		if (RocksimCommonConstants.ATTACHED_PARTS.equals(element)) {
+		if (RockSimCommonConstants.ATTACHED_PARTS.equals(element)) {
 			return new AttachedPartsHandler(context, bodyTube);
 		}
 		return PlainTextHandler.INSTANCE;
@@ -58,26 +58,26 @@ class BodyTubeHandler extends BaseHandler<BodyTube> {
 		super.closeElement(element, attributes, content, warnings);
 		
 		try {
-			if (RocksimCommonConstants.OD.equals(element)) {
-				bodyTube.setOuterRadius(Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+			if (RockSimCommonConstants.OD.equals(element)) {
+				bodyTube.setOuterRadius(Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
 			}
-			if (RocksimCommonConstants.ID.equals(element)) {
-				final double r = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS;
+			if (RockSimCommonConstants.ID.equals(element)) {
+				final double r = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS;
 				bodyTube.setInnerRadius(r);
 			}
-			if (RocksimCommonConstants.LEN.equals(element)) {
-				bodyTube.setLength(Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+			if (RockSimCommonConstants.LEN.equals(element)) {
+				bodyTube.setLength(Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 			}
-			if (RocksimCommonConstants.FINISH_CODE.equals(element)) {
-				bodyTube.setFinish(RocksimFinishCode.fromCode(Integer.parseInt(content)).asOpenRocket());
+			if (RockSimCommonConstants.FINISH_CODE.equals(element)) {
+				bodyTube.setFinish(RockSimFinishCode.fromCode(Integer.parseInt(content)).asOpenRocket());
 			}
-			if (RocksimCommonConstants.IS_MOTOR_MOUNT.equals(element)) {
+			if (RockSimCommonConstants.IS_MOTOR_MOUNT.equals(element)) {
 				bodyTube.setMotorMount("1".equals(content));
 			}
-			if (RocksimCommonConstants.ENGINE_OVERHANG.equals(element)) {
-				bodyTube.setMotorOverhang(Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+			if (RockSimCommonConstants.ENGINE_OVERHANG.equals(element)) {
+				bodyTube.setMotorOverhang(Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 			}
-			if (RocksimCommonConstants.MATERIAL.equals(element)) {
+			if (RockSimCommonConstants.MATERIAL.equals(element)) {
 				setMaterialName(content);
 			}
 		} catch (NumberFormatException nfe) {

--- a/core/src/net/sf/openrocket/file/rocksim/importt/FinSetHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/FinSetHandler.java
@@ -13,9 +13,9 @@ import org.xml.sax.SAXException;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.DocumentLoadingContext;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
-import net.sf.openrocket.file.rocksim.RocksimFinishCode;
-import net.sf.openrocket.file.rocksim.RocksimLocationMode;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimFinishCode;
+import net.sf.openrocket.file.rocksim.RockSimLocationMode;
 import net.sf.openrocket.file.simplesax.AbstractElementHandler;
 import net.sf.openrocket.file.simplesax.ElementHandler;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
@@ -176,17 +176,17 @@ class FinSetHandler extends AbstractElementHandler {
 	public void closeElement(String element, HashMap<String, String> attributes, String content, WarningSet warnings)
 			throws SAXException {
 		try {
-			if (RocksimCommonConstants.NAME.equals(element)) {
+			if (RockSimCommonConstants.NAME.equals(element)) {
 				name = content;
 			}
-			if (RocksimCommonConstants.MATERIAL.equals(element)) {
+			if (RockSimCommonConstants.MATERIAL.equals(element)) {
 				materialName = content;
 			}
-			if (RocksimCommonConstants.FINISH_CODE.equals(element)) {
-				finish = RocksimFinishCode.fromCode(Integer.parseInt(content)).asOpenRocket();
+			if (RockSimCommonConstants.FINISH_CODE.equals(element)) {
+				finish = RockSimFinishCode.fromCode(Integer.parseInt(content)).asOpenRocket();
 			}
-			if (RocksimCommonConstants.XB.equals(element)) {
-				location = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
+			if (RockSimCommonConstants.XB.equals(element)) {
+				location = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
 
 				// Account for the different relative distance directions used
 				// Issue Ref: https://github.com/openrocket/openrocket/issues/881
@@ -198,8 +198,8 @@ class FinSetHandler extends AbstractElementHandler {
 
 				this.locationLoaded = true;
 			}
-			if (RocksimCommonConstants.LOCATION_MODE.equals(element)) {
-				axialMethod = RocksimLocationMode.fromCode(Integer.parseInt(content)).asOpenRocket();
+			if (RockSimCommonConstants.LOCATION_MODE.equals(element)) {
+				axialMethod = RockSimLocationMode.fromCode(Integer.parseInt(content)).asOpenRocket();
 
 				// If the location is loaded before the axialMethod, we still need to correct for the different relative distance directions
 				if (locationLoaded) {
@@ -208,65 +208,65 @@ class FinSetHandler extends AbstractElementHandler {
 					}
 				}
 			}
-			if (RocksimCommonConstants.FIN_COUNT.equals(element)) {
+			if (RockSimCommonConstants.FIN_COUNT.equals(element)) {
 				finCount = Integer.parseInt(content);
 			}
-			if (RocksimCommonConstants.ROOT_CHORD.equals(element)) {
-				rootChord = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
+			if (RockSimCommonConstants.ROOT_CHORD.equals(element)) {
+				rootChord = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
 			}
-			if (RocksimCommonConstants.TIP_CHORD.equals(element)) {
-				tipChord = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
+			if (RockSimCommonConstants.TIP_CHORD.equals(element)) {
+				tipChord = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
 			}
-			if (RocksimCommonConstants.SEMI_SPAN.equals(element)) {
-				semiSpan = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
+			if (RockSimCommonConstants.SEMI_SPAN.equals(element)) {
+				semiSpan = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
 			}
 			if ("MidChordLen".equals(element)) {
-				midChordLen = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
+				midChordLen = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
 			}
-			if (RocksimCommonConstants.SWEEP_DISTANCE.equals(element)) {
-				sweepDistance = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
+			if (RockSimCommonConstants.SWEEP_DISTANCE.equals(element)) {
+				sweepDistance = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
 			}
-			if (RocksimCommonConstants.THICKNESS.equals(element)) {
-				thickness = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
+			if (RockSimCommonConstants.THICKNESS.equals(element)) {
+				thickness = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
 			}
-			if (RocksimCommonConstants.TIP_SHAPE_CODE.equals(element)) {
+			if (RockSimCommonConstants.TIP_SHAPE_CODE.equals(element)) {
 				tipShapeCode = Integer.parseInt(content);
 			}
-			if (RocksimCommonConstants.TAB_LENGTH.equals(element)) {
-				tabLength = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
+			if (RockSimCommonConstants.TAB_LENGTH.equals(element)) {
+				tabLength = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
 			}
-			if (RocksimCommonConstants.TAB_DEPTH.equals(element)) {
-				tabDepth = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
+			if (RockSimCommonConstants.TAB_DEPTH.equals(element)) {
+				tabDepth = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
 			}
-			if (RocksimCommonConstants.TAB_OFFSET.equals(element)) {
-				taboffset = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
+			if (RockSimCommonConstants.TAB_OFFSET.equals(element)) {
+				taboffset = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
 			}
-			if (RocksimCommonConstants.RADIAL_ANGLE.equals(element)) {
+			if (RockSimCommonConstants.RADIAL_ANGLE.equals(element)) {
 				radialAngle = Double.parseDouble(content);
 			}
-			if (RocksimCommonConstants.SHAPE_CODE.equals(element)) {
+			if (RockSimCommonConstants.SHAPE_CODE.equals(element)) {
 				shapeCode = Integer.parseInt(content);
 			}
-			if (RocksimCommonConstants.POINT_LIST.equals(element)) {
+			if (RockSimCommonConstants.POINT_LIST.equals(element)) {
 				pointList = content;
 			}
-			if (RocksimCommonConstants.KNOWN_MASS.equals(element)) {
-				mass = Math.max(0d, Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
+			if (RockSimCommonConstants.KNOWN_MASS.equals(element)) {
+				mass = Math.max(0d, Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
 			}
-			if (RocksimCommonConstants.DENSITY.equals(element)) {
-				density = Math.max(0d, Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_BULK_DENSITY);
+			if (RockSimCommonConstants.DENSITY.equals(element)) {
+				density = Math.max(0d, Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_BULK_DENSITY);
 			}
-			if (RocksimCommonConstants.KNOWN_CG.equals(element)) {
-				cg = Math.max(0d, Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
+			if (RockSimCommonConstants.KNOWN_CG.equals(element)) {
+				cg = Math.max(0d, Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
 			}
-			if (RocksimCommonConstants.USE_KNOWN_CG.equals(element)) {
+			if (RockSimCommonConstants.USE_KNOWN_CG.equals(element)) {
 				override = "1".equals(content);
 			}
-			if (RocksimCommonConstants.CALC_MASS.equals(element)) {
-				calcMass = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS;
+			if (RockSimCommonConstants.CALC_MASS.equals(element)) {
+				calcMass = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS;
 			}
-			if (RocksimCommonConstants.CALC_CG.equals(element)) {
-				calcCg = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
+			if (RockSimCommonConstants.CALC_CG.equals(element)) {
+				calcCg = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
 			}
 
 			appearanceBuilder.processElement(element, content, warnings);
@@ -385,8 +385,8 @@ class FinSetHandler extends AbstractElementHandler {
 					}
 
 					Coordinate c = new Coordinate(
-							Double.parseDouble(aPoint[0]) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH,
-							Double.parseDouble(aPoint[1]) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+							Double.parseDouble(aPoint[0]) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH,
+							Double.parseDouble(aPoint[1]) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 					if (result.size() == 0) {
 						result.add(c);
 						continue;

--- a/core/src/net/sf/openrocket/file/rocksim/importt/InnerBodyTubeHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/InnerBodyTubeHandler.java
@@ -9,7 +9,7 @@ import org.xml.sax.SAXException;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.DocumentLoadingContext;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.file.simplesax.ElementHandler;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
 import net.sf.openrocket.material.Material;
@@ -46,7 +46,7 @@ class InnerBodyTubeHandler extends PositionDependentHandler<InnerTube> {
 	
 	@Override
 	public ElementHandler openElement(String element, HashMap<String, String> attributes, WarningSet warnings) {
-		if (RocksimCommonConstants.ATTACHED_PARTS.equals(element)) {
+		if (RockSimCommonConstants.ATTACHED_PARTS.equals(element)) {
 			return new AttachedPartsHandler(context, bodyTube);
 		}
 		return PlainTextHandler.INSTANCE;
@@ -58,30 +58,30 @@ class InnerBodyTubeHandler extends PositionDependentHandler<InnerTube> {
 		super.closeElement(element, attributes, content, warnings);
 		
 		try {
-			if (RocksimCommonConstants.OD.equals(element)) {
-				bodyTube.setOuterRadius(Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+			if (RockSimCommonConstants.OD.equals(element)) {
+				bodyTube.setOuterRadius(Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
 			}
-			if (RocksimCommonConstants.ID.equals(element)) {
-				final double r = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS;
+			if (RockSimCommonConstants.ID.equals(element)) {
+				final double r = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS;
 				bodyTube.setInnerRadius(r);
 			}
-			if (RocksimCommonConstants.LEN.equals(element)) {
-				bodyTube.setLength(Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+			if (RockSimCommonConstants.LEN.equals(element)) {
+				bodyTube.setLength(Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 			}
-			if (RocksimCommonConstants.IS_MOTOR_MOUNT.equals(element)) {
+			if (RockSimCommonConstants.IS_MOTOR_MOUNT.equals(element)) {
 				bodyTube.setMotorMount("1".equals(content));
 			}
-			if (RocksimCommonConstants.ENGINE_OVERHANG.equals(element)) {
-				bodyTube.setMotorOverhang(Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+			if (RockSimCommonConstants.ENGINE_OVERHANG.equals(element)) {
+				bodyTube.setMotorOverhang(Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 			}
-			if (RocksimCommonConstants.MATERIAL.equals(element)) {
+			if (RockSimCommonConstants.MATERIAL.equals(element)) {
 				setMaterialName(content);
 			}
-			if (RocksimCommonConstants.RADIAL_ANGLE.equals(element)) {
+			if (RockSimCommonConstants.RADIAL_ANGLE.equals(element)) {
 				bodyTube.setRadialDirection(Double.parseDouble(content));
 			}
-			if (RocksimCommonConstants.RADIAL_LOC.equals(element)) {
-				bodyTube.setRadialPosition(Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+			if (RockSimCommonConstants.RADIAL_LOC.equals(element)) {
+				bodyTube.setRadialPosition(Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 			}
 		} catch (NumberFormatException nfe) {
 			warnings.add("Could not convert " + element + " value of " + content + ".  It is expected to be a number.");

--- a/core/src/net/sf/openrocket/file/rocksim/importt/LaunchLugHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/LaunchLugHandler.java
@@ -9,8 +9,8 @@ import org.xml.sax.SAXException;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.DocumentLoadingContext;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
-import net.sf.openrocket.file.rocksim.RocksimFinishCode;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimFinishCode;
 import net.sf.openrocket.file.simplesax.ElementHandler;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
 import net.sf.openrocket.material.Material;
@@ -57,23 +57,23 @@ class LaunchLugHandler extends PositionDependentHandler<LaunchLug> {
 		super.closeElement(element, attributes, content, warnings);
 		
 		try {
-			if (RocksimCommonConstants.OD.equals(element)) {
-				lug.setOuterRadius(Math.max(0, Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS));
+			if (RockSimCommonConstants.OD.equals(element)) {
+				lug.setOuterRadius(Math.max(0, Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS));
 			}
-			if (RocksimCommonConstants.ID.equals(element)) {
-				lug.setInnerRadius(Math.max(0, Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS));
+			if (RockSimCommonConstants.ID.equals(element)) {
+				lug.setInnerRadius(Math.max(0, Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS));
 			}
-			if (RocksimCommonConstants.LEN.equals(element)) {
-				lug.setLength(Math.max(0, Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
+			if (RockSimCommonConstants.LEN.equals(element)) {
+				lug.setLength(Math.max(0, Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
 			}
-			if (RocksimCommonConstants.MATERIAL.equals(element)) {
+			if (RockSimCommonConstants.MATERIAL.equals(element)) {
 				setMaterialName(content);
 			}
-			if (RocksimCommonConstants.RADIAL_ANGLE.equals(element)) {
+			if (RockSimCommonConstants.RADIAL_ANGLE.equals(element)) {
 				lug.setAngleOffset(Double.parseDouble(content));
 			}
-			if (RocksimCommonConstants.FINISH_CODE.equals(element)) {
-				lug.setFinish(RocksimFinishCode.fromCode(Integer.parseInt(content)).asOpenRocket());
+			if (RockSimCommonConstants.FINISH_CODE.equals(element)) {
+				lug.setFinish(RockSimFinishCode.fromCode(Integer.parseInt(content)).asOpenRocket());
 			}
 		} catch (NumberFormatException nfe) {
 			warnings.add("Could not convert " + element + " value of " + content + ".  It is expected to be a number.");

--- a/core/src/net/sf/openrocket/file/rocksim/importt/MassObjectHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/MassObjectHandler.java
@@ -7,8 +7,8 @@ import java.util.HashMap;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.DocumentLoadingContext;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
-import net.sf.openrocket.file.rocksim.RocksimDensityType;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimDensityType;
 import net.sf.openrocket.file.simplesax.ElementHandler;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
 import net.sf.openrocket.material.Material;
@@ -82,13 +82,13 @@ class MassObjectHandler extends PositionDependentHandler<MassObject> {
 			throws SAXException {
 		super.closeElement(element, attributes, content, warnings);
 		try {
-			if (RocksimCommonConstants.LEN.equals(element)) {
-				mass.setLength(Double.parseDouble(content) / (RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
+			if (RockSimCommonConstants.LEN.equals(element)) {
+				mass.setLength(Double.parseDouble(content) / (RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
 			}
-			if (RocksimCommonConstants.KNOWN_MASS.equals(element)) {
-				mass.setComponentMass(Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
+			if (RockSimCommonConstants.KNOWN_MASS.equals(element)) {
+				mass.setComponentMass(Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
 			}
-			if (RocksimCommonConstants.KNOWN_CG.equals(element)) {
+			if (RockSimCommonConstants.KNOWN_CG.equals(element)) {
 				//Setting the CG of the Mass Object to 0 is important because of the different ways that Rocksim and
 				//OpenRocket treat mass objects.  Rocksim treats them as points (even though the data file contains a
 				//length) and because Rocksim sets the CG of the mass object to really be relative to the front of
@@ -96,10 +96,10 @@ class MassObjectHandler extends PositionDependentHandler<MassObject> {
 				//Thus it needs to be set to 0 to say that the mass object's CG is at the point of the mass object.
 				super.setCG(0);
 			}
-			if (RocksimCommonConstants.TYPE_CODE.equals(element)) {
+			if (RockSimCommonConstants.TYPE_CODE.equals(element)) {
 				typeCode = Integer.parseInt(content);
 			}
-			if (RocksimCommonConstants.MATERIAL.equals(element)) {
+			if (RockSimCommonConstants.MATERIAL.equals(element)) {
 				setMaterialName(content);
 			}
 		} catch (NumberFormatException nfe) {
@@ -133,7 +133,7 @@ class MassObjectHandler extends PositionDependentHandler<MassObject> {
 	 * @return true if we think it's a shock cord
 	 */
 	private boolean inferAsShockCord(int theTypeCode, WarningSet warnings) {
-		return (theTypeCode == 1 || (mass.getLength() >= 2 * parent.getLength() && RocksimDensityType.ROCKSIM_LINE
+		return (theTypeCode == 1 || (mass.getLength() >= 2 * parent.getLength() && RockSimDensityType.ROCKSIM_LINE
 				.equals(getDensityType()))) && isCompatible(parent, ShockCord.class, warnings, true);
 	}
 	

--- a/core/src/net/sf/openrocket/file/rocksim/importt/NoseConeHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/NoseConeHandler.java
@@ -7,9 +7,9 @@ import java.util.HashMap;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.DocumentLoadingContext;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
-import net.sf.openrocket.file.rocksim.RocksimFinishCode;
-import net.sf.openrocket.file.rocksim.RocksimNoseConeCode;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimFinishCode;
+import net.sf.openrocket.file.rocksim.RockSimNoseConeCode;
 import net.sf.openrocket.file.simplesax.ElementHandler;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
 import net.sf.openrocket.material.Material;
@@ -56,7 +56,7 @@ class NoseConeHandler extends BaseHandler<NoseCone> {
 	@Override
 	public ElementHandler openElement(String element, HashMap<String, String> attributes, WarningSet warnings) {
 		//Nose cones in Rocksim may have attached parts - namely Mass Objects - as children.
-		if (RocksimCommonConstants.ATTACHED_PARTS.equals(element)) {
+		if (RockSimCommonConstants.ATTACHED_PARTS.equals(element)) {
 			return new AttachedPartsHandler(context, noseCone);
 		}
 		return PlainTextHandler.INSTANCE;
@@ -68,27 +68,27 @@ class NoseConeHandler extends BaseHandler<NoseCone> {
 		super.closeElement(element, attributes, content, warnings);
 		
 		try {
-			if (RocksimCommonConstants.SHAPE_CODE.equals(element)) {
-				noseCone.setType(RocksimNoseConeCode.fromCode(Integer.parseInt(content)).asOpenRocket());
+			if (RockSimCommonConstants.SHAPE_CODE.equals(element)) {
+				noseCone.setType(RockSimNoseConeCode.fromCode(Integer.parseInt(content)).asOpenRocket());
 			}
-			if (RocksimCommonConstants.LEN.equals(element)) {
-				noseCone.setLength(Math.max(0, Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
+			if (RockSimCommonConstants.LEN.equals(element)) {
+				noseCone.setLength(Math.max(0, Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
 			}
-			if (RocksimCommonConstants.BASE_DIA.equals(element)) {
-				noseCone.setAftRadius(Math.max(0, Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS));
+			if (RockSimCommonConstants.BASE_DIA.equals(element)) {
+				noseCone.setAftRadius(Math.max(0, Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS));
 			}
-			if (RocksimCommonConstants.WALL_THICKNESS.equals(element)) {
-				thickness = Math.max(0, Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+			if (RockSimCommonConstants.WALL_THICKNESS.equals(element)) {
+				thickness = Math.max(0, Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 			}
-			if (RocksimCommonConstants.SHOULDER_OD.equals(element)) {
+			if (RockSimCommonConstants.SHOULDER_OD.equals(element)) {
 				noseCone.setAftShoulderRadius(Math.max(0, Double.parseDouble(
-						content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS));
+						content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS));
 			}
-			if (RocksimCommonConstants.SHOULDER_LEN.equals(element)) {
+			if (RockSimCommonConstants.SHOULDER_LEN.equals(element)) {
 				noseCone.setAftShoulderLength(Math.max(0, Double.parseDouble(
-						content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
+						content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
 			}
-			if (RocksimCommonConstants.SHAPE_PARAMETER.equals(element)) {
+			if (RockSimCommonConstants.SHAPE_PARAMETER.equals(element)) {
 				//The Rocksim ShapeParameter only applies to certain shapes, although it is included
 				//in the design file for all nose cones.  Applying it when it should not be causes oddities so 
 				//a check is made for the allowable shapes.
@@ -98,7 +98,7 @@ class NoseConeHandler extends BaseHandler<NoseCone> {
 					noseCone.setShapeParameter(Double.parseDouble(content));
 				}
 			}
-			if (RocksimCommonConstants.CONSTRUCTION_TYPE.equals(element)) {
+			if (RockSimCommonConstants.CONSTRUCTION_TYPE.equals(element)) {
 				int typeCode = Integer.parseInt(content);
 				if (typeCode == 0) {
 					//SOLID
@@ -109,10 +109,10 @@ class NoseConeHandler extends BaseHandler<NoseCone> {
 					noseCone.setFilled(false);
 				}
 			}
-			if (RocksimCommonConstants.FINISH_CODE.equals(element)) {
-				noseCone.setFinish(RocksimFinishCode.fromCode(Integer.parseInt(content)).asOpenRocket());
+			if (RockSimCommonConstants.FINISH_CODE.equals(element)) {
+				noseCone.setFinish(RockSimFinishCode.fromCode(Integer.parseInt(content)).asOpenRocket());
 			}
-			if (RocksimCommonConstants.MATERIAL.equals(element)) {
+			if (RockSimCommonConstants.MATERIAL.equals(element)) {
 				setMaterialName(content);
 			}
 		} catch (NumberFormatException nfe) {

--- a/core/src/net/sf/openrocket/file/rocksim/importt/ParachuteHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/ParachuteHandler.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.DocumentLoadingContext;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.file.simplesax.ElementHandler;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
 import net.sf.openrocket.material.Material;
@@ -66,8 +66,8 @@ class ParachuteHandler extends RecoveryDeviceHandler<Parachute> {
 			throws SAXException {
 		super.closeElement(element, attributes, content, warnings);
 		try {
-			if (RocksimCommonConstants.DIAMETER.equals(element)) {
-				chute.setDiameter(Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+			if (RockSimCommonConstants.DIAMETER.equals(element)) {
+				chute.setDiameter(Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 				/* Rocksim doesn't have a packed parachute radius, so we approximate it. */
 				double packed;
 				RocketComponent parent = chute.getParent();
@@ -82,29 +82,29 @@ class ParachuteHandler extends RecoveryDeviceHandler<Parachute> {
 				}
 				chute.setRadius(packed);
 			}
-			if (RocksimCommonConstants.SHROUD_LINE_COUNT.equals(element)) {
+			if (RockSimCommonConstants.SHROUD_LINE_COUNT.equals(element)) {
 				chute.setLineCount(Math.max(0, Integer.parseInt(content)));
 			}
-			if (RocksimCommonConstants.SHROUD_LINE_LEN.equals(element)) {
-				chute.setLineLength(Math.max(0, Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
+			if (RockSimCommonConstants.SHROUD_LINE_LEN.equals(element)) {
+				chute.setLineLength(Math.max(0, Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
 			}
-			if (RocksimCommonConstants.SPILL_HOLE_DIA.equals(element)) {
+			if (RockSimCommonConstants.SPILL_HOLE_DIA.equals(element)) {
 				//Not supported in OpenRocket
-				double spillHoleRadius = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS;
+				double spillHoleRadius = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS;
 				if (spillHoleRadius > 0) {
 					warnings.add("Parachute spill holes are not supported. Ignoring.");
 				}
 			}
-			if (RocksimCommonConstants.SHROUD_LINE_MASS_PER_MM.equals(element)) {
-				shroudLineDensity = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LINE_DENSITY;
+			if (RockSimCommonConstants.SHROUD_LINE_MASS_PER_MM.equals(element)) {
+				shroudLineDensity = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LINE_DENSITY;
 			}
-			if (RocksimCommonConstants.SHROUD_LINE_MATERIAL.equals(element)) {
+			if (RockSimCommonConstants.SHROUD_LINE_MATERIAL.equals(element)) {
 				chute.setLineMaterial(createCustomMaterial(Material.Type.LINE, content, shroudLineDensity));
 			}
-			if (RocksimCommonConstants.DRAG_COEFFICIENT.equals(element)) {
+			if (RockSimCommonConstants.DRAG_COEFFICIENT.equals(element)) {
 				chute.setCD(Double.parseDouble(content));
 			}
-			if (RocksimCommonConstants.MATERIAL.equals(element)) {
+			if (RockSimCommonConstants.MATERIAL.equals(element)) {
 				setMaterialName(content);
 			}
 		} catch (NumberFormatException nfe) {

--- a/core/src/net/sf/openrocket/file/rocksim/importt/PositionDependentHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/PositionDependentHandler.java
@@ -7,8 +7,8 @@ import java.util.HashMap;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.DocumentLoadingContext;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
-import net.sf.openrocket.file.rocksim.RocksimLocationMode;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimLocationMode;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.rocketcomponent.position.AxialMethod;
 
@@ -39,11 +39,11 @@ public abstract class PositionDependentHandler<C extends RocketComponent> extend
 	public void closeElement(String element, HashMap<String, String> attributes, String content, WarningSet warnings)
 			throws SAXException {
 		super.closeElement(element, attributes, content, warnings);
-		if (RocksimCommonConstants.XB.equals(element)) {
-			positionValue = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
+		if (RockSimCommonConstants.XB.equals(element)) {
+			positionValue = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
 		}
-		if (RocksimCommonConstants.LOCATION_MODE.equals(element)) {
-			axialMethod = RocksimLocationMode.fromCode(Integer.parseInt(
+		if (RockSimCommonConstants.LOCATION_MODE.equals(element)) {
+			axialMethod = RockSimLocationMode.fromCode(Integer.parseInt(
 					content)).asOpenRocket();
 		}
 	}

--- a/core/src/net/sf/openrocket/file/rocksim/importt/RecoveryDeviceHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/RecoveryDeviceHandler.java
@@ -7,8 +7,8 @@ import java.util.HashMap;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.DocumentLoadingContext;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
-import net.sf.openrocket.file.rocksim.RocksimDensityType;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimDensityType;
 import net.sf.openrocket.material.Material;
 import net.sf.openrocket.rocketcomponent.RecoveryDevice;
 
@@ -45,11 +45,11 @@ public abstract class RecoveryDeviceHandler<C extends RecoveryDevice> extends Po
 		super.closeElement(element, attributes, content, warnings);
 		
 		try {
-			if (RocksimCommonConstants.THICKNESS.equals(element)) {
-				thickness = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
+			if (RockSimCommonConstants.THICKNESS.equals(element)) {
+				thickness = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
 			}
-			if (RocksimCommonConstants.CALC_MASS.equals(element)) {
-				calcMass = Math.max(0d, Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
+			if (RockSimCommonConstants.CALC_MASS.equals(element)) {
+				calcMass = Math.max(0d, Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS);
 			}
 		} catch (NumberFormatException nfe) {
 			warnings.add("Could not convert " + element + " value of " + content + ".  It is expected to be a number.");
@@ -66,7 +66,7 @@ public abstract class RecoveryDeviceHandler<C extends RecoveryDevice> extends Po
 	 * @return a value in OpenRocket SURFACE density units
 	 */
 	@Override
-	protected double computeDensity(RocksimDensityType type, double rawDensity) {
+	protected double computeDensity(RockSimDensityType type, double rawDensity) {
 		
 		double result;
 		
@@ -74,8 +74,8 @@ public abstract class RecoveryDeviceHandler<C extends RecoveryDevice> extends Po
 			//ROCKSIM_SURFACE is a square area density; compute normally
 			//ROCKSIM_LINE is a single length dimension (kg/m) but Rocksim ignores thickness for this type and treats
 			//it like a SURFACE.
-			if (RocksimDensityType.ROCKSIM_SURFACE.equals(type) || RocksimDensityType.ROCKSIM_LINE.equals(type)) {
-				result = rawDensity / RocksimDensityType.ROCKSIM_SURFACE.asOpenRocket();
+			if (RockSimDensityType.ROCKSIM_SURFACE.equals(type) || RockSimDensityType.ROCKSIM_LINE.equals(type)) {
+				result = rawDensity / RockSimDensityType.ROCKSIM_SURFACE.asOpenRocket();
 			}
 			//ROCKSIM_BULK is a cubic area density; multiple by thickness to make per square area; the result, when
 			//multiplied by the area will then equal Rocksim's computed mass.
@@ -87,7 +87,7 @@ public abstract class RecoveryDeviceHandler<C extends RecoveryDevice> extends Po
 			result = calcMass / getComponent().getArea();
 			//A Rocksim bug on streamers/parachutes results in a 0 density at times.  When that is detected, try
 			//to compute an approximate density from Rocksim's computed mass.
-			if (RocksimDensityType.ROCKSIM_BULK.equals(type)) {
+			if (RockSimDensityType.ROCKSIM_BULK.equals(type)) {
 				//ROCKSIM_BULK is a cubic area density; multiple by thickness to make per square area
 				result *= thickness;
 			}

--- a/core/src/net/sf/openrocket/file/rocksim/importt/RingHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/RingHandler.java
@@ -9,7 +9,7 @@ import org.xml.sax.SAXException;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.DocumentLoadingContext;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.file.simplesax.ElementHandler;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
 import net.sf.openrocket.material.Material;
@@ -66,19 +66,19 @@ class RingHandler extends PositionDependentHandler<CenteringRing> {
 		super.closeElement(element, attributes, content, warnings);
 		
 		try {
-			if (RocksimCommonConstants.OD.equals(element)) {
-				ring.setOuterRadius(Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+			if (RockSimCommonConstants.OD.equals(element)) {
+				ring.setOuterRadius(Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
 			}
-			if (RocksimCommonConstants.ID.equals(element)) {
-				ring.setInnerRadius(Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
+			if (RockSimCommonConstants.ID.equals(element)) {
+				ring.setInnerRadius(Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
 			}
-			if (RocksimCommonConstants.LEN.equals(element)) {
-				ring.setLength(Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+			if (RockSimCommonConstants.LEN.equals(element)) {
+				ring.setLength(Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 			}
-			if (RocksimCommonConstants.MATERIAL.equals(element)) {
+			if (RockSimCommonConstants.MATERIAL.equals(element)) {
 				setMaterialName(content);
 			}
-			if (RocksimCommonConstants.USAGE_CODE.equals(element)) {
+			if (RockSimCommonConstants.USAGE_CODE.equals(element)) {
 				usageCode = Integer.parseInt(content);
 			}
 		} catch (NumberFormatException nfe) {

--- a/core/src/net/sf/openrocket/file/rocksim/importt/RockSimAppearanceBuilder.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/RockSimAppearanceBuilder.java
@@ -9,7 +9,7 @@ import net.sf.openrocket.appearance.AppearanceBuilder;
 import net.sf.openrocket.appearance.Decal.EdgeMode;
 import net.sf.openrocket.document.Attachment;
 import net.sf.openrocket.file.DocumentLoadingContext;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.util.Color;
 
 public class RockSimAppearanceBuilder extends AppearanceBuilder {
@@ -25,7 +25,7 @@ public class RockSimAppearanceBuilder extends AppearanceBuilder {
 	
 	public void processElement(String element, String content, WarningSet warnings) {
 		try {
-			if (RocksimCommonConstants.TEXTURE.equals(element)) {
+			if (RockSimCommonConstants.TEXTURE.equals(element)) {
 				parseTexture(content);
 			} else if ("Ambient".equals(element)) {
 				//ignored

--- a/core/src/net/sf/openrocket/file/rocksim/importt/RockSimHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/RockSimHandler.java
@@ -1,5 +1,5 @@
 /*
- * RocksimHandler.java
+ * RockSimHandler.java
  *
  */
 package net.sf.openrocket.file.rocksim.importt;
@@ -10,7 +10,7 @@ import net.sf.openrocket.aerodynamics.Warning;
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.file.DocumentLoadingContext;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.file.simplesax.AbstractElementHandler;
 import net.sf.openrocket.file.simplesax.ElementHandler;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
@@ -27,16 +27,16 @@ import org.xml.sax.SAXException;
  * <p/>
  * Limitations: Rocksim flight simulations are not imported; tube fins are not supported; Rocksim 'pods' are not supported.
  */
-public class RocksimHandler extends AbstractElementHandler {
+public class RockSimHandler extends AbstractElementHandler {
 	
 	/**
 	 * The main content handler.
 	 */
-	private RocksimContentHandler handler = null;
+	private RockSimContentHandler handler = null;
 	
 	private final DocumentLoadingContext context;
 	
-	public RocksimHandler(DocumentLoadingContext context) {
+	public RockSimHandler(DocumentLoadingContext context) {
 		super();
 		this.context = context;
 	}
@@ -68,7 +68,7 @@ public class RocksimHandler extends AbstractElementHandler {
 			return null;
 		}
 		
-		handler = new RocksimContentHandler(context);
+		handler = new RockSimContentHandler(context);
 		return handler;
 	}
 	
@@ -77,7 +77,7 @@ public class RocksimHandler extends AbstractElementHandler {
 /**
  * Handles the content of the <DesignInformation> tag.
  */
-class RocksimContentHandler extends AbstractElementHandler {
+class RockSimContentHandler extends AbstractElementHandler {
 	/**
 	 * The DocumentLoadingContext
 	 */
@@ -93,7 +93,7 @@ class RocksimContentHandler extends AbstractElementHandler {
 	 */
 	private String version;
 	
-	public RocksimContentHandler(DocumentLoadingContext context) {
+	public RockSimContentHandler(DocumentLoadingContext context) {
 		super();
 		this.context = context;
 		this.rocket = context.getOpenRocketDocument().getRocket();
@@ -111,15 +111,15 @@ class RocksimContentHandler extends AbstractElementHandler {
 	@Override
 	public ElementHandler openElement(String element, HashMap<String, String> attributes,
 			WarningSet warnings) {
-		if (RocksimCommonConstants.DESIGN_INFORMATION.equals(element)) {
+		if (RockSimCommonConstants.DESIGN_INFORMATION.equals(element)) {
 			//The next sub-element is "RocketDesign", which is really the only thing that matters.  Rather than
 			//create another handler just for that element, handle it here.
 			return this;
 		}
-		if (RocksimCommonConstants.FILE_VERSION.equals(element)) {
+		if (RockSimCommonConstants.FILE_VERSION.equals(element)) {
 			return PlainTextHandler.INSTANCE;
 		}
-		if (RocksimCommonConstants.ROCKET_DESIGN.equals(element)) {
+		if (RockSimCommonConstants.ROCKET_DESIGN.equals(element)) {
 			return new RocketDesignHandler(context, rocket);
 		}
 		return null;
@@ -132,7 +132,7 @@ class RocksimContentHandler extends AbstractElementHandler {
 		 * SAX handler for Rocksim file version number.  The value is not used currently, but could be used in the future
 		 * for backward/forward compatibility reasons (different lower level handlers could be called via a strategy pattern).
 		 */
-		if (RocksimCommonConstants.FILE_VERSION.equals(element)) {
+		if (RockSimCommonConstants.FILE_VERSION.equals(element)) {
 			version = content;
 		}
 	}
@@ -253,7 +253,7 @@ class RocketDesignHandler extends AbstractElementHandler {
 				return new StageHandler(context, stage);
 			}
 		}
-		if (RocksimCommonConstants.NAME.equals(element)) {
+		if (RockSimCommonConstants.NAME.equals(element)) {
 			return PlainTextHandler.INSTANCE;
 		}
 		if ("StageCount".equals(element)) {
@@ -284,29 +284,29 @@ class RocketDesignHandler extends AbstractElementHandler {
 	public void closeElement(String element, HashMap<String, String> attributes,
 			String content, WarningSet warnings) throws SAXException {
 		try {
-			if (RocksimCommonConstants.NAME.equals(element)) {
+			if (RockSimCommonConstants.NAME.equals(element)) {
 				component.setName(content);
 			}
 			if ("StageCount".equals(element)) {
 				stageCount = Integer.parseInt(content);
 			}
 			if ("Stage3Mass".equals(element)) {
-				stage3Mass = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS;
+				stage3Mass = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS;
 			}
 			if ("Stage2Mass".equals(element)) {
-				stage2Mass = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS;
+				stage2Mass = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS;
 			}
 			if ("Stage1Mass".equals(element)) {
-				stage1Mass = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS;
+				stage1Mass = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS;
 			}
 			if ("Stage3CG".equals(element)) {
-				stage3CG = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
+				stage3CG = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
 			}
 			if ("Stage2CGAlone".equals(element)) {
-				stage2CG = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
+				stage2CG = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
 			}
 			if ("Stage1CGAlone".equals(element)) {
-				stage1CG = Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
+				stage1CG = Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
 			}
 		} catch (NumberFormatException nfe) {
 			warnings.add("Could not convert " + element + " value of " + content + ".  It is expected to be a number.");
@@ -341,13 +341,13 @@ class StageHandler extends AbstractElementHandler {
 	
 	@Override
 	public ElementHandler openElement(String element, HashMap<String, String> attributes, WarningSet warnings) {
-		if (RocksimCommonConstants.NOSE_CONE.equals(element)) {
+		if (RockSimCommonConstants.NOSE_CONE.equals(element)) {
 			return new NoseConeHandler(context, component, warnings);
 		}
-		if (RocksimCommonConstants.BODY_TUBE.equals(element)) {
+		if (RockSimCommonConstants.BODY_TUBE.equals(element)) {
 			return new BodyTubeHandler(context, component, warnings);
 		}
-		if (RocksimCommonConstants.TRANSITION.equals(element)) {
+		if (RockSimCommonConstants.TRANSITION.equals(element)) {
 			return new TransitionHandler(context, component, warnings);
 		}
 		return null;

--- a/core/src/net/sf/openrocket/file/rocksim/importt/RockSimLoader.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/RockSimLoader.java
@@ -1,5 +1,5 @@
 /*
- * RocksimLoader.java
+ * RockSimLoader.java
  */
 package net.sf.openrocket.file.rocksim.importt;
 
@@ -30,7 +30,7 @@ import net.sf.openrocket.file.simplesax.SimpleSAX;
  *          setMaterial
  *          getMaterial
  */
-public class RocksimLoader extends AbstractRocketLoader {
+public class RockSimLoader extends AbstractRocketLoader {
 	/**
 	 * This method is called by the default implementations of {@link #load(java.io.File)}
 	 * and {@link #load(java.io.InputStream)} to load the rocket.
@@ -43,7 +43,7 @@ public class RocksimLoader extends AbstractRocketLoader {
 		
 		InputSource xmlSource = new InputSource(source);
 		
-		RocksimHandler handler = new RocksimHandler(context);
+		RockSimHandler handler = new RockSimHandler(context);
 		
 		try {
 			SimpleSAX.readXML(xmlSource, handler, warnings);

--- a/core/src/net/sf/openrocket/file/rocksim/importt/RockSimLoader.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/RockSimLoader.java
@@ -39,7 +39,7 @@ public class RockSimLoader extends AbstractRocketLoader {
 	 *          if an error occurs during loading.
 	 */
 	@Override
-	protected void loadFromStream(DocumentLoadingContext context, InputStream source) throws IOException, RocketLoadException {
+	public void loadFromStream(DocumentLoadingContext context, InputStream source) throws IOException, RocketLoadException {
 		
 		InputSource xmlSource = new InputSource(source);
 		

--- a/core/src/net/sf/openrocket/file/rocksim/importt/StreamerHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/StreamerHandler.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.DocumentLoadingContext;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.file.simplesax.ElementHandler;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
@@ -61,16 +61,16 @@ class StreamerHandler extends RecoveryDeviceHandler<Streamer> {
 		super.closeElement(element, attributes, content, warnings);
 		
 		try {
-			if (RocksimCommonConstants.WIDTH.equals(element)) {
-				streamer.setStripWidth(Math.max(0, Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
+			if (RockSimCommonConstants.WIDTH.equals(element)) {
+				streamer.setStripWidth(Math.max(0, Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
 			}
-			if (RocksimCommonConstants.LEN.equals(element)) {
-				streamer.setStripLength(Math.max(0, Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
+			if (RockSimCommonConstants.LEN.equals(element)) {
+				streamer.setStripLength(Math.max(0, Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
 			}
-			if (RocksimCommonConstants.DRAG_COEFFICIENT.equals(element)) {
+			if (RockSimCommonConstants.DRAG_COEFFICIENT.equals(element)) {
 				streamer.setCD(Double.parseDouble(content));
 			}
-			if (RocksimCommonConstants.MATERIAL.equals(element)) {
+			if (RockSimCommonConstants.MATERIAL.equals(element)) {
 				setMaterialName(content);
 			}
 		} catch (NumberFormatException nfe) {

--- a/core/src/net/sf/openrocket/file/rocksim/importt/SubAssemblyHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/SubAssemblyHandler.java
@@ -3,7 +3,7 @@ package net.sf.openrocket.file.rocksim.importt;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.DocumentLoadingContext;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.file.simplesax.ElementHandler;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 
@@ -30,11 +30,11 @@ public class SubAssemblyHandler extends AttachedPartsHandler {
         // the AttachedPartsHandler assumes that all body tubes are inner body tubes (Rocksim makes no distinction).  OR does not allow things
         // like fins to be attached to inner body tubes - which is often what these Rocksim subassemblies contain.  So just return this instance
         // which treats body tubes as external body tubes.
-        if (RocksimCommonConstants.ATTACHED_PARTS.equals(element)) {
+        if (RockSimCommonConstants.ATTACHED_PARTS.equals(element)) {
             return this;
         }
         // The key override of this class - treat body tubes as external body tubes.
-        else if (RocksimCommonConstants.BODY_TUBE.equals(element)) {
+        else if (RockSimCommonConstants.BODY_TUBE.equals(element)) {
             return new BodyTubeHandler(getContext(), getComponent(), warnings);
         }
         return super.openElement(element, attributes, warnings);

--- a/core/src/net/sf/openrocket/file/rocksim/importt/TransitionHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/TransitionHandler.java
@@ -7,9 +7,9 @@ import java.util.HashMap;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.DocumentLoadingContext;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
-import net.sf.openrocket.file.rocksim.RocksimFinishCode;
-import net.sf.openrocket.file.rocksim.RocksimNoseConeCode;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimFinishCode;
+import net.sf.openrocket.file.rocksim.RockSimNoseConeCode;
 import net.sf.openrocket.file.simplesax.ElementHandler;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
 import net.sf.openrocket.material.Material;
@@ -51,7 +51,7 @@ class TransitionHandler extends BaseHandler<Transition> {
 	
 	@Override
 	public ElementHandler openElement(String element, HashMap<String, String> attributes, WarningSet warnings) {
-		if (RocksimCommonConstants.ATTACHED_PARTS.equals(element)) {
+		if (RockSimCommonConstants.ATTACHED_PARTS.equals(element)) {
 			return new AttachedPartsHandler(context, transition);
 		}
 		return PlainTextHandler.INSTANCE;
@@ -64,38 +64,38 @@ class TransitionHandler extends BaseHandler<Transition> {
 		
 		try {
 			if ("ShapeCode".equals(element)) {
-				transition.setType(RocksimNoseConeCode.fromCode(Integer.parseInt(content)).asOpenRocket());
+				transition.setType(RockSimNoseConeCode.fromCode(Integer.parseInt(content)).asOpenRocket());
 			}
 			if ("Len".equals(element)) {
 				transition.setLength(Math.max(0, Double.parseDouble(
-						content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
+						content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
 			}
 			if ("FrontDia".equals(element)) {
 				transition.setForeRadius(Math.max(0, Double.parseDouble(
-						content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS));
+						content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS));
 			}
 			if ("RearDia".equals(element)) {
 				transition.setAftRadius(Math.max(0, Double.parseDouble(
-						content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS));
+						content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS));
 			}
 			if ("WallThickness".equals(element)) {
-				thickness = Math.max(0d, Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+				thickness = Math.max(0d, Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 			}
 			if ("FrontShoulderDia".equals(element)) {
 				transition.setForeShoulderRadius(Math.max(0d, Double.parseDouble(
-						content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS));
+						content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS));
 			}
 			if ("RearShoulderDia".equals(element)) {
 				transition.setAftShoulderRadius(Math.max(0d, Double.parseDouble(
-						content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS));
+						content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS));
 			}
 			if ("FrontShoulderLen".equals(element)) {
 				transition.setForeShoulderLength(Math.max(0d, Double.parseDouble(
-						content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
+						content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
 			}
 			if ("RearShoulderLen".equals(element)) {
 				transition.setAftShoulderLength(Math.max(0d, Double.parseDouble(
-						content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
+						content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
 			}
 			if ("ShapeParameter".equals(element)) {
 				if (Transition.Shape.POWER.equals(transition.getType()) ||
@@ -116,7 +116,7 @@ class TransitionHandler extends BaseHandler<Transition> {
 				}
 			}
 			if ("FinishCode".equals(element)) {
-				transition.setFinish(RocksimFinishCode.fromCode(Integer.parseInt(content)).asOpenRocket());
+				transition.setFinish(RockSimFinishCode.fromCode(Integer.parseInt(content)).asOpenRocket());
 			}
 			if ("Material".equals(element)) {
 				setMaterialName(content);

--- a/core/src/net/sf/openrocket/file/rocksim/importt/TubeFinSetHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/TubeFinSetHandler.java
@@ -2,8 +2,8 @@ package net.sf.openrocket.file.rocksim.importt;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.file.DocumentLoadingContext;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
-import net.sf.openrocket.file.rocksim.RocksimFinishCode;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimFinishCode;
 import net.sf.openrocket.file.simplesax.ElementHandler;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
 import net.sf.openrocket.material.Material;
@@ -80,26 +80,26 @@ public class TubeFinSetHandler extends PositionDependentHandler<TubeFinSet> {
    		super.closeElement(element, attributes, content, warnings);
 
    		try {
-   			if (RocksimCommonConstants.OD.equals(element)) {
-   				tubeFin.setOuterRadius(Math.max(0, Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS));
+   			if (RockSimCommonConstants.OD.equals(element)) {
+   				tubeFin.setOuterRadius(Math.max(0, Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS));
    			}
-   			if (RocksimCommonConstants.ID.equals(element)) {
-                tubeFin.setInnerRadius(Math.max(0, Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS));
+   			if (RockSimCommonConstants.ID.equals(element)) {
+                tubeFin.setInnerRadius(Math.max(0, Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS));
    			}
-   			if (RocksimCommonConstants.LEN.equals(element)) {
-                tubeFin.setLength(Math.max(0, Double.parseDouble(content) / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
+   			if (RockSimCommonConstants.LEN.equals(element)) {
+                tubeFin.setLength(Math.max(0, Double.parseDouble(content) / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH));
    			}
-   			if (RocksimCommonConstants.MATERIAL.equals(element)) {
+   			if (RockSimCommonConstants.MATERIAL.equals(element)) {
    				setMaterialName(content);
    			}
-            if (RocksimCommonConstants.RADIAL_ANGLE.equals(element)) {
+            if (RockSimCommonConstants.RADIAL_ANGLE.equals(element)) {
                 tubeFin.setBaseRotation(Double.parseDouble(content));
             }
-   			if (RocksimCommonConstants.TUBE_COUNT.equals(element)) {
+   			if (RockSimCommonConstants.TUBE_COUNT.equals(element)) {
                 tubeFin.setFinCount(Integer.parseInt(content));
    			}
-   			if (RocksimCommonConstants.FINISH_CODE.equals(element)) {
-                tubeFin.setFinish(RocksimFinishCode.fromCode(Integer.parseInt(content)).asOpenRocket());
+   			if (RockSimCommonConstants.FINISH_CODE.equals(element)) {
+                tubeFin.setFinish(RockSimFinishCode.fromCode(Integer.parseInt(content)).asOpenRocket());
    			}
    		} catch (NumberFormatException nfe) {
    			warnings.add("Could not convert " + element + " value of " + content + ".  It is expected to be a number.");

--- a/core/src/net/sf/openrocket/preset/loader/BaseColumnParser.java
+++ b/core/src/net/sf/openrocket/preset/loader/BaseColumnParser.java
@@ -5,7 +5,7 @@ import java.util.Locale;
 import net.sf.openrocket.preset.TypedPropertyMap;
 
 
-public abstract class BaseColumnParser implements RocksimComponentFileColumnParser {
+public abstract class BaseColumnParser implements RockSimComponentFileColumnParser {
 
 	protected String columnHeader;
 	protected boolean isConfigured = false;

--- a/core/src/net/sf/openrocket/preset/loader/BaseComponentLoader.java
+++ b/core/src/net/sf/openrocket/preset/loader/BaseComponentLoader.java
@@ -9,7 +9,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class BaseComponentLoader extends RocksimComponentFileLoader {
+public abstract class BaseComponentLoader extends RockSimComponentFileLoader {
 
 	List<ComponentPreset> presets;
 

--- a/core/src/net/sf/openrocket/preset/loader/BodyTubeLoader.java
+++ b/core/src/net/sf/openrocket/preset/loader/BodyTubeLoader.java
@@ -23,8 +23,8 @@ public class BodyTubeLoader extends BaseComponentLoader {
 
 
 	@Override
-	protected RocksimComponentFileType getFileType() {
-		return RocksimComponentFileType.BODY_TUBE;
+	protected RockSimComponentFileType getFileType() {
+		return RockSimComponentFileType.BODY_TUBE;
 	}
 
 }

--- a/core/src/net/sf/openrocket/preset/loader/BulkHeadLoader.java
+++ b/core/src/net/sf/openrocket/preset/loader/BulkHeadLoader.java
@@ -22,8 +22,8 @@ public class BulkHeadLoader extends BaseComponentLoader {
 
 
 	@Override
-	protected RocksimComponentFileType getFileType() {
-		return RocksimComponentFileType.BULKHEAD;
+	protected RockSimComponentFileType getFileType() {
+		return RockSimComponentFileType.BULKHEAD;
 	}
 
 	@Override

--- a/core/src/net/sf/openrocket/preset/loader/CenteringRingLoader.java
+++ b/core/src/net/sf/openrocket/preset/loader/CenteringRingLoader.java
@@ -17,8 +17,8 @@ public class CenteringRingLoader extends BodyTubeLoader {
 	}
 
 	@Override
-	protected RocksimComponentFileType getFileType() {
-		return RocksimComponentFileType.CENTERING_RING;
+	protected RockSimComponentFileType getFileType() {
+		return RockSimComponentFileType.CENTERING_RING;
 	}
 
 }

--- a/core/src/net/sf/openrocket/preset/loader/EngineBlockLoader.java
+++ b/core/src/net/sf/openrocket/preset/loader/EngineBlockLoader.java
@@ -17,8 +17,8 @@ public class EngineBlockLoader extends BodyTubeLoader {
 	}
 
 	@Override
-	protected RocksimComponentFileType getFileType() {
-		return RocksimComponentFileType.ENGINE_BLOCK;
+	protected RockSimComponentFileType getFileType() {
+		return RockSimComponentFileType.ENGINE_BLOCK;
 	}
 
 }

--- a/core/src/net/sf/openrocket/preset/loader/LaunchLugLoader.java
+++ b/core/src/net/sf/openrocket/preset/loader/LaunchLugLoader.java
@@ -23,8 +23,8 @@ public class LaunchLugLoader extends BaseComponentLoader {
 
 
 	@Override
-	protected RocksimComponentFileType getFileType() {
-		return RocksimComponentFileType.LAUNCH_LUG;
+	protected RockSimComponentFileType getFileType() {
+		return RockSimComponentFileType.LAUNCH_LUG;
 	}
 
 }

--- a/core/src/net/sf/openrocket/preset/loader/MaterialLoader.java
+++ b/core/src/net/sf/openrocket/preset/loader/MaterialLoader.java
@@ -8,7 +8,7 @@ import net.sf.openrocket.preset.TypedKey;
 import net.sf.openrocket.preset.TypedPropertyMap;
 import net.sf.openrocket.util.BugException;
 
-public class MaterialLoader extends RocksimComponentFileLoader {
+public class MaterialLoader extends RockSimComponentFileLoader {
 	
 	private final MaterialHolder materialMap = new MaterialHolder();
 	
@@ -24,8 +24,8 @@ public class MaterialLoader extends RocksimComponentFileLoader {
 	}
 	
 	@Override
-	protected RocksimComponentFileType getFileType() {
-		return RocksimComponentFileType.MATERIAL;
+	protected RockSimComponentFileType getFileType() {
+		return RockSimComponentFileType.MATERIAL;
 	}
 	
 	public MaterialHolder getMaterialMap() {

--- a/core/src/net/sf/openrocket/preset/loader/NoseConeLoader.java
+++ b/core/src/net/sf/openrocket/preset/loader/NoseConeLoader.java
@@ -24,8 +24,8 @@ public class NoseConeLoader extends BaseComponentLoader {
 	}
 
 	@Override
-	protected RocksimComponentFileType getFileType() {
-		return RocksimComponentFileType.NOSE_CONE;
+	protected RockSimComponentFileType getFileType() {
+		return RockSimComponentFileType.NOSE_CONE;
 	}
 
 	@Override

--- a/core/src/net/sf/openrocket/preset/loader/ParachuteLoader.java
+++ b/core/src/net/sf/openrocket/preset/loader/ParachuteLoader.java
@@ -31,8 +31,8 @@ public class ParachuteLoader extends BaseComponentLoader {
 
 
 	@Override
-	protected RocksimComponentFileType getFileType() {
-		return RocksimComponentFileType.PARACHUTE;
+	protected RockSimComponentFileType getFileType() {
+		return RockSimComponentFileType.PARACHUTE;
 	}
 
 

--- a/core/src/net/sf/openrocket/preset/loader/RailButtonLoader.java
+++ b/core/src/net/sf/openrocket/preset/loader/RailButtonLoader.java
@@ -25,8 +25,8 @@ public class RailButtonLoader extends BaseComponentLoader {
 
 
 	@Override
-	protected RocksimComponentFileType getFileType() {
-		return RocksimComponentFileType.LAUNCH_LUG;
+	protected RockSimComponentFileType getFileType() {
+		return RockSimComponentFileType.LAUNCH_LUG;
 	}
 
 }

--- a/core/src/net/sf/openrocket/preset/loader/RockSimComponentFileColumnParser.java
+++ b/core/src/net/sf/openrocket/preset/loader/RockSimComponentFileColumnParser.java
@@ -2,7 +2,7 @@ package net.sf.openrocket.preset.loader;
 
 import net.sf.openrocket.preset.TypedPropertyMap;
 
-public interface RocksimComponentFileColumnParser {
+public interface RockSimComponentFileColumnParser {
 
 	/**
 	 * Examine the array of column headers and configure parsing for this type. 

--- a/core/src/net/sf/openrocket/preset/loader/RockSimComponentFileLoader.java
+++ b/core/src/net/sf/openrocket/preset/loader/RockSimComponentFileLoader.java
@@ -24,7 +24,7 @@ import com.opencsv.CSVReader;
 /**
  * Primary entry point for parsing component CSV files that are in Rocksim format.
  */
-public abstract class RocksimComponentFileLoader {
+public abstract class RockSimComponentFileLoader {
 	
 	private static final PrintStream LOGGER = System.err;
 	
@@ -32,14 +32,14 @@ public abstract class RocksimComponentFileLoader {
 	
 	private final File dir;
 	
-	protected List<RocksimComponentFileColumnParser> fileColumns = new ArrayList<RocksimComponentFileColumnParser>();
+	protected List<RockSimComponentFileColumnParser> fileColumns = new ArrayList<RockSimComponentFileColumnParser>();
 	
 	/**
 	 * Constructor.
 	 *
 	 * @param theBasePathToLoadFrom base path
 	 */
-	public RocksimComponentFileLoader(File theBasePathToLoadFrom) {
+	public RockSimComponentFileLoader(File theBasePathToLoadFrom) {
 		dir = theBasePathToLoadFrom;
 		basePath = dir.getAbsolutePath();
 	}
@@ -49,12 +49,12 @@ public abstract class RocksimComponentFileLoader {
 	 *
 	 * @param theBasePathToLoadFrom base path
 	 */
-	public RocksimComponentFileLoader(String theBasePathToLoadFrom) {
+	public RockSimComponentFileLoader(String theBasePathToLoadFrom) {
 		dir = new File(basePath);
 		basePath = theBasePathToLoadFrom;
 	}
 	
-	protected abstract RocksimComponentFileType getFileType();
+	protected abstract RockSimComponentFileType getFileType();
 	
 	public void load() {
 		try {
@@ -74,7 +74,7 @@ public abstract class RocksimComponentFileLoader {
 	 *         component data file; the element in the list itself is an array of String, where each item in the array
 	 *         is a column (cell) in the row.  The string array is in sequential order as it appeared in the file.
 	 */
-	private void load(RocksimComponentFileType type) throws FileNotFoundException {
+	private void load(RockSimComponentFileType type) throws FileNotFoundException {
 		if (!dir.exists()) {
 			throw new IllegalArgumentException(basePath + " does not exist");
 		}
@@ -158,7 +158,7 @@ public abstract class RocksimComponentFileLoader {
 	}
 	
 	protected void parseHeaders(String[] headers) {
-		for (RocksimComponentFileColumnParser column : fileColumns) {
+		for (RockSimComponentFileColumnParser column : fileColumns) {
 			column.configure(headers);
 		}
 	}
@@ -171,7 +171,7 @@ public abstract class RocksimComponentFileLoader {
 		
 		preProcess(data);
 		
-		for (RocksimComponentFileColumnParser column : fileColumns) {
+		for (RockSimComponentFileColumnParser column : fileColumns) {
 			column.parse(data, props);
 		}
 		postProcess(props);

--- a/core/src/net/sf/openrocket/preset/loader/RockSimComponentFileType.java
+++ b/core/src/net/sf/openrocket/preset/loader/RockSimComponentFileType.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 /**
  * Definition of the typical Rocksim component files and their formats.
  */
-public enum RocksimComponentFileType {
+public enum RockSimComponentFileType {
     BODY_TUBE("BTDATA.CSV", "Mfg.", "Part No.", "Desc.", "Units", "ID", "OD", "Length", "Material", "Engine"),
     BULKHEAD("BHDATA.CSV", "Mfg.", "Part No.", "Desc.", "Units", "ID", "OD", "Length", "Material", "Engine", "Engine",
             "Engine", "Engine", "Engine", "Engine", "Engine", "Engine", "Engine", "Engine", "Engine"),
@@ -44,7 +44,7 @@ public enum RocksimComponentFileType {
      * @param theDefaultFileName  the default filename
      * @param theColumns the array of column names in the file
      */
-    private RocksimComponentFileType(final String theDefaultFileName, String... theColumns) {
+    private RockSimComponentFileType(final String theDefaultFileName, String... theColumns) {
         defaultFileName = theDefaultFileName;
         columns = theColumns;
     }
@@ -64,10 +64,10 @@ public enum RocksimComponentFileType {
      * @param headers an array of column names
      * @return the data type of the file, or null if unable to match the header names
      */
-    public static RocksimComponentFileType determineType(String[] headers) {
-        RocksimComponentFileType[] types = values();
+    public static RockSimComponentFileType determineType(String[] headers) {
+        RockSimComponentFileType[] types = values();
         for (int i = 0; i < types.length; i++) {
-            RocksimComponentFileType type = types[i];
+            RockSimComponentFileType type = types[i];
             if (Arrays.equals(headers, type.columns)) {
                 return type;
             }

--- a/core/src/net/sf/openrocket/preset/loader/StreamerLoader.java
+++ b/core/src/net/sf/openrocket/preset/loader/StreamerLoader.java
@@ -18,7 +18,7 @@ public class StreamerLoader extends BaseComponentLoader {
         //The base component loader adds a bulk material loader, which is incompatible with the surface loader
         //for a streamer.  Remove the file column parser here so we can set your own in the code that follows.
         for (int i = 0; i < fileColumns.size(); i++) {
-            RocksimComponentFileColumnParser rocksimComponentFileColumnParser = fileColumns.get(i);
+            RockSimComponentFileColumnParser rocksimComponentFileColumnParser = fileColumns.get(i);
             if (rocksimComponentFileColumnParser instanceof MaterialColumnParser) {
                 fileColumns.remove(rocksimComponentFileColumnParser);
             }
@@ -38,8 +38,8 @@ public class StreamerLoader extends BaseComponentLoader {
 
 
 	@Override
-	protected RocksimComponentFileType getFileType() {
-		return RocksimComponentFileType.STREAMER;
+	protected RockSimComponentFileType getFileType() {
+		return RockSimComponentFileType.STREAMER;
 	}
 
 

--- a/core/src/net/sf/openrocket/preset/loader/TransitionLoader.java
+++ b/core/src/net/sf/openrocket/preset/loader/TransitionLoader.java
@@ -23,8 +23,8 @@ public class TransitionLoader extends NoseConeLoader {
 	}
 
 	@Override
-	protected RocksimComponentFileType getFileType() {
-		return RocksimComponentFileType.TRANSITION;
+	protected RockSimComponentFileType getFileType() {
+		return RockSimComponentFileType.TRANSITION;
 	}
 
 }

--- a/core/src/net/sf/openrocket/preset/loader/TubeCouplerLoader.java
+++ b/core/src/net/sf/openrocket/preset/loader/TubeCouplerLoader.java
@@ -17,8 +17,8 @@ public class TubeCouplerLoader extends BodyTubeLoader {
 	}
 
 	@Override
-	protected RocksimComponentFileType getFileType() {
-		return RocksimComponentFileType.TUBE_COUPLER;
+	protected RockSimComponentFileType getFileType() {
+		return RockSimComponentFileType.TUBE_COUPLER;
 	}
 
 }

--- a/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
@@ -1765,6 +1765,22 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 		this.checkComponentStructure();
 		return children.clone();
 	}
+
+	/**
+	 * Returns all the children of this component, including children of sub-components (children of children).
+	 * The order is the same as you would read in the component tree (disregarding parent-child relations; just top to
+	 * bottom).
+	 */
+	public final List<RocketComponent> getAllChildren() {
+		checkState();
+		this.checkComponentStructure();
+		List<RocketComponent> children = new ArrayList<>();
+		for (RocketComponent child : getChildren()) {
+			children.add(child);
+			children.addAll(child.getAllChildren());
+		}
+		return children;
+	}
 	
 	
 	/**

--- a/core/test/net/sf/openrocket/file/motor/TestMotorLoader.java
+++ b/core/test/net/sf/openrocket/file/motor/TestMotorLoader.java
@@ -9,7 +9,6 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 
-import net.sf.openrocket.motor.Motor;
 import net.sf.openrocket.motor.ThrustCurveMotor;
 
 import org.junit.Test;
@@ -37,12 +36,12 @@ public class TestMotorLoader {
 	}
 	
 	@Test
-	public void testRocksimMotorLoader() throws IOException {
+	public void testRockSimMotorLoader() throws IOException {
 		test(new RockSimMotorLoader(), "test2.rse", DIGEST2);
 	}
 	
 	@Test
-	public void testRocksimMotorLoader3() throws IOException {
+	public void testRockSimMotorLoader3() throws IOException {
 		test(new RockSimMotorLoader(), "test3.rse", DIGEST3);
 	}
 	

--- a/core/test/net/sf/openrocket/file/rocksim/export/RockSimDocumentDTOTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/export/RockSimDocumentDTOTest.java
@@ -8,20 +8,20 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Marshaller;
 
 import net.sf.openrocket.document.OpenRocketDocument;
-import net.sf.openrocket.file.rocksim.importt.RocksimLoader;
-import net.sf.openrocket.file.rocksim.importt.RocksimLoaderTest;
-import net.sf.openrocket.file.rocksim.importt.RocksimTestBase;
+import net.sf.openrocket.file.rocksim.importt.RockSimLoader;
+import net.sf.openrocket.file.rocksim.importt.RockSimLoaderTest;
+import net.sf.openrocket.file.rocksim.importt.RockSimTestBase;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 /**
  */
-public class RocksimDocumentDTOTest extends RocksimTestBase {
+public class RockSimDocumentDTOTest extends RockSimTestBase {
 	
 	@Test
 	public void testDTO() throws Exception {
-		JAXBContext binder = JAXBContext.newInstance(RocksimDocumentDTO.class);
+		JAXBContext binder = JAXBContext.newInstance(RockSimDocumentDTO.class);
 		Marshaller marshaller = binder.createMarshaller();
 		marshaller.setProperty("jaxb.fragment", Boolean.TRUE);
 		
@@ -36,9 +36,9 @@ public class RocksimDocumentDTOTest extends RocksimTestBase {
 		design2.setName("Test");
 		design2.setStage3(stage1);
 		
-		RocksimDesignDTO design = new RocksimDesignDTO();
+		RockSimDesignDTO design = new RockSimDesignDTO();
 		design.setDesign(design2);
-		RocksimDocumentDTO message = new RocksimDocumentDTO();
+		RockSimDocumentDTO message = new RockSimDocumentDTO();
 		message.setDesign(design);
 		
 		StringWriter stringWriter = new StringWriter();
@@ -53,10 +53,10 @@ public class RocksimDocumentDTOTest extends RocksimTestBase {
 	@Test
 	public void testRoundTrip() throws Exception {
 		// TODO need checks here to validate that correct things were done
-		OpenRocketDocument ord = RocksimLoaderTest.loadRocksimRocket3(new RocksimLoader());
+		OpenRocketDocument ord = RockSimLoaderTest.loadRockSimRocket3(new RockSimLoader());
 		
 		Assert.assertNotNull(ord);
-		String result = new RocksimSaver().marshalToRocksim(ord);
+		String result = new RockSimSaver().marshalToRockSim(ord);
 		
 		//  System.err.println(result);
 		

--- a/core/test/net/sf/openrocket/file/rocksim/export/RockSimDocumentDTOTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/export/RockSimDocumentDTOTest.java
@@ -1,18 +1,43 @@
 package net.sf.openrocket.file.rocksim.export;
 
+import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileWriter;
+import java.io.InputStream;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Marshaller;
 
 import net.sf.openrocket.document.OpenRocketDocument;
+import net.sf.openrocket.document.OpenRocketDocumentFactory;
+import net.sf.openrocket.file.DatabaseMotorFinder;
+import net.sf.openrocket.file.DocumentLoadingContext;
 import net.sf.openrocket.file.rocksim.importt.RockSimLoader;
 import net.sf.openrocket.file.rocksim.importt.RockSimLoaderTest;
 import net.sf.openrocket.file.rocksim.importt.RockSimTestBase;
 
+import net.sf.openrocket.rocketcomponent.AxialStage;
+import net.sf.openrocket.rocketcomponent.BodyTube;
+import net.sf.openrocket.rocketcomponent.Bulkhead;
+import net.sf.openrocket.rocketcomponent.CenteringRing;
+import net.sf.openrocket.rocketcomponent.EngineBlock;
+import net.sf.openrocket.rocketcomponent.InnerTube;
+import net.sf.openrocket.rocketcomponent.MassComponent;
+import net.sf.openrocket.rocketcomponent.NoseCone;
+import net.sf.openrocket.rocketcomponent.Parachute;
+import net.sf.openrocket.rocketcomponent.Rocket;
+import net.sf.openrocket.rocketcomponent.RocketComponent;
+import net.sf.openrocket.rocketcomponent.ShockCord;
+import net.sf.openrocket.rocketcomponent.Streamer;
+import net.sf.openrocket.rocketcomponent.TubeCoupler;
 import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 /**
@@ -67,5 +92,103 @@ public class RockSimDocumentDTOTest extends RockSimTestBase {
 		fw.close();
 		
 		output.delete();
+	}
+
+	/**
+	 * Tests exporting a design where a tube coupler has children, which is not supported by RockSim, so the children
+	 * need to be moved outside the tube coupler.
+	 */
+	@Test
+	public void testTubeCouplerChildrenExport() throws Exception {
+		OpenRocketDocument originalDocument = makeTubeCouplerRocket();
+		Rocket originalRocket = originalDocument.getRocket();
+
+		// Convert to RockSim XML
+		String result = new RockSimSaver().marshalToRockSim(originalDocument);
+
+		// Write to .rkt file
+		Path output = Files.createTempFile("tubeCouplerRocket", ".rkt");
+		Files.write(output, result.getBytes(StandardCharsets.UTF_8));
+
+		// Read the file
+		RockSimLoader loader = new RockSimLoader();
+		InputStream stream = new FileInputStream(output.toFile());
+		Assert.assertNotNull("Could not open tubeCouplerRocket.rkt", stream);
+		OpenRocketDocument importedDocument = OpenRocketDocumentFactory.createEmptyRocket();
+		DocumentLoadingContext context = new DocumentLoadingContext();
+		context.setOpenRocketDocument(importedDocument);
+		context.setMotorFinder(new DatabaseMotorFinder());
+		loader.loadFromStream(context, new BufferedInputStream(stream));
+		Rocket importedRocket = importedDocument.getRocket();
+
+		// Test children counts
+		List<RocketComponent> originalChildren = originalRocket.getAllChildren();
+		List<RocketComponent> importedChildren = importedRocket.getAllChildren();
+		assertEquals(" Number of total children doesn't match",
+				originalChildren.size(), importedChildren.size());
+		assertEquals(" Number of rocket children doesn't match", 1, importedRocket.getChildCount());
+		AxialStage stage = (AxialStage) importedRocket.getChild(0);
+		assertEquals(" Number of stage children doesn't match", 2, stage.getChildCount());
+		BodyTube tube = (BodyTube) stage.getChild(1);
+		assertEquals(" Number of body tube children doesn't match", 12, tube.getChildCount());
+
+		// Test component names
+		for (int i = 1; i < originalChildren.size(); i++) {
+			assertEquals(" Child " + i + " does not match",
+					originalChildren.get(i).getName(), importedChildren.get(i).getName());
+		}
+
+		stream.close();
+		Files.delete(output);
+	}
+
+	private OpenRocketDocument makeTubeCouplerRocket() {
+		OpenRocketDocument document = OpenRocketDocumentFactory.createNewRocket();
+		Rocket rocket = document.getRocket();
+		AxialStage stage = rocket.getStage(0);
+		NoseCone noseCone = new NoseCone();
+		noseCone.setName("Nose Cone");
+		stage.addChild(noseCone);
+		BodyTube tube = new BodyTube();
+		tube.setName("Body Tube");
+		stage.addChild(tube);
+		TubeCoupler coupler = new TubeCoupler();
+		coupler.setName("Tube coupler 1");
+		tube.addChild(coupler);
+		InnerTube innerTube = new InnerTube();
+		innerTube.setName("Inner Tube");
+		coupler.addChild(innerTube);
+		TubeCoupler coupler2 =  new TubeCoupler();
+		coupler2.setName("Tube Coupler 2");
+		coupler.addChild(coupler2);
+		CenteringRing centeringRing = new CenteringRing();
+		centeringRing.setName("Centering Ring");
+		coupler.addChild(centeringRing);
+		Bulkhead bulkhead = new Bulkhead();
+		bulkhead.setName("Bulkhead");
+		coupler.addChild(bulkhead);
+		EngineBlock engineBlock = new EngineBlock();
+		engineBlock.setName("Engine Block");
+		coupler.addChild(engineBlock);
+		Parachute parachute = new Parachute();
+		parachute.setName("Parachute 1");
+		coupler.addChild(parachute);
+		Streamer streamer = new Streamer();
+		streamer.setName("Streamer");
+		coupler.addChild(streamer);
+		ShockCord shockCord = new ShockCord();
+		shockCord.setName("Shock Cord");
+		coupler.addChild(shockCord);
+		MassComponent massComponent = new MassComponent();
+		massComponent.setName("Mass Component");
+		coupler.addChild(massComponent);
+		TubeCoupler coupler3 = new TubeCoupler();
+		coupler3.setName("Tube Coupler 3");
+		tube.addChild(coupler3);
+		Parachute parachute2 = new Parachute();
+		parachute2.setName("Parachute 2");
+		coupler3.addChild(parachute2);
+
+		return document;
 	}
 }

--- a/core/test/net/sf/openrocket/file/rocksim/importt/BodyTubeHandlerTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/importt/BodyTubeHandlerTest.java
@@ -4,7 +4,7 @@
 package net.sf.openrocket.file.rocksim.importt;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
 import net.sf.openrocket.material.Material;
 import net.sf.openrocket.rocketcomponent.BodyTube;
@@ -19,7 +19,7 @@ import java.util.HashMap;
  * BodyTubeHandler Tester.
  *
  */
-public class BodyTubeHandlerTest extends RocksimTestBase {
+public class BodyTubeHandlerTest extends RockSimTestBase {
 
     /**
      * Method: constructor
@@ -73,7 +73,7 @@ public class BodyTubeHandlerTest extends RocksimTestBase {
         handler.closeElement("OD", attributes, "0", warnings);
         Assert.assertEquals(0d, component.getInnerRadius(), 0.001);
         handler.closeElement("OD", attributes, "75", warnings);
-        Assert.assertEquals(75d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getInnerRadius(), 0.001);
+        Assert.assertEquals(75d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getInnerRadius(), 0.001);
         handler.closeElement("OD", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -83,7 +83,7 @@ public class BodyTubeHandlerTest extends RocksimTestBase {
         handler.closeElement("ID", attributes, "0", warnings);
         Assert.assertEquals(0d, component.getInnerRadius(), 0.001);
         handler.closeElement("ID", attributes, "75", warnings);
-        Assert.assertEquals(75d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getInnerRadius(), 0.001);
+        Assert.assertEquals(75d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getInnerRadius(), 0.001);
         handler.closeElement("ID", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -91,9 +91,9 @@ public class BodyTubeHandlerTest extends RocksimTestBase {
         handler.closeElement("Len", attributes, "-1", warnings);
         Assert.assertEquals(0d, component.getLength(), 0.001);
         handler.closeElement("Len", attributes, "10", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
         handler.closeElement("Len", attributes, "10.0", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
         handler.closeElement("Len", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -106,11 +106,11 @@ public class BodyTubeHandlerTest extends RocksimTestBase {
         Assert.assertFalse(component.isMotorMount());
 
         handler.closeElement("EngineOverhang", attributes, "-1", warnings);
-        Assert.assertEquals(-1d/ RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getMotorOverhang(), 0.001);
+        Assert.assertEquals(-1d/ RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getMotorOverhang(), 0.001);
         handler.closeElement("EngineOverhang", attributes, "10", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getMotorOverhang(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getMotorOverhang(), 0.001);
         handler.closeElement("EngineOverhang", attributes, "10.0", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getMotorOverhang(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getMotorOverhang(), 0.001);
         handler.closeElement("EngineOverhang", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();

--- a/core/test/net/sf/openrocket/file/rocksim/importt/InnerBodyTubeHandlerTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/importt/InnerBodyTubeHandlerTest.java
@@ -4,7 +4,7 @@
 package net.sf.openrocket.file.rocksim.importt;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
 import net.sf.openrocket.material.Material;
 import net.sf.openrocket.rocketcomponent.BodyTube;
@@ -18,7 +18,7 @@ import java.util.HashMap;
  * InnerBodyTubeHandler Tester.
  *
  */
-public class InnerBodyTubeHandlerTest extends RocksimTestBase {
+public class InnerBodyTubeHandlerTest extends RockSimTestBase {
 
     /**
      * Method: constructor
@@ -72,7 +72,7 @@ public class InnerBodyTubeHandlerTest extends RocksimTestBase {
         handler.closeElement("OD", attributes, "0", warnings);
         Assert.assertEquals(0d, component.getInnerRadius(), 0.001);
         handler.closeElement("OD", attributes, "75", warnings);
-        Assert.assertEquals(75d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getInnerRadius(), 0.001);
+        Assert.assertEquals(75d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getInnerRadius(), 0.001);
         handler.closeElement("OD", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -82,7 +82,7 @@ public class InnerBodyTubeHandlerTest extends RocksimTestBase {
         handler.closeElement("ID", attributes, "0", warnings);
         Assert.assertEquals(0d, component.getInnerRadius(), 0.001);
         handler.closeElement("ID", attributes, "75", warnings);
-        Assert.assertEquals(75d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getInnerRadius(), 0.001);
+        Assert.assertEquals(75d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getInnerRadius(), 0.001);
         handler.closeElement("ID", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -90,9 +90,9 @@ public class InnerBodyTubeHandlerTest extends RocksimTestBase {
         handler.closeElement("Len", attributes, "-1", warnings);
         Assert.assertEquals(0d, component.getLength(), 0.001);
         handler.closeElement("Len", attributes, "10", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
         handler.closeElement("Len", attributes, "10.0", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
         handler.closeElement("Len", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -105,11 +105,11 @@ public class InnerBodyTubeHandlerTest extends RocksimTestBase {
         Assert.assertFalse(component.isMotorMount());
 
         handler.closeElement("EngineOverhang", attributes, "-1", warnings);
-        Assert.assertEquals(-1d/ RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getMotorOverhang(), 0.001);
+        Assert.assertEquals(-1d/ RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getMotorOverhang(), 0.001);
         handler.closeElement("EngineOverhang", attributes, "10", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getMotorOverhang(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getMotorOverhang(), 0.001);
         handler.closeElement("EngineOverhang", attributes, "10.0", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getMotorOverhang(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getMotorOverhang(), 0.001);
         handler.closeElement("EngineOverhang", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();

--- a/core/test/net/sf/openrocket/file/rocksim/importt/LaunchLugHandlerTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/importt/LaunchLugHandlerTest.java
@@ -4,7 +4,7 @@
 package net.sf.openrocket.file.rocksim.importt;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
 import net.sf.openrocket.material.Material;
 import net.sf.openrocket.rocketcomponent.BodyTube;
@@ -19,7 +19,7 @@ import java.util.HashMap;
  * LaunchLugHandler Tester.
  *
  */
-public class LaunchLugHandlerTest extends RocksimTestBase {
+public class LaunchLugHandlerTest extends RockSimTestBase {
 
     /**
      * Method: constructor
@@ -72,7 +72,7 @@ public class LaunchLugHandlerTest extends RocksimTestBase {
         handler.closeElement("OD", attributes, "0", warnings);
         Assert.assertEquals(0d, component.getOuterRadius(), 0.001);
         handler.closeElement("OD", attributes, "75", warnings);
-        Assert.assertEquals(75d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getOuterRadius(), 0.001);
+        Assert.assertEquals(75d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getOuterRadius(), 0.001);
         handler.closeElement("OD", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -82,7 +82,7 @@ public class LaunchLugHandlerTest extends RocksimTestBase {
         handler.closeElement("ID", attributes, "0", warnings);
         Assert.assertEquals(0d, component.getInnerRadius(), 0.001);
         handler.closeElement("ID", attributes, "75", warnings);
-        Assert.assertEquals(75d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getInnerRadius(), 0.001);
+        Assert.assertEquals(75d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getInnerRadius(), 0.001);
         handler.closeElement("ID", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -90,9 +90,9 @@ public class LaunchLugHandlerTest extends RocksimTestBase {
         handler.closeElement("Len", attributes, "-1", warnings);
         Assert.assertEquals(0d, component.getLength(), 0.001);
         handler.closeElement("Len", attributes, "10", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
         handler.closeElement("Len", attributes, "10.0", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
         handler.closeElement("Len", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();

--- a/core/test/net/sf/openrocket/file/rocksim/importt/MassObjectHandlerTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/importt/MassObjectHandlerTest.java
@@ -4,7 +4,7 @@
 package net.sf.openrocket.file.rocksim.importt;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
 import net.sf.openrocket.material.Material;
 import net.sf.openrocket.rocketcomponent.BodyTube;
@@ -18,7 +18,7 @@ import java.util.HashMap;
  * MassObjectHandler Tester.
  *
  */
-public class MassObjectHandlerTest extends RocksimTestBase {
+public class MassObjectHandlerTest extends RockSimTestBase {
 
     /**
      * Method: constructor
@@ -83,7 +83,7 @@ public class MassObjectHandlerTest extends RocksimTestBase {
         handler.closeElement("KnownMass", attributes, "-1", warnings);
         Assert.assertEquals(0d, component.getComponentMass(), 0.001);
         handler.closeElement("KnownMass", attributes, "100", warnings);
-        Assert.assertEquals(100d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS, component.getComponentMass(), 0.001);
+        Assert.assertEquals(100d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_MASS, component.getComponentMass(), 0.001);
         handler.closeElement("KnownMass", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();

--- a/core/test/net/sf/openrocket/file/rocksim/importt/NoseConeHandlerTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/importt/NoseConeHandlerTest.java
@@ -4,8 +4,8 @@
 package net.sf.openrocket.file.rocksim.importt;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
-import net.sf.openrocket.file.rocksim.RocksimNoseConeCode;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimNoseConeCode;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
 import net.sf.openrocket.material.Material;
 import net.sf.openrocket.rocketcomponent.ExternalComponent;
@@ -21,7 +21,7 @@ import java.util.HashMap;
  * NoseConeHandler Tester.
  *
  */
-public class NoseConeHandlerTest extends RocksimTestBase {
+public class NoseConeHandlerTest extends RockSimTestBase {
 
     /**
      * Method: constructor
@@ -77,7 +77,7 @@ public class NoseConeHandlerTest extends RocksimTestBase {
         handler.closeElement("ShapeCode", attributes, "1", warnings);
         Assert.assertEquals(Transition.Shape.OGIVE, component.getType());
         handler.closeElement("ShapeCode", attributes, "17", warnings);
-        Assert.assertEquals(RocksimNoseConeCode.PARABOLIC.asOpenRocket(), component.getType());  //test of default
+        Assert.assertEquals(RockSimNoseConeCode.PARABOLIC.asOpenRocket(), component.getType());  //test of default
         handler.closeElement("ShapeCode", attributes, "foo", warnings);
         Assert.assertNotNull(component.getType());
         Assert.assertEquals(1, warnings.size());
@@ -86,9 +86,9 @@ public class NoseConeHandlerTest extends RocksimTestBase {
         handler.closeElement("Len", attributes, "-1", warnings);
         Assert.assertEquals(0d, component.getLength(), 0.001);
         handler.closeElement("Len", attributes, "10", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
         handler.closeElement("Len", attributes, "10.0", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
         handler.closeElement("Len", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -96,7 +96,7 @@ public class NoseConeHandlerTest extends RocksimTestBase {
         handler.closeElement("BaseDia", attributes, "-1", warnings);
         Assert.assertEquals(0d, component.getAftRadius(), 0.001);
         handler.closeElement("BaseDia", attributes, "100", warnings);
-        Assert.assertEquals(100d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getAftRadius(), 0.001);
+        Assert.assertEquals(100d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getAftRadius(), 0.001);
         handler.closeElement("BaseDia", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -127,15 +127,15 @@ public class NoseConeHandlerTest extends RocksimTestBase {
         Assert.assertEquals(0d, component.getAftShoulderThickness(), 0.001);
         handler.closeElement("WallThickness", attributes, "1.1", warnings);
         handler.endHandler("Transition", attributes, null, warnings);
-        Assert.assertEquals(1.1d/ RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getThickness(), 0.001);
-        Assert.assertEquals(1.1d/ RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getAftShoulderThickness(), 0.001);
+        Assert.assertEquals(1.1d/ RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getThickness(), 0.001);
+        Assert.assertEquals(1.1d/ RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getAftShoulderThickness(), 0.001);
         
         handler.closeElement("ShoulderLen", attributes, "-1", warnings);
         Assert.assertEquals(0d, component.getAftShoulderLength(), 0.001);
         handler.closeElement("ShoulderLen", attributes, "10", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getAftShoulderLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getAftShoulderLength(), 0.001);
         handler.closeElement("ShoulderLen", attributes, "10.0", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getAftShoulderLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getAftShoulderLength(), 0.001);
         handler.closeElement("ShoulderLen", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -143,7 +143,7 @@ public class NoseConeHandlerTest extends RocksimTestBase {
         handler.closeElement("ShoulderOD", attributes, "-1", warnings);
         Assert.assertEquals(0d, component.getAftShoulderRadius(), 0.001);
         handler.closeElement("ShoulderOD", attributes, "100", warnings);
-        Assert.assertEquals(100d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getAftShoulderRadius(), 0.001);
+        Assert.assertEquals(100d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getAftShoulderRadius(), 0.001);
         handler.closeElement("ShoulderOD", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();

--- a/core/test/net/sf/openrocket/file/rocksim/importt/ParachuteHandlerTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/importt/ParachuteHandlerTest.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
 import org.junit.Assert;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
 import net.sf.openrocket.material.Material;
 import net.sf.openrocket.rocketcomponent.BodyTube;
@@ -18,7 +18,7 @@ import net.sf.openrocket.rocketcomponent.position.AxialMethod;
 /**
  * ParachuteHandler Tester.
  */
-public class ParachuteHandlerTest extends RocksimTestBase {
+public class ParachuteHandlerTest extends RockSimTestBase {
 
     /**
      * Method: openElement(String element, HashMap<String, String> attributes, WarningSet warnings)
@@ -56,9 +56,9 @@ public class ParachuteHandlerTest extends RocksimTestBase {
         warnings.clear();
 
         handler.closeElement("Dia", attributes, "-1", warnings);
-        Assert.assertEquals(-1d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getDiameter(), 0.001);
+        Assert.assertEquals(-1d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getDiameter(), 0.001);
         handler.closeElement("Dia", attributes, "10", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getDiameter(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getDiameter(), 0.001);
         handler.closeElement("Dia", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -74,7 +74,7 @@ public class ParachuteHandlerTest extends RocksimTestBase {
         handler.closeElement("ShroudLineLen", attributes, "-1", warnings);
         Assert.assertEquals(0d, component.getLineLength(), 0.001);
         handler.closeElement("ShroudLineLen", attributes, "10", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLineLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLineLength(), 0.001);
         handler.closeElement("ShroudLineLen", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -154,12 +154,12 @@ public class ParachuteHandlerTest extends RocksimTestBase {
         handler.closeElement("LocationMode", attributes, "1", warnings);
         handler.endHandler("Parachute", attributes, null, warnings);
         Assert.assertEquals(AxialMethod.ABSOLUTE, component.getAxialMethod());
-        Assert.assertEquals(component.getAxialOffset(), -10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, 0.001);
+        Assert.assertEquals(component.getAxialOffset(), -10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, 0.001);
 
         handler.closeElement("Xb", attributes, "-10", warnings);
         handler.closeElement("LocationMode", attributes, "2", warnings);
         handler.endHandler("Parachute", attributes, null, warnings);
         Assert.assertEquals(AxialMethod.BOTTOM, component.getAxialMethod());
-        Assert.assertEquals(component.getAxialOffset(), 10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, 0.001);
+        Assert.assertEquals(component.getAxialOffset(), 10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, 0.001);
     }
 }

--- a/core/test/net/sf/openrocket/file/rocksim/importt/RingHandlerTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/importt/RingHandlerTest.java
@@ -9,7 +9,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
 import net.sf.openrocket.material.Material;
 import net.sf.openrocket.rocketcomponent.BodyTube;
@@ -23,7 +23,7 @@ import net.sf.openrocket.rocketcomponent.position.AxialMethod;
 /**
  * RingHandler Tester.
  */
-public class RingHandlerTest extends RocksimTestBase {
+public class RingHandlerTest extends RockSimTestBase {
 
     /**
      * Method: openElement(String element, HashMap<String, String> attributes, WarningSet warnings)
@@ -52,7 +52,7 @@ public class RingHandlerTest extends RocksimTestBase {
         handler.closeElement("OD", attributes, "0", warnings);
         Assert.assertEquals(0d, component.getOuterRadius(), 0.001);
         handler.closeElement("OD", attributes, "75", warnings);
-        Assert.assertEquals(75d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getOuterRadius(), 0.001);
+        Assert.assertEquals(75d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getOuterRadius(), 0.001);
         handler.closeElement("OD", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -60,7 +60,7 @@ public class RingHandlerTest extends RocksimTestBase {
         handler.closeElement("ID", attributes, "0", warnings);
         Assert.assertEquals(0d, component.getInnerRadius(), 0.001);
         handler.closeElement("ID", attributes, "75", warnings);
-        Assert.assertEquals(75d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getInnerRadius(), 0.001);
+        Assert.assertEquals(75d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getInnerRadius(), 0.001);
         handler.closeElement("ID", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -68,9 +68,9 @@ public class RingHandlerTest extends RocksimTestBase {
         handler.closeElement("Len", attributes, "-1", warnings);
         Assert.assertEquals(0d, component.getLength(), 0.001);
         handler.closeElement("Len", attributes, "10", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
         handler.closeElement("Len", attributes, "10.0", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
         handler.closeElement("Len", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -108,9 +108,9 @@ public class RingHandlerTest extends RocksimTestBase {
         Assert.assertEquals(1, tube.getChildren().size());
         RingComponent child = (RingComponent)tube.getChild(0);
 
-        Assert.assertEquals(75d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, child.getOuterRadius(), 0.001);
-        Assert.assertEquals(0d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, child.getInnerRadius(), 0.001);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, child.getLength(), 0.001);
+        Assert.assertEquals(75d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, child.getOuterRadius(), 0.001);
+        Assert.assertEquals(0d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, child.getInnerRadius(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, child.getLength(), 0.001);
         Assert.assertEquals("Test Name", child.getName());
         Assert.assertEquals(109.9/1000, child.getMass(), 0.001);
         Assert.assertEquals(0, child.getAxialOffset(), 0.0);
@@ -144,9 +144,9 @@ public class RingHandlerTest extends RocksimTestBase {
         RingComponent child = (RingComponent)tube.getChild(0);
         Assert.assertTrue(child instanceof TubeCoupler);
 
-        Assert.assertEquals(75d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, child.getOuterRadius(), 0.001);
-        Assert.assertEquals(70d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, child.getInnerRadius(), 0.001);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, child.getLength(), 0.001);
+        Assert.assertEquals(75d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, child.getOuterRadius(), 0.001);
+        Assert.assertEquals(70d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, child.getInnerRadius(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, child.getLength(), 0.001);
         Assert.assertEquals("Test Name", child.getName());
         Assert.assertEquals(109.9/1000, child.getMass(), 0.001);
         Assert.assertEquals(0, child.getAxialOffset(), 0.0);
@@ -179,14 +179,14 @@ public class RingHandlerTest extends RocksimTestBase {
         RingComponent child = (RingComponent)tube.getChild(0);
         Assert.assertTrue(child instanceof EngineBlock);
 
-        Assert.assertEquals(75d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, child.getOuterRadius(), 0.001);
-        Assert.assertEquals(70d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, child.getInnerRadius(), 0.001);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, child.getLength(), 0.001);
+        Assert.assertEquals(75d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, child.getOuterRadius(), 0.001);
+        Assert.assertEquals(70d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, child.getInnerRadius(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, child.getLength(), 0.001);
         Assert.assertEquals("Test Name", child.getName());
         Assert.assertEquals(109.9/1000, child.getMass(), 0.001);
         Assert.assertEquals(0, child.getAxialOffset(), 0.0);
         Assert.assertEquals(AxialMethod.TOP, child.getAxialMethod());
-        Assert.assertEquals(4d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, child.getCG().x, 0.000001);
+        Assert.assertEquals(4d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, child.getCG().x, 0.000001);
         
     }
 
@@ -214,9 +214,9 @@ public class RingHandlerTest extends RocksimTestBase {
         Assert.assertEquals(1, tube.getChildren().size());
         RingComponent child = (RingComponent)tube.getChild(0);
 
-        Assert.assertEquals(75d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, child.getOuterRadius(), 0.001);
-        Assert.assertEquals(0d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, child.getInnerRadius(), 0.001);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, child.getLength(), 0.001);
+        Assert.assertEquals(75d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, child.getOuterRadius(), 0.001);
+        Assert.assertEquals(0d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, child.getInnerRadius(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, child.getLength(), 0.001);
         Assert.assertEquals("Test Name", child.getName());
         Assert.assertEquals(109.9/1000, child.getMass(), 0.001);
         Assert.assertEquals(0, child.getAxialOffset(), 0.0);

--- a/core/test/net/sf/openrocket/file/rocksim/importt/RockSimLoaderTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/importt/RockSimLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * RocksimLoaderTest.java
+ * RockSimLoaderTest.java
  *
  */
 package net.sf.openrocket.file.rocksim.importt;
@@ -22,9 +22,9 @@ import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.util.BaseTestCase.BaseTestCase;
 
 /**
- * RocksimLoader Tester.
+ * RockSimLoader Tester.
  */
-public class RocksimLoaderTest extends BaseTestCase {
+public class RockSimLoaderTest extends BaseTestCase {
 
     /**
      * Test a bug reported via automated bug report.  I have been unable to reproduce this bug (hanging finset off of an inner body tube) when creating
@@ -32,7 +32,7 @@ public class RocksimLoaderTest extends BaseTestCase {
      */
     @org.junit.Test
     public void testFinsOnInnerTube() throws Exception {
-        RocksimLoader loader = new RocksimLoader();
+        RockSimLoader loader = new RockSimLoader();
         InputStream stream = this.getClass().getResourceAsStream("PodFins.rkt");
         Assert.assertNotNull("Could not open PodFins.rkt", stream);
         try {
@@ -57,9 +57,9 @@ public class RocksimLoaderTest extends BaseTestCase {
      */
     @org.junit.Test
     public void testLoadFromStream() throws Exception {
-        RocksimLoader loader = new RocksimLoader();
+        RockSimLoader loader = new RockSimLoader();
         //Stupid single stage rocket
-        OpenRocketDocument doc = loadRocksimRocket(loader);
+        OpenRocketDocument doc = loadRockSimRocket(loader);
         InputStream stream;
 
         Assert.assertNotNull(doc);
@@ -147,9 +147,9 @@ public class RocksimLoaderTest extends BaseTestCase {
 
     @org.junit.Test
     public void testSubAssemblyRocket() throws IOException, RocketLoadException {
-        RocksimLoader loader = new RocksimLoader();
+        RockSimLoader loader = new RockSimLoader();
         //Stupid single stage rocket
-        OpenRocketDocument doc = loadRocksimSubassemblyRocket(loader);
+        OpenRocketDocument doc = loadRockSimSubassemblyRocket(loader);
         InputStream stream;
 
         Assert.assertNotNull(doc);
@@ -188,8 +188,8 @@ public class RocksimLoaderTest extends BaseTestCase {
         Assert.assertEquals("Centering ring", subassemblyBodyTube.getChild(7).getName());
     }
 
-    public static OpenRocketDocument loadRocksimRocket(RocksimLoader theLoader) throws IOException, RocketLoadException {
-        InputStream stream = RocksimLoaderTest.class.getResourceAsStream("rocksimTestRocket1.rkt");
+    public static OpenRocketDocument loadRockSimRocket(RockSimLoader theLoader) throws IOException, RocketLoadException {
+        InputStream stream = RockSimLoaderTest.class.getResourceAsStream("rocksimTestRocket1.rkt");
         try {
             Assert.assertNotNull("Could not open rocksimTestRocket1.rkt", stream);
             OpenRocketDocument doc = OpenRocketDocumentFactory.createEmptyRocket();
@@ -204,8 +204,8 @@ public class RocksimLoaderTest extends BaseTestCase {
         }
     }
 
-    public static OpenRocketDocument loadRocksimRocket3(RocksimLoader theLoader) throws IOException, RocketLoadException {
-        InputStream stream = RocksimLoaderTest.class.getResourceAsStream("rocksimTestRocket3.rkt");
+    public static OpenRocketDocument loadRockSimRocket3(RockSimLoader theLoader) throws IOException, RocketLoadException {
+        InputStream stream = RockSimLoaderTest.class.getResourceAsStream("rocksimTestRocket3.rkt");
         try {
             Assert.assertNotNull("Could not open rocksimTestRocket3.rkt", stream);
             OpenRocketDocument doc = OpenRocketDocumentFactory.createEmptyRocket();
@@ -220,8 +220,8 @@ public class RocksimLoaderTest extends BaseTestCase {
         }
     }
 
-    public static OpenRocketDocument loadRocksimSubassemblyRocket(RocksimLoader theLoader) throws IOException, RocketLoadException {
-        InputStream stream = RocksimLoaderTest.class.getResourceAsStream("SubAssemblyTest.rkt");
+    public static OpenRocketDocument loadRockSimSubassemblyRocket(RockSimLoader theLoader) throws IOException, RocketLoadException {
+        InputStream stream = RockSimLoaderTest.class.getResourceAsStream("SubAssemblyTest.rkt");
         try {
             Assert.assertNotNull("Could not open SubAssemblyTest.rkt", stream);
             OpenRocketDocument doc = OpenRocketDocumentFactory.createEmptyRocket();

--- a/core/test/net/sf/openrocket/file/rocksim/importt/RockSimTestBase.java
+++ b/core/test/net/sf/openrocket/file/rocksim/importt/RockSimTestBase.java
@@ -14,7 +14,7 @@ import org.junit.Assert;
 /**
  * A base class for the Rocksim tests.  Includes code from the junitx.addons project.
  */
-public abstract class RocksimTestBase extends BaseTestCase {
+public abstract class RockSimTestBase extends BaseTestCase {
 	
 	public void assertContains(RocketComponent child, List<RocketComponent> components) {
 		Assert.assertTrue("Components did not contain child", components.contains(child));

--- a/core/test/net/sf/openrocket/file/rocksim/importt/StreamerHandlerTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/importt/StreamerHandlerTest.java
@@ -9,8 +9,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
-import net.sf.openrocket.file.rocksim.RocksimDensityType;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimDensityType;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
 import net.sf.openrocket.material.Material;
 import net.sf.openrocket.rocketcomponent.BodyTube;
@@ -20,7 +20,7 @@ import net.sf.openrocket.rocketcomponent.position.AxialMethod;
 /**
  * StreamerHandler Tester.
  */
-public class StreamerHandlerTest extends RocksimTestBase {
+public class StreamerHandlerTest extends RockSimTestBase {
 
     /**
      * Method: openElement(String element, HashMap<String, String> attributes, WarningSet warnings)
@@ -47,9 +47,9 @@ public class StreamerHandlerTest extends RocksimTestBase {
         WarningSet warnings = new WarningSet();
 
         handler.closeElement("Width", attributes, "0", warnings);
-        Assert.assertEquals(0d/ RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getStripWidth(), 0.001);
+        Assert.assertEquals(0d/ RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getStripWidth(), 0.001);
         handler.closeElement("Width", attributes, "10", warnings);
-        Assert.assertEquals(10d/ RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getStripWidth(), 0.001);
+        Assert.assertEquals(10d/ RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getStripWidth(), 0.001);
         handler.closeElement("Width", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -57,9 +57,9 @@ public class StreamerHandlerTest extends RocksimTestBase {
         handler.closeElement("Len", attributes, "-1", warnings);
         Assert.assertEquals(0d, component.getStripLength(), 0.001);
         handler.closeElement("Len", attributes, "10", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getStripLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getStripLength(), 0.001);
         handler.closeElement("Len", attributes, "10.0", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getStripLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getStripLength(), 0.001);
         handler.closeElement("Len", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -150,16 +150,16 @@ public class StreamerHandlerTest extends RocksimTestBase {
         handler.closeElement("LocationMode", attributes, "1", warnings);
         handler.endHandler("Streamer", attributes, null, warnings);
         Assert.assertEquals(AxialMethod.ABSOLUTE, component.getAxialMethod());
-        Assert.assertEquals(component.getAxialOffset(), -10d/ RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, 0.001);
+        Assert.assertEquals(component.getAxialOffset(), -10d/ RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, 0.001);
 
         handler.closeElement("Xb", attributes, "-10", warnings);
         handler.closeElement("LocationMode", attributes, "2", warnings);
         handler.endHandler("Streamer", attributes, null, warnings);
         Assert.assertEquals(AxialMethod.BOTTOM, component.getAxialMethod());
-        Assert.assertEquals(component.getAxialOffset(), 10d/ RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, 0.001);
+        Assert.assertEquals(component.getAxialOffset(), 10d/ RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, 0.001);
 
         handler.closeElement("Thickness", attributes, "0.02", warnings);
-        Assert.assertEquals(0.01848, handler.computeDensity(RocksimDensityType.ROCKSIM_BULK, 924d), 0.001);
+        Assert.assertEquals(0.01848, handler.computeDensity(RockSimDensityType.ROCKSIM_BULK, 924d), 0.001);
 
         //Test Density Type 0 (Bulk)
         handler.closeElement("Density", attributes, "924.0", warnings);

--- a/core/test/net/sf/openrocket/file/rocksim/importt/TransitionHandlerTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/importt/TransitionHandlerTest.java
@@ -4,8 +4,8 @@
 package net.sf.openrocket.file.rocksim.importt;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
-import net.sf.openrocket.file.rocksim.RocksimNoseConeCode;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimNoseConeCode;
 import net.sf.openrocket.file.simplesax.PlainTextHandler;
 import net.sf.openrocket.material.Material;
 import net.sf.openrocket.rocketcomponent.ExternalComponent;
@@ -18,7 +18,7 @@ import java.util.HashMap;
 /**
  * TransitionHandler Tester.
  */
-public class TransitionHandlerTest extends RocksimTestBase {
+public class TransitionHandlerTest extends RockSimTestBase {
 
     /**
      * Method: constructor
@@ -72,7 +72,7 @@ public class TransitionHandlerTest extends RocksimTestBase {
         handler.closeElement("ShapeCode", attributes, "1", warnings);
         Assert.assertEquals(Transition.Shape.OGIVE, component.getType());
         handler.closeElement("ShapeCode", attributes, "17", warnings);
-        Assert.assertEquals(RocksimNoseConeCode.PARABOLIC.asOpenRocket(), component.getType());  //test of default
+        Assert.assertEquals(RockSimNoseConeCode.PARABOLIC.asOpenRocket(), component.getType());  //test of default
         handler.closeElement("ShapeCode", attributes, "foo", warnings);
         Assert.assertNotNull(component.getType());
         Assert.assertEquals(1, warnings.size());
@@ -81,9 +81,9 @@ public class TransitionHandlerTest extends RocksimTestBase {
         handler.closeElement("Len", attributes, "-1", warnings);
         Assert.assertEquals(0d, component.getLength(), 0.001);
         handler.closeElement("Len", attributes, "10", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
         handler.closeElement("Len", attributes, "10.0", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getLength(), 0.001);
         handler.closeElement("Len", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -91,7 +91,7 @@ public class TransitionHandlerTest extends RocksimTestBase {
         handler.closeElement("FrontDia", attributes, "-1", warnings);
         Assert.assertEquals(0d, component.getForeRadius(), 0.001);
         handler.closeElement("FrontDia", attributes, "100", warnings);
-        Assert.assertEquals(100d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getForeRadius(), 0.001);
+        Assert.assertEquals(100d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getForeRadius(), 0.001);
         handler.closeElement("FrontDia", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -99,7 +99,7 @@ public class TransitionHandlerTest extends RocksimTestBase {
         handler.closeElement("RearDia", attributes, "-1", warnings);
         Assert.assertEquals(0d, component.getAftRadius(), 0.001);
         handler.closeElement("RearDia", attributes, "100", warnings);
-        Assert.assertEquals(100d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getAftRadius(), 0.001);
+        Assert.assertEquals(100d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getAftRadius(), 0.001);
         handler.closeElement("RearDia", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -133,17 +133,17 @@ public class TransitionHandlerTest extends RocksimTestBase {
         Assert.assertEquals(0d, component.getForeShoulderThickness(), 0.001);
         handler.closeElement("WallThickness", attributes, "1.1", warnings);
         handler.endHandler("Transition", attributes, null, warnings);
-        Assert.assertEquals(1.1d/ RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getThickness(), 0.001);
-        Assert.assertEquals(1.1d/ RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getAftShoulderThickness(), 0.001);
-        Assert.assertEquals(1.1d/ RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getForeShoulderThickness(), 0.001);
+        Assert.assertEquals(1.1d/ RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getThickness(), 0.001);
+        Assert.assertEquals(1.1d/ RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getAftShoulderThickness(), 0.001);
+        Assert.assertEquals(1.1d/ RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getForeShoulderThickness(), 0.001);
         
 
         handler.closeElement("FrontShoulderLen", attributes, "-1", warnings);
         Assert.assertEquals(0d, component.getForeShoulderLength(), 0.001);
         handler.closeElement("FrontShoulderLen", attributes, "10", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getForeShoulderLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getForeShoulderLength(), 0.001);
         handler.closeElement("FrontShoulderLen", attributes, "10.0", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getForeShoulderLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getForeShoulderLength(), 0.001);
         handler.closeElement("FrontShoulderLen", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -151,9 +151,9 @@ public class TransitionHandlerTest extends RocksimTestBase {
         handler.closeElement("RearShoulderLen", attributes, "-1", warnings);
         Assert.assertEquals(0d, component.getAftShoulderLength(), 0.001);
         handler.closeElement("RearShoulderLen", attributes, "10", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getAftShoulderLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getAftShoulderLength(), 0.001);
         handler.closeElement("RearShoulderLen", attributes, "10.0", warnings);
-        Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getAftShoulderLength(), 0.001);
+        Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, component.getAftShoulderLength(), 0.001);
         handler.closeElement("RearShoulderLen", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -161,7 +161,7 @@ public class TransitionHandlerTest extends RocksimTestBase {
         handler.closeElement("FrontShoulderDia", attributes, "-1", warnings);
         Assert.assertEquals(0d, component.getForeShoulderRadius(), 0.001);
         handler.closeElement("FrontShoulderDia", attributes, "100", warnings);
-        Assert.assertEquals(100d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getForeShoulderRadius(), 0.001);
+        Assert.assertEquals(100d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getForeShoulderRadius(), 0.001);
         handler.closeElement("FrontShoulderDia", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();
@@ -169,7 +169,7 @@ public class TransitionHandlerTest extends RocksimTestBase {
         handler.closeElement("RearShoulderDia", attributes, "-1", warnings);
         Assert.assertEquals(0d, component.getAftShoulderRadius(), 0.001);
         handler.closeElement("RearShoulderDia", attributes, "100", warnings);
-        Assert.assertEquals(100d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getAftShoulderRadius(), 0.001);
+        Assert.assertEquals(100d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, component.getAftShoulderRadius(), 0.001);
         handler.closeElement("RearShoulderDia", attributes, "foo", warnings);
         Assert.assertEquals(1, warnings.size());
         warnings.clear();

--- a/core/test/net/sf/openrocket/file/rocksim/importt/TubeFinSetHandlerTest.java
+++ b/core/test/net/sf/openrocket/file/rocksim/importt/TubeFinSetHandlerTest.java
@@ -1,7 +1,7 @@
 package net.sf.openrocket.file.rocksim.importt;
 
 import net.sf.openrocket.aerodynamics.WarningSet;
-import net.sf.openrocket.file.rocksim.RocksimCommonConstants;
+import net.sf.openrocket.file.rocksim.RockSimCommonConstants;
 import net.sf.openrocket.rocketcomponent.BodyTube;
 import net.sf.openrocket.rocketcomponent.ExternalComponent;
 import net.sf.openrocket.rocketcomponent.TubeFinSet;
@@ -45,7 +45,7 @@ public class TubeFinSetHandlerTest {
          handler.closeElement("OD", attributes, "0", warnings);
          Assert.assertEquals(0d, fins.getOuterRadius(), 0.001);
          handler.closeElement("OD", attributes, "75", warnings);
-         Assert.assertEquals(75d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, fins.getOuterRadius(), 0.001);
+         Assert.assertEquals(75d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, fins.getOuterRadius(), 0.001);
          handler.closeElement("OD", attributes, "foo", warnings);
          Assert.assertEquals(1, warnings.size());
          warnings.clear();
@@ -55,7 +55,7 @@ public class TubeFinSetHandlerTest {
          handler.closeElement("ID", attributes, "0", warnings);
          Assert.assertEquals(0d, fins.getInnerRadius(), 0.001);
          handler.closeElement("ID", attributes, "75", warnings);
-         Assert.assertEquals(75d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, fins.getInnerRadius(), 0.001);
+         Assert.assertEquals(75d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS, fins.getInnerRadius(), 0.001);
          handler.closeElement("ID", attributes, "foo", warnings);
          Assert.assertEquals(1, warnings.size());
          warnings.clear();
@@ -63,9 +63,9 @@ public class TubeFinSetHandlerTest {
          handler.closeElement("Len", attributes, "-1", warnings);
          Assert.assertEquals(0d, fins.getLength(), 0.001);
          handler.closeElement("Len", attributes, "10", warnings);
-         Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, fins.getLength(), 0.001);
+         Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, fins.getLength(), 0.001);
          handler.closeElement("Len", attributes, "10.0", warnings);
-         Assert.assertEquals(10d / RocksimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, fins.getLength(), 0.001);
+         Assert.assertEquals(10d / RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH, fins.getLength(), 0.001);
          handler.closeElement("Len", attributes, "foo", warnings);
          Assert.assertEquals(1, warnings.size());
          warnings.clear();

--- a/swing/build.xml
+++ b/swing/build.xml
@@ -140,7 +140,7 @@
 		<attribute name="vendor"/>
 		<sequential>
 			<echo>Generating ORC file for vendor @{vendor}</echo>
-			<java classname="net.sf.openrocket.utils.RocksimComponentFileTranslator"
+			<java classname="net.sf.openrocket.utils.RockSimComponentFileTranslator"
 				fork="true"
 				classpathref="run-classpath"
 				failonerror="true">

--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -62,7 +62,6 @@ import net.sf.openrocket.gui.util.Icons;
 import net.sf.openrocket.gui.util.OpenFileWorker;
 import net.sf.openrocket.gui.util.SaveFileWorker;
 import net.sf.openrocket.gui.util.SwingPreferences;
-import net.sf.openrocket.gui.widgets.IconButton;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.logging.Markers;
 import net.sf.openrocket.rocketcomponent.AxialStage;
@@ -406,7 +405,7 @@ public class BasicFrame extends JFrame {
 		JMenu exportSubMenu = new JMenu();
 		JMenuItem exportMenu = new JMenuItem(),
 				RASAero= new JMenuItem("RASAero (Unavailable)"),
-				Rocksim = new JMenuItem("Rocksim"),
+				RockSim = new JMenuItem("RockSim"),
 				Print3D = new JMenuItem("Exterior airframe");
 
 		//	//	CREATE File > "Export as" menu line with icon, and "Export as" submenu
@@ -426,14 +425,14 @@ public class BasicFrame extends JFrame {
 			public void actionPerformed(ActionEvent e) {
 				exportRASAeroAction();}});
 */
-		//	//	ADD Rocksim to "Export as" exportSubMenu options
-		exportSubMenu.add(Rocksim);
+		//	//	ADD RockSim to "Export as" exportSubMenu options
+		exportSubMenu.add(RockSim);
 
-		//	//	CREATE Rocksim listener
-		Rocksim.addActionListener(new ActionListener() {
+		//	//	CREATE RockSim listener
+		RockSim.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				exportRocksimAction();}});
+				exportRockSimAction();}});
 
 		//	//	ADD Export options in exportSubMenu to "Export as" menu
 		menu.add(exportSubMenu);
@@ -492,7 +491,7 @@ public class BasicFrame extends JFrame {
 
 		menu.addSeparator();
 
-		////	BEGIN IMPORT Rocksim RKT design file
+		////	BEGIN IMPORT RockSim RKT design file
 		JMenuItem importMenu;
 		item = new JMenuItem(trans.get("main.menu.file.import"));
 		item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.file.import.desc"));
@@ -505,7 +504,7 @@ public class BasicFrame extends JFrame {
 			}
 		});
 		menu.add(item);
-		////	END IMPORT Rocksim RKT design file
+		////	END IMPORT RockSim RKT design file
 */
 
 /* 		////	PENDING Future development
@@ -1308,7 +1307,7 @@ public class BasicFrame extends JFrame {
 	 * "Save" action.  If the design is new, then this is identical to "Save As", with a default file filter for .ork.
 	 * If the rocket being edited previously was opened from a .ork file, then it will be saved immediately to the same
 	 * file.  But clicking on 'Save' for an existing design file with a .rkt will bring up a confirmation dialog because
-	 * it's potentially a destructive write (loss of some fidelity if it's truly an original Rocksim generated file).
+	 * it's potentially a destructive write (loss of some fidelity if it's truly an original RockSim generated file).
 	 *
 	 * @return true if the file was saved, false otherwise
 	 */
@@ -1350,7 +1349,7 @@ public class BasicFrame extends JFrame {
 	*
 	* @return true if the file was saved, false otherwise
 	*/
-	public boolean exportRocksimAction() {
+	public boolean exportRockSimAction() {
 		File file;
 
 		final SaveAsFileChooser chooser = SaveAsFileChooser.build(document, FileType.ROCKSIM);
@@ -1372,7 +1371,7 @@ public class BasicFrame extends JFrame {
 
 		file = FileHelper.forceExtension(file, "rkt");
 		if (FileHelper.confirmWrite(file, this) ) {
-			return saveAsRocksim(file);
+			return saveAsRockSim(file);
 		}
 		return false;
 	}
@@ -1380,15 +1379,15 @@ public class BasicFrame extends JFrame {
 
 
 	/**
-	 * Perform the writing of the design to the given file in Rocksim format.
+	 * Perform the writing of the design to the given file in RockSim format.
 	 *
 	 * @param file  the chosen file
 	 *
 	 * @return true if the file was written
 	 */
-	private boolean saveAsRocksim(File file) {
+	private boolean saveAsRockSim(File file) {
 		if ( prefs.getShowRockSimFormatWarning() ) {
-			// Show Rocksim format warning
+			// Show RockSim format warning
 			JPanel panel = new JPanel(new MigLayout());
 			panel.add(new StyledLabel(trans.get("SaveRktWarningDialog.txt1")), "wrap");
 			final JCheckBox check = new JCheckBox(trans.get("SaveRktWarningDialog.donotshow"));
@@ -1415,17 +1414,17 @@ public class BasicFrame extends JFrame {
 
 		StorageOptions options = new StorageOptions();
 		options.setFileType(StorageOptions.FileType.ROCKSIM);
-		return saveRocksimFile(file, options);
+		return saveRockSimFile(file, options);
 	}
 
 
 	/**
-	 * Perform the actual saving of the Rocksim file
+	 * Perform the actual saving of the RockSim file
 	 * @param file file to be stored
 	 * @param options storage options to use
 	 * @return true if the file was written
 	 */
-	private boolean saveRocksimFile(File file, StorageOptions options) {
+	private boolean saveRockSimFile(File file, StorageOptions options) {
 		try {
 			ROCKET_SAVER.save(file, document, options);
 			// Do not update the save state of the document.
@@ -1438,7 +1437,7 @@ public class BasicFrame extends JFrame {
 			if (!DecalNotFoundDialog.showDialog(null, decex) && decal != null) {
 				decal.setIgnored(true);
 			}
-			return saveRocksimFile(file, options);	// Re-save
+			return saveRockSimFile(file, options);	// Re-save
 		}
 	}
 

--- a/swing/src/net/sf/openrocket/utils/ComponentPresetEditor.java
+++ b/swing/src/net/sf/openrocket/utils/ComponentPresetEditor.java
@@ -363,7 +363,7 @@ public class ComponentPresetEditor extends JPanel implements PresetResultListene
 					file = file.getParentFile();
 				}
 				presets = new ArrayList<ComponentPreset>();
-				MaterialHolder materialHolder = RocksimComponentFileTranslator.loadAll(presets, file);
+				MaterialHolder materialHolder = RockSimComponentFileTranslator.loadAll(presets, file);
 				editContext.setMaterialsLoaded(materialHolder);
 			}
 			if (presets != null) {

--- a/swing/src/net/sf/openrocket/utils/RockSimComponentFileTranslator.java
+++ b/swing/src/net/sf/openrocket/utils/RockSimComponentFileTranslator.java
@@ -23,13 +23,13 @@ import net.sf.openrocket.preset.loader.TubeCouplerLoader;
 import net.sf.openrocket.preset.xml.OpenRocketComponentSaver;
 import net.sf.openrocket.util.ArrayList;
 
-public class RocksimComponentFileTranslator {
+public class RockSimComponentFileTranslator {
 
     private static PrintStream LOGGER = System.err;
 
     private static void printUsage() {
-        LOGGER.println("RocksimComponentFileLoader <dir> <file>");
-        LOGGER.println("<dir> is base directory for a set of Rocksim component csv files");
+        LOGGER.println("RockSimComponentFileLoader <dir> <file>");
+        LOGGER.println("<dir> is base directory for a set of RockSim component csv files");
         LOGGER.println("<file> is where the orc file is written");
     }
 

--- a/swing/src/net/sf/openrocket/utils/RockSimConverter.java
+++ b/swing/src/net/sf/openrocket/utils/RockSimConverter.java
@@ -17,11 +17,11 @@ import net.sf.openrocket.util.DecalNotFoundException;
  * File is saved with the .rkt extension replaced with .ork.
  * 
  * Usage:
- *   java -cp OpenRocket.jar net.sf.openrocket.utils.RocksimConverter <files...>
+ *   java -cp OpenRocket.jar net.sf.openrocket.utils.RockSimConverter <files...>
  * 
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
-public class RocksimConverter {
+public class RockSimConverter {
 	
 	
 	public static void main(String[] args) {


### PR DESCRIPTION
This PR fixes #1321 and moves tube coupler children outside of the tube coupler during RockSim export.

I also renamed code occurrences of  `Rocksim` to `RockSim` (personal annoyance of mine).