### PR TITLE
Increase default PS settings window size

### DIFF
--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoFrame.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoFrame.java
@@ -91,8 +91,8 @@ public class PhotoFrame extends JFrame {
 			}
 		});
 
-		setSize(1024, 768);
 		this.setMinimumSize(new Dimension(160, 150));
+		this.setSize(1024, 768);
 		photoPanel = new PhotoPanel(document, p);
 		photoPanel.setDoc(document);
 		setJMenuBar(getMenu(app));
@@ -117,6 +117,7 @@ public class PhotoFrame extends JFrame {
 		settings = new JDialog(this, trans.get("PhotoSettingsConfig.title")) {
 			{
 				setContentPane(new PhotoSettingsConfig(p, document));
+				setPreferredSize(new Dimension(600, 500));
 				pack();
 				this.setLocationByPlatform(true);
 				GUIUtil.rememberWindowSize(this);


### PR DESCRIPTION
If you opened PhotoStudio for the first time, the settings window was way too small:
<img width="1552" alt="Screenshot 2022-12-12 at 21 05 40" src="https://user-images.githubusercontent.com/11031519/207143908-a26d8dca-2fba-4ca6-8494-1c83181f4b37.png">

This PR fixes it:
<img width="1557" alt="image" src="https://user-images.githubusercontent.com/11031519/207144346-5fb7530f-4f66-4652-a94d-7d3e42669208.png">

You can now also close the settings dialog using the escape key, and the settings dialog now gains focus when starting up PhotoStudio, instead of the PhotoFrame having focus.