### PR TITLE
Disallow stage separation at launch

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/StageSeparationConfiguration.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/StageSeparationConfiguration.java
@@ -60,14 +60,6 @@ public class StageSeparationConfiguration implements FlightConfigurableParameter
 				return (mount == ignition);
 			}
 		},
-		//// Launch
-		LAUNCH(trans.get("Stage.SeparationEvent.LAUNCH")) {
-			@Override
-			public boolean isSeparationEvent(FlightEvent e, AxialStage stage) {
-				return e.getType() == FlightEvent.Type.LAUNCH;
-			}
-		},
-		//// Never
 		NEVER(trans.get("Stage.SeparationEvent.NEVER")) {
 			@Override
 			public boolean isSeparationEvent(FlightEvent e, AxialStage stage) {


### PR DESCRIPTION
Nobody has been able to think of a situation in which this is necessary or helpful, and it provides a way for new users to get in trouble.

Fixes #1611