### PR TITLE
[#1021] Add extra root point(s) if fin is outside parent's bounds

### DIFF
--- a/core/test/net/sf/openrocket/rocketcomponent/FreeformFinSetTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/FreeformFinSetTest.java
@@ -1339,6 +1339,8 @@ public class FreeformFinSetTest extends BaseTestCase {
 
 			assertEquals("incorrect body points! ", 0.5f, rootPoints[2].x, EPSILON);
 			assertEquals("incorrect body points! ", -0.2f, rootPoints[2].y, EPSILON);
+
+			assertEquals("incorrect fin mass! ", 0.306, fins.getMass(), EPSILON);
 		} { // move both first and last point out of bounds to the left
 			fins.setAxialOffset(AxialMethod.TOP, 0);
 			fins.setPoints(initialPoints);
@@ -1357,6 +1359,8 @@ public class FreeformFinSetTest extends BaseTestCase {
 
 			assertEquals("incorrect body points! ", 0.1f, rootPoints[1].x, EPSILON);
 			assertEquals("incorrect body points! ", 0f, rootPoints[1].y, EPSILON);
+
+			assertEquals("incorrect fin mass! ", 0.034, fins.getMass(), EPSILON);
 		} { // move last point out of bounds, keep first point in bounds
 			fins.setPoints(initialPoints);
 			fins.setAxialOffset(AxialMethod.BOTTOM, fins.getLength());
@@ -1378,6 +1382,8 @@ public class FreeformFinSetTest extends BaseTestCase {
 
 			assertEquals("incorrect body points! ", 0.2f, rootPoints[2].x, EPSILON);
 			assertEquals("incorrect body points! ", -0.05f, rootPoints[2].y, EPSILON);
+
+			assertEquals("incorrect fin mass! ", 0.102, fins.getMass(), EPSILON);
 		} { // move both first and last point out of bounds to the right
 			fins.setPoints(initialPoints);
 			fins.setAxialOffset(AxialMethod.BOTTOM, fins.getLength());
@@ -1396,6 +1402,8 @@ public class FreeformFinSetTest extends BaseTestCase {
 
 			assertEquals("incorrect body points! ", 0.2f, rootPoints[1].x, EPSILON);
 			assertEquals("incorrect body points! ", 0f, rootPoints[1].y, EPSILON);
+
+			assertEquals("incorrect fin mass! ", 0.068, fins.getMass(), EPSILON);
 		}  { // move first point out of bounds to the left, and last point out of bounds to the right
 			fins.setAxialOffset(AxialMethod.TOP, 0);
 			fins.setPoints(initialPoints);
@@ -1420,6 +1428,8 @@ public class FreeformFinSetTest extends BaseTestCase {
 
 			assertEquals("incorrect body points! ", 1.2f, rootPoints[3].x, EPSILON);
 			assertEquals("incorrect body points! ", -0.5f, rootPoints[3].y, EPSILON);
+
+			assertEquals("incorrect fin mass! ", 0.833, fins.getMass(), EPSILON);
 		}
 	}
 

--- a/core/test/net/sf/openrocket/rocketcomponent/FreeformFinSetTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/FreeformFinSetTest.java
@@ -1311,6 +1311,119 @@ public class FreeformFinSetTest extends BaseTestCase {
 	}
 
 	@Test
+	public void testGenerateBodyPointsWhenFinOutsideParentBounds() {
+		final Rocket rkt = createTemplateRocket();
+		final Transition tailCone = (Transition) rkt.getChild(0).getChild(2);
+		final FreeformFinSet fins = this.createFinOnConicalTransition(tailCone);
+		final Coordinate[] initialPoints = fins.getFinPoints();
+
+		assertEquals(1.0, tailCone.getLength(), EPSILON);
+
+		{ // move first point out of bounds, keep last point in bounds
+			fins.setAxialOffset(AxialMethod.TOP, 0);
+			fins.setPoints(initialPoints);
+			assertEquals(0f, fins.getFinFront().x, EPSILON);
+			assertEquals(1f, fins.getFinFront().y, EPSILON);
+
+			// Move first point
+			fins.setPoint(0, -0.1, 0.1f);
+
+			final Coordinate[] rootPoints = fins.getRootPoints();
+			assertEquals(3, rootPoints.length);
+
+			assertEquals("incorrect body points! ", 0f, rootPoints[0].x, EPSILON);
+			assertEquals("incorrect body points! ", 0f, rootPoints[0].y, EPSILON);
+
+			assertEquals("incorrect body points! ", 0.1f, rootPoints[1].x, EPSILON);
+			assertEquals("incorrect body points! ", 0f, rootPoints[1].y, EPSILON);
+
+			assertEquals("incorrect body points! ", 0.5f, rootPoints[2].x, EPSILON);
+			assertEquals("incorrect body points! ", -0.2f, rootPoints[2].y, EPSILON);
+		} { // move both first and last point out of bounds to the left
+			fins.setAxialOffset(AxialMethod.TOP, 0);
+			fins.setPoints(initialPoints);
+			assertEquals(0f, fins.getFinFront().x, EPSILON);
+			assertEquals(1f, fins.getFinFront().y, EPSILON);
+
+			// Move first and last point
+			fins.setPoint(0, -0.2, 0.1f);
+			fins.setPoint(fins.getPointCount()-1, 0.1, 0.1f);
+
+			final Coordinate[] rootPoints = fins.getRootPoints();
+			assertEquals(2, rootPoints.length);
+
+			assertEquals("incorrect body points! ", 0f, rootPoints[0].x, EPSILON);
+			assertEquals("incorrect body points! ", 0f, rootPoints[0].y, EPSILON);
+
+			assertEquals("incorrect body points! ", 0.1f, rootPoints[1].x, EPSILON);
+			assertEquals("incorrect body points! ", 0f, rootPoints[1].y, EPSILON);
+		} { // move last point out of bounds, keep first point in bounds
+			fins.setPoints(initialPoints);
+			fins.setAxialOffset(AxialMethod.BOTTOM, fins.getLength());
+			assertEquals(1f, fins.getFinFront().x, EPSILON);
+			assertEquals(0.5f, fins.getFinFront().y, EPSILON);
+
+			// Move first point
+			fins.setPoint(0, -0.1f, 0.1f);
+			fins.setPoint(fins.getPointCount()-1, 0.2f, 0f);
+
+			final Coordinate[] rootPoints = fins.getRootPoints();
+			assertEquals(3, rootPoints.length);
+
+			assertEquals("incorrect body points! ", 0f, rootPoints[0].x, EPSILON);
+			assertEquals("incorrect body points! ", 0f, rootPoints[0].y, EPSILON);
+
+			assertEquals("incorrect body points! ", 0.1f, rootPoints[1].x, EPSILON);
+			assertEquals("incorrect body points! ", -0.05f, rootPoints[1].y, EPSILON);
+
+			assertEquals("incorrect body points! ", 0.2f, rootPoints[2].x, EPSILON);
+			assertEquals("incorrect body points! ", -0.05f, rootPoints[2].y, EPSILON);
+		} { // move both first and last point out of bounds to the right
+			fins.setPoints(initialPoints);
+			fins.setAxialOffset(AxialMethod.BOTTOM, fins.getLength());
+			assertEquals(1f, fins.getFinFront().x, EPSILON);
+			assertEquals(0.5f, fins.getFinFront().y, EPSILON);
+
+			// Move first and last point
+			fins.setPoint(0, 0.1, 0.1f);
+			fins.setPoint(fins.getPointCount()-1, 0.2, 0.1f);
+
+			final Coordinate[] rootPoints = fins.getRootPoints();
+			assertEquals(2, rootPoints.length);
+
+			assertEquals("incorrect body points! ", 0f, rootPoints[0].x, EPSILON);
+			assertEquals("incorrect body points! ", 0f, rootPoints[0].y, EPSILON);
+
+			assertEquals("incorrect body points! ", 0.2f, rootPoints[1].x, EPSILON);
+			assertEquals("incorrect body points! ", 0f, rootPoints[1].y, EPSILON);
+		}  { // move first point out of bounds to the left, and last point out of bounds to the right
+			fins.setAxialOffset(AxialMethod.TOP, 0);
+			fins.setPoints(initialPoints);
+			assertEquals(0, fins.getFinFront().x, EPSILON);
+			assertEquals(1, fins.getFinFront().y, EPSILON);
+
+			// Move first and last point
+			fins.setPoint(0, -0.1, 0.1f);
+			fins.setPoint(fins.getPointCount()-1, 1.2, -0.1f);
+
+			final Coordinate[] rootPoints = fins.getRootPoints();
+			assertEquals(4, rootPoints.length);
+
+			assertEquals("incorrect body points! ", 0f, rootPoints[0].x, EPSILON);
+			assertEquals("incorrect body points! ", 0f, rootPoints[0].y, EPSILON);
+
+			assertEquals("incorrect body points! ", 0.1f, rootPoints[1].x, EPSILON);
+			assertEquals("incorrect body points! ", 0f, rootPoints[1].y, EPSILON);
+
+			assertEquals("incorrect body points! ", 1.1f, rootPoints[2].x, EPSILON);
+			assertEquals("incorrect body points! ", -0.5f, rootPoints[2].y, EPSILON);
+
+			assertEquals("incorrect body points! ", 1.2f, rootPoints[3].x, EPSILON);
+			assertEquals("incorrect body points! ", -0.5f, rootPoints[3].y, EPSILON);
+		}
+	}
+
+	@Test
 	public void testFreeFormCMWithNegativeY() throws Exception {
 		final Rocket rkt = createTemplateRocket();
 	    final BodyTube body = (BodyTube) rkt.getChild(0).getChild(1);

--- a/swing/src/net/sf/openrocket/gui/scalefigure/FinPointFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/FinPointFigure.java
@@ -226,7 +226,7 @@ public class FinPointFigure extends AbstractScaleFigure {
 
 	private void paintFinShape(final Graphics2D g2){
 		// excludes fin tab points
-		final Coordinate[] drawPoints = finset.getFinPoints();
+		final Coordinate[] drawPoints = finset.getFinPointsWithRoot();
 
 		Path2D.Double shape = new Path2D.Double();
 		Coordinate startPoint= drawPoints[0];


### PR DESCRIPTION
This PR fixes #1021. There is now an extra root point added at the front of the parent when the first fin point goes out of the parent's bounds. Same effect for the last point. When both the first and last fin point are outside the bounds (either to the left or right), no extra root point is added.


https://user-images.githubusercontent.com/11031519/206334470-56ddebac-726c-4f22-b6a6-e6a4d8cac56c.mov

