### PR TITLE
Re-add nose cone config translations

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -1150,6 +1150,8 @@ NoseConeCfg.tab.General = General
 NoseConeCfg.tab.ttip.General = General properties
 NoseConeCfg.tab.Shoulder = Shoulder
 NoseConeCfg.tab.ttip.Shoulder = Shoulder properties
+NoseConeCfg.checkbox.Flip = Flip to tail cone
+NoseConeCfg.checkbox.Flip.ttip = Flips the nose cone direction to a tail cone.
 
 ! ParachuteConfig
 Parachute.Parachute = Parachute


### PR DESCRIPTION
No idea when those got deleted, but anyway, now they're back. Fixes the issue reported by @hcraigmiller [here](https://github.com/openrocket/openrocket/pull/1931#issuecomment-1367029948) (the first issue).