### PR TITLE
[#1679] Render fin set even if zero length

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FinSet.java
@@ -644,7 +644,7 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 
 			// calculate marginal area
 			final double delta_x = (cur.x - prev.x);
-			final double y_avg = (cur.y + prev.y)*0.5;
+			final double y_avg = (cur.y + prev.y)*0.5;	// TODO: MEDIUM: what if one of the points is below the x-axis? (can produce negative area)
 			double area_increment = delta_x*y_avg;
 			if( MathUtil.equals( 0, area_increment)){
 				prev = cur;
@@ -661,6 +661,11 @@ public abstract class FinSet extends ExternalComponent implements AxialPositiona
 			centroidSum = centroidSum.average( centroid_increment );
 
             prev=cur;
+		}
+
+		// Negative weight => make positive. TODO: This is NOT a correct solution, but at least it won't throw an exception...
+		if (centroidSum.weight < 0) {
+			centroidSum = new Coordinate(centroidSum.x, -centroidSum.y, centroidSum.z, Math.abs(centroidSum.weight));
 		}
 		
 		return centroidSum;

--- a/swing/src/net/sf/openrocket/gui/figure3d/geometry/FinRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/geometry/FinRenderer.java
@@ -81,7 +81,7 @@ public class FinRenderer {
 			GLU.gluTessCallback(tess, GLU.GLU_TESS_COMBINE, cb);
 
 			// fin side: +z
-			if (finSet.getSpan() > 0 && finSet.getLength() > 0 && which == Surface.INSIDE) {		// Right side
+			if (finSet.getSpan() > 0 && which == Surface.INSIDE) {		// Right side
 				GLU.gluTessBeginPolygon(tess, null);
 				GLU.gluTessBeginContour(tess);
 				gl.glNormal3f(0, 0, 1);
@@ -110,7 +110,7 @@ public class FinRenderer {
 			}
 			
 			// fin side: -z
-			if (finSet.getSpan() > 0 && finSet.getLength() > 0 && which == Surface.OUTSIDE) {		// Left side
+			if (finSet.getSpan() > 0 && which == Surface.OUTSIDE) {		// Left side
 				GLU.gluTessBeginPolygon(tess, null);
 				GLU.gluTessBeginContour(tess);
 				gl.glNormal3f(0, 0, -1);
@@ -142,7 +142,7 @@ public class FinRenderer {
 			GLU.gluDeleteTess(tess);
 			
 			// Fin strip around the edge
-			if (finSet.getSpan() > 0 && finSet.getLength() > 0 && which == Surface.EDGES) {
+			if (finSet.getSpan() > 0 && which == Surface.EDGES) {
 				if (!(finSet instanceof EllipticalFinSet))
 					gl.glShadeModel(GLLightingFunc.GL_FLAT);
 				gl.glBegin(GL.GL_TRIANGLE_STRIP);


### PR DESCRIPTION
This PR fixes #1679 by still rendering the fin set even if it has a zero-length (which happens when the last fin point is overlapping with the first one).