### PR TITLE
Darker warning color

### DIFF
--- a/swing/src/net/sf/openrocket/gui/figureelements/RocketInfo.java
+++ b/swing/src/net/sf/openrocket/gui/figureelements/RocketInfo.java
@@ -348,7 +348,7 @@ public class RocketInfo implements FigureElement {
 		
 
 		float y = y2 - line * warnings.size();
-		g2.setColor(new Color(255,0,0,130));
+		g2.setColor(Color.RED);
 
 		for (GlyphVector v: texts) {
 			Rectangle2D rect = v.getVisualBounds();


### PR DESCRIPTION
This PR increases the darkness of the geometry warning color.

Before:
<img width="1667" alt="Screenshot 2022-12-27 at 20 38 37" src="https://user-images.githubusercontent.com/11031519/209715184-965b3c3b-ace9-4af9-923f-09b90695876c.png">

After:
<img width="1667" alt="Screenshot 2022-12-27 at 20 38 32" src="https://user-images.githubusercontent.com/11031519/209715195-c060e26c-3b64-4a0a-abc9-685e3cae2ed5.png">
