### PR TITLE
[#1819] Update simulation extensions after new extension creation

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -470,6 +470,8 @@ SimulationExtension.javacode.name = Java code
 SimulationExtension.javacode.name.none = none
 SimulationExtension.javacode.desc = Add a custom SimulationListener to the simulation
 SimulationExtension.javacode.className = Fully-qualified Java class name:
+SimulationExtension.javacode.classnotfound = Could not find class
+SimulationExtension.javacode.couldnotinstantiate = <html>Could not instantiate class %s.<br>Does it have a zero-argument, or @Inject constructor?</html>
 
 SimulationExtension.scripting.name = {language} script
 SimulationExtension.scripting.desc = Extend OpenRocket simulations by custom scripts.

--- a/core/src/net/sf/openrocket/simulation/extension/impl/JavaCode.java
+++ b/core/src/net/sf/openrocket/simulation/extension/impl/JavaCode.java
@@ -1,5 +1,6 @@
 package net.sf.openrocket.simulation.extension.impl;
 
+import com.google.inject.ConfigurationException;
 import net.sf.openrocket.simulation.SimulationConditions;
 import net.sf.openrocket.simulation.exception.SimulationException;
 import net.sf.openrocket.simulation.extension.AbstractSimulationExtension;
@@ -23,11 +24,15 @@ public class JavaCode extends AbstractSimulationExtension {
 				if (!SimulationListener.class.isAssignableFrom(clazz)) {
 					throw new SimulationException("Class " + className + " does not implement SimulationListener");
 				}
-				SimulationListener listener = (SimulationListener) injector.getInstance(clazz);
-				conditions.getSimulationListenerList().add(listener);
+				try {
+					SimulationListener listener = (SimulationListener) injector.getInstance(clazz);
+					conditions.getSimulationListenerList().add(listener);
+				} catch (ConfigurationException e) {
+					throw new SimulationException(String.format(trans.get("SimulationExtension.javacode.couldnotinstantiate"), className), e);
+				}
 			}
 		} catch (ClassNotFoundException e) {
-			throw new SimulationException("Could not find class " + className);
+			throw new SimulationException(trans.get("SimulationExtension.javacode.classnotfound") + " " + className);
 		}
 	}
 	

--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationOptionsPanel.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationOptionsPanel.java
@@ -234,6 +234,7 @@ class SimulationOptionsPanel extends JPanel {
 							SwingSimulationExtensionConfigurator configurator = findConfigurator(e);
 							if (configurator != null) {
 								configurator.configure(e, simulation, SwingUtilities.windowForComponent(SimulationOptionsPanel.this));
+								updateCurrentExtensions();
 							}
 						}
 					});
@@ -257,6 +258,7 @@ class SimulationOptionsPanel extends JPanel {
 							SwingSimulationExtensionConfigurator configurator = findConfigurator(e);
 							if (configurator != null) {
 								configurator.configure(e, simulation, SwingUtilities.windowForComponent(SimulationOptionsPanel.this));
+								updateCurrentExtensions();
 							}
 						}
 					});

--- a/swing/src/net/sf/openrocket/simulation/extension/AbstractSwingSimulationExtensionConfigurator.java
+++ b/swing/src/net/sf/openrocket/simulation/extension/AbstractSwingSimulationExtensionConfigurator.java
@@ -4,6 +4,8 @@ import java.awt.Dialog.ModalityType;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -50,17 +52,21 @@ public abstract class AbstractSwingSimulationExtensionConfigurator<E extends Sim
 		close.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				dialog.setVisible(false);
+				close();
 			}
 		});
 		panel.add(close, "right");
-		
+
+		dialog.addWindowListener(new WindowAdapter() {
+			@Override
+			public void windowClosing(WindowEvent e) {
+				close();
+			}
+		});
+
 		dialog.add(panel);
 		GUIUtil.setDisposableDialogOptions(dialog, close);
 		dialog.setVisible(true);
-		close();
-		GUIUtil.setNullModels(dialog);
-		dialog = null;
 	}
 	
 	/**
@@ -78,10 +84,12 @@ public abstract class AbstractSwingSimulationExtensionConfigurator<E extends Sim
 	}
 	
 	/**
-	 * Called when the default dialog is closed.  By default does nothing.
+	 * Called when the default dialog is closed.  By default hides the dialog and cleans up the component models.
 	 */
 	protected void close() {
-		
+		dialog.setVisible(false);
+		GUIUtil.setNullModels(dialog);
+		dialog = null;
 	}
 	
 	protected abstract JComponent getConfigurationComponent(E extension, Simulation simulation, JPanel panel);

--- a/swing/src/net/sf/openrocket/simulation/extension/impl/JavaCodeConfigurator.java
+++ b/swing/src/net/sf/openrocket/simulation/extension/impl/JavaCodeConfigurator.java
@@ -19,6 +19,7 @@ import net.sf.openrocket.util.Color;
 public class JavaCodeConfigurator extends AbstractSwingSimulationExtensionConfigurator<JavaCode> {
 	private JavaCode extension;
 	private JTextField classNameField;
+	private StyledLabel errorMsg;
 
 	private static final Translator trans = Application.getTranslator();
 
@@ -33,7 +34,7 @@ public class JavaCodeConfigurator extends AbstractSwingSimulationExtensionConfig
 		panel.add(new JLabel(trans.get("SimulationExtension.javacode.className")), "wrap rel");
 		classNameField = new JTextField(extension.getClassName());
 		panel.add(classNameField, "growx, wrap");
-		StyledLabel errorMsg = new StyledLabel();
+		this.errorMsg = new StyledLabel();
 		errorMsg.setFontColor(Color.DARK_RED.toAWTColor());
 		errorMsg.setVisible(false);
 		panel.add(errorMsg, "growx, wrap");
@@ -52,24 +53,32 @@ public class JavaCodeConfigurator extends AbstractSwingSimulationExtensionConfig
 			}
 			
 			public void update() {
-				// Display error message if the class name is invalid
-				String text = classNameField.getText().trim();
-				try {
-					Class.forName(text);
-					errorMsg.setVisible(false);
-				} catch (ClassNotFoundException e) {
-					// Don't display an error message for an empty field
-					if (text.length() == 0) {
-						errorMsg.setVisible(false);
-						return;
-					}
-					errorMsg.setText(trans.get("SimulationExtension.javacode.classnotfound"));
-					errorMsg.setVisible(true);
-				}
+				updateErrorMsg();
 			}
 		});
+		updateErrorMsg();
 
 		return panel;
+	}
+
+	private void updateErrorMsg() {
+		if (this.errorMsg == null) {
+			return;
+		}
+		// Display error message if the class name is invalid
+		String text = classNameField.getText().trim();
+		try {
+			Class.forName(text);
+			errorMsg.setVisible(false);
+		} catch (ClassNotFoundException e) {
+			// Don't display an error message for an empty field
+			if (text.length() == 0) {
+				errorMsg.setVisible(false);
+				return;
+			}
+			errorMsg.setText(trans.get("SimulationExtension.javacode.classnotfound"));
+			errorMsg.setVisible(true);
+		}
 	}
 
 	@Override

--- a/swing/src/net/sf/openrocket/simulation/extension/impl/JavaCodeConfigurator.java
+++ b/swing/src/net/sf/openrocket/simulation/extension/impl/JavaCodeConfigurator.java
@@ -8,22 +8,37 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
 import net.sf.openrocket.document.Simulation;
+import net.sf.openrocket.gui.components.StyledLabel;
+import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.plugin.Plugin;
 import net.sf.openrocket.simulation.extension.AbstractSwingSimulationExtensionConfigurator;
+import net.sf.openrocket.startup.Application;
+import net.sf.openrocket.util.Color;
 
 @Plugin
 public class JavaCodeConfigurator extends AbstractSwingSimulationExtensionConfigurator<JavaCode> {
-	
+	private JavaCode extension;
+	private JTextField classNameField;
+
+	private static final Translator trans = Application.getTranslator();
+
 	public JavaCodeConfigurator() {
 		super(JavaCode.class);
 	}
 	
 	@Override
 	protected JComponent getConfigurationComponent(final JavaCode extension, Simulation simulation, JPanel panel) {
+		this.extension = extension;
 		panel.add(new JLabel(trans.get("SimulationExtension.javacode.desc")), "wrap para");
 		panel.add(new JLabel(trans.get("SimulationExtension.javacode.className")), "wrap rel");
-		final JTextField textField = new JTextField(extension.getClassName());
-		textField.getDocument().addDocumentListener(new DocumentListener() {
+		classNameField = new JTextField(extension.getClassName());
+		panel.add(classNameField, "growx, wrap");
+		StyledLabel errorMsg = new StyledLabel();
+		errorMsg.setFontColor(Color.DARK_RED.toAWTColor());
+		errorMsg.setVisible(false);
+		panel.add(errorMsg, "growx, wrap");
+
+		classNameField.getDocument().addDocumentListener(new DocumentListener() {
 			public void changedUpdate(DocumentEvent e) {
 				update();
 			}
@@ -37,11 +52,33 @@ public class JavaCodeConfigurator extends AbstractSwingSimulationExtensionConfig
 			}
 			
 			public void update() {
-				extension.setClassName(textField.getText());
+				// Display error message if the class name is invalid
+				String text = classNameField.getText().trim();
+				try {
+					Class.forName(text);
+					errorMsg.setVisible(false);
+				} catch (ClassNotFoundException e) {
+					// Don't display an error message for an empty field
+					if (text.length() == 0) {
+						errorMsg.setVisible(false);
+						return;
+					}
+					errorMsg.setText(trans.get("SimulationExtension.javacode.classnotfound"));
+					errorMsg.setVisible(true);
+				}
 			}
 		});
-		panel.add(textField, "growx");
+
 		return panel;
+	}
+
+	@Override
+	protected void close() {
+		if (this.extension != null && this.classNameField != null) {
+			this.extension.setClassName(this.classNameField.getText().trim());
+
+		}
+		super.close();
 	}
 	
 }


### PR DESCRIPTION
This PR fixes #1819.

I also added a better simulation exception message for errors similar to #1817. It will now include the message "Could not instantiate class <classname>.Does it have a zero-argument, or @Inject constructor?". (should have done this in PR #1823, things got entangled a bit, my apologies)

Finally, I also added a small error text when the class entered in the simulation listener dialog was not valid (a small step towards #1719), and trimmed the TextField output so that typing whitespaces in the beginning or end of the classname does not affect the result. Error text demo:

https://user-images.githubusercontent.com/11031519/201666941-60e1e6c7-9300-4c3a-90a4-0e5cea04782f.mov

