### PR TITLE
[#1829] Fix tessellation issue on fins with curved root

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -33,7 +33,7 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 	 * Maximum number of root points in the root geometry.
 	 */
 	private static final int MAX_ROOT_DIVISIONS = 100;
-	private static final int MAX_ROOT_DIVISIONS_LOW_RES = 15;
+	private static final int MAX_ROOT_DIVISIONS_LOW_RES = MAX_ROOT_DIVISIONS / 5;
 
     public void setOverrideMass() {
     }


### PR DESCRIPTION
This PR fixes #1829. There was an issue with the tessellation creation of the fin polygon. Not gonna lie, I don't know what the actual issue was (I'm not used to OpenGL). I just searched for a bunch of example code on tessellation creation, tried a bunch of stuff and GitHub Copilot happened to propose the exact right piece of code for the tessellation `combine` method. So yeah, this PR is a happy little accident :) .

Because the fin 3D rendering is now more stable, I also increased the low poly fin resolution. So the root of a fin on curved surfaces is now rendered slightly more smooth than before. I still make it more low-poly than usual, otherwise the rendering can get slow.


https://user-images.githubusercontent.com/11031519/202320048-233ff2db-e662-4e24-bdf1-480d080e48c2.mov

