### PR TITLE
[#1817] Create zero-argument constructor for StopSimulationListener

### DIFF
--- a/core/src/net/sf/openrocket/simulation/listeners/example/StopSimulationListener.java
+++ b/core/src/net/sf/openrocket/simulation/listeners/example/StopSimulationListener.java
@@ -22,7 +22,11 @@ public class StopSimulationListener extends AbstractSimulationListener {
 	
 	private long startTime = -1;
 	private long time = -1;
-	
+
+	public StopSimulationListener() {
+		this(0, 0);
+	}
+
 	public StopSimulationListener(double t, int n) {
 		stopTime = t;
 		stopStep = n;


### PR DESCRIPTION
This PR fixes #1817. The issue was that StopSimulationListener had no zero-argument constructor. We should probably at one point support constructor parameter support for custom simulation listeners (tied with the radical UI improvement of #1719.