### PR TITLE
Uniform bug report info section + add user-defined thrust curves location

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/BugReportDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/BugReportDialog.java
@@ -108,31 +108,10 @@ public class BugReportDialog extends JDialog {
 	 * @param parent	the parent window (may be null).
 	 */
 	public static void showBugReportDialog(Window parent) {
-		
 		StringBuilder sb = new StringBuilder();
-		
-		sb.append("<html>---------- Bug report ----------\n");
-		sb.append('\n');
-		sb.append("<b>Include detailed steps on how to trigger the bug:</b>\n");
-		sb.append("<i>(You can edit text directly in this window)</i>\n");
-		sb.append('\n');
-		sb.append("1. \n");
-		sb.append("2. \n");
-		sb.append("3. \n");
-		sb.append('\n');
-		
-		sb.append("<b>What does the software do and what in your opinion should it do in the " +
-				"case described above:</b>\n");
-		sb.append('\n');
-		sb.append('\n');
-		sb.append('\n');
-		
-		sb.append("Include your email address (optional; it helps if we can " +
-				"contact you in case we need additional information):\n");
-		sb.append('\n');
-		sb.append('\n');
-		sb.append('\n');
-		
+
+		// ---------- Bug report ----------
+		addBugReportInformation(sb);
 		
 		sb.append("(Do not modify anything below this line.)\n");
 		sb.append("---------- System information ----------\n");
@@ -157,28 +136,9 @@ public class BugReportDialog extends JDialog {
 	 */
 	public static void showExceptionDialog(Window parent, Thread t, Throwable e) {
 		StringBuilder sb = new StringBuilder();
-		
-		sb.append("<html>---------- Bug report ----------\n");
-		sb.append('\n');
-		sb.append("<b style='color:rgb(210, 20, 5)'>Please include a description about what actions you were " +
-				"performing when the exception occurred:</b>\n");
-		sb.append("<i>(You can edit text directly in this window)</i>\n");
-		sb.append('\n');
-		sb.append("1. \n");
-		sb.append("2. \n");
-		sb.append("3. \n");
 
-		sb.append("\n");
-		sb.append("<b>If possible, please send us the .ork file that caused the bug.</b>\n");
-		sb.append('\n');
-		
-		
-		sb.append("Include your email address (optional; it helps if we can " +
-				"contact you in case we need additional information):\n");
-		sb.append('\n');
-		sb.append('\n');
-		sb.append('\n');
-		sb.append('\n');
+		// ---------- Bug report ----------
+		addBugReportInformation(sb);
 		
 		sb.append("(Do not modify anything below this line.)\n");
 		sb.append("---------- Exception stack trace ----------\n");
@@ -210,6 +170,30 @@ public class BugReportDialog extends JDialog {
 				//// <html><b>Please include a short description about what you were doing when the exception occurred.</b>
 				new BugReportDialog(parent, trans.get("bugreport.reportDialog.txt2"), sb.toString(), true);
 		reportDialog.setVisible(true);
+	}
+
+	private static void addBugReportInformation(StringBuilder sb) {
+		sb.append("<html>---------- Bug report ----------\n");
+		sb.append('\n');
+		sb.append("<b style='color:rgb(210, 20, 5)'>Please include a description about what actions you were " +
+				"performing when the exception occurred:</b>\n");
+		sb.append("<i>(You can edit text directly in this window)</i>\n");
+		sb.append('\n');
+		sb.append("1. \n");
+		sb.append("2. \n");
+		sb.append("3. \n");
+
+		sb.append("\n");
+		sb.append("<b>If possible, please send us the .ork file that caused the bug.</b>\n");
+		sb.append('\n');
+
+
+		sb.append("Include your email address (optional; it helps if we can " +
+				"contact you in case we need additional information):\n");
+		sb.append('\n');
+		sb.append('\n');
+		sb.append('\n');
+		sb.append('\n');
 	}
 	
 	private static void addSystemInformation(StringBuilder sb) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/BugReportDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/BugReportDialog.java
@@ -27,6 +27,7 @@ import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.components.URLLabel;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.SwingPreferences;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.logging.LogLevelBufferLogger;
 import net.sf.openrocket.logging.LogLine;
@@ -44,6 +45,7 @@ public class BugReportDialog extends JDialog {
 	private static final String REPORT_EMAIL_URL = "mailto:" + REPORT_EMAIL;
 	
 	private static final Translator trans = Application.getTranslator();
+	private static final SwingPreferences preferences = (SwingPreferences) Application.getPreferences();
 	
 	
 	public BugReportDialog(Window parent, String labelText, final String message, final boolean sendIfUnchanged) {
@@ -201,6 +203,7 @@ public class BugReportDialog extends JDialog {
 		sbTemp.append("OpenRocket version: " + BuildProperties.getVersion() + "\n");
 		sbTemp.append("OpenRocket source: " + BuildProperties.getBuildSource() + "\n");
 		sbTemp.append("OpenRocket location: " + JarUtil.getCurrentJarFile() + "\n");
+		sbTemp.append("User-defined thrust curves location: " + preferences.getUserThrustCurveFilesAsString() + "\n");
 		sbTemp.append("JOGL version: " + JoglVersion.getInstance().getImplementationVersion() + "\n");
 		sbTemp.append("Current default locale: " + Locale.getDefault() + "\n");
 		sbTemp.append("System properties:\n");

--- a/swing/src/net/sf/openrocket/gui/dialogs/preferences/GeneralPreferencesPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preferences/GeneralPreferencesPanel.java
@@ -86,14 +86,7 @@ public class GeneralPreferencesPanel extends PreferencesPanel {
 		//// User-defined thrust curves:
 		this.add(new JLabel(trans.get("pref.dlg.lbl.User-definedthrust")), "spanx, wrap");
 		final JTextField field = new JTextField();
-		List<File> files = preferences.getUserThrustCurveFiles();
-		String str = "";
-		for (File file : files) {
-			if (str.length() > 0) {
-				str += ";";
-			}
-			str += file.getAbsolutePath();
-		}
+		String str = preferences.getUserThrustCurveFilesAsString();
 		field.setText(str);
 		field.getDocument().addDocumentListener(new DocumentListener() {
 			@Override

--- a/swing/src/net/sf/openrocket/gui/util/SwingPreferences.java
+++ b/swing/src/net/sf/openrocket/gui/util/SwingPreferences.java
@@ -304,6 +304,24 @@ public class SwingPreferences extends net.sf.openrocket.startup.Preferences {
 		
 		return list;
 	}
+
+	/**
+	 * Returns the files/directories to be loaded as custom thrust curves, formatting as a string. If there are multiple
+	 * locations, they are separated by a semicolon.
+	 *
+	 * @return a list of files to load as thrust curves, formatted as a semicolon separated string.
+	 */
+	public String getUserThrustCurveFilesAsString() {
+		List<File> files = getUserThrustCurveFiles();
+		StringBuilder sb = new StringBuilder();
+		for (File file : files) {
+			if (sb.length() > 0) {
+				sb.append(";");
+			}
+			sb.append(file.getAbsolutePath());
+		}
+		return sb.toString();
+	}
 	
 	public File getDefaultUserThrustCurveFile() {
 		File appdir = SystemInfo.getUserApplicationDirectory();


### PR DESCRIPTION
This PR improves the bug report dialog in two ways:
1. Previously, there were was a different formatting of the "---------- Bug report ----------" section between the exception dialog (bug report dialog that pops up after an error occurred), and the normal bug report dialog (bug report dialog that opens when you go to the application ribbon > Help > Bug report). Now they have the same formatting.
2. I adding one line in the system information section to display the user-defined thrust curves location. This can be useful when users have thrust curve import issues.

Previous normal bug report dialog: (did not use the same formatting as the exception dialog)
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/11031519/209418476-6d6e04ef-f470-4545-9aca-da4a3e0fe383.png">


New one: (uses the same formatting as the exception dialog + added the thrust curves line)
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/11031519/209418481-1f252aa9-848d-4c7a-9e9d-ba3e07a4a53f.png">
