### PR TITLE
Consider number of parachutes in landing drag calculation

### DIFF
--- a/core/src/net/sf/openrocket/simulation/BasicLandingStepper.java
+++ b/core/src/net/sf/openrocket/simulation/BasicLandingStepper.java
@@ -1,6 +1,7 @@
 package net.sf.openrocket.simulation;
 
 import net.sf.openrocket.models.atmosphere.AtmosphericConditions;
+import net.sf.openrocket.rocketcomponent.InstanceMap;
 import net.sf.openrocket.rocketcomponent.RecoveryDevice;
 import net.sf.openrocket.simulation.exception.SimulationException;
 import net.sf.openrocket.util.Coordinate;
@@ -35,8 +36,10 @@ public class BasicLandingStepper extends AbstractSimulationStepper {
 		
 		// Get total CD
 		double mach = airSpeed.length() / atmosphere.getMachSpeed();
+		
+		final InstanceMap imap = status.getConfiguration().getActiveInstances();
 		for (RecoveryDevice c : status.getDeployedRecoveryDevices()) {
-			totalCD += c.getCD(mach) * c.getArea() / refArea;
+			totalCD += imap.count(c) * c.getCD(mach) * c.getArea() / refArea;
 		}
 		
 		// Compute drag force


### PR DESCRIPTION
Fixes #1910

The .ork file associated with that bug report now shows descents at speeds of roughly 18.7, 13, and 10.8 fps for 1, 2, and 3 boosters in the booster set. 18/13 is approximately sqrt(2), and 18/10.8 is approximately sqrt(3) so this is expected.