### PR TITLE
Modify Falcon9H test rocket and FlightEventsTest to get predictable results

### DIFF
--- a/core/src/net/sf/openrocket/util/TestRockets.java
+++ b/core/src/net/sf/openrocket/util/TestRockets.java
@@ -217,7 +217,7 @@ public class TestRockets {
 				.setDiameter(0.029)
 				.setLength(0.124)
 				.setTimePoints(new double[] { 0, 1, 2 })
-				.setThrustPoints(new double[] { 0, 1, 0 })
+				.setThrustPoints(new double[] { 0, 20, 0 })
 				.setCGPoints(new Coordinate[] {
 						new Coordinate(.062, 0, 0, 0.123),new Coordinate(.062, 0, 0, .0935),new Coordinate(.062, 0, 0, 0.064)})
 				.setDigest("digest G77 test")

--- a/core/test/net/sf/openrocket/simulation/FlightEventsTest.java
+++ b/core/test/net/sf/openrocket/simulation/FlightEventsTest.java
@@ -76,10 +76,10 @@ public class FlightEventsTest extends BaseTestCase {
             switch (b) {
                 case 0:
                     expectedEventTypes = new FlightEvent.Type[]{FlightEvent.Type.LAUNCH, FlightEvent.Type.IGNITION, FlightEvent.Type.IGNITION,
-                            FlightEvent.Type.LIFTOFF, FlightEvent.Type.LAUNCHROD, FlightEvent.Type.APOGEE, FlightEvent.Type.BURNOUT,
-                            FlightEvent.Type.BURNOUT, FlightEvent.Type.EJECTION_CHARGE, FlightEvent.Type.EJECTION_CHARGE,
-                            FlightEvent.Type.STAGE_SEPARATION, FlightEvent.Type.STAGE_SEPARATION, FlightEvent.Type.TUMBLE, FlightEvent.Type.GROUND_HIT,
-                            FlightEvent.Type.SIMULATION_END};
+                            FlightEvent.Type.LIFTOFF, FlightEvent.Type.LAUNCHROD, FlightEvent.Type.APOGEE,
+                            FlightEvent.Type.BURNOUT, FlightEvent.Type.EJECTION_CHARGE, FlightEvent.Type.STAGE_SEPARATION,
+                            FlightEvent.Type.BURNOUT, FlightEvent.Type.EJECTION_CHARGE, FlightEvent.Type.STAGE_SEPARATION,
+                            FlightEvent.Type.TUMBLE, FlightEvent.Type.GROUND_HIT, FlightEvent.Type.SIMULATION_END};
                     break;
                 case 1:
                 case 2:


### PR DESCRIPTION
The problem with the occasional failure of the flight events test results in PR #1798 was that the rocket apogee was exactly at motor burnout.  A tiny variation in time to apogee would change the order of the events in the flight, and even whether some of the events were associated with the sustainer or one of the boosters..

Change peak thrust of G77 simulation motor so Falcon9H test rocket do…esn't tumble until well after stage separations

Put order of expected events to match the new test rocket