### PR TITLE
Replace "Data is out of date" to "Out of date"

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -545,7 +545,7 @@ simpanel.col.Timetoapogee = Time to apogee
 simpanel.col.Flighttime = Flight time
 simpanel.col.Groundhitvelocity = Ground hit velocity
 simpanel.ttip.uptodate = <i>Up to date</i>
-simpanel.ttip.outdated = <i><font color=\"red\">Data is out of date</font></i><br>Click <i><b>Run simulations</b></i> to simulate.
+simpanel.ttip.outdated = <i><font color=\"red\">Out of date</font></i><br>Click <i><b>Run simulations</b></i> to simulate.
 simpanel.ttip.external = <i>Imported data</i>
 simpanel.ttip.notSimulated = <i>Not simulated yet</i><br>Click <i><b>Run simulations</b></i> to simulate.
 simpanel.ttip.noData = No simulation data available.

--- a/core/resources/l10n/messages_uk_UA.properties
+++ b/core/resources/l10n/messages_uk_UA.properties
@@ -446,7 +446,7 @@ simpanel.col.Timetoapogee = Time to apogee
 simpanel.col.Flighttime = Flight time
 simpanel.col.Groundhitvelocity = Ground hit velocity
 simpanel.ttip.uptodate = <i>Up to date</i>
-simpanel.ttip.outdated = <i><font color=\"red\">Data is out of date</font></i><br>Click <i><b>Run simulations</b></i> to simulate.
+simpanel.ttip.outdated = <i><font color=\"red\">Out of date</font></i><br>Click <i><b>Run simulations</b></i> to simulate.
 simpanel.ttip.external = <i>Imported data</i>
 simpanel.ttip.notSimulated = <i>Not simulated yet</i><br>Click <i><b>Run simulations</b></i> to simulate.
 simpanel.ttip.noData = No simulation data available.

--- a/core/src/net/sf/openrocket/file/CSVExport.java
+++ b/core/src/net/sf/openrocket/file/CSVExport.java
@@ -182,7 +182,7 @@ public class CSVExport {
 			break;
 
 		case OUTDATED:
-			line += " (Data is out of date)";
+			line += " (Out of date)";
 			break;
 
 		case EXTERNAL:


### PR DESCRIPTION
#1821 made clear that my personal annoyance is unjustified. But it did bring up the fact that the text "Data is out of date" should be replace by "Out of date", analogous to how "Up to date" is displayed.