### PR TITLE
[#1851] Reset button foreground on focus loss

### DIFF
--- a/swing/src/net/sf/openrocket/gui/widgets/SelectColorButton.java
+++ b/swing/src/net/sf/openrocket/gui/widgets/SelectColorButton.java
@@ -8,6 +8,8 @@ import javax.swing.UIManager;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import java.awt.Graphics;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
 
 public class SelectColorButton extends JButton {
     public SelectColorButton() {
@@ -51,6 +53,14 @@ public class SelectColorButton extends JButton {
                 else {
                     setForeground(UIManager.getColor("Button.foreground"));
                 }
+            }
+        });
+
+        // Need to add this, otherwise the foreground can remain in the selectForeground state when the button is clicked
+        addFocusListener(new FocusAdapter() {
+            @Override
+            public void focusLost(FocusEvent e) {
+                setForeground(UIManager.getColor("Button.foreground"));
             }
         });
     }


### PR DESCRIPTION
This PR fixes #1851. Since this is a macOS-issue, @hcraigmiller can't test it so I'll just assume that my testing was adequate and it functions as expected.