### PR TITLE
Tell user where discontinuities in body tube diameter are

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -1829,7 +1829,7 @@ PlotConfiguration.Groundtrack = Ground track
 ! Warning
 Warning.LargeAOA.str1 = Large angle of attack encountered.
 Warning.LargeAOA.str2 = Large angle of attack encountered (
-Warning.DISCONTINUITY = Discontinuity in rocket body diameter.
+Warning.DISCONTINUITY = Discontinuity in rocket body diameter
 Warning.THICK_FIN = Thick fins may not be modeled accurately.
 Warning.JAGGED_EDGED_FIN = Jagged-edged fin predictions may be inaccurate.
 Warning.LISTENERS_AFFECTED = Listeners modified the flight simulation

--- a/core/resources/l10n/messages_cs.properties
+++ b/core/resources/l10n/messages_cs.properties
@@ -1315,7 +1315,7 @@ PlotConfiguration.Simulationtime = Simulacní krok a výpocetní cas
 ! Warning
 Warning.LargeAOA.str1 = Velký úhel nábehu.
 Warning.LargeAOA.str2 = Velký úhel nábehu (
-Warning.DISCONTINUITY = Nespojitost v prumeru tela rakety.
+Warning.DISCONTINUITY = Nespojitost v prumeru tela rakety
 Warning.THICK_FIN = Tlou\u0161tka stabilizátoru se nemu\u017Ee modelovat presne.
 Warning.JAGGED_EDGED_FIN = Zubaté hrany stabilizátoru mohou být vypocteny nepresne.
 Warning.LISTENERS_AFFECTED = Listeners modified the flight simulation

--- a/core/resources/l10n/messages_es.properties
+++ b/core/resources/l10n/messages_es.properties
@@ -1225,7 +1225,7 @@ TrapezoidFinSetCfg.tab.Generalproperties = Propiedades generales
 ! TubeCoupler
 TubeCoupler.TubeCoupler = Acoplador
 
-Warning.DISCONTINUITY                     = Discontinuidad en el di\u00e1metro del fuselaje.
+Warning.DISCONTINUITY                     = Discontinuidad en el di\u00e1metro del fuselaje
 Warning.FILE_INVALID_PARAMETER            = Par\u00e1metro encontrado no v\u00e1lido, ignorado.
 Warning.JAGGED_EDGED_FIN                  = El perfil afilado de las aletas puede ser inexacto.
 Warning.LISTENERS_AFFECTED                = Las Extensiones se ejecutaron con la simulaci\u00f3n del vuelo

--- a/core/resources/l10n/messages_fr.properties
+++ b/core/resources/l10n/messages_fr.properties
@@ -1219,7 +1219,7 @@ TrapezoidFinSetCfg.tab.Generalproperties = Propri\u00E9t\u00E9s g\u00E9n\u00E9ra
 ! TubeCoupler
 TubeCoupler.TubeCoupler = Coupleur de tube
 
-Warning.DISCONTINUITY                     = Discontinuit\u00E9 dans le diam\u00E8tre du corps de la fus\u00E9e.
+Warning.DISCONTINUITY                     = Discontinuit\u00E9 dans le diam\u00E8tre du corps de la fus\u00E9e
 Warning.FILE_INVALID_PARAMETER            = Param\u00E8tre invalide rencontr\u00E9, ignorer.
 Warning.JAGGED_EDGED_FIN                  = Des ailerons aux bords irr\u00E9guliers ne seront pas mod\u00E9lis\u00E9s correctement.
 Warning.LISTENERS_AFFECTED                = Les \u00E9couteurs ont modifi\u00E9 la simulation de vol

--- a/core/resources/l10n/messages_it.properties
+++ b/core/resources/l10n/messages_it.properties
@@ -1379,7 +1379,7 @@ PlotConfiguration.Simulationtime = Intervallo temporale della simulazione e temp
 ! Warning
 Warning.LargeAOA.str1 = Incontrato grande angolo d'attacco.
 Warning.LargeAOA.str2 = Incontrato grande angolo d'attacco (
-Warning.DISCONTINUITY = Discontinuita' nel diametro del tubo del corpo.
+Warning.DISCONTINUITY = Discontinuita' nel diametro del tubo del corpo
 Warning.THICK_FIN = Le pinne sottili potrebbero non essere modellate in modo accurato.
 Warning.JAGGED_EDGED_FIN = Jagged-edged fin Le predizioni per le pinne potrebbero non essere accurate.
 Warning.LISTENERS_AFFECTED = Gli osservatori possono modificare le condizioni di simulazione

--- a/core/resources/l10n/messages_nl.properties
+++ b/core/resources/l10n/messages_nl.properties
@@ -1688,7 +1688,7 @@ PlotConfiguration.Groundtrack = Grondspoor
 ! Warning
 Warning.LargeAOA.str1 = Grote invalshoek aangetroffen.
 Warning.LargeAOA.str2 = Grote invalshoek aangetroffen (
-Warning.DISCONTINUITY = Discontinuïteit in raketromp diameter.
+Warning.DISCONTINUITY = Discontinuïteit in raketromp diameter
 Warning.THICK_FIN = Dikke vinnen worden mogelijk niet nauwkeurig gemodelleerd.
 Warning.JAGGED_EDGED_FIN = De voorspellingen van gekartelde vinnen kunnen onnauwkeurig zijn.
 Warning.LISTENERS_AFFECTED = Luisteraars veranderden de vluchtsimulatie

--- a/core/resources/l10n/messages_pl.properties
+++ b/core/resources/l10n/messages_pl.properties
@@ -1319,7 +1319,7 @@ update.dlg.latestVersion = Korzystasz z najnowszej wersji OpenRocket: %s.
  ! Warning
  Warning.LargeAOA.str1  =  Wyst\u0105pi\u0142 du\u017Cy k\u0105t natarcia.
  Warning.LargeAOA.str2  =  Wyst\u0105pi\u0142 du\u017Cy k\u0105t natarcia (
- Warning.DISCONTINUITY  =  Nieci\u0105g\u0142o\u015B\u0107 \u015Brednicy rakiety.
+ Warning.DISCONTINUITY  =  Nieci\u0105g\u0142o\u015B\u0107 \u015Brednicy rakiety
  Warning.THICK_FIN  =  Grube stateczniki mog\u0105 nie by\u0107 modelowane dok\u0142adnie.
  Warning.JAGGED_EDGED_FIN  =  Stateczniki o nieregularnych kraw\u0119dziach mog\u0105 zmniejszy\u0107 dok\u0142adno\u015B\u0107 prognoz.
  Warning.LISTENERS_AFFECTED  =  Detektory zmodyfikowa\u0142y symulacj\u0119 lotu

--- a/core/resources/l10n/messages_pt.properties
+++ b/core/resources/l10n/messages_pt.properties
@@ -1182,7 +1182,7 @@ TrapezoidFinSetCfg.tab.Generalproperties = Propriedades gerais
 # TubeCoupler
 TubeCoupler.TubeCoupler = Acoplador de tubo
 
-Warning.DISCONTINUITY                     = Descontinuidade no di\u00e2metro do corpo do foguete.
+Warning.DISCONTINUITY                     = Descontinuidade no di\u00e2metro do corpo do foguete
 Warning.FILE_INVALID_PARAMETER            = Par\u00e2metro inv\u00e1lido encontrado, ignorando.
 Warning.JAGGED_EDGED_FIN                  = Previs\u00f5es com aletas de bordo irregular podem ser imprecisos.
 Warning.LISTENERS_AFFECTED                = Observador modificou a simula\u00e7\u00e3o de voo

--- a/core/resources/l10n/messages_uk_UA.properties
+++ b/core/resources/l10n/messages_uk_UA.properties
@@ -1535,7 +1535,7 @@ PlotConfiguration.Simulationtime = Simulation time step and computation time
 ! Warning
 Warning.LargeAOA.str1 = Large angle of attack encountered.
 Warning.LargeAOA.str2 = Large angle of attack encountered (
-Warning.DISCONTINUITY = Discontinuity in rocket body diameter.
+Warning.DISCONTINUITY = Discontinuity in rocket body diameter
 Warning.THICK_FIN = Thick fins may not be modeled accurately.
 Warning.JAGGED_EDGED_FIN = Jagged-edged fin predictions may be inaccurate.
 Warning.LISTENERS_AFFECTED = Listeners modified the flight simulation

--- a/core/resources/l10n/messages_zh_CN.properties
+++ b/core/resources/l10n/messages_zh_CN.properties
@@ -1299,7 +1299,7 @@ TubeFinSetCfg.lbl.Outerdiam        = \u5916\u76F4\u5F84:
 TubeFinSetCfg.lbl.Thickness        = \u539A\u5EA6:
 TubeFinSetCfg.lbl.ttip.Finrotation = \u7A33\u5B9A\u7FFC\u7EC4\u5408\u91CC\u7B2C\u4E00\u7247\u7684\u89D2\u5EA6
 
-Warning.DISCONTINUITY                     = \u7BAD\u4F53\u76F4\u5F84\u4E0D\u8FDE\u7EED.
+Warning.DISCONTINUITY                     = \u7BAD\u4F53\u76F4\u5F84\u4E0D\u8FDE\u7EED
 Warning.FILE_INVALID_PARAMETER            = \u65E0\u6548\u53C2\u6570, \u5FFD\u7565.
 Warning.JAGGED_EDGED_FIN                  = \u952F\u9F7F\u7FFC\u9884\u6D4B\u53EF\u80FD\u4E0D\u51C6\u786E.
 Warning.LISTENERS_AFFECTED                = \u76D1\u542C\u5668\u4FEE\u6539\u4E86\u98DE\u884C\u4EFF\u771F

--- a/core/src/net/sf/openrocket/aerodynamics/AerodynamicCalculator.java
+++ b/core/src/net/sf/openrocket/aerodynamics/AerodynamicCalculator.java
@@ -67,4 +67,9 @@ public interface AerodynamicCalculator extends Monitorable {
 	 * @return	a new, independent instance of this aerodynamic calculator type
 	 */
 	public AerodynamicCalculator newInstance();
+
+	/**
+	 * Test component assembly for continuity (esp. diameter), and post any needed warnings
+	 */
+	public void testIsContinuous(FlightConfiguration configuration, final RocketComponent component, WarningSet warnings);
 }

--- a/core/src/net/sf/openrocket/aerodynamics/AerodynamicCalculator.java
+++ b/core/src/net/sf/openrocket/aerodynamics/AerodynamicCalculator.java
@@ -67,6 +67,4 @@ public interface AerodynamicCalculator extends Monitorable {
 	 * @return	a new, independent instance of this aerodynamic calculator type
 	 */
 	public AerodynamicCalculator newInstance();
-		
-	public boolean isContinuous(FlightConfiguration configuration, final Rocket rkt);
 }

--- a/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
+++ b/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
@@ -274,8 +274,9 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 
 		return assemblyForces;
 	}
-	
-	private void testIsContinuous(FlightConfiguration configuration, final RocketComponent treeRoot, WarningSet warnings ){
+
+	@Override
+	public void testIsContinuous(FlightConfiguration configuration, final RocketComponent treeRoot, WarningSet warnings ){
 		Queue<RocketComponent> queue = new LinkedList<>();
 		for (RocketComponent child : treeRoot.getChildren()) {
 			// Ignore inactive stages

--- a/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
+++ b/core/src/net/sf/openrocket/aerodynamics/BarrowmanCalculator.java
@@ -251,10 +251,8 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 
 		if (calcMap == null)
 			buildCalcMap(configuration);
-		
-		if (!isContinuous(configuration, configuration.getRocket())){
-			warnings.add( Warning.DIAMETER_DISCONTINUITY);
-		}
+
+		testIsContinuous(configuration, configuration.getRocket(), warnings);
 		
 		final InstanceMap imap = configuration.getActiveInstances();
 
@@ -277,12 +275,7 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 		return assemblyForces;
 	}
 	
-	@Override
-	public boolean isContinuous(FlightConfiguration configuration, final Rocket rkt){
-		return testIsContinuous(configuration, rkt);
-	}
-	
-	private boolean testIsContinuous(FlightConfiguration configuration, final RocketComponent treeRoot ){
+	private void testIsContinuous(FlightConfiguration configuration, final RocketComponent treeRoot, WarningSet warnings ){
 		Queue<RocketComponent> queue = new LinkedList<>();
 		for (RocketComponent child : treeRoot.getChildren()) {
 			// Ignore inactive stages
@@ -292,9 +285,8 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 			queue.add(child);
 		}
 		
-		boolean isContinuous = true;
 		SymmetricComponent prevComp = null; 
-		while((isContinuous)&&( null != queue.peek())){
+		while(null != queue.peek()) {
 			RocketComponent comp = queue.poll();
 			if( comp instanceof SymmetricComponent ){
 				for (RocketComponent child : comp.getChildren()) {
@@ -313,7 +305,7 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 				
 				// Check for radius discontinuity
 				if ( !MathUtil.equals(sym.getForeRadius(), prevComp.getAftRadius())) {
-					isContinuous = false;
+					warnings.add( Warning.DIAMETER_DISCONTINUITY, sym + ", " + prevComp);					
 				}
 				
 				// double x = component.toAbsolute(Coordinate.NUL)[0].x;
@@ -327,11 +319,10 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 						
 				prevComp = sym;
 			}else if( comp instanceof ComponentAssembly ){
-				isContinuous &= testIsContinuous(configuration, comp);
+				testIsContinuous(configuration, comp, warnings);
 			}
 			
 		}
-		return isContinuous;
 	}
 		
 	

--- a/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java
+++ b/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java
@@ -288,8 +288,10 @@ public class BarrowmanCalculatorTest {
 		Rocket rocket = TestRockets.makeEstesAlphaIII();
 		AerodynamicCalculator calc = new BarrowmanCalculator();
 		FlightConfiguration configuration = rocket.getSelectedConfiguration();
+		WarningSet warnings = new WarningSet();
 		
-		assertTrue("Estes Alpha III should be continuous: ", calc.isContinuous(configuration, rocket));
+		calc.testIsContinuous(configuration, rocket, warnings);
+		assertTrue("Estes Alpha III should be continuous: ", warnings.isEmpty());		
 	}
 	
 	@Test
@@ -297,8 +299,10 @@ public class BarrowmanCalculatorTest {
 		Rocket rocket = TestRockets.makeFalcon9Heavy();
 		AerodynamicCalculator calc = new BarrowmanCalculator();
 		FlightConfiguration configuration = rocket.getSelectedConfiguration();
+		WarningSet warnings = new WarningSet();
 		
-		assertTrue("F9H should be continuous: ", calc.isContinuous(configuration, rocket));
+		calc.testIsContinuous(configuration, rocket, warnings);
+		assertTrue("F9H should be continuous: ", warnings.isEmpty());		
 	}
 	
 	@Test
@@ -306,6 +310,7 @@ public class BarrowmanCalculatorTest {
 		Rocket rocket = TestRockets.makeEstesAlphaIII();
 		AerodynamicCalculator calc = new BarrowmanCalculator();
 		FlightConfiguration configuration = rocket.getSelectedConfiguration();
+		WarningSet warnings = new WarningSet();
 		
 		NoseCone nose = (NoseCone)rocket.getChild(0).getChild(0);
 		BodyTube body = (BodyTube)rocket.getChild(0).getChild(1);
@@ -313,8 +318,9 @@ public class BarrowmanCalculatorTest {
 		nose.setAftRadius(0.015);
 		body.setOuterRadius( 0.012 );
 		body.setName( body.getName()+"  << discontinuous");
-		
-		assertFalse(" Estes Alpha III has an undetected discontinuity:", calc.isContinuous(configuration, rocket));
+
+		calc.testIsContinuous(configuration, rocket, warnings);
+		assertFalse(" Estes Alpha III has an undetected discontinuity:", warnings.isEmpty());		
 	}
 	
 	@Test
@@ -322,6 +328,7 @@ public class BarrowmanCalculatorTest {
 		Rocket rocket = TestRockets.makeFalcon9Heavy();
 		AerodynamicCalculator calc = new BarrowmanCalculator();
 		FlightConfiguration configuration = rocket.getSelectedConfiguration();
+		WarningSet warnings = new WarningSet();
 		
 		final AxialStage coreStage = (AxialStage)rocket.getChild(1);
 		final ParallelStage booster = (ParallelStage)coreStage.getChild(0).getChild(0);
@@ -333,7 +340,8 @@ public class BarrowmanCalculatorTest {
 		body.setOuterRadius( 0.012 );
 		body.setName( body.getName()+"  << discontinuous");
 		
-		assertFalse(" Missed discontinuity in Falcon 9 Heavy:", calc.isContinuous(configuration, rocket));
+		calc.testIsContinuous(configuration, rocket, warnings);
+		assertFalse(" Missed discontinuity in Falcon 9 Heavy:" , warnings.isEmpty());		
 	}
 
 	@Test


### PR DESCRIPTION
Now that warnings have an easy way to add additional information, let's make use of it to tell users *where* discontinuities exist in body tubes.

A simple .ork showing the changed warning is attached.

Fixes 241

[discontinuous.ork.txt](https://github.com/openrocket/openrocket/files/10024071/discontinuous.ork.txt)