### PR TITLE
[#1848] Allow only booster stage to be active

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
@@ -209,16 +209,16 @@ public class Rocket extends ComponentAssembly {
 	}
 
 	/**
-	 * Get the topmost stage, only taking into account active stages from the flight configuration.
+	 * Get the topmost stage (including boosters), only taking into account active stages from the flight configuration.
 	 * @param config flight configuration dictating which stages are active
 	 * @return the topmost active stage, or null if there are no active stages.
 	 */
 	public AxialStage getTopmostStage(FlightConfiguration config) {
 		if (config == null) return null;
 
-		for (int i = 0; i < getChildCount(); i++) {
-			if (getChild(i) instanceof AxialStage && config.isStageActive(getChild(i).getStageNumber())) {
-				return (AxialStage) getChild(i);
+		for (AxialStage stage : getStageList()) {
+			if (config.isStageActive(stage.getStageNumber())) {
+				return stage;
 			}
 		}
 		return null;

--- a/core/test/net/sf/openrocket/simulation/DisableStageTest.java
+++ b/core/test/net/sf/openrocket/simulation/DisableStageTest.java
@@ -236,6 +236,34 @@ public class DisableStageTest extends BaseTestCase {
     }
 
     /**
+     * Test whether the simulations run when only the booster stage is active.
+     */
+    @Test
+    public void testBooster3() {
+        Rocket rocketDisabled = TestRockets.makeFalcon9Heavy();
+
+        FlightConfigurationId fid =  new FlightConfigurationId(TestRockets.FALCON_9H_FCID_1);
+        Simulation simDisabled = new Simulation(rocketDisabled);
+        simDisabled.setFlightConfigurationId(fid);
+        simDisabled.getOptions().setISAAtmosphere(true);
+        simDisabled.getOptions().setTimeStep(0.05);
+
+        //// Test only enabling the booster stage (test for GitHub issue #1848)
+        simDisabled.getActiveConfiguration().setOnlyStage(2);
+
+        //// Test that the top stage is the booster stage
+        Assert.assertEquals(rocketDisabled.getTopmostStage(simDisabled.getActiveConfiguration()), rocketDisabled.getStage(2));
+
+        try {       // Just check that the simulation runs without exceptions
+            simDisabled.simulate();
+        } catch (SimulationException e) {
+            if (!(e instanceof MotorIgnitionException)) {
+                Assert.fail("Simulation failed: " + e);
+            }
+        }
+    }
+
+    /**
      * Compare simActual to simExpected and fail the unit test if there was an error during simulation or
      * the two don't match.
      * Tested parameters:


### PR DESCRIPTION
This PR fixes #1848 and allows to run simulations with only a booster stage active. I don't know how accurate the simulations are when you do that, but at least running the sim won't throw an exception.