### PR TITLE
Support multi-comp fin set shape editing

### DIFF
--- a/core/test/net/sf/openrocket/rocketcomponent/FreeformFinSetTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/FreeformFinSetTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.awt.geom.Point2D;
 
@@ -432,7 +433,11 @@ public class FreeformFinSetTest extends BaseTestCase {
 		//   /    |
 		//  +=====+
 		Point2D.Double toAdd = new Point2D.Double(1.01, 0.8);
-		fin.addPoint(3, toAdd);
+		try {
+			fin.addPoint(3, toAdd);
+		} catch (IllegalFinPointException e) {
+			fail("IllegalFinPointException thrown");
+		}
 		
         assertEquals(5, fin.getPointCount());
         final Coordinate added = fin.getFinPoints()[3];
@@ -441,7 +446,7 @@ public class FreeformFinSetTest extends BaseTestCase {
 	}
 
     @Test
-    public void testSetFirstPoint() {
+    public void testSetFirstPoint() throws IllegalFinPointException {
     	// more transitions trigger more complicated positioning math:  
 		final Rocket rkt = createTemplateRocket();
 		final Transition tailCone = (Transition) rkt.getChild(0).getChild(2);
@@ -605,7 +610,7 @@ public class FreeformFinSetTest extends BaseTestCase {
     }
 
     @Test
-    public void testSetLastPoint() {
+    public void testSetLastPoint() throws IllegalFinPointException {
     	final Rocket rkt = createTemplateRocket();
 		final Transition tailCone = (Transition) rkt.getChild(0).getChild(2);
 		final FreeformFinSet fins = createFinOnConicalTransition(tailCone);
@@ -771,7 +776,7 @@ public class FreeformFinSetTest extends BaseTestCase {
 	}
 
     @Test
-    public void testSetInteriorPoint() {
+    public void testSetInteriorPoint() throws IllegalFinPointException {
     	final Rocket rkt = createTemplateRocket();
     	final Transition tailCone = (Transition) rkt.getChild(0).getChild(2);
 		final FreeformFinSet fins = this.createFinOnConicalTransition(tailCone);
@@ -875,7 +880,7 @@ public class FreeformFinSetTest extends BaseTestCase {
 	}
 
     @Test
-    public void testSetFirstPoint_clampToLast() {
+    public void testSetFirstPoint_clampToLast() throws IllegalFinPointException {
     	final Rocket rkt = createTemplateRocket();
     	final Transition tailCone = (Transition) rkt.getChild(0).getChild(2);
 		final FreeformFinSet fins = this.createFinOnConicalTransition(tailCone);
@@ -906,7 +911,7 @@ public class FreeformFinSetTest extends BaseTestCase {
     }
     
     @Test
-    public void testSetPoint_otherPoint(){
+    public void testSetPoint_otherPoint() throws IllegalFinPointException {
     	// combine the simple case with the complicated to ensure that the simple case is flagged, tested, and debugged before running the more complicated case...
     	{ // setting points on a Tube Body is the simpler case. Test this first: 
 	    	final Rocket rkt = createTemplateRocket();

--- a/swing/src/net/sf/openrocket/gui/configdialog/FreeformFinSetConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/FreeformFinSetConfig.java
@@ -466,7 +466,7 @@ public class FreeformFinSetConfig extends FinSetConfig {
 	 * Insert a new fin point between the currently selected point and the next point.
 	 * The coordinates of the new point will be the average of the two points.
 	 */
-	private void insertPoint() {
+	private void insertPoint() throws IllegalFinPointException {
 		int currentPointIdx = table.getSelectedRow();
 		if (currentPointIdx == -1 || currentPointIdx >= table.getRowCount() - 1) {
 			return;
@@ -532,7 +532,11 @@ public class FreeformFinSetConfig extends FinSetConfig {
 			final int segmentIndex = getSegment(event);
 			if (segmentIndex >= 0) {
 				Point2D.Double point = getCoordinates(event);
-				finset.addPoint(segmentIndex, point);
+				try {
+					finset.addPoint(segmentIndex, point);
+				} catch (IllegalFinPointException e) {
+					throw new RuntimeException(e);
+				}
 
 				dragIndex = segmentIndex;
 				dragPoint = event.getPoint();
@@ -554,7 +558,11 @@ public class FreeformFinSetConfig extends FinSetConfig {
 
 			Point2D.Double point = getCoordinates(event);
 			final FreeformFinSet finset = (FreeformFinSet) component;
-			finset.setPoint(dragIndex, point.x, point.y);
+			try {
+				finset.setPoint(dragIndex, point.x, point.y);
+			} catch (IllegalFinPointException e) {
+				throw new RuntimeException(e);
+			}
 
 			dragPoint.x = event.getX();
 			dragPoint.y = event.getY();
@@ -782,6 +790,8 @@ public class FreeformFinSetConfig extends FinSetConfig {
 				updateFields();
 			} catch (NumberFormatException ignore) {
 			    log.warn("ignoring NumberFormatException while editing a Freeform Fin");
+			} catch (IllegalFinPointException e) {
+				throw new RuntimeException(e);
 			}
 		}
 	}
@@ -800,7 +810,11 @@ public class FreeformFinSetConfig extends FinSetConfig {
 
 		@Override
 		public void actionPerformed(ActionEvent e) {
-			insertPoint();
+			try {
+				insertPoint();
+			} catch (IllegalFinPointException ex) {
+				throw new RuntimeException(ex);
+			}
 		}
 
 		@Override


### PR DESCRIPTION
This PR support multi-component fin set shape editing.

The basic principle is:
1. Editing the first fin point of the main fin set will edit the first fin point of the listener fin set
2. Editing the last fin point of the main fin set will edit the last fin point of the listener fin set
3. Editing intermediate fin points of the main fin set will edit the correspondingly indexed fin points of the listener fin set
    1. If the main fin set has more points than the listener fin set, then ignore the out-of-bound points for the listener fin set
    2. If the main fin set has more points than the listener fin set, e.g. main set has 5 points, listener set 4 points, if you edit point 4 of the main fin set (second-to-last point if the main set, last point of the listener set), then point 4 of the listener fin set will **not** be edited. You can only edit the last point of the listener set by editing the last point of the main fin set.

Basically a lot of rules that try to say: "Just use multi-comp fin set shape editing for fins that have the same shape".


https://user-images.githubusercontent.com/11031519/205123751-037f18f7-aa4f-4dbb-9cdb-cb41008396bd.mp4

