### PR TITLE
[#1655] Use minimum mount bounds for fin set editor origin updating

### DIFF
--- a/core/src/net/sf/openrocket/util/BoundingBox.java
+++ b/core/src/net/sf/openrocket/util/BoundingBox.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 public class BoundingBox {
-	public Coordinate min;
-	public Coordinate max;
+	public Coordinate min;		// Top-left coordinate of the bounding box
+	public Coordinate max;		// Bottom-right coordinate of the bounding box
 
 	public BoundingBox() {
 	    clear();
@@ -158,7 +158,7 @@ public class BoundingBox {
 	public Rectangle2D toRectangle() {
 		return new Rectangle2D.Double(min.x, min.y, (max.x-min.x), (max.y - min.y));
     }
-	
+
 	@Override
 	public String toString() {
 		return String.format("[( %g, %g, %g) < ( %g, %g, %g)]",

--- a/swing/src/net/sf/openrocket/gui/scalefigure/AbstractScaleFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/AbstractScaleFigure.java
@@ -40,7 +40,7 @@ public abstract class AbstractScaleFigure extends JPanel {
 	protected double userScale = 1.0;
 	protected double scale = -1;
 
-	// pixel offset from the the subject's origin to the canvas's upper-left-corner.
+	// pixel offset from the subject's origin to the canvas's upper-left-corner.
 	protected Point originLocation_px = new Point(0,0);
 	
 	// size of the visible region

--- a/swing/src/net/sf/openrocket/gui/scalefigure/FinPointFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/FinPointFigure.java
@@ -54,6 +54,7 @@ public class FinPointFigure extends AbstractScaleFigure {
 	private int modID = -1;
 
 	protected BoundingBox finBounds_m = null;
+	// Fin parent bounds
 	protected BoundingBox mountBounds_m = null;
 
 	protected final List<StateChangeListener> listeners = new LinkedList<>();
@@ -386,20 +387,20 @@ public class FinPointFigure extends AbstractScaleFigure {
 
 	@Override
 	protected void updateCanvasOrigin() {
-		final int finHeightPx = (int)(finBounds_m.max.y*scale);
-		final int mountHeightPx = (int)(mountBounds_m.span().y*scale);
+		final int finBottomPy = (int)(finBounds_m.max.y*scale);
+		final int mountHeight = (int)(mountBounds_m.span().y*scale);
 		// this is non-intuitive: it's an offset _from_ the origin(0,0) _to_ the lower-left of the content --
 		// because the canvas is drawn from that lower-left corner of the content, and the fin-front
 		// is fixed-- by definition-- to the origin.
 		final int finFrontPx = -(int)(contentBounds_m.getX()*scale);  // pixels from left-border to fin-front
-		final int contentHeightPx = (int)(contentBounds_m.getHeight()*scale);
+		final int contentHeight = (int)(contentBounds_m.getHeight()*scale);
 
 		originLocation_px.x = borderThickness_px.width + finFrontPx;
 
-		if( visibleBounds_px.height > (contentHeightPx + 2*borderThickness_px.height)){
-			originLocation_px.y = getHeight() - mountHeightPx - borderThickness_px.height;
+		if( visibleBounds_px.height > (contentHeight + 2*borderThickness_px.height)){
+			originLocation_px.y = getHeight() - mountHeight - borderThickness_px.height;
 		}else {
-			originLocation_px.y = borderThickness_px.height + finHeightPx;
+			originLocation_px.y = borderThickness_px.height + finBottomPy;
 		}
 	}
 


### PR DESCRIPTION
This PR fixes #1655, where the fin set editor could sometimes go off-screen for fins on nose cones or transitions.