### PR TITLE
Inhibit reignition of already ignited motor

### DIFF
--- a/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
+++ b/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
@@ -396,7 +396,13 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 			
 			case IGNITION: {
 				MotorClusterState motorState = (MotorClusterState) event.getData();
-				
+
+				// If there are multiple ignition events (as is the case if the preceding stage has several burnout events, for instance)
+				// We get multiple ignition events for the upper stage motor.  Ignore are all after the first.
+				if (motorState.getIgnitionTime() < currentStatus.getSimulationTime()) {
+					log.info("Ignoring motor " +motorState.toDescription()+" ignition event @"+currentStatus.getSimulationTime());
+					continue;
+				}
 				log.info("  Igniting motor: "+motorState.toDescription()+" @"+currentStatus.getSimulationTime());
 				motorState.ignite( event.getTime());
 


### PR DESCRIPTION
The problem in #1938 turned out not to be the recovery devices in the pods, but rather that the sustainer motor was ignited again when each of the motors in the first stage burned out.

If a later stage motor's ignition event is triggered by burnout of earlier stage motors, an ignition event gets queued for every burnout in the earlier stage. This checks to see if a motor is already burning when an ignition event is processed for it, and ignores the event if so.

Fixes #1938