### PR TITLE
[#1809] Ignore stages with no sim data in plots

### DIFF
--- a/swing/src/net/sf/openrocket/gui/plot/PlotConfiguration.java
+++ b/swing/src/net/sf/openrocket/gui/plot/PlotConfiguration.java
@@ -458,6 +458,10 @@ public class PlotConfiguration implements Cloneable {
 			double max = unit.toUnit(data.get(0).getMaximum(type));
 
 			for (int j = 1; j < data.size(); j++) {
+				// Ignore empty data
+				if (data.get(j).getLength() == 0) {
+					continue;
+				}
 				min = Math.min(min, unit.toUnit(data.get(j).getMinimum(type)));
 				max = Math.max(max, unit.toUnit(data.get(j).getMaximum(type)));
 			}

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlot.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlot.java
@@ -193,6 +193,15 @@ public class SimulationPlot {
 				FlightDataBranch primaryBranch = simulation.getSimulatedData().getBranch(0);
 				FlightDataBranch thisBranch = simulation.getSimulatedData().getBranch(branchIndex);
 
+				// Ignore empty branches
+				if (thisBranch.getLength() == 0) {
+					// Add an empty series to keep the series count consistent
+					XYSeries series = new XYSeries(seriesCount++, false, true);
+					series.setDescription(thisBranch.getBranchName() + ": " + name);
+					data[axis].addSeries(series);
+					continue;
+				}
+
 				// Get first time index used in secondary branch;
 				double firstSampleTime = thisBranch.get(FlightDataType.TYPE_TIME).get(0);
 


### PR DESCRIPTION
This PR fixes #1809. Data branches with no actual content are now ignored in the plots.