### PR TITLE
Throw exception at simulation startup if CP can't be calculated.

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -562,6 +562,7 @@ SimuRunDlg.msg.Unabletosim = Unable to simulate:
 SimuRunDlg.msg.errorOccurred = An error occurred during the simulation:
 
 BasicEventSimulationEngine.error.noMotorsDefined = No motors defined in the simulation.
+BasicEventSimulationEngine.error.cantCalculateStability = Can't calculate rocket stability.
 BasicEventSimulationEngine.error.earlyMotorBurnout = Motor burnout without liftoff.
 BasicEventSimulationEngine.error.noConfiguredIgnition = No motors configured to ignite at liftoff
 BasicEventSimulationEngine.error.noIgnition = No motors ignited.
@@ -1148,8 +1149,6 @@ NoseConeCfg.tab.General = General
 NoseConeCfg.tab.ttip.General = General properties
 NoseConeCfg.tab.Shoulder = Shoulder
 NoseConeCfg.tab.ttip.Shoulder = Shoulder properties
-NoseConeCfg.checkbox.Flip = Flip to tail cone
-NoseConeCfg.checkbox.Flip.ttip = Flips the nose cone direction to a tail cone.
 
 ! ParachuteConfig
 Parachute.Parachute = Parachute
@@ -1364,7 +1363,7 @@ TCMotorSelPan.lbl.Datapoints = Data points:
 TCMotorSelPan.lbl.Digest = Digest:
 TCMotorSelPan.title.Thrustcurve = Thrust curve:
 TCMotorSelPan.title.Thrust = Thrust
-TCMotorSelPan.delayBox.None = Plugged (none)
+TCMotorSelPan.delayBox.None = None
 TCMotorSelPan.noDescription = No description available.
 TCMotorSelPan.btn.checkAll = Select All
 TCMotorSelPan.btn.checkNone = Clear All

--- a/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
+++ b/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
@@ -7,7 +7,9 @@ import java.util.Deque;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.sf.openrocket.aerodynamics.FlightConditions;
 import net.sf.openrocket.aerodynamics.Warning;
+import net.sf.openrocket.aerodynamics.WarningSet;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.motor.IgnitionEvent;
 import net.sf.openrocket.motor.MotorConfiguration;
@@ -83,6 +85,13 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 		if (!simulationConfig.hasMotors() ) {
 			throw new MotorIgnitionException(trans.get("BasicEventSimulationEngine.error.noMotorsDefined"));
 		}
+
+		// Can't calculate stability
+		if (currentStatus.getSimulationConditions().getAerodynamicCalculator()
+			.getCP(currentStatus.getConfiguration(),
+				   new FlightConditions(currentStatus.getConfiguration()),
+				   new WarningSet()).weight < MathUtil.EPSILON)
+			throw new SimulationException(trans.get("BasicEventSimulationEngine.error.cantCalculateStability"));
 
 		// Problems that let us simulate, but result is likely bad
 			


### PR DESCRIPTION
Exception says "Can't calculate rocket stability."

The basic problem with #1898 is it's impossible to calculate the flying motor mount "rocket"'s center of pressure except when it's flying backwards (at nearly 180 degrees).  This results in ever-faster gyrations until one parameter or another exceeds OR's limits.  I spent a little while seeing if I could adjust the simulation time step in response to the speed of the gyrations; the end of result of these experiments was I could calculate with ever-tinier timesteps which made the simulation speed drop to a crawl before finally throwing the exception.

This PR observes that the CP of the rocket assembly has a 0 or negative weight at launch and throws a more meaningful exception at that point.

Fixes #1898 