### PR TITLE
[#1895] Maintain tree cell font after override icon

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/componenttree/ComponentTreeRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/main/componenttree/ComponentTreeRenderer.java
@@ -1,7 +1,9 @@
 package net.sf.openrocket.gui.main.componenttree;
 
 import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.FlowLayout;
+import java.awt.Font;
 import java.util.List;
 
 import javax.swing.JLabel;
@@ -80,6 +82,8 @@ public class ComponentTreeRenderer extends DefaultTreeCellRenderer {
 				p.setToolTipText(getToolTipSingleComponent(c));
 			}
 
+			Font originalFont = tree.getFont();
+			p.setFont(originalFont);
 			comp = p;
 		}
 


### PR DESCRIPTION
This PR fixes #1895.

<img width="234" alt="image" src="https://user-images.githubusercontent.com/11031519/208929161-c75d8567-943d-4537-9a02-dbdb2a3d63c1.png">
