### PR TITLE
[#1842] More general string conversion to double for fin editor table

### DIFF
--- a/core/src/net/sf/openrocket/unit/UnitGroup.java
+++ b/core/src/net/sf/openrocket/unit/UnitGroup.java
@@ -18,6 +18,7 @@ import java.util.regex.Pattern;
 
 import net.sf.openrocket.rocketcomponent.FlightConfiguration;
 import net.sf.openrocket.rocketcomponent.Rocket;
+import net.sf.openrocket.util.StringUtil;
 
 
 /**
@@ -670,8 +671,8 @@ public class UnitGroup {
 		if (!matcher.matches()) {
 			throw new NumberFormatException("string did not match required pattern");
 		}
-		
-		double value = Double.parseDouble(matcher.group(1));
+
+		double value = StringUtil.convertToDouble(matcher.group(1));
 		String unit = matcher.group(2).trim();
 		
 		if (unit.equals("")) {

--- a/core/src/net/sf/openrocket/util/StringUtil.java
+++ b/core/src/net/sf/openrocket/util/StringUtil.java
@@ -19,5 +19,24 @@ public class StringUtil {
 		}
 		return "".equals(s.trim());
 	}
+
+	/**
+	 * Converts a string to a double, but with a more robust locale handling.
+	 * Some systems use a comma as a decimal separator, some a dot. This method
+	 * should work for both cases
+	 * @param input string to convert
+	 * @return double converted from string
+	 * @throws NumberFormatException   if the string cannot be parsed.
+	 */
+	public static double convertToDouble(String input) {
+		input = input.replace(',', '.');
+		int decimalSeparator = input.lastIndexOf('.');
+
+		if (decimalSeparator > -1) {
+			input = input.substring(0, decimalSeparator).replace(".", "") + input.substring(decimalSeparator);
+		}
+
+		return Double.parseDouble(input);
+	}
 	
 }

--- a/core/test/net/sf/openrocket/util/StringUtilTest.java
+++ b/core/test/net/sf/openrocket/util/StringUtilTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 /**
  * A class that tests
@@ -21,5 +22,26 @@ public class StringUtilTest {
 
         assertFalse(StringUtil.isEmpty("A"));
         assertFalse(StringUtil.isEmpty("         .        "));
+    }
+
+    @Test
+    public void testConvertToDouble() {
+        assertEquals(0.2, StringUtil.convertToDouble(".2"), MathUtil.EPSILON);
+        assertEquals(0.2, StringUtil.convertToDouble(",2"), MathUtil.EPSILON);
+        assertEquals(1, StringUtil.convertToDouble("1,"), MathUtil.EPSILON);
+        assertEquals(2, StringUtil.convertToDouble("2."), MathUtil.EPSILON);
+        assertEquals(1, StringUtil.convertToDouble("1"), MathUtil.EPSILON);
+        assertEquals(1.52, StringUtil.convertToDouble("1.52"), MathUtil.EPSILON);
+        assertEquals(1.52, StringUtil.convertToDouble("1,52"), MathUtil.EPSILON);
+        assertEquals(1.5, StringUtil.convertToDouble("1.500"), MathUtil.EPSILON);
+        assertEquals(1.5, StringUtil.convertToDouble("1,500"), MathUtil.EPSILON);
+        assertEquals(1500.61, StringUtil.convertToDouble("1.500,61"), MathUtil.EPSILON);
+        assertEquals(1500.61, StringUtil.convertToDouble("1,500.61"), MathUtil.EPSILON);
+        assertEquals(1500.2, StringUtil.convertToDouble("1,500,200"), MathUtil.EPSILON);
+        assertEquals(1500.2, StringUtil.convertToDouble("1.500.200"), MathUtil.EPSILON);
+        assertEquals(1500200.23, StringUtil.convertToDouble("1500200.23"), MathUtil.EPSILON);
+        assertEquals(1500200.23, StringUtil.convertToDouble("1500200,23"), MathUtil.EPSILON);
+        assertEquals(1500200.23, StringUtil.convertToDouble("1,500,200.23"), MathUtil.EPSILON);
+        assertEquals(1500200.23, StringUtil.convertToDouble("1.500.200,23"), MathUtil.EPSILON);
     }
 }


### PR DESCRIPTION
This PR fixes #1842. You can now type decimals using commas and dots in the fin shape editor table.