### PR TITLE
[#2036] Fix incorrect position of parachute when auto radius

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/MassObject.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/MassObject.java
@@ -232,17 +232,17 @@ public abstract class MassObject extends InternalComponent {
 	
 	@Override
 	public final Coordinate getComponentCG() {
-		return new Coordinate(length / 2, shiftY, shiftZ, getComponentMass());
+		return new Coordinate(getLength() / 2, shiftY, shiftZ, getComponentMass());
 	}
 	
 	@Override
 	public final double getLongitudinalUnitInertia() {
-		return (3 * pow2(radius) + pow2(length)) / 12;
+		return (3 * pow2(getRadius()) + pow2(getLength())) / 12;
 	}
 	
 	@Override
 	public final double getRotationalUnitInertia() {
-		return pow2(radius) / 2;
+		return pow2(getRadius()) / 2;
 	}
 	
 	@Override

--- a/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
@@ -1273,14 +1273,14 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 	 */
 	public double getAxialOffset(AxialMethod asMethod) {
 		double parentLength = 0;
-		if (null != this.parent) {
-		    parentLength = this.parent.length;
+		if (this.parent != null && !(this.parent instanceof Rocket)) {
+		    parentLength = this.parent.getLength();
 		}
 
 		if(AxialMethod.ABSOLUTE == asMethod){
 			return this.getComponentLocations()[0].x;
 		}else {
-			return asMethod.getAsOffset(this.position.x, this.length, parentLength);
+			return asMethod.getAsOffset(this.position.x, getLength(), parentLength);
 		}
 	}
 	
@@ -1368,7 +1368,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 			this.setAfter();
 			return;
 		} else {
-			newX = requestedMethod.getAsPosition(requestedOffset, this.length, this.parent.getLength());
+			newX = requestedMethod.getAsPosition(requestedOffset, getLength(), this.parent.getLength());
 		}
 		
 		// snap to zero if less than the threshold 'EPSILON'
@@ -2704,7 +2704,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 		buf.append(String.format(" >> Dumping Detailed Information from: %s\n", callingMethod));
 		buf.append(String.format("      At Component: %s, of class: %s \n", this.getName(), this.getClass().getSimpleName()));
 		buf.append(String.format("      position: %.6f    at offset: %.4f via: %s\n", this.position.x, this.axialOffset, this.axialMethod.name()));
-		buf.append(String.format("      length: %.4f\n", this.length ));
+		buf.append(String.format("      length: %.4f\n", getLength() ));
 		return buf;
 	}
 	

--- a/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
@@ -179,7 +179,7 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 	public Collection<Coordinate> getComponentBounds() {
 		List<Coordinate> list = new ArrayList<Coordinate>(20);
 		for (int n = 0; n <= 5; n++) {
-			double x = n * length / 5;
+			double x = n * getLength() / 5;
 			double r = getRadius(x);
 			addBound(list, x, r);
 		}
@@ -333,14 +333,14 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 		cg = Coordinate.NUL;
 
 		// Check length > 0
-		if (length <= 0) {
+		if (getLength() <= 0) {
 			return;
 		}
 		
 
 		// Integrate for volume, CG, wetted area and planform area
 		
-		final double step = length / DIVISIONS;
+		final double step = getLength() / DIVISIONS;
 		final double pi3 = Math.PI / 3.0;
 		r1 = getRadius(0);
 		x = 0;
@@ -360,11 +360,11 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 			 * during the last iteration (n== DIVISIONS) we recompute l to be
 			 * whatever is left.
 			 */
-			double l = (n==DIVISIONS) ? length -x : step;
+			double l = (n==DIVISIONS) ? getLength() -x : step;
 
 			// Further to prevent round off error from the previous statement,
 			// we clamp r2 to length at the last iteration.
-			r2 = getRadius((n==DIVISIONS) ? length : x + l);
+			r2 = getRadius((n==DIVISIONS) ? getLength() : x + l);
 			
 			final double hyp = MathUtil.hypot(r2 - r1, l);
 			
@@ -416,7 +416,7 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 		
 		if (volume < 0.0000000001) { // 0.1 mm^3
 			volume = 0;
-			cg = new Coordinate(length / 2, 0, 0, 0);
+			cg = new Coordinate(getLength() / 2, 0, 0, 0);
 		} else {
 			// the mass of this shape is the material density * volume.
 			// it cannot come from super.getComponentMass() since that 
@@ -436,9 +436,9 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 		longitudinalInertia = 0;
 		rotationalInertia = 0;
 
-		if (length <= 0) return;
+		if (getLength() <= 0) return;
 
-		final double l = length / DIVISIONS;
+		final double l = getLength() / DIVISIONS;
 		final double pil = Math.PI * l; // PI * l
 		final double pil3 = Math.PI * l / 3; // PI * l/3
 		
@@ -506,9 +506,9 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 		longitudinalInertia = 0;
 		rotationalInertia = 0;
 
-		if (length <= 0) return;
+		if (getLength() <= 0) return;
 
-		final double l = length / DIVISIONS;
+		final double l = getLength() / DIVISIONS;
 		
 		r1 = getRadius(0);
 		x = 0;

--- a/core/test/net/sf/openrocket/rocketcomponent/MassObjectTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/MassObjectTest.java
@@ -27,12 +27,16 @@ public class MassObjectTest extends BaseTestCase {
                     0.1, mo.getLength(), MathUtil.EPSILON);
             Assert.assertEquals(String.format(" No auto %s incorrect no auto length", mo.getClass().getName()),
                     0.1, mo.getLengthNoAuto(), MathUtil.EPSILON);
+            Assert.assertEquals(String.format(" No auto %s incorrect CG", mo.getClass().getName()),
+                    0.05, mo.getComponentCG().x, MathUtil.EPSILON);
 
             mo.setLengthNoAuto(0.1);
             Assert.assertEquals(String.format(" No auto 2 %s incorrect length", mo.getClass().getName()),
                     0.1, mo.getLength(), MathUtil.EPSILON);
             Assert.assertEquals(String.format(" No auto 2 %s incorrect no auto length", mo.getClass().getName()),
                     0.1, mo.getLengthNoAuto(), MathUtil.EPSILON);
+            Assert.assertEquals(String.format(" No auto %s incorrect CG", mo.getClass().getName()),
+                    0.05, mo.getComponentCG().x, MathUtil.EPSILON);
 
             // Test auto
             BodyTube parent = new BodyTube();
@@ -48,6 +52,8 @@ public class MassObjectTest extends BaseTestCase {
                     0.4, mo.getLength(), MathUtil.EPSILON);
             Assert.assertEquals(String.format(" Auto 1 %s incorrect no auto length", mo.getClass().getName()),
                     0.1, mo.getLengthNoAuto(), MathUtil.EPSILON);
+            Assert.assertEquals(String.format(" Auto 1 %s incorrect CG", mo.getClass().getName()),
+                    0.2, mo.getComponentCG().x, MathUtil.EPSILON);
 
             parent.setOuterRadius(0.1);
             parent.setInnerRadius(0.1);
@@ -59,6 +65,8 @@ public class MassObjectTest extends BaseTestCase {
                     0.1, mo.getLength(), MathUtil.EPSILON);
             Assert.assertEquals(String.format(" Auto 2 %s incorrect no auto length", mo.getClass().getName()),
                     0.1, mo.getLengthNoAuto(), MathUtil.EPSILON);
+            Assert.assertEquals(String.format(" Auto 2 %s incorrect CG", mo.getClass().getName()),
+                    0.05, mo.getComponentCG().x, MathUtil.EPSILON);
 
             parent.setOuterRadius(0.075);
             parent.setInnerRadius(0.075);
@@ -71,6 +79,8 @@ public class MassObjectTest extends BaseTestCase {
                     0.075, mo.getLength(), MathUtil.EPSILON);
             Assert.assertEquals(String.format(" Auto 3 %s incorrect no auto length", mo.getClass().getName()),
                     0.0422, mo.getLengthNoAuto(), 0.001);
+            Assert.assertEquals(String.format(" Auto 3 %s incorrect CG", mo.getClass().getName()),
+                    0.0375, mo.getComponentCG().x, MathUtil.EPSILON);
 
             mo.setLengthNoAuto(0.05);
             Assert.assertEquals(String.format(" Auto 4 %s incorrect radius", mo.getClass().getName()),
@@ -81,6 +91,8 @@ public class MassObjectTest extends BaseTestCase {
                     0.0889, mo.getLength(), 0.001);
             Assert.assertEquals(String.format(" Auto 4 %s incorrect no auto length", mo.getClass().getName()),
                     0.05, mo.getLengthNoAuto(), MathUtil.EPSILON);
+            Assert.assertEquals(String.format(" Auto 4 %s incorrect CG", mo.getClass().getName()),
+                    0.044444444444, mo.getComponentCG().x, MathUtil.EPSILON);
         }
     }
 }


### PR DESCRIPTION
This PR fixes #2036. The issue was that some places use a direct call to `this.length` instead of using the `getLength()` method.

I never noticed it before, but the component CG of the parachute would not update when changing the auto radius (if the parachute suddenly halved in length, its CG should also update - which was previously not the case). This PR fixes that as well.