### PR TITLE
Require designation match

### DIFF
--- a/core/src/net/sf/openrocket/database/motor/ThrustCurveMotorSet.java
+++ b/core/src/net/sf/openrocket/database/motor/ThrustCurveMotorSet.java
@@ -220,6 +220,9 @@ public class ThrustCurveMotorSet implements Comparable<ThrustCurveMotorSet> {
 				(type != m.getMotorType())) {
 			return false;
 		}
+
+		if (!designation.equalsIgnoreCase(m.getDesignation()))
+			return false;
 		
 		if (!commonName.equalsIgnoreCase(m.getCommonName()))
 			return false;

--- a/core/test/net/sf/openrocket/database/ThrustCurveMotorSetTest.java
+++ b/core/test/net/sf/openrocket/database/ThrustCurveMotorSetTest.java
@@ -23,7 +23,7 @@ public class ThrustCurveMotorSetTest {
 	private static final ThrustCurveMotor motor1 = new ThrustCurveMotor.Builder()
 			.setManufacturer(Manufacturer.getManufacturer("A"))
 			.setCommonName("F12")
-			.setDesignation("F12X")
+			.setDesignation("F12")
 			.setDescription("Desc")
 			.setMotorType(Motor.Type.UNKNOWN)
 			.setStandardDelays(new double[] {})
@@ -38,7 +38,7 @@ public class ThrustCurveMotorSetTest {
 	private static final ThrustCurveMotor motor2 = new ThrustCurveMotor.Builder()
 			.setManufacturer(Manufacturer.getManufacturer("A"))
 			.setCommonName("F12")
-			.setDesignation("F12H")
+			.setDesignation("F12")
 			.setDescription("Desc")
 			.setMotorType(Motor.Type.SINGLE)
 			.setStandardDelays(new double[] { 5 })
@@ -51,20 +51,6 @@ public class ThrustCurveMotorSetTest {
 			.build();
 	
 	private static final ThrustCurveMotor motor3 = new ThrustCurveMotor.Builder()
-			.setManufacturer(Manufacturer.getManufacturer("A"))
-			.setCode("F12")
-			.setDescription("Desc")
-			.setMotorType(Motor.Type.UNKNOWN)
-			.setStandardDelays(new double[] { 0, Motor.PLUGGED_DELAY })
-			.setDiameter(0.024)
-			.setLength(0.07)
-			.setTimePoints(new double[] { 0, 1, 2 })
-			.setThrustPoints(new double[] { 0, 2, 0 })
-			.setCGPoints(new Coordinate[] { Coordinate.NUL, Coordinate.NUL, Coordinate.NUL })
-			.setDigest("digestC")
-			.build();
-	
-	private static final ThrustCurveMotor motor4 = new ThrustCurveMotor.Builder()
 			.setManufacturer(Manufacturer.getManufacturer("A"))
 			.setDesignation("F12")
 			.setDescription("Desc")
@@ -113,39 +99,20 @@ public class ThrustCurveMotorSetTest {
 		// Add motor2
 		assertTrue(set.matches(motor2));
 		set.addMotor(motor2);
-		assertEquals(motor1.getManufacturer(), set.getManufacturer());
-		assertEquals(motor3.getCommonName(), set.getCommonName());
+		assertEquals(motor2.getManufacturer(), set.getManufacturer());
+		assertEquals(motor2.getCommonName(), set.getCommonName());
 		assertEquals(Motor.Type.SINGLE, set.getType());
-		assertEquals(motor1.getDiameter(), set.getDiameter(), 0.00001);
-		assertEquals(motor1.getLength(), set.getLength(), 0.00001);
+		assertEquals(motor2.getDiameter(), set.getDiameter(), 0.00001);
+		assertEquals(motor2.getLength(), set.getLength(), 0.00001);
 		assertEquals(2, set.getMotors().size());
-		assertEquals(motor2, set.getMotors().get(0));
-		assertEquals(motor1, set.getMotors().get(1));
+		assertEquals(motor1, set.getMotors().get(0));
+		assertEquals(motor2, set.getMotors().get(1));
 		assertEquals(Arrays.asList(5.0), set.getDelays());
 
-		// Add motor3
-		assertTrue(set.matches(motor3));
-		set.addMotor(motor3);
-		assertEquals(motor1.getManufacturer(), set.getManufacturer());
-		assertEquals(motor3.getCommonName(), set.getCommonName());
-		assertEquals(Motor.Type.SINGLE, set.getType());
-		assertEquals(motor1.getDiameter(), set.getDiameter(), 0.00001);
-		assertEquals(motor1.getLength(), set.getLength(), 0.00001);
-		assertEquals(3, set.getMotors().size());
-		System.out.println("motor set");
-		System.out.println(set.getMotors());
-		System.out.println(motor3);
-		System.out.println(motor2);
-		System.out.println(motor1);
-		assertEquals(motor3, set.getMotors().get(0));
-		assertEquals(motor2, set.getMotors().get(1));
-		assertEquals(motor1, set.getMotors().get(2));
-		assertEquals(Arrays.asList(0.0, 5.0, Motor.PLUGGED_DELAY), set.getDelays());
-
-		// Test that adding motor4 fails
-		assertFalse(set.matches(motor4));
+		// Test that adding motor3 fails
+		assertFalse(set.matches(motor3));
 		try {
-			set.addMotor(motor4);
+			set.addMotor(motor3);
 			fail("Did not throw exception");
 		} catch (IllegalArgumentException e) {
 		}


### PR DESCRIPTION
Require motor designations to match before motors can be said to match.  I *think* this is really leftover unfinished business from my PR #1032; that PR stopped trying to parse motor designations to create a "simplified designation" instead using common names for most purposes that previously used simplified designations.

The main reason for this is to get rid of the annoyance of MICRO_MAXX and MICRO_MAXX_II motors being confounded with each other in the motor selection dialog.

In general, I can't think of  a reason we'd want to be able to have multiple designations turn up as a single motor.

One possible concern with this is we want to make sure we can still find motors saved in 15.03 designs when loading from the new version.  That was only really a problem with CTI motors; I tried creating a couple of designs with CTI motors under 15.03 and then opening the file; at least for the ones I tried this found them.