### PR TITLE
[#1973] Don't mark all simulations out-of-date on flight config change

### DIFF
--- a/core/src/net/sf/openrocket/document/Simulation.java
+++ b/core/src/net/sf/openrocket/document/Simulation.java
@@ -339,7 +339,13 @@ public class Simulation implements ChangeSource, Cloneable {
 	public static boolean isStatusUpToDate(Status status) {
 		return status == Status.UPTODATE || status == Status.LOADED || status == Status.EXTERNAL;
 	}
-	
+
+	/**
+	 * Syncs the modID with its flight configuration.
+	 */
+	public void syncModID() {
+		this.simulatedConfigurationID = getActiveConfiguration().getModID();
+	}
 	
 	
 	/**

--- a/core/src/net/sf/openrocket/document/Simulation.java
+++ b/core/src/net/sf/openrocket/document/Simulation.java
@@ -75,7 +75,7 @@ public class Simulation implements ChangeSource, Cloneable {
 	
 	private String name = "";
 	
-	private Status status = Status.NOT_SIMULATED;
+	private Status status;
 	
 	/** The conditions to use */
 	// TODO: HIGH: Change to use actual conditions class??
@@ -98,7 +98,7 @@ public class Simulation implements ChangeSource, Cloneable {
 	private SimulationOptions simulatedConditions = null;
 	private String simulatedConfigurationDescription = null;
 	private FlightData simulatedData = null;
-	private int simulatedRocketID = -1;
+	private int simulatedConfigurationID = -1;
 	
 	
 	/**
@@ -147,7 +147,8 @@ public class Simulation implements ChangeSource, Cloneable {
 		
 		this.options = options;
 
-		this.setFlightConfigurationId( rocket.getSelectedConfiguration().getFlightConfigurationID());
+		final FlightConfiguration config = rocket.getSelectedConfiguration();
+		this.setFlightConfigurationId(config.getFlightConfigurationID());
 				
 		options.addChangeListener(new ConditionListener());
 		
@@ -160,7 +161,7 @@ public class Simulation implements ChangeSource, Cloneable {
 			simulatedData = data;
 			if (this.status == Status.LOADED) {
 				simulatedConditions = options.clone();
-				simulatedRocketID = rocket.getModID();
+				simulatedConfigurationID = config.getModID();
 			}
 		}
 		
@@ -308,8 +309,10 @@ public class Simulation implements ChangeSource, Cloneable {
 	 */
 	public Status getStatus() {
 		mutex.verify();
+		final FlightConfiguration config = rocket.getFlightConfiguration(this.getId()).clone();
+
 		if (isStatusUpToDate(status)) {
-			if (rocket.getFunctionalModID() != simulatedRocketID || !options.equals(simulatedConditions)) {
+			if (config.getModID() != simulatedConfigurationID || !options.equals(simulatedConditions)) {
 				status = Status.OUTDATED;
 			}
 		}
@@ -320,8 +323,6 @@ public class Simulation implements ChangeSource, Cloneable {
 			status = Status.CANT_RUN;
 			return status;
 		}
-		
-		FlightConfiguration config = rocket.getFlightConfiguration( this.getId()).clone();
 				
 		//Make sure this simulation has motors.
 		if ( ! config.hasMotors() ){
@@ -392,7 +393,7 @@ public class Simulation implements ChangeSource, Cloneable {
 			// Set simulated info after simulation
 			simulatedConditions = options.clone();
 			simulatedConfigurationDescription = descriptor.format( this.rocket, getId());
-			simulatedRocketID = rocket.getFunctionalModID();
+			simulatedConfigurationID = getActiveConfiguration().getModID();
 			
 			status = Status.UPTODATE;
 			fireChangeEvent();
@@ -492,7 +493,7 @@ public class Simulation implements ChangeSource, Cloneable {
 			copy.simulatedConditions = null;
 			copy.simulatedConfigurationDescription = null;
 			copy.simulatedData = null;
-			copy.simulatedRocketID = -1;
+			copy.simulatedConfigurationID = -1;
 			
 			return copy;
 			

--- a/core/src/net/sf/openrocket/file/openrocket/importt/OpenRocketLoader.java
+++ b/core/src/net/sf/openrocket/file/openrocket/importt/OpenRocketLoader.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
+import net.sf.openrocket.rocketcomponent.ComponentChangeEvent;
 import net.sf.openrocket.rocketcomponent.FlightConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,6 +63,7 @@ public class OpenRocketLoader extends AbstractRocketLoader {
 		// Deduce suitable time skip
 		double timeSkip = StorageOptions.SIMULATION_DATA_NONE;
 		for (Simulation s : doc.getSimulations()) {
+			s.syncModID();		// The config's modID can be out of sync with the simulation's after the whole loading process
 			if (s.getStatus() == Simulation.Status.EXTERNAL ||
 					s.getStatus() == Simulation.Status.NOT_SIMULATED)
 				continue;

--- a/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
@@ -525,6 +525,13 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 		updateMotors();
 		updateActiveInstances();
 	}
+
+	/**
+	 * Update the configuration's modID, thus staging it in need to update.
+	 */
+	public void updateModID() {
+		this.modID++;
+	}
 	
 	private void updateStages() {
 		Map<Integer, FlightConfiguration.StageFlags> stagesBackup = new HashMap<>(this.stages);
@@ -890,13 +897,7 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 
 	@Override
 	public int getModID() {
-		// TODO: this doesn't seem consistent...
-		int id = modID;
-//		for (MotorInstance motor : motors.values()) {
-//			id += motor.getModID();
-//		}
-		id += rocket.getModID();
-		return id; 
+		return modID;
 	}
 
 	public void setName(final String newName) {

--- a/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/FlightConfiguration.java
@@ -159,8 +159,6 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 	 */
 	public void clearStage(final int stageNumber) {
 		_setStageActive( stageNumber, false );
-		updateMotors();
-		updateActiveInstances();
 	}
 
 	/**
@@ -174,8 +172,6 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 		for (int i = stageNumber; i < rocket.getStageCount(); i++) {
 			_setStageActive(i, false, false);
 		}
-		updateMotors();
-		updateActiveInstances();
 	}
 
 	/**
@@ -187,8 +183,6 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 		for (int i = 0; i < stageNumber; i++) {
 			_setStageActive(i, false, false);
 		}
-		updateMotors();
-		updateActiveInstances();
 	}
 	
 	/**
@@ -214,8 +208,6 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 		for (int i=0; i <= stage.getStageNumber(); i++) {
 			_setStageActive(i, true);
 		}
-		updateMotors();
-		updateActiveInstances();
 	}
 	
 	/** 
@@ -226,8 +218,6 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 	public void setOnlyStage(final int stageNumber) {
 		_setAllStages(false);
 		_setStageActive(stageNumber, true, false);
-		updateMotors();
-		updateActiveInstances();
 	}
 
 	/**

--- a/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
@@ -467,17 +467,28 @@ public class Rocket extends ComponentAssembly {
 		listenerList.remove(l);
 		log.trace("Removed ComponentChangeListener " + l + ", current number of listeners is " + listenerList.size());
 	}
-	
-	@Override
-	protected void fireComponentChangeEvent(ComponentChangeEvent cce) {
-		if( ! this.eventsEnabled ){
+
+	/**
+	 * Fires a ComponentChangeEvent of the given type.  The source of the event is set to
+	 * this rocket.
+	 *
+	 * @param type  Type of event
+	 * @param ids IDs of the flight configurations to update, or null to update all.
+	 * @see #fireComponentChangeEvent(ComponentChangeEvent)
+	 */
+	public void fireComponentChangeEvent(int type, FlightConfigurationId[] ids) {
+		fireComponentChangeEvent(new ComponentChangeEvent(this, type), ids);
+	}
+
+	protected void fireComponentChangeEvent(ComponentChangeEvent cce, FlightConfigurationId[] ids) {
+		if (!this.eventsEnabled) {
 			return;
 		}
-		
+
 		mutex.lock("fireComponentChangeEvent");
 		try {
 			checkState();
-			
+
 			// Update modification ID's only for normal (not undo/redo) events
 			if (!cce.isUndoChange()) {
 				modID = UniqueID.next();
@@ -487,30 +498,37 @@ public class Rocket extends ComponentAssembly {
 					aeroModID = modID;
 				if (cce.isTreeChange())
 					treeModID = modID;
-				if (cce.isFunctionalChange())
+				if (cce.isFunctionalChange()) {
 					functionalModID = modID;
+					updateConfigurationsModID(ids);
+				}
 			}
-			
+
 			// Check whether frozen
 			if (freezeList != null) {
 				log.debug("Rocket is in frozen state, adding event " + cce + " info freeze list");
 				freezeList.add(cce);
 				return;
 			}
-		
+
 			// Notify all components first
 			Iterator<RocketComponent> iterator = this.iterator(true);
 			while (iterator.hasNext()) {
 				RocketComponent next = iterator.next();
 				next.componentChanged(cce);
 			}
-			updateConfigurations();
+			updateConfigurations(ids);
 
 			notifyAllListeners(cce);
-			
+
 		} finally {
 			mutex.unlock("fireComponentChangeEvent");
 		}
+	}
+	
+	@Override
+	protected void fireComponentChangeEvent(ComponentChangeEvent cce) {
+		fireComponentChangeEvent(cce, null);
 	}
 	
 	@Override
@@ -537,11 +555,51 @@ public class Rocket extends ComponentAssembly {
 			trackStage(stage);
 		}
 	}
-	
-	private void updateConfigurations(){
-		for( FlightConfiguration config : configSet ){
-			config.update();
+
+	/**
+	 * Update the modIDs of the supplied flight configurations.
+	 * @param ids IDs of the flight configurations to update, or null to update all.
+	 */
+	private void updateConfigurationsModID(FlightConfigurationId[] ids) {
+		if (ids == null) {
+			for (FlightConfiguration config : configSet) {
+				config.updateModID();
+			}
+			return;
 		}
+		for (FlightConfiguration config : configSet) {
+			for (FlightConfigurationId id : ids) {
+				if (config.getId().equals(id)) {
+					config.updateModID();
+					break;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Update the flight configurations.
+	 * @param ids IDs of the flight configurations to update, or null to update all.
+	 */
+	private void updateConfigurations(FlightConfigurationId[] ids) {
+		if (ids == null) {
+			for (FlightConfiguration config : configSet) {
+				config.update();
+			}
+			return;
+		}
+		for (FlightConfiguration config : configSet) {
+			for (FlightConfigurationId id : ids) {
+				if (config.getId().equals(id)) {
+					config.update();
+					break;
+				}
+			}
+		}
+	}
+	
+	private void updateConfigurations() {
+		updateConfigurations(null);
 	}
 	
 	
@@ -678,8 +736,8 @@ public class Rocket extends ComponentAssembly {
 		}
 				
 		// Get current configuration:
-		this.configSet.reset( fcid);
-		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
+		this.configSet.reset(fcid);
+		fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 	}
 	
 	

--- a/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Rocket.java
@@ -476,11 +476,23 @@ public class Rocket extends ComponentAssembly {
 	 * @param ids IDs of the flight configurations to update, or null to update all.
 	 * @see #fireComponentChangeEvent(ComponentChangeEvent)
 	 */
-	public void fireComponentChangeEvent(int type, FlightConfigurationId[] ids) {
+	public void fireComponentChangeEvent(int type, final FlightConfigurationId[] ids) {
 		fireComponentChangeEvent(new ComponentChangeEvent(this, type), ids);
 	}
 
-	protected void fireComponentChangeEvent(ComponentChangeEvent cce, FlightConfigurationId[] ids) {
+	/**
+	 * Fires a ComponentChangeEvent of the given type.  The source of the event is set to
+	 * this rocket.
+	 *
+	 * @param type  Type of event
+	 * @param id ID of the flight configurations to update, or null to update all.
+	 * @see #fireComponentChangeEvent(ComponentChangeEvent)
+	 */
+	public void fireComponentChangeEvent(int type, FlightConfigurationId id) {
+		fireComponentChangeEvent(type, new FlightConfigurationId[]{ id });
+	}
+
+	protected void fireComponentChangeEvent(ComponentChangeEvent cce, final FlightConfigurationId[] ids) {
 		if (!this.eventsEnabled) {
 			return;
 		}

--- a/core/src/net/sf/openrocket/simulation/SimulationStatus.java
+++ b/core/src/net/sf/openrocket/simulation/SimulationStatus.java
@@ -33,8 +33,7 @@ import net.sf.openrocket.util.WorldCoordinate;
  */
 
 public class SimulationStatus implements Monitorable {
-	private static final Logger log = LoggerFactory.getLogger(SimulationStatus.class);
-	
+
 	private SimulationConditions simulationConditions;
 	private FlightConfiguration configuration;
 	private FlightDataBranch flightData;

--- a/swing/src/net/sf/openrocket/gui/components/StageSelector.java
+++ b/swing/src/net/sf/openrocket/gui/components/StageSelector.java
@@ -96,8 +96,10 @@ public class StageSelector extends JPanel implements StateChangeListener {
 				setEnabled(true);
 				putValue(SHORT_DESCRIPTION, trans.get("RocketPanel.btn.Stages.Toggle.ttip"));
 			}
-			rocket.getSelectedConfiguration().toggleStage(stage.getStageNumber());
-			rocket.fireComponentChangeEvent(ComponentChangeEvent.AEROMASS_CHANGE | ComponentChangeEvent.MOTOR_CHANGE );
+			FlightConfiguration config = rocket.getSelectedConfiguration();
+			config.toggleStage(stage.getStageNumber());
+			rocket.fireComponentChangeEvent(ComponentChangeEvent.AEROMASS_CHANGE | ComponentChangeEvent.MOTOR_CHANGE,
+					config.getFlightConfigurationID());
 		}
 		
 	}

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
@@ -64,11 +64,12 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 	/**
 	 * Update the data in the table, with component change event type {cce}
 	 * @param cce index of the ComponentChangeEvent to use (e.g. ComponentChangeEvent.NONFUNCTIONAL_CHANGE)
+	 * @param ids: the IDs of the flight configurations that are affected by the change
 	 */
-	public void fireTableDataChanged(int cce) {
+	public void fireTableDataChanged(int cce, FlightConfigurationId[] ids) {
 		int selectedRow = table.getSelectedRow();
 		int selectedColumn = table.getSelectedColumn();
-		this.rocket.fireComponentChangeEvent(cce);
+		this.rocket.fireComponentChangeEvent(cce, ids);
 		((AbstractTableModel)table.getModel()).fireTableDataChanged();
 		restoreSelection(selectedRow,selectedColumn);
 		updateButtonState();

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
@@ -330,7 +330,7 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 		}
 
 		if (update) {
-			fireTableDataChanged(ComponentChangeEvent.MOTOR_CHANGE);
+			fireTableDataChanged(ComponentChangeEvent.MOTOR_CHANGE, fcIds.toArray(new FlightConfigurationId[0]));
 		} else {
 			table.requestFocusInWindow();
 		}
@@ -349,7 +349,7 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 			}
 		}
 		
-		fireTableDataChanged(ComponentChangeEvent.MOTOR_CHANGE);
+		fireTableDataChanged(ComponentChangeEvent.MOTOR_CHANGE, fcIds.toArray(new FlightConfigurationId[0]));
 	}
 
 	private void selectIgnition() {
@@ -396,7 +396,7 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 		}
 
 		if (update) {
-			fireTableDataChanged(ComponentChangeEvent.MOTOR_CHANGE);
+			fireTableDataChanged(ComponentChangeEvent.MOTOR_CHANGE, fcIds.toArray(new FlightConfigurationId[0]));
 		} else {
 			table.requestFocusInWindow();
 		}
@@ -426,7 +426,7 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 		}
 
 		if (update) {
-			fireTableDataChanged(ComponentChangeEvent.MOTOR_CHANGE);
+			fireTableDataChanged(ComponentChangeEvent.MOTOR_CHANGE, fcIds.toArray(new FlightConfigurationId[0]));
 		} else {
 			table.requestFocusInWindow();
 		}

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
@@ -209,7 +209,7 @@ public class RecoveryConfigurationPanel extends FlightConfigurablePanel<Recovery
 		}
 
 		if (update) {
-			fireTableDataChanged(ComponentChangeEvent.AERODYNAMIC_CHANGE);
+			fireTableDataChanged(ComponentChangeEvent.AERODYNAMIC_CHANGE, fcIds.toArray(new FlightConfigurationId[0]));
 		} else {
 			table.requestFocusInWindow();
 		}
@@ -235,7 +235,7 @@ public class RecoveryConfigurationPanel extends FlightConfigurablePanel<Recovery
 			}
 		}
 		if (update) {
-			fireTableDataChanged(ComponentChangeEvent.AERODYNAMIC_CHANGE);
+			fireTableDataChanged(ComponentChangeEvent.AERODYNAMIC_CHANGE, fcIds.toArray(new FlightConfigurationId[0]));
 		} else {
 			table.requestFocusInWindow();
 		}

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
@@ -219,7 +219,7 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialS
 		}
 
 		if (update) {
-			fireTableDataChanged(ComponentChangeEvent.AEROMASS_CHANGE);
+			fireTableDataChanged(ComponentChangeEvent.AEROMASS_CHANGE, fcIds.toArray(new FlightConfigurationId[0]));
 		} else {
 			table.requestFocusInWindow();
 		}
@@ -245,7 +245,7 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialS
 		}
 
 		if (update) {
-			fireTableDataChanged(ComponentChangeEvent.AEROMASS_CHANGE);
+			fireTableDataChanged(ComponentChangeEvent.AEROMASS_CHANGE, fcIds.toArray(new FlightConfigurationId[0]));
 		} else {
 			table.requestFocusInWindow();
 		}


### PR DESCRIPTION
This PR fixes #1973. Instead of marking simulations out-of-date based on the rocket's modID, I changed it to the modID of the flight configuration of that simulation. This ensures that any changes made to a flight configuration (new stage, remove stage, motor selection, ignition change, recovery/stage change...) will not affect simulations based on another flight configuration. If there are multiple simulations of flight configuration A, and flight configuration A is changed, then all those flight config A simulations will be marked out-of-date.


https://user-images.githubusercontent.com/11031519/212572691-3d9e5fd8-f645-499a-90f7-ef5bd7d6e6a9.mp4

