### PR TITLE
Add GitHub sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: openrocket


### PR DESCRIPTION
Not that we really need extra funding right now, but for completeness sake, this PR adds a Support button on the GitHub page.