### PR TITLE
Sort on source stage for simultaneous events

### DIFF
--- a/core/src/net/sf/openrocket/simulation/FlightEvent.java
+++ b/core/src/net/sf/openrocket/simulation/FlightEvent.java
@@ -146,15 +146,33 @@ public class FlightEvent implements Comparable<FlightEvent> {
 	
 	/**
 	 * Compares this event to another event depending on the event time.  Secondary
+	 * sorting is performed on stages; lower (numerically higher) stage first.  Tertiary
 	 * sorting is performed based on the event type ordinal.
 	 */
 	@Override
 	public int compareTo(FlightEvent o) {
+
+		// first, sort on time
 		if (this.time < o.time)
 			return -1;
 		if (this.time > o.time)
 			return 1;
 		
+		// second, sort on stage presence.  Events with no source go first
+		if ((this.getSource() == null) && (o.getSource() != null))
+			return -1;
+		if ((this.getSource() != null) && (o.getSource() == null))
+			return 1;
+
+		// third, sort on stage order.  Bigger stage number goes first
+		if ((this.getSource() != null) && (o.getSource() != null)) {
+			if (this.getSource().getStageNumber() > o.getSource().getStageNumber())
+				return -1;
+			if (this.getSource().getStageNumber() < o.getSource().getStageNumber())
+				return 1;
+		}
+
+		// finally, sort on event type
 		return this.type.ordinal() - o.type.ordinal();
 	}
 	


### PR DESCRIPTION
-- if only one of the events has a source, the other one goes first.
-- if both have sources, lower (numerically higher) stage goes first.

In cases where two stages could separate simultaneously it was possible for either to land in the event queue first, which was disconcerting when looking at debug logs and unit test results.  This imposes an order based on stage number.  It should make no material difference to simulation results.