### PR TITLE
[#1479] Add option to automatically open preset dialog when creating a new component

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -2127,6 +2127,7 @@ ComponentPresetChooserDialog.menu.sortDesc = Sort Descending
 ComponentPresetChooserDialog.menu.units = Units
 ComponentPresetChooserDialog.checkbox.showLegacyCheckBox = Show Legacy Database
 ComponentPresetChooserDialog.lbl.favorites = Check to add preset to the preset drop-down menu in the component edit dialog<br>Directly apply a preset by double-clicking it or by selecting it and closing this window.
+ComponentPresetChooserDialog.checkbox.alwaysOpenPreset = Always open this dialog when creating a new %s
 table.column.Favorite = Favorite
 table.column.Legacy = Legacy
 table.column.Manufacturer = Manufacturer

--- a/core/resources/l10n/messages_nl.properties
+++ b/core/resources/l10n/messages_nl.properties
@@ -1983,6 +1983,7 @@ ComponentPresetChooserDialog.menu.sortAsc = Sorteer oplopend
 ComponentPresetChooserDialog.menu.sortDesc = Sorteer aflopend
 ComponentPresetChooserDialog.menu.units = Eenheden
 ComponentPresetChooserDialog.lbl.favorites = Selecteer om preset aan drop-down menu toe te voegen
+ComponentPresetChooserDialog.checkbox.alwaysOpenPreset = Open dit venster altijd bij het aanmaken van een
 table.column.Favorite = Favoriet
 table.column.Manufacturer = Fabrikant
 table.column.PartNo = Onderdeelnummer

--- a/swing/src/net/sf/openrocket/gui/configdialog/ComponentConfigDialog.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/ComponentConfigDialog.java
@@ -236,9 +236,9 @@ public class ComponentConfigDialog extends JDialog implements ComponentChangeLis
 	 * @param document		the document to configure.
 	 * @param component		the component to configure.
 	 * @param rememberPreviousTab if true, the previous tab will be remembered and used for the new dialog
-	 * @param includeUndoModify	if true, include a 'Modify component' undo action
+	 * @param isNewComponent	whether the component is just created, or has already been created and is being edited
 	 */
-	public static void showDialog(Window parent, OpenRocketDocument document, RocketComponent component, boolean rememberPreviousTab, boolean includeUndoModify) {
+	public static void showDialog(Window parent, OpenRocketDocument document, RocketComponent component, boolean rememberPreviousTab, boolean isNewComponent) {
 		if (dialog != null) {
 			// Don't remember the previous tab for rockets or stages, because this will leave you in the override tab for
 			// the next component, which is generally not what you want.
@@ -267,13 +267,20 @@ public class ComponentConfigDialog extends JDialog implements ComponentChangeLis
 			WindowLocationUtil.moveIfOutsideOfParentMonitor(dialog, parent);
 		}
 
-		////Modify
-		if (includeUndoModify) {
+		// Only add a modify undo action if the component is not a new component (because a "Create new component" undo action is already added)
+		if (!isNewComponent) {
 			if (component.getConfigListeners().size() == 0) {
 				document.addUndoPosition(trans.get("ComponentCfgDlg.Modify") + " " + component.getComponentName());
 			} else {
 				document.addUndoPosition(trans.get("ComponentCfgDlg.ModifyComponents"));
 			}
+		}
+
+		// Open preset dialog if set in preferences
+		if (isNewComponent && component.getPresetType() != null &&
+				preferences.getBoolean(component.getComponentName() + "AlwaysOpenPreset", true) &&
+				component.getConfigListeners().size() == 0) {
+			dialog.configurator.selectPreset();
 		}
 	}
 
@@ -286,7 +293,7 @@ public class ComponentConfigDialog extends JDialog implements ComponentChangeLis
 	 * @param rememberPreviousTab if true, the previous tab will be remembered and used for the new dialog
 	 */
 	public static void showDialog(Window parent, OpenRocketDocument document, RocketComponent component, boolean rememberPreviousTab) {
-		ComponentConfigDialog.showDialog(parent, document, component, rememberPreviousTab, true);
+		ComponentConfigDialog.showDialog(parent, document, component, rememberPreviousTab, false);
 	}
 
 	/**

--- a/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
@@ -270,7 +270,10 @@ public class RocketComponentConfig extends JPanel {
 		}
 	}
 
-	private void selectPreset() {
+	/**
+	 * Open the component preset dialog.
+	 */
+	public void selectPreset() {
 		SwingUtilities.invokeLater(new Runnable() {
 			@Override
 			public void run() {

--- a/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
@@ -179,6 +179,18 @@ public class ComponentPresetChooserDialog extends JDialog {
 				}
 			}
 		});
+
+		// Always open this window when creating a new component
+		JCheckBox alwaysOpenPreset = new JCheckBox(String.format(trans.get("ComponentPresetChooserDialog.checkbox.alwaysOpenPreset"),
+				component.getComponentName()));
+		alwaysOpenPreset.setSelected(preferences.getBoolean(component.getComponentName() +  "AlwaysOpenPreset", true));
+		alwaysOpenPreset.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				preferences.putBoolean(component.getComponentName() + "AlwaysOpenPreset", ((JCheckBox) e.getSource()).isSelected());
+			}
+		});
+		panel.add(alwaysOpenPreset, "spanx 2");
 		
 		// Close buttons
 		JButton closeButton = new SelectColorButton(trans.get("dlg.but.close"));

--- a/swing/src/net/sf/openrocket/gui/main/ComponentAddButtons.java
+++ b/swing/src/net/sf/openrocket/gui/main/ComponentAddButtons.java
@@ -488,7 +488,7 @@ public class ComponentAddButtons extends JPanel implements Scrollable {
 				}
 			}
 			
-			ComponentConfigDialog.showDialog(parent, document, component, false, false);
+			ComponentConfigDialog.showDialog(parent, document, component, false, true);
 		}
 	}
 	


### PR DESCRIPTION
This PR fixes #1479. There is now an option in the component preset dialog for opening the dialog when creating a new component. The dialog will not automatically open when you have created a component, close the config dialog, and edit the component again. It only works for newly created components. This feature is enabled by default. If you want it disabled by default, let me know.

Demo:

https://user-images.githubusercontent.com/11031519/201204718-232c73f5-e9f0-4736-a122-58e0dc4e6151.mp4

