### PR TITLE
When a simulation fails badly enough to be aborted, don't turn the exception into a warning

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -554,6 +554,7 @@ SimuRunDlg.msg.errorOccurred = An error occurred during the simulation:
 
 BasicEventSimulationEngine.error.noMotorsDefined = No motors defined in the simulation.
 BasicEventSimulationEngine.error.earlyMotorBurnout = Motor burnout without liftoff.
+BasicEventSimulationEngine.error.noConfiguredIgnition = No motors configured to ignite at liftoff
 BasicEventSimulationEngine.error.noIgnition = No motors ignited.
 BasicEventSimulationEngine.error.NaNResult = Simulation resulted in not-a-number (NaN) value, please report a bug.
 

--- a/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
+++ b/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
@@ -73,6 +73,14 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 		}
 		
 		currentStatus = new SimulationStatus(simulationConfig, simulationConditions);
+
+		// Sanity checks on design and configuration
+		
+		// No recovery device
+		if (!currentStatus.getConfiguration().hasRecoveryDevice()) {
+			currentStatus.getWarnings().add(Warning.NO_RECOVERY_DEVICE);
+		}
+		
 		currentStatus.getEventQueue().add(new FlightEvent(FlightEvent.Type.LAUNCH, 0, simulationConditions.getRocket()));
 		{
 			// main simulation branch 
@@ -340,11 +348,6 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 					addEvent(new FlightEvent(FlightEvent.Type.RECOVERY_DEVICE_DEPLOYMENT,
 							event.getTime() + Math.max(0.001, deployConfig.getDeployDelay()), c));
 				}
-			}
-
-			// Add a warning if there is no recovery device defined.
-			if (!currentStatus.getConfiguration().hasRecoveryDevice()) {
-				currentStatus.getWarnings().add(Warning.NO_RECOVERY_DEVICE);
 			}
 			
 			// Handle event


### PR DESCRIPTION
At present, when a simulation throws an exception it gets caught and turned into a warning.  Really, anything so bad the simulation can't finish ought to bring up the simulation error dialog.  This PR causes the "catch" code to record the abort in the flight event branch and then rethrow the exception.

Fixes #1611.  This is actually a more general solution than what I asked for there.

The attached .ork aborts because there are no motors configured to start at launch time.
[empty-booster.ork.txt](https://github.com/openrocket/openrocket/files/10015053/empty-booster.ork.txt)