### PR TITLE
[#966] Fix weird behavior when clicking on textured part in 3D view

### DIFF
--- a/swing/src/net/sf/openrocket/gui/figure3d/RocketFigure3d.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/RocketFigure3d.java
@@ -321,6 +321,9 @@ public class RocketFigure3d extends JPanel implements GLEventListener {
 
 			gl.glEnable(GL.GL_MULTISAMPLE);
 			gl.glEnable(GLLightingFunc.GL_LIGHTING);
+
+			flushTextureCaches();
+			updateFigure();
 		}
 		rr.render(drawable, configuration, selection);
 		

--- a/swing/src/net/sf/openrocket/gui/figure3d/RocketFigure3d.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/RocketFigure3d.java
@@ -322,7 +322,6 @@ public class RocketFigure3d extends JPanel implements GLEventListener {
 			gl.glEnable(GL.GL_MULTISAMPLE);
 			gl.glEnable(GLLightingFunc.GL_LIGHTING);
 
-			flushTextureCaches();
 			updateFigure();
 		}
 		rr.render(drawable, configuration, selection);


### PR DESCRIPTION
This PR fixes #966, which was a weird 3D behavior (on macOS, but maybe also others?) when clicking on a textured part (e.g. the body tube or fins of 'A simple model rocket').