### PR TITLE
[#1849] Fix bounding box calculations for pods with mass components

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
@@ -748,7 +748,12 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 			} else {
 				// Legacy Case: These components do not implement the BoxBounded Interface.
 				Collection<Coordinate> instanceCoordinates = component.getComponentBounds();
+				List<RocketComponent> parsedContexts = new ArrayList<>();
 				for (InstanceContext context : contexts) {
+					// Don't parse the same context component twice (e.g. multiple copies in a pod set).
+					if (parsedContexts.contains(context.component)) {
+						continue;
+					}
 					Collection<Coordinate> transformedCoords = new ArrayList<>(instanceCoordinates);
 					// mutating.  Transforms coordinates in place.
 					context.transform.transform(instanceCoordinates);
@@ -759,7 +764,9 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 						}
 						componentBounds.update(tc);
 					}
+					parsedContexts.add(context.component);
 				}
+				parsedContexts.clear();
 			}
 
 			rocketBoundsAerodynamic.update(componentBoundsAerodynamic);

--- a/core/test/net/sf/openrocket/rocketcomponent/BoundingBoxTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/BoundingBoxTest.java
@@ -102,4 +102,37 @@ public class BoundingBoxTest extends BaseTestCase {
 		assertEquals(  0.12069451, bounds.max.z, EPSILON);
 	}
 
+	@Test
+	public void testPodsBoundingBox() {
+		Rocket rocket = TestRockets.makeEndPlateRocket();
+
+		// DEBUG
+		System.err.println(rocket.toDebugTree());
+
+		BoundingBox bounds = rocket.getBoundingBox();
+		assertEquals( 0.0,   bounds.min.x,  EPSILON);
+		assertEquals( 0.304, bounds.max.x, EPSILON);
+
+		assertEquals( -0.0365, bounds.min.y, EPSILON);
+		assertEquals(  0.0365, bounds.max.y, EPSILON);
+
+		assertEquals( -0.0365, bounds.min.z, EPSILON);
+		assertEquals(  0.0365, bounds.max.z, EPSILON);
+
+		// Add a mass component to the pod set (to test GitHub issue #1849)
+		PodSet podSet = (PodSet) rocket.getChild(0).getChild(1).getChild(1);
+		BodyTube tube = (BodyTube) podSet.getChild(0);
+		tube.addChild(new MassComponent());
+
+		bounds = rocket.getBoundingBox();
+		assertEquals( 0.0,   bounds.min.x,  EPSILON);
+		assertEquals( 0.304, bounds.max.x, EPSILON);
+
+		assertEquals( -0.0365, bounds.min.y, EPSILON);
+		assertEquals(  0.0365, bounds.max.y, EPSILON);
+
+		assertEquals( -0.0365, bounds.min.z, EPSILON);
+		assertEquals(  0.0365, bounds.max.z, EPSILON);
+	}
+
 }


### PR DESCRIPTION
This PR fixes #1849