### PR TITLE
Generalize error-catching of motor file loading

### DIFF
--- a/core/src/net/sf/openrocket/file/motor/ZipFileMotorLoader.java
+++ b/core/src/net/sf/openrocket/file/motor/ZipFileMotorLoader.java
@@ -44,7 +44,7 @@ public class ZipFileMotorLoader implements MotorLoader {
 	
 	
 	@Override
-	public List<ThrustCurveMotor.Builder> load(InputStream stream, String filename) throws IOException {
+	public List<ThrustCurveMotor.Builder> load(InputStream stream, String filename) throws IOException, IllegalArgumentException {
 		List<ThrustCurveMotor.Builder> motors = new ArrayList<>();
 		
 		ZipInputStream is = new ZipInputStream(stream);

--- a/swing/src/net/sf/openrocket/database/MotorDatabaseLoader.java
+++ b/swing/src/net/sf/openrocket/database/MotorDatabaseLoader.java
@@ -127,8 +127,8 @@ public class MotorDatabaseLoader extends AsynchronousDatabaseLoader {
 					new Pair<String,InputStream>(
 							file.getName(),
 							new BufferedInputStream(new FileInputStream(file))));
-		} catch (IOException e) {
-			log.warn("IOException while reading " + file + ": " + e, e);
+		} catch (Exception e) {
+			log.warn("Exception while reading " + file + ": " + e, e);
 		}
 	}
 	
@@ -158,8 +158,8 @@ public class MotorDatabaseLoader extends AsynchronousDatabaseLoader {
 				dialog.setVisible(true);
 			}
 			f.getV().close();
-		} catch (IOException e) {
-			log.warn("IOException while loading file " + f.getU() + ": " + e, e);
+		} catch (Exception e) {
+			log.warn("Exception while loading file " + f.getU() + ": " + e, e);
 			try {
 				f.getV().close();
 			} catch (IOException e1) {
@@ -178,7 +178,7 @@ public class MotorDatabaseLoader extends AsynchronousDatabaseLoader {
 		FileIterator iterator;
 		try {
 			iterator = new DirectoryIterator(file, fileFilter, true);
-		} catch (IOException e) {
+		} catch (Exception e) {
 			log.warn("Unable to read directory " + file + ": " + e, e);
 			return;
 		}


### PR DESCRIPTION
In light of PR #1919, I think it is reasonable to generalize the exception-catching for motor file loading. So, instead of only catching IOExceptions during motor file loading, now every exception is caught. The upside is that however messed up the files and directories in the user's thrust curve directory is, it will (hopefully) not crash the entire program - as was the case for the TRF user from PR #1919. The downside is that - assuming that the exception dialogs work (PR #1919 shows that this is not always the case) - users will not have a direct feedback that an import failed due to a file/directory issue. You can still view the import error in the debug log though. 

FYI: with "file/directory issue", I mean an issue caused by the raw format of the file/directory, e.g. when you have a corrupted file. I'm not talking about the normal thrust curve import issues like "Thrust curve xx has two different thrust values for the same time value". Those issues will still show up fine. This PR only affects raw file import errors.