### PR TITLE
Display nan as n/a

### DIFF
--- a/core/src/net/sf/openrocket/unit/Unit.java
+++ b/core/src/net/sf/openrocket/unit/Unit.java
@@ -90,8 +90,11 @@ public abstract class Unit {
 	 * @return       A string representation of the number in these units.
 	 */
 	public String toString(double value) {
-		double val = toUnit(value);
+		if (Double.isNaN(value))
+			return "N/A";
 		
+		double val = toUnit(value);
+
 		if (Math.abs(val) > 1E6) {
 			return expFormat.format(val);
 		}

--- a/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
@@ -571,7 +571,12 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 			}
 
 			if (forces.getCP() != null) {
-				row.cpx = forces.getCP().x;
+				if ((comp instanceof Rocket) &&
+					(forces.getCP().weight < MathUtil.EPSILON)) {
+					row.cpx = Double.NaN;
+				} else {
+					row.cpx = forces.getCP().x;
+				}
 				row.cna = forces.getCNa();
 			}
 


### PR DESCRIPTION
This is related to PR 1924, but separate enough I wanted it to be its own PR.  Either of these two can be merged without the other.

This one makes two small changes: 
Iinstead of displaying Not a Number values as NaN, Unit.toString() now displays them as N/A.  This brings it into agreement with Unit.toStringUnit(), which already did that.  While a developer knows what NaN means, someone without a software background will probably find N/A more understandable.  You can see a place where toStringUnit() was using N/A in the RocketPanel display from Issue #1898, where it is used to identify the CP (which has a negative weight) as N/A

In the ComponentAnalysisDialog, if the rocket CP has a negative weight, this now displays it as N/A.  Previously, it would go ahead and display the calculated value, while the RocketPanel would display N/A.  The dialog will now display the same value, including N/A where appropriate, as the RocketPanel.