### PR TITLE
Increase error margin

### DIFF
--- a/core/test/net/sf/openrocket/simulation/FlightEventsTest.java
+++ b/core/test/net/sf/openrocket/simulation/FlightEventsTest.java
@@ -24,6 +24,8 @@ import static org.junit.Assert.assertSame;
  * Tests to verify that simulations contain all the expected flight events.
  */
 public class FlightEventsTest extends BaseTestCase {
+    private static final double EPSILON = 0.005;
+
     /**
      * Tests for a single stage design.
      */
@@ -66,7 +68,7 @@ public class FlightEventsTest extends BaseTestCase {
         // Test that the event times are correct
         for (int i = 0; i < expectedEventTimes.length; i++) {
             assertEquals(" Flight type " + expectedEventTypes[i] + " has wrong time",
-                    expectedEventTimes[i], eventList.get(i).getTime(), 0.002);
+                    expectedEventTimes[i], eventList.get(i).getTime(), EPSILON);
 
         }
 
@@ -142,7 +144,7 @@ public class FlightEventsTest extends BaseTestCase {
             // Test that the event times are correct
             for (int i = 0; i < expectedEventTimes.length; i++) {
                 assertEquals(" Flight type " + expectedEventTypes[i] + " has wrong time",
-                        expectedEventTimes[i], eventList.get(i).getTime(), 0.002);
+                        expectedEventTimes[i], eventList.get(i).getTime(), EPSILON);
             }
 
             // Test that the event sources are correct


### PR DESCRIPTION
There was just recently a build failure because the flight event time differed for more than 0.002 seconds (namely 0.003 seconds). So I'm gonna increase the error margin yet again, this time to a more safe yet very reasonable 0.005 seconds range.