### PR TITLE
Grey out texture edit button if using default material

### DIFF
--- a/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
@@ -576,13 +576,19 @@ public class AppearancePanel extends JPanel {
 		order.add(textureDropDown);
 		JButton editBtn = new SelectColorButton(
 				trans.get("AppearanceCfg.but.edit"));
-		editBtn.setEnabled(builder.getImage() != null);
+		editBtn.setEnabled(!materialDefault.isSelected() && builder.getImage() != null);
 		// Enable the editBtn only when the appearance builder has an Image
 		// assigned to it.
 		builder.addChangeListener(new StateChangeListener() {
 			@Override
 			public void stateChanged(EventObject e) {
-				editBtn.setEnabled(builder.getImage() != null);
+				editBtn.setEnabled(!materialDefault.isSelected() && builder.getImage() != null);
+			}
+		});
+		materialDefault.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				editBtn.setEnabled(!materialDefault.isSelected() && builder.getImage() != null);
 			}
 		});
 


### PR DESCRIPTION
When the default material is used, the edit button should be greyed out.

<img width="1557" alt="image" src="https://user-images.githubusercontent.com/11031519/213884830-32d858c2-05d0-4b8f-b568-a16ec11213b6.png">
