### PR TITLE
[#1966] Pass File in FileIterator instead of filename

### DIFF
--- a/core/src/net/sf/openrocket/file/iterator/DirectoryIterator.java
+++ b/core/src/net/sf/openrocket/file/iterator/DirectoryIterator.java
@@ -56,7 +56,7 @@ public class DirectoryIterator extends FileIterator {
 
 
 	@Override
-	protected Pair<String, InputStream> findNext() {
+	protected Pair<File, InputStream> findNext() {
 		
 		// Check if we're recursing
 		if (subIterator != null) {
@@ -86,7 +86,7 @@ public class DirectoryIterator extends FileIterator {
 				}
 				
 				InputStream is = new BufferedInputStream(new FileInputStream(file));
-				return new Pair<String, InputStream>(file.getName(), is);
+				return new Pair<>(file, is);
 			} catch (IOException e) {
 				logger.warn("Error opening file/directory " + file, e);
 			}

--- a/core/src/net/sf/openrocket/file/iterator/FileIterator.java
+++ b/core/src/net/sf/openrocket/file/iterator/FileIterator.java
@@ -1,5 +1,6 @@
 package net.sf.openrocket.file.iterator;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
@@ -20,10 +21,10 @@ import net.sf.openrocket.util.Pair;
  * 
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
-public abstract class FileIterator implements Iterator<Pair<String, InputStream>> {
+public abstract class FileIterator implements Iterator<Pair<File, InputStream>> {
 	private static final Logger logger = LoggerFactory.getLogger(FileIterator.class);
 	
-	private Pair<String, InputStream> next = null;
+	private Pair<File, InputStream> next = null;
 	private int fileCount = 0;
 	
 	@Override
@@ -37,7 +38,7 @@ public abstract class FileIterator implements Iterator<Pair<String, InputStream>
 	
 	
 	@Override
-	public Pair<String, InputStream> next() {
+	public Pair<File, InputStream> next() {
 		if (next == null) {
 			next = findNext();
 		}
@@ -45,7 +46,7 @@ public abstract class FileIterator implements Iterator<Pair<String, InputStream>
 			throw new NoSuchElementException("No more files");
 		}
 		
-		Pair<String, InputStream> n = next;
+		Pair<File, InputStream> n = next;
 		next = null;
 		fileCount++;
 		return n;
@@ -86,10 +87,10 @@ public abstract class FileIterator implements Iterator<Pair<String, InputStream>
 	}
 	
 	/**
-	 * Return the next pair of file name and InputStream.
+	 * Return the next pair of file and InputStream.
 	 * 
-	 * @return	a pair with the file name and input stream reading the file.
+	 * @return	a pair with the file and input stream reading the file.
 	 */
-	protected abstract Pair<String, InputStream> findNext();
+	protected abstract Pair<File, InputStream> findNext();
 	
 }

--- a/core/src/net/sf/openrocket/file/iterator/ZipDirectoryIterator.java
+++ b/core/src/net/sf/openrocket/file/iterator/ZipDirectoryIterator.java
@@ -78,7 +78,7 @@ public class ZipDirectoryIterator extends FileIterator {
 	
 	
 	@Override
-	protected Pair<String, InputStream> findNext() {
+	protected Pair<File, InputStream> findNext() {
 		if (entries == null) {
 			return null;
 		}
@@ -90,7 +90,7 @@ public class ZipDirectoryIterator extends FileIterator {
 			if (name.startsWith(directory) && filter.accept(file)) {
 				try {
 					InputStream is = zipFile.getInputStream(entry);
-					return new Pair<String, InputStream>(name, is);
+					return new Pair<>(file, is);
 				} catch (IOException e) {
 					logger.error("IOException when reading ZIP file " + zipFileName, e);
 				}

--- a/core/src/net/sf/openrocket/thrustcurve/SerializeThrustcurveMotors.java
+++ b/core/src/net/sf/openrocket/thrustcurve/SerializeThrustcurveMotors.java
@@ -185,8 +185,8 @@ public class SerializeThrustcurveMotors {
 			System.exit(1);
 		} else {
 			while (iterator.hasNext()) {
-				Pair<String, InputStream> f = iterator.next();
-				String fileName = f.getU();
+				Pair<File, InputStream> f = iterator.next();
+				String fileName = f.getU().getName();
 				InputStream is = f.getV();
 				
 				List<ThrustCurveMotor.Builder> motors = loader.load(is, fileName);

--- a/core/test/net/sf/openrocket/file/iterator/TestFileIterator.java
+++ b/core/test/net/sf/openrocket/file/iterator/TestFileIterator.java
@@ -3,6 +3,7 @@ package net.sf.openrocket.file.iterator;
 import static org.junit.Assert.*;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.InputStream;
 
 import net.sf.openrocket.util.Pair;
@@ -13,14 +14,14 @@ public class TestFileIterator {
 	
 	@Test
 	public void testFileIterator() {
-		final Pair<String, InputStream> one = new Pair<String, InputStream>("one", new ByteArrayInputStream(new byte[] { 1 }));
-		final Pair<String, InputStream> two = new Pair<String, InputStream>("two", new ByteArrayInputStream(new byte[] { 2 }));
+		final Pair<File, InputStream> one = new Pair<>(new File("one"), new ByteArrayInputStream(new byte[] { 1 }));
+		final Pair<File, InputStream> two = new Pair<>(new File("two"), new ByteArrayInputStream(new byte[] { 2 }));
 		
 		FileIterator iterator = new FileIterator() {
 			private int count = 0;
 			
 			@Override
-			protected Pair<String, InputStream> findNext() {
+			protected Pair<File, InputStream> findNext() {
 				count++;
 				switch (count) {
 				case 1:

--- a/swing/src/net/sf/openrocket/database/ComponentPresetDatabaseLoader.java
+++ b/swing/src/net/sf/openrocket/database/ComponentPresetDatabaseLoader.java
@@ -1,5 +1,6 @@
 package net.sf.openrocket.database;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
@@ -77,8 +78,8 @@ public class ComponentPresetDatabaseLoader extends AsynchronousDatabaseLoader {
 			return;
 		}
 		while (iterator.hasNext()) {
-			Pair<String, InputStream> f = iterator.next();
-			Collection<ComponentPreset> presets = loadFile(f.getU(), f.getV());
+			Pair<File, InputStream> f = iterator.next();
+			Collection<ComponentPreset> presets = loadFile(f.getU().getName(), f.getV());
 			componentPresetDao.addAll(presets);
 			fileCount++;
 			presetCount += presets.size();
@@ -97,8 +98,8 @@ public class ComponentPresetDatabaseLoader extends AsynchronousDatabaseLoader {
 			return;
 
 		while (iterator.hasNext()) {
-			Pair<String, InputStream> f = iterator.next();
-			Collection<ComponentPreset> presets = loadFile(f.getU(), f.getV());
+			Pair<File, InputStream> f = iterator.next();
+			Collection<ComponentPreset> presets = loadFile(f.getU().getName(), f.getV());
 			componentPresetDao.addAll(presets);
 			fileCount++;
 			presetCount += presets.size();

--- a/swing/src/net/sf/openrocket/database/MotorDatabaseLoader.java
+++ b/swing/src/net/sf/openrocket/database/MotorDatabaseLoader.java
@@ -89,7 +89,7 @@ public class MotorDatabaseLoader extends AsynchronousDatabaseLoader {
 		log.info("Starting reading serialized motor database");
 		FileIterator iterator = DirectoryIterator.findDirectory(THRUSTCURVE_DIRECTORY, new SimpleFileFilter("", false, "ser"));
 		while (iterator.hasNext()) {
-			Pair<String, InputStream> f = iterator.next();
+			Pair<File, InputStream> f = iterator.next();
 			loadSerialized(f);
 		}
 		log.info("Ending reading serialized motor database, motorCount=" + motorCount);
@@ -99,12 +99,12 @@ public class MotorDatabaseLoader extends AsynchronousDatabaseLoader {
 	/**
 	 * loads a serailized motor data from an stream
 	 * 
-	 * @param f	the pair of a String with the filename (for logging) and the input stream
+	 * @param f	the pair of a File (for logging) and the input stream
 	 */
 	@SuppressWarnings("unchecked")
-	private void loadSerialized(Pair<String, InputStream> f) {
+	private void loadSerialized(Pair<File, InputStream> f) {
 		try {
-			log.debug("Reading motors from file " + f.getU());
+			log.debug("Reading motors from file " + f.getU().getPath());
 			ObjectInputStream ois = new ObjectInputStream(f.getV());
 			List<ThrustCurveMotor> motors = (List<ThrustCurveMotor>) ois.readObject();
 			addMotors(motors);
@@ -124,8 +124,8 @@ public class MotorDatabaseLoader extends AsynchronousDatabaseLoader {
 			log.debug("Loading motors from file " + file);
 			loadFile(
 					loader,
-					new Pair<String,InputStream>(
-							file.getName(),
+					new Pair<>(
+							file,
 							new BufferedInputStream(new FileInputStream(file))));
 		} catch (Exception e) {
 			log.warn("Exception while reading " + file + ": " + e, e);
@@ -138,18 +138,17 @@ public class MotorDatabaseLoader extends AsynchronousDatabaseLoader {
 	 * @param loader	an object to handle the loading
 	 * @param f			the pair of File name and its input stream
 	 */
-	private void loadFile(GeneralMotorLoader loader, Pair<String, InputStream> f) {
+	private void loadFile(GeneralMotorLoader loader, Pair<File, InputStream> f) {
 		try {
-			List<ThrustCurveMotor.Builder> motors = loader.load(f.getV(), f.getU());
+			List<ThrustCurveMotor.Builder> motors = loader.load(f.getV(), f.getU().getName());
 			try {
 				addMotorsFromBuilders(motors);
 			}
 			catch (IllegalArgumentException e) {
 				Translator trans = Application.getTranslator();
-				File thrustCurveDir = ((SwingPreferences) Application.getPreferences()).getDefaultUserThrustCurveFile();
-				File fullPath = new File(thrustCurveDir, f.getU());
+				String fullPath = f.getU().getPath();
 				String message = "<html><body><p style='width: 400px;'><i>" + e.getMessage() +
-						"</i>.<br><br>" + MessageFormat.format( trans.get("MotorDbLoaderDlg.message1"), fullPath.getPath()) +
+						"</i>.<br><br>" + MessageFormat.format( trans.get("MotorDbLoaderDlg.message1"), fullPath) +
 						"<br>" + trans.get("MotorDbLoaderDlg.message2") + "</p></body></html>";
 				JOptionPane pane = new JOptionPane(message, JOptionPane.WARNING_MESSAGE);
 				JDialog dialog = pane.createDialog(null, trans.get("MotorDbLoaderDlg.title"));

--- a/swing/src/net/sf/openrocket/file/motor/MotorLoaderHelper.java
+++ b/swing/src/net/sf/openrocket/file/motor/MotorLoaderHelper.java
@@ -95,10 +95,10 @@ public final class MotorLoaderHelper {
 		List<ThrustCurveMotor.Builder> list = new ArrayList<ThrustCurveMotor.Builder>();
 
 		while (iterator.hasNext()) {
-			final Pair<String, InputStream> input = iterator.next();
+			final Pair<File, InputStream> input = iterator.next();
 			log.debug("Loading motors from file " + input.getU());
 			try {
-				List<ThrustCurveMotor.Builder> motors = load(input.getV(), input.getU());
+				List<ThrustCurveMotor.Builder> motors = load(input.getV(), input.getU().getName());
 				for (ThrustCurveMotor.Builder m : motors) {
 					list.add(m);
 				}

--- a/swing/src/net/sf/openrocket/utils/SerializePresets.java
+++ b/swing/src/net/sf/openrocket/utils/SerializePresets.java
@@ -50,8 +50,8 @@ public class SerializePresets extends BasicApplication {
 			}
 			
 			while (iterator.hasNext()) {
-				Pair<String, InputStream> f = iterator.next();
-				String fileName = f.getU();
+				Pair<File, InputStream> f = iterator.next();
+				String fileName = f.getU().getName();
 				InputStream is = f.getV();
 				
 				OpenRocketComponentLoader loader = new OpenRocketComponentLoader();


### PR DESCRIPTION
This PR fixes #1966. The `FileIterator` now passes a pair of the File and InputStream, instead of simply the file name and InputStream.
<img width="1557" alt="image" src="https://user-images.githubusercontent.com/11031519/211940550-a90f5c28-6d70-4411-bec6-ddd889d184c9.png">
