### PR TITLE
[#1792] Don't clamp SymmetricComponent thickness when importing

### DIFF
--- a/core/src/net/sf/openrocket/file/openrocket/importt/DocumentConfig.java
+++ b/core/src/net/sf/openrocket/file/openrocket/importt/DocumentConfig.java
@@ -171,9 +171,10 @@ class DocumentConfig {
        
 		// SymmetricComponent
 		setters.put("SymmetricComponent:thickness", new DoubleSetter(
-				Reflection.findMethod(SymmetricComponent.class, "setThickness", double.class),
+				Reflection.findMethod(SymmetricComponent.class, "setThickness", double.class, boolean.class),
 				"filled",
-				Reflection.findMethod(SymmetricComponent.class, "setFilled", boolean.class)));
+				Reflection.findMethod(SymmetricComponent.class, "setFilled", boolean.class),
+				false));
 		
 		// LaunchLug
 		setters.put("LaunchLug:instancecount", new IntSetter(
@@ -218,13 +219,15 @@ class DocumentConfig {
 				Reflection.findMethod(Transition.class, "setShapeParameter", double.class)));
 		
 		setters.put("Transition:foreradius", new DoubleSetter(
-				Reflection.findMethod(Transition.class, "setForeRadius", double.class),
+				Reflection.findMethod(Transition.class, "setForeRadius", double.class, boolean.class),
 				"auto", " ",
-				Reflection.findMethod(Transition.class, "setForeRadiusAutomatic", boolean.class)));
+				Reflection.findMethod(Transition.class, "setForeRadiusAutomatic", boolean.class),
+				false));
 		setters.put("Transition:aftradius", new DoubleSetter(
-				Reflection.findMethod(Transition.class, "setAftRadius", double.class),
+				Reflection.findMethod(Transition.class, "setAftRadius", double.class, boolean.class),
 				"auto", " ",
-				Reflection.findMethod(Transition.class, "setAftRadiusAutomatic", boolean.class)));
+				Reflection.findMethod(Transition.class, "setAftRadiusAutomatic", boolean.class),
+				false));
 		
 		setters.put("Transition:foreshoulderradius", new DoubleSetter(
 				Reflection.findMethod(Transition.class, "setForeShoulderRadius", double.class)));

--- a/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
@@ -7,8 +7,6 @@ import java.util.Collection;
 import java.util.List;
 
 import net.sf.openrocket.preset.ComponentPreset;
-import net.sf.openrocket.rocketcomponent.PodSet;
-import net.sf.openrocket.rocketcomponent.position.AxialMethod;
 import net.sf.openrocket.util.BoundingBox;
 import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.MathUtil;
@@ -94,8 +92,14 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 	public final double getInnerRadius(double x, double theta) {
 		return getInnerRadius(x);
 	}
-	
-	
+
+	/**
+	 * Returns the largest radius of the component (either the aft radius, or the fore radius).
+	 */
+	public double getMaxRadius() {
+		return MathUtil.max(getForeRadius(), getAftRadius());
+	}
+
 
 	/**
 	 * Return the component wall thickness.
@@ -120,7 +124,7 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 
 		if ((this.thickness == thickness) && !filled)
 			return;
-		this.thickness = doClamping ? MathUtil.clamp(thickness, 0, Math.max(getForeRadius(), getAftRadius())) : thickness;
+		this.thickness = doClamping ? MathUtil.clamp(thickness, 0, getMaxRadius()) : thickness;
 		filled = false;
 		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
 		clearPreset();

--- a/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
@@ -103,15 +103,15 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 	public double getThickness() {
 		if (filled)
 			return Math.max(getForeRadius(), getAftRadius());
-		return Math.min(thickness, Math.max(getForeRadius(), getAftRadius()));
+		return thickness;
 	}
-	
-	
+
 	/**
-	 * Set the component wall thickness.  Values greater than the maximum radius are not
-	 * allowed, and will result in setting the thickness to the maximum radius.
+	 * Set the component wall thickness.  If <code>doClamping</code> is true, values greater than
+	 * the maximum radius will be clamped the thickness to the maximum radius.
+	 * @param doClamping If true, the thickness will be clamped to the maximum radius.
 	 */
-	public void setThickness(double thickness) {
+	public void setThickness(double thickness, boolean doClamping) {
 		for (RocketComponent listener : configListeners) {
 			if (listener instanceof SymmetricComponent) {
 				((SymmetricComponent) listener).setThickness(thickness);
@@ -120,10 +120,19 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 
 		if ((this.thickness == thickness) && !filled)
 			return;
-		this.thickness = MathUtil.clamp(thickness, 0, Math.max(getForeRadius(), getAftRadius()));
+		this.thickness = doClamping ? MathUtil.clamp(thickness, 0, Math.max(getForeRadius(), getAftRadius())) : thickness;
 		filled = false;
 		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
 		clearPreset();
+	}
+	
+	
+	/**
+	 * Set the component wall thickness.  Values greater than the maximum radius are not
+	 * allowed, and will result in setting the thickness to the maximum radius.
+	 */
+	public void setThickness(double thickness) {
+		setThickness(thickness, true);
 	}
 	
 	

--- a/core/src/net/sf/openrocket/rocketcomponent/Transition.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Transition.java
@@ -102,7 +102,12 @@ public class Transition extends SymmetricComponent implements InsideColorCompone
 		return foreRadius;
 	}
 
-	public void setForeRadius(double radius) {
+	/**
+	 * Set the new fore radius, with option to clamp the thickness to the new radius if it's too large.
+	 * @param radius new radius
+	 * @param doClamping whether to clamp the thickness
+	 */
+	public void setForeRadius(double radius, boolean doClamping) {
 		for (RocketComponent listener : configListeners) {
 			if (listener instanceof Transition) {
 				((Transition) listener).setForeRadius(radius);
@@ -115,11 +120,15 @@ public class Transition extends SymmetricComponent implements InsideColorCompone
 		this.autoForeRadius = false;
 		this.foreRadius = Math.max(radius, 0);
 
-		if (this.thickness > this.foreRadius && this.thickness > this.aftRadius)
+		if (doClamping && this.thickness > this.foreRadius && this.thickness > this.aftRadius)
 			this.thickness = Math.max(this.foreRadius, this.aftRadius);
 
 		clearPreset();
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
+	}
+
+	public void setForeRadius(double radius) {
+		setForeRadius(radius, true);
 	}
 
 	@Override
@@ -170,7 +179,12 @@ public class Transition extends SymmetricComponent implements InsideColorCompone
 		return aftRadius;
 	}
 
-	public void setAftRadius(double radius) {
+	/**
+	 * Set the new aft radius, with option to clamp the thickness to the new radius if it's too large.
+	 * @param radius new radius
+	 * @param doClamping whether to clamp the thickness
+	 */
+	public void setAftRadius(double radius, boolean doClamping) {
 		for (RocketComponent listener : configListeners) {
 			if (listener instanceof Transition) {
 				((Transition) listener).setAftRadius(radius);
@@ -183,11 +197,15 @@ public class Transition extends SymmetricComponent implements InsideColorCompone
 		this.autoAftRadius2 = false;
 		this.aftRadius = Math.max(radius, 0);
 
-		if (this.thickness > this.foreRadius && this.thickness > this.aftRadius)
+		if (doClamping && this.thickness > this.foreRadius && this.thickness > this.aftRadius)
 			this.thickness = Math.max(this.foreRadius, this.aftRadius);
 
 		clearPreset();
 		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
+	}
+
+	public void setAftRadius(double radius) {
+		setAftRadius(radius, true);
 	}
 
 	@Override

--- a/core/src/net/sf/openrocket/rocketcomponent/Transition.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Transition.java
@@ -230,7 +230,6 @@ public class Transition extends SymmetricComponent implements InsideColorCompone
 	}
 
 
-
 	//// Radius automatics
 
 	@Override

--- a/swing/src/net/sf/openrocket/gui/configdialog/NoseConeConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/NoseConeConfig.java
@@ -133,7 +133,9 @@ public class NoseConeConfig extends RocketComponentConfig {
 			order.add(((SpinnerEditor) thicknessSpinner.getEditor()).getTextField());
 
 			panel.add(new UnitSelector(thicknessModel), "growx");
-			panel.add(new BasicSlider(thicknessModel.getSliderModel(0, 0.01)), "w 100lp, wrap 0px");
+			panel.add(new BasicSlider(thicknessModel.getSliderModel(0,
+							new DoubleModel(component, "MaxRadius", UnitGroup.UNITS_LENGTH))),
+					"w 100lp, wrap 0px");
 
 
 			final JCheckBox filledCheckbox = new JCheckBox(new BooleanModel(component, "Filled"));

--- a/swing/src/net/sf/openrocket/gui/configdialog/TransitionConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/TransitionConfig.java
@@ -170,7 +170,9 @@ public class TransitionConfig extends RocketComponentConfig {
 			order.add(((SpinnerEditor) thicknessSpinner.getEditor()).getTextField());
 
 			panel.add(new UnitSelector(thicknessModel), "growx");
-			panel.add(new BasicSlider(thicknessModel.getSliderModel(0, 0.01)), "w 100lp, wrap 0px");
+			panel.add(new BasicSlider(thicknessModel.getSliderModel(0,
+					new DoubleModel(component, "MaxRadius", UnitGroup.UNITS_LENGTH))),
+					"w 100lp, wrap 0px");
 
 			//// Filled
 			final JCheckBox thicknessCheckbox = new JCheckBox(new BooleanModel(component, "Filled"));


### PR DESCRIPTION
This PR fixes #1792. The issue was that when a transition, nose cone, or body tube got imported, first the thickness of the component was set and then the fore and aft radius. However, the thickness setter method clamped the thickness if it was greater than the aft and fore radius. Since the correct aft and fore radius was not yet set at that point, the thickness setter took the default fore and aft radius, which is 2.5 cm. So: if you saved the thickness with a value greater than 2.5 cm, that value would get clamped when re-opening the design.

This PR ignores the clamping of the thickness during import.

I also took the liberty of fixing the maximum value of the thickness slider, which was fixed at 1 cm. Now it updates dynamically with the fore and aft radius.