### PR TITLE
Provide user with warning when a simulation branch contains no data

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -1835,6 +1835,7 @@ Warning.ZERO_LENGTH_BODY = Zero length bodies may not result in accurate simulat
 Warning.ZERO_RADIUS_BODY = Zero length bodies may not result in accurate simulations.
 Warning.TUBE_SEPARATION = Space between tube fins may not result in accurate simulations.
 Warning.TUBE_OVERLAP = Overlapping tube fins may not result in accurate simulations.
+Warning.EMPTY_BRANCH = Simulation branch contains no data
 Warning.SEPARATION_ORDER = Stages separated in an unreasonable order
 
 ! Scale dialog

--- a/core/src/net/sf/openrocket/aerodynamics/Warning.java
+++ b/core/src/net/sf/openrocket/aerodynamics/Warning.java
@@ -18,7 +18,6 @@ public abstract class Warning {
 		return new Warning.Other(text);
 	}
 	
-	
 	/**
 	 * Return <code>true</code> if the <code>other</code> warning should replace
 	 * this warning.  The method should return <code>true</code> if the other
@@ -398,4 +397,6 @@ public abstract class Warning {
 	public static final Warning TUBE_OVERLAP = new Other(trans.get("Warning.TUBE_OVERLAP"));
 
 	public static final Warning SEPARATION_ORDER = new Other(trans.get("Warning.SEPARATION_ORDER"));
+
+	public static final Warning EMPTY_BRANCH = new Other(trans.get("Warning.EMPTY_BRANCH"));
 }

--- a/core/src/net/sf/openrocket/aerodynamics/WarningSet.java
+++ b/core/src/net/sf/openrocket/aerodynamics/WarningSet.java
@@ -67,7 +67,17 @@ public class WarningSet extends AbstractSet<Warning> implements Cloneable, Monit
 		mutable.check();
 		return add(Warning.fromString(s));
 	}
-	
+
+	/**
+	 * Add a <code>Warning</code> of the specified type with the specified discriminator to the
+	 * set.
+	 * @param w the warning
+	 * @param d the extra discriminator
+	 *
+	 */
+	public boolean add (Warning w, String d) {
+		return this.add(w.toString() + ": " + d);
+	}
 	
 	@Override
 	public Iterator<Warning> iterator() {

--- a/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
+++ b/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
@@ -97,6 +97,12 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 							dataBranch.getBranchName(),
 							currentStatus.getSimulationTime(),
 							dataBranch.getLast(FlightDataType.TYPE_TIME)));
+
+
+			// Did the branch generate any data?
+			if (dataBranch.getLength() == 0) {
+				flightData.getWarningSet().add(Warning.EMPTY_BRANCH, dataBranch.getBranchName());
+			}
 		}while( ! toSimulate.isEmpty());
 		
 		SimulationListenerHelper.fireEndSimulation(currentStatus, null);


### PR DESCRIPTION
Also, add a method to WarningSet making it easy to add a "discriminator" to warnings, informing the user what in a design or simulation is causing the warning.

The attached .ork results in an empty data branch for Stage 1
[empty-booster.ork.txt](https://github.com/openrocket/openrocket/files/9998418/empty-booster.ork.txt)
