### PR TITLE
Reformat bug report dialog

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -157,14 +157,14 @@ bugreport.dlg.but.Sendbugreport.Ttip = Automatically send the bug report to the 
 bugreport.dlg.successmsg1 = Bug report successfully sent.
 bugreport.dlg.successmsg2 = Thank you for helping make OpenRocket better!
 bugreport.dlg.successmsg3 = Bug report sent
-bugreport.dlg.connectedInternet = <html>To submit a bug online, include the text below at:
-bugreport.dlg.otherwise = <html>To submit a bug via email, send the text below to:
+bugreport.dlg.connectedInternet = <html>&nbsp;&nbsp; To submit a bug online, include the text below at:
+bugreport.dlg.otherwise = <html>&nbsp;&nbsp; To submit a bug via email, send the text below to:
 bugreport.lbl.Theinformation = The information above may be included in a public bug report. Make sure it does not contain any sensitive information you do not want to be made public.
 bugreport.dlg.failedmsg1 = OpenRocket was unable to send the bug report:
 bugreport.dlg.failedmsg2 = Please send the report manually to
 bugreport.dlg.failedmsg3 = Error sending report
 bugreport.reportDialog.txt = <html><b>Bugs can be reported at the OpenRocket Github project site or by email.</b>
-bugreport.reportDialog.txt2 = <html><b>Please include a short description about what you were doing when the exception occurred.</b>
+bugreport.reportDialog.txt2 = <html><b>Sorry for the bug\u2026 \u2639 Please help us fix it by sending this bug report!</b>
 bugreport.dlg.provideDescription = Please provide a description of the bug first.
 bugreport.dlg.provideDescription.title = Bug description missing
 

--- a/core/resources/l10n/messages_ja.properties
+++ b/core/resources/l10n/messages_ja.properties
@@ -146,7 +146,7 @@ bugreport.dlg.failedmsg1  = OpenRocket was unable to send the bug report:
 bugreport.dlg.failedmsg2  = Please send the report manually to
 bugreport.dlg.failedmsg3  = Error sending report
 bugreport.reportDialog.txt  = <html><b>You can report a bug in OpenRocket by filling in and submitting the form below.</b><br>You can also report bugs and include attachments on the project web site.
-bugreport.reportDialog.txt2  = <html><b>Please include a short description about what you were doing when the exception occurred.</b>
+bugreport.reportDialog.txt2  = <html><b>Sorry for the bug\u2026 \u2639 Please help us fix it by sending this bug report!</b>
 bugreport.dlg.provideDescription  = Please provide a description of the bug first.
 bugreport.dlg.provideDescription.title  = Bug description missing
 

--- a/core/resources/l10n/messages_nl.properties
+++ b/core/resources/l10n/messages_nl.properties
@@ -150,7 +150,7 @@ bugreport.dlg.failedmsg1 = OpenRocket was niet in staat om het foutrapport te ve
 bugreport.dlg.failedmsg2 = Stuur het rapport handmatig naar
 bugreport.dlg.failedmsg3 = Fout bij verzenden rapport
 bugreport.reportDialog.txt = <html><b>Fouten kunnen worden gemeld op de OpenRocket Github projectsite of via e-mail.</b>
-bugreport.reportDialog.txt2 = <html><b>Geef een korte beschrijving van wat u aan het doen was toen de uitzondering zich voordeed.</b>
+bugreport.reportDialog.txt2 = <html><b>Sorry voor de fout \u2026 \u2639 Help ons het op te lossen door dit rapport te versturen!</b>
 bugreport.dlg.provideDescription = Geef eerst een beschrijving van de fout.
 bugreport.dlg.provideDescription.title = Foutbeschrijving ontbreekt
 

--- a/core/resources/l10n/messages_uk_UA.properties
+++ b/core/resources/l10n/messages_uk_UA.properties
@@ -153,7 +153,7 @@ bugreport.dlg.failedmsg1 = OpenRocket was unable to send the bug report:
 bugreport.dlg.failedmsg2 = Please send the report manually to
 bugreport.dlg.failedmsg3 = Error sending report
 bugreport.reportDialog.txt = <html><b>You can report a bug in OpenRocket by filling in and submitting the form below.</b><br>You can also report bugs and include attachments on the project web site.
-bugreport.reportDialog.txt2 = <html><b>Please include a short description about what you were doing when the exception occurred.</b>
+bugreport.reportDialog.txt2 = <html><b>Sorry for the bug\u2026 \u2639 Please help us fix it by sending this bug report!</b>
 bugreport.dlg.provideDescription = Please provide a description of the bug first.
 bugreport.dlg.provideDescription.title = Bug description missing
 

--- a/swing/src/net/sf/openrocket/gui/dialogs/BugReportDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/BugReportDialog.java
@@ -53,15 +53,15 @@ public class BugReportDialog extends JDialog {
 		JPanel panel = new JPanel(new MigLayout("fill"));
 		
 		// Some fscking Swing bug that makes html labels initially way too high
-		JLabel label = new JLabel(labelText);
-		Dimension d = label.getPreferredSize();
+		StyledLabel titleLabel = new StyledLabel(labelText, 0);
+		Dimension d = titleLabel.getPreferredSize();
 		d.width = 100000;
-		label.setMaximumSize(d);
-		panel.add(label, "gapleft para, wrap para");
+		titleLabel.setMaximumSize(d);
+		panel.add(titleLabel, "gapleft para, wrap para");
 		
 		//// <html>If connected to the Internet, you can simply click 
 		//// <em>Send bug report</em>.
-		label = new JLabel(trans.get("bugreport.dlg.connectedInternet"));
+		JLabel label = new JLabel(trans.get("bugreport.dlg.connectedInternet"));
 		panel.add(label, "gapleft para, split 2, gapright rel");
 		
 		panel.add(new URLLabel(NEW_ISSUES_URL), "growx, wrap para");
@@ -160,13 +160,17 @@ public class BugReportDialog extends JDialog {
 		
 		sb.append("<html>---------- Bug report ----------\n");
 		sb.append('\n');
-		sb.append("<b>Please include a description about what actions you were " +
+		sb.append("<b style='color:rgb(210, 20, 5)'>Please include a description about what actions you were " +
 				"performing when the exception occurred:</b>\n");
 		sb.append("<i>(You can edit text directly in this window)</i>\n");
 		sb.append('\n');
 		sb.append("1. \n");
 		sb.append("2. \n");
 		sb.append("3. \n");
+
+		sb.append("\n");
+		sb.append("<b>If possible, please send us the .ork file that caused the bug.</b>\n");
+		sb.append('\n');
 		
 		
 		sb.append("Include your email address (optional; it helps if we can " +


### PR DESCRIPTION
Since we have to ask users a thousand times to send their .ork file and give the steps to reproduce an error:
![image](https://user-images.githubusercontent.com/11031519/205098429-8592ce9f-51b3-4195-915c-c60bd4ace45e.png)
