### PR TITLE
Enable decal editing in Linux

### DIFF
--- a/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
@@ -32,6 +32,8 @@ import net.sf.openrocket.appearance.AppearanceBuilder;
 import net.sf.openrocket.appearance.Decal.EdgeMode;
 import net.sf.openrocket.appearance.DecalImage;
 import net.sf.openrocket.appearance.defaults.DefaultAppearance;
+import net.sf.openrocket.arch.SystemInfo;
+import net.sf.openrocket.arch.SystemInfo.Platform;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.gui.SpinnerEditor;
 import net.sf.openrocket.gui.adaptors.BooleanModel;
@@ -576,14 +578,14 @@ public class AppearancePanel extends JPanel {
 		p.add(textureDropDown, "grow");
 		panel.add(p, "spanx 3, growx, wrap");
 		order.add(textureDropDown);
-
+			
 		//// Edit button
-		if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.EDIT)) {
+		if ((SystemInfo.getPlatform() != Platform.UNIX) || !SystemInfo.isConfined()) {
 			JButton editBtn = new SelectColorButton(
 					trans.get("AppearanceCfg.but.edit"));
-			editBtn.setEnabled(!materialDefault.isSelected() && builder.getImage() != null);
 			// Enable the editBtn only when the appearance builder has an Image
 			// assigned to it.
+			editBtn.setEnabled(!materialDefault.isSelected() && builder.getImage() != null);
 			builder.addChangeListener(new StateChangeListener() {
 				@Override
 				public void stateChanged(EventObject e) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/EditDecalDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/EditDecalDialog.java
@@ -96,11 +96,11 @@ public class EditDecalDialog extends JDialog {
 				
 			} else {
 				commandText = new JTextArea();
-				commandText.setEnabled(false);
+				commandText.setEnabled(true);
 				panel.add(commandText, "growx, wrap");
 				
 				final JButton chooser = new SelectColorButton(trans.get("EditDecalDialog.btn.chooser"));
-				chooser.setEnabled(false);
+				chooser.setEnabled(true);
 				chooser.addActionListener(new ActionListener() {
 					
 					@Override

--- a/swing/src/net/sf/openrocket/gui/dialogs/preferences/GraphicsPreferencesPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preferences/GraphicsPreferencesPanel.java
@@ -145,7 +145,7 @@ public class GraphicsPreferencesPanel extends PreferencesPanel {
 		 * we will rely on using the xdg-open command which allows the user to pick
 		 * their preferred application.
 		 */
-		if (SystemInfo.getPlatform() != Platform.UNIX || !SystemInfo.isConfined()) {
+		if ((SystemInfo.getPlatform() != Platform.UNIX) || !SystemInfo.isConfined()) {
 			this.add(editorPrefPanel, "growx, span");
 		}
 		

--- a/swing/src/net/sf/openrocket/gui/dialogs/preferences/GraphicsPreferencesPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preferences/GraphicsPreferencesPanel.java
@@ -145,7 +145,7 @@ public class GraphicsPreferencesPanel extends PreferencesPanel {
 		 * we will rely on using the xdg-open command which allows the user to pick
 		 * their preferred application.
 		 */
-		if (SystemInfo.getPlatform() != Platform.UNIX && !SystemInfo.isConfined()) {
+		if (SystemInfo.getPlatform() != Platform.UNIX || !SystemInfo.isConfined()) {
 			this.add(editorPrefPanel, "growx, span");
 		}
 		


### PR DESCRIPTION
There appear to have been a total of three typos preventing decal editing in Linux
1) The test for snap confinement ended up not allowing any UNIX-like OSes to set the editor in the preferences
2) When the tests for desktop support failed, the text entry field for the command name and the command chooser were not enabled.
