### PR TITLE
Add option to switch (time) flight event markers to icons

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -719,6 +719,11 @@ simplotpanel.RIGHT_NAME = Right
 simplotpanel.CUSTOM = Custom
 SimulationPlotPanel.error.noPlotSelected = Please add one or more variables to plot on the Y-axis.
 SimulationPlotPanel.error.noPlotSelected.title = Nothing to plot
+simplotpanel.MarkerStyle.lbl.MarkerStyle = Marker style:
+simplotpanel.MarkerStyle.lbl.MarkerStyle.ttip = Style of the flight event marker (how it's drawn in the simulation plot)
+simplotpanel.MarkerStyle.btn.VerticalMarker = Vertical marker
+simplotpanel.MarkerStyle.btn.Icon = Icon
+simplotpanel.MarkerStyle.OnlyInTime = Only available for time domain, other domains only support icon markers
 
 ! Component add buttons
 compaddbuttons.AxialStage = Stage

--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -721,7 +721,7 @@ SimulationPlotPanel.error.noPlotSelected = Please add one or more variables to p
 SimulationPlotPanel.error.noPlotSelected.title = Nothing to plot
 simplotpanel.MarkerStyle.lbl.MarkerStyle = Marker style:
 simplotpanel.MarkerStyle.lbl.MarkerStyle.ttip = Style of the flight event marker (how it's drawn in the simulation plot)
-simplotpanel.MarkerStyle.btn.VerticalMarker = Vertical marker
+simplotpanel.MarkerStyle.btn.VerticalMarker = Vertical line
 simplotpanel.MarkerStyle.btn.Icon = Icon
 simplotpanel.MarkerStyle.OnlyInTime = Only available for time domain, other domains only support icon markers
 

--- a/core/src/net/sf/openrocket/startup/Preferences.java
+++ b/core/src/net/sf/openrocket/startup/Preferences.java
@@ -76,6 +76,7 @@ public abstract class Preferences implements ChangeSource {
 	public static final String PREFERRED_THRUST_CURVE_MOTOR_NODE = "preferredThrustCurveMotors";
 	private static final String AUTO_OPEN_LAST_DESIGN = "AUTO_OPEN_LAST_DESIGN";
 	private static final String OPEN_LEFTMOST_DESIGN_TAB = "OPEN_LEFTMOST_DESIGN_TAB";
+	public static final String MARKER_STYLE_ICON = "MARKER_STYLE_ICON";
 	private static final String SHOW_MARKERS = "SHOW_MARKERS";
 	private static final String SHOW_ROCKSIM_FORMAT_WARNING = "SHOW_ROCKSIM_FORMAT_WARNING";
 	

--- a/core/src/net/sf/openrocket/util/LinearInterpolator.java
+++ b/core/src/net/sf/openrocket/util/LinearInterpolator.java
@@ -82,7 +82,7 @@ public class LinearInterpolator implements Cloneable {
 
 		if ( y1 != null ) {
 			// Wow, x was a key in the map.  Such luck.
-			return y1.doubleValue();
+			return y1;
 		}
 
 		// we now know that x is not in the map, so we need to find the lower and higher keys.
@@ -96,16 +96,16 @@ public class LinearInterpolator implements Cloneable {
 		Double firstKey = sortMap.firstKey();
 
 		// x is smaller than the first entry in the map.
-		if ( x < firstKey.doubleValue() ) {
+		if ( x < firstKey) {
 			y1 = sortMap.get(firstKey);
-			return y1.doubleValue();
+			return y1;
 		}
 		
 		// floor key is the largest key smaller than x - since we have at least one key,
 		// and x>=firstKey, we know that floorKey != null.
 		Double floorKey = sortMap.subMap(firstKey, x).lastKey();
 
-		x1 = floorKey.doubleValue();
+		x1 = floorKey;
 		y1 = sortMap.get(floorKey);
 
 		// Now we need to find the key that is greater or equal to x
@@ -113,16 +113,16 @@ public class LinearInterpolator implements Cloneable {
 
 		// Check if x is bigger than all the entries.
 		if ( tailMap.isEmpty() ) {
-			return y1.doubleValue();
+			return y1;
 		}
 		Double ceilKey = tailMap.firstKey();
 		
 		// Check if x is bigger than all the entries.
 		if ( ceilKey == null ) {
-			return y1.doubleValue();
+			return y1;
 		}
 		
-		x2 = ceilKey.doubleValue();
+		x2 = ceilKey;
 		y2 = sortMap.get(ceilKey);
 
 		return (x - x1)/(x2-x1) * (y2-y1) + y1;

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlot.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlot.java
@@ -421,7 +421,7 @@ public class SimulationPlot {
 		// Plot the markers
 		if (config.getDomainAxisType() == FlightDataType.TYPE_TIME && !preferences.getBoolean(Preferences.MARKER_STYLE_ICON, false)) {
 			fillEventLists(branch, eventTimes, eventLabels, eventColors, eventImages);
-			plotVerticalMarkers(plot, eventTimes, eventLabels, eventColors);
+			plotVerticalLineMarkers(plot, eventTimes, eventLabels, eventColors);
 
 		} else {	// Other domains are plotted as image annotations
 			if (branch == -1) {
@@ -490,10 +490,10 @@ public class SimulationPlot {
 		}
 	}
 
-	private static void plotVerticalMarkers(XYPlot plot, List<Double> eventTimes, List<String> eventLabels, List<Color> eventColors) {
+	private static void plotVerticalLineMarkers(XYPlot plot, List<Double> eventTimes, List<String> eventLabels, List<Color> eventColors) {
 		double markerWidth = 0.01 * plot.getDomainAxis().getUpperBound();
 
-		// Domain time is plotted as vertical markers
+		// Domain time is plotted as vertical lines
 		for (int i = 0; i < eventTimes.size(); i++) {
 			double t = eventTimes.get(i);
 			String event = eventLabels.get(i);

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlot.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlot.java
@@ -94,6 +94,7 @@ public class SimulationPlot {
 
 	void setShowBranch(int branch) {
 		XYPlot plot = (XYPlot) chart.getPlot();
+		plot.clearAnnotations();
 		int datasetcount = plot.getDatasetCount();
 		for (int i = 0; i < datasetcount; i++) {
 			int seriescount = ((XYSeriesCollection) plot.getDataset(i)).getSeriesCount();
@@ -400,9 +401,13 @@ public class SimulationPlot {
 		return name;
 	}
 
-	private void drawDomainMarkers(int stage) {
+	/**
+	 * Draw the domain markers for a certain branch. Draws all the markers if the branch is -1.
+	 * @param branch branch to draw, or -1 to draw all
+	 */
+	private void drawDomainMarkers(int branch) {
 		XYPlot plot = chart.getXYPlot();
-		FlightDataBranch mainBranch = simulation.getSimulatedData().getBranch(0);
+		FlightDataBranch dataBranch = simulation.getSimulatedData().getBranch(Math.max(branch, 0));
 
 		// Clear existing domain markers
 		plot.clearDomainMarkers();
@@ -420,7 +425,7 @@ public class SimulationPlot {
 			Color color = null;
 			Image image = null;
 			for (EventDisplayInfo info : eventList) {
-				if (stage >= 0 && stage != info.stage) {
+				if (branch >= 0 && branch != info.stage) {
 					continue;
 				}
 
@@ -484,11 +489,9 @@ public class SimulationPlot {
 				}
 			}
 
-		} else {
-
-			// Other domains are plotted as image annotations
-			List<Double> time = mainBranch.get(FlightDataType.TYPE_TIME);
-			List<Double> domain = mainBranch.get(config.getDomainAxisType());
+		} else {	// Other domains are plotted as image annotations
+			List<Double> time = dataBranch.get(FlightDataType.TYPE_TIME);
+			List<Double> domain = dataBranch.get(config.getDomainAxisType());
 
 			LinearInterpolator domainInterpolator = new LinearInterpolator(time, domain);
 
@@ -503,7 +506,7 @@ public class SimulationPlot {
 
 				for (int index = 0; index < config.getTypeCount(); index++) {
 					FlightDataType type = config.getType(index);
-					List<Double> range = mainBranch.get(type);
+					List<Double> range = dataBranch.get(type);
 
 					LinearInterpolator rangeInterpolator = new LinearInterpolator(time, range);
 					// Image annotations are not supported on the right-side axis

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlot.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlot.java
@@ -20,9 +20,12 @@ import java.util.regex.Pattern;
 
 import net.sf.openrocket.document.Simulation;
 import net.sf.openrocket.gui.simulation.SimulationPlotPanel;
+import net.sf.openrocket.gui.util.SwingPreferences;
 import net.sf.openrocket.simulation.FlightDataBranch;
 import net.sf.openrocket.simulation.FlightDataType;
 import net.sf.openrocket.simulation.FlightEvent;
+import net.sf.openrocket.startup.Application;
+import net.sf.openrocket.startup.Preferences;
 import net.sf.openrocket.unit.Unit;
 import net.sf.openrocket.unit.UnitGroup;
 import net.sf.openrocket.util.LinearInterpolator;
@@ -65,6 +68,8 @@ import org.jfree.ui.TextAnchor;
  */
 @SuppressWarnings("serial")
 public class SimulationPlot {
+	private static final SwingPreferences preferences = (SwingPreferences) Application.getPreferences();
+
 
 	private static final float PLOT_STROKE_WIDTH = 1.5f;
 
@@ -79,7 +84,7 @@ public class SimulationPlot {
 
 	private final LegendItems legendItems;
 
-	int branchCount;
+	private int branchCount;
 
 	void setShowPoints(boolean showPoints) {
 		for (ModifiedXYItemRenderer r : renderers) {
@@ -457,7 +462,7 @@ public class SimulationPlot {
 		}
 
 		// Plot the markers
-		if (config.getDomainAxisType() == FlightDataType.TYPE_TIME) {
+		if (config.getDomainAxisType() == FlightDataType.TYPE_TIME && !preferences.getBoolean(Preferences.MARKER_STYLE_ICON, false)) {
 			double markerWidth = 0.01 * plot.getDomainAxis().getUpperBound();
 
 			// Domain time is plotted as vertical markers


### PR DESCRIPTION
I recently noticed that apparently, when you make a sim plot where the x axis type is not time, OpenRocket plots the flight event markers using icons, instead of vertical markers. Since I think the markers can get messy pretty easily, I now added the option for time domain plots to switch between vertical markers and icon markers.

I also made the tooltip text of flight event icons more elaborate, to include the x axis value and sample count.

https://user-images.githubusercontent.com/11031519/210019076-360ffd3f-450b-4cc1-82cc-75e4aa53cd57.mp4


