### PR TITLE
Attach flight data to simulation exceptions so it can be preserved to help user track down the problem

### DIFF
--- a/core/src/net/sf/openrocket/document/Simulation.java
+++ b/core/src/net/sf/openrocket/document/Simulation.java
@@ -384,15 +384,19 @@ public class Simulation implements ChangeSource, Cloneable {
 			simulatedData = simulator.simulate(simulationConditions);
 			t2 = System.currentTimeMillis();
 			log.debug("Simulation: returning from simulator, simulation took " + (t2 - t1) + "ms");
-			
-			// Set simulated info after simulation, will not be set in case of exception
+
+		} catch (SimulationException e) {
+			simulatedData = e.getFlightData();
+			throw e;
+		} finally {
+			// Set simulated info after simulation
 			simulatedConditions = options.clone();
 			simulatedConfigurationDescription = descriptor.format( this.rocket, getId());
 			simulatedRocketID = rocket.getFunctionalModID();
 			
 			status = Status.UPTODATE;
 			fireChangeEvent();
-		} finally {
+
 			mutex.unlock("simulate");
 		}
 	}

--- a/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
+++ b/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
@@ -58,12 +58,14 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 	
 	// this is just a list of simulation branches to 
 	Deque<SimulationStatus> toSimulate = new ArrayDeque<SimulationStatus>();
+
+	FlightData flightData;
 	
 	@Override
 	public FlightData simulate(SimulationConditions simulationConditions) throws SimulationException {
 		
 		// Set up flight data
-		FlightData flightData = new FlightData();
+		flightData = new FlightData();
 		
 		// Set up rocket configuration
 		this.fcid = simulationConditions.getFlightConfigurationID();
@@ -268,6 +270,11 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 
 			// Add FlightEvent for Abort.
 			currentStatus.getFlightData().addEvent(new FlightEvent(FlightEvent.Type.EXCEPTION, currentStatus.getSimulationTime(), currentStatus.getConfiguration().getRocket(), e.getLocalizedMessage()));
+
+			flightData.addBranch(currentStatus.getFlightData());
+			flightData.getWarningSet().addAll(currentStatus.getWarnings());
+
+			e.setFlightData(flightData);
 			
 			throw e;
 		}

--- a/core/src/net/sf/openrocket/simulation/exception/SimulationException.java
+++ b/core/src/net/sf/openrocket/simulation/exception/SimulationException.java
@@ -1,7 +1,11 @@
 package net.sf.openrocket.simulation.exception;
 
+import net.sf.openrocket.simulation.FlightData;
+	
 public class SimulationException extends Exception {
 
+	private FlightData flightData = null;
+	
 	public SimulationException() {
 
 	}
@@ -18,4 +22,11 @@ public class SimulationException extends Exception {
 		super(message, cause);
 	}
 
+	public void setFlightData(FlightData f) {
+		flightData = f;
+	}
+
+	public FlightData getFlightData() {
+		return flightData;
+	}
 }


### PR DESCRIPTION
So for instance, in the flying motor mount in Issue #1898, the simulation can proceed through many steps before failing with a SimulationException.  This lets a user look at the data generated before the exception.