### PR TITLE
[#1942] Fix text component selection key behavior

### DIFF
--- a/swing/src/net/sf/openrocket/gui/adaptors/TextComponentSelectionKeyListener.java
+++ b/swing/src/net/sf/openrocket/gui/adaptors/TextComponentSelectionKeyListener.java
@@ -1,0 +1,43 @@
+package net.sf.openrocket.gui.adaptors;
+
+import javax.swing.text.JTextComponent;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+
+/**
+ * This key listener fixes a default behavior by Java Swing text components, where if you select a text, pressing the
+ * left or right arrow key would not bring the text cursor to the beginning or the end of the selection
+ * (@Java, please fix...).
+ * <p>
+ * This listener's behavior:
+ * If some text of the editor is selected, set the caret position to:
+ *      - the end of the selection if the user presses the right arrow key
+ *      - the beginning of the selection if the user presses the left arrow key
+ */
+public class TextComponentSelectionKeyListener extends KeyAdapter {
+    private final JTextComponent textField;
+
+    public TextComponentSelectionKeyListener(JTextComponent textField) {
+        this.textField = textField;
+    }
+
+    @Override
+    public void keyPressed(KeyEvent e) {
+        if (e.isShiftDown()) {
+            return;
+        }
+        if (e.getKeyCode() == KeyEvent.VK_LEFT || e.getKeyCode() == KeyEvent.VK_KP_LEFT) {
+            int start = textField.getSelectionStart();
+            int end = textField.getSelectionEnd();
+            if (end > start) {
+                textField.setCaretPosition(start + 1);
+            }
+        } else if (e.getKeyCode() == KeyEvent.VK_RIGHT || e.getKeyCode() == KeyEvent.VK_KP_RIGHT) {
+            int start = textField.getSelectionStart();
+            int end = textField.getSelectionEnd();
+            if (end > start) {
+                textField.setCaretPosition(end - 1);
+            }
+        }
+    }
+}

--- a/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
@@ -5,7 +5,10 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Font;
-import java.awt.event.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -35,6 +38,7 @@ import net.sf.openrocket.gui.adaptors.BooleanModel;
 import net.sf.openrocket.gui.adaptors.DoubleModel;
 import net.sf.openrocket.gui.adaptors.IntegerModel;
 import net.sf.openrocket.gui.adaptors.PresetModel;
+import net.sf.openrocket.gui.adaptors.TextComponentSelectionKeyListener;
 import net.sf.openrocket.gui.components.BasicSlider;
 import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.components.StyledLabel.Style;
@@ -114,6 +118,7 @@ public class RocketComponentConfig extends JPanel {
 		textFieldListener = new TextFieldListener();
 		componentNameField.addActionListener(textFieldListener);
 		componentNameField.addFocusListener(textFieldListener);
+		componentNameField.addKeyListener(new TextComponentSelectionKeyListener(componentNameField));
 		//// The component name.
 		componentNameField.setToolTipText(trans.get("RocketCompCfg.lbl.Componentname.ttip"));
 		this.add(componentNameField, "growx");
@@ -603,6 +608,7 @@ public class RocketComponentConfig extends JPanel {
 		commentTextArea.setEditable(true);
 		GUIUtil.setTabToFocusing(commentTextArea);
 		commentTextArea.addFocusListener(textFieldListener);
+		commentTextArea.addKeyListener(new TextComponentSelectionKeyListener(commentTextArea));
 		
 		panel.add(new JScrollPane(commentTextArea), "grow");
 		order.add(commentTextArea);


### PR DESCRIPTION
This PR fixes #1942:

https://user-images.githubusercontent.com/11031519/211022585-567b42e9-32c4-4134-bdd3-8f1fb1292f15.mp4

Note: this fix is now only applied to spinner editors (practically all number-input fields in OR), and the component name and comment text fields. In the future, I may post a general fix for every text field etc., which would just require writing a new JTextField class and applying the fixed key listener to it. But for now, this PR should be good enough.