### PR TITLE
[#2003] Increase resolution of launch temp and pressure to 2 decimals

### DIFF
--- a/core/src/net/sf/openrocket/unit/TemperatureUnit.java
+++ b/core/src/net/sf/openrocket/unit/TemperatureUnit.java
@@ -3,9 +3,9 @@ package net.sf.openrocket.unit;
 public class TemperatureUnit extends FixedPrecisionUnit {
 
 	protected final double addition;
-	
-	public TemperatureUnit(double multiplier, double addition, String unit) {
-		super(unit, 1, multiplier);
+
+	public TemperatureUnit(double multiplier, double addition, double precision, String unit) {
+		super(unit, precision, multiplier);
 
 		this.addition = addition;
 	}

--- a/core/src/net/sf/openrocket/unit/UnitGroup.java
+++ b/core/src/net/sf/openrocket/unit/UnitGroup.java
@@ -257,17 +257,17 @@ public class UnitGroup {
 		UNITS_ROLL.addUnit(new GeneralUnit(2 * Math.PI / 60, "rpm"));
 		
 		UNITS_TEMPERATURE = new UnitGroup();
-		UNITS_TEMPERATURE.addUnit(new FixedPrecisionUnit("K", 1));
-		UNITS_TEMPERATURE.addUnit(new TemperatureUnit(1, 273.15, DEGREE + "C"));
-		UNITS_TEMPERATURE.addUnit(new TemperatureUnit(5.0 / 9.0, 459.67, DEGREE + "F"));
+		UNITS_TEMPERATURE.addUnit(new FixedPrecisionUnit("K", 0.01));
+		UNITS_TEMPERATURE.addUnit(new TemperatureUnit(1, 273.15, 0.01, DEGREE + "C"));
+		UNITS_TEMPERATURE.addUnit(new TemperatureUnit(5.0 / 9.0, 459.67, 0.01, DEGREE + "F"));
 		
 		UNITS_PRESSURE = new UnitGroup();
-		UNITS_PRESSURE.addUnit(new FixedPrecisionUnit("mbar", 1, 1.0e2));
+		UNITS_PRESSURE.addUnit(new FixedPrecisionUnit("mbar", 0.01, 1.0e2));
 		UNITS_PRESSURE.addUnit(new FixedPrecisionUnit("bar", 0.001, 1.0e5));
 		UNITS_PRESSURE.addUnit(new FixedPrecisionUnit("atm", 0.001, 1.01325e5));
-		UNITS_PRESSURE.addUnit(new GeneralUnit(101325.0 / 760.0, "mmHg"));
-		UNITS_PRESSURE.addUnit(new GeneralUnit(3386.389, "inHg"));
-		UNITS_PRESSURE.addUnit(new GeneralUnit(6894.75729, "psi"));
+		UNITS_PRESSURE.addUnit(new FixedPrecisionUnit("mmHg", 0.01, 101325.0 / 760.0));
+		UNITS_PRESSURE.addUnit(new FixedPrecisionUnit("inHg", 0.01, 3386.389));
+		UNITS_PRESSURE.addUnit(new FixedPrecisionUnit("psi", 0.01, 6894.75729));
 		UNITS_PRESSURE.addUnit(new GeneralUnit(1, "Pa"));
 		
 		UNITS_RELATIVE = new UnitGroup();

--- a/core/test/net/sf/openrocket/unit/ValueTest.java
+++ b/core/test/net/sf/openrocket/unit/ValueTest.java
@@ -11,7 +11,7 @@ public class ValueTest {
 		Value v1, v2;
 		
 		v1 = new Value(273.15, UnitGroup.UNITS_TEMPERATURE.findApproximate("F"));
-		v2 = new Value(283.15, UnitGroup.UNITS_TEMPERATURE.findApproximate("C"));
+		v2 = new Value(283.153, UnitGroup.UNITS_TEMPERATURE.findApproximate("C"));
 		
 		assertTrue(v1.compareTo(v2) > 0);
 		assertTrue(v2.compareTo(v1) < 0);
@@ -21,7 +21,7 @@ public class ValueTest {
 		v2 = new Value(283.15, UnitGroup.UNITS_TEMPERATURE.findApproximate("K"));
 		assertTrue(v1.compareTo(v2) > 0);
 		assertTrue(v2.compareTo(v1) < 0);
-		assertEquals("283 K", v2.toString());
+		assertEquals("283.15 K", v2.toString());
 		
 		v2 = new Value(283.15, UnitGroup.UNITS_TEMPERATURE.findApproximate("F"));
 		assertTrue(v1.compareTo(v2) < 0);

--- a/swing/src/net/sf/openrocket/gui/dialogs/preferences/LaunchPreferencesPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preferences/LaunchPreferencesPanel.java
@@ -179,7 +179,7 @@ public class LaunchPreferencesPanel extends PreferencesPanel {
 
 		// // Temperature and pressure
 		sub = new JPanel(new MigLayout("fill, gap rel unrel",
-				"[grow][65lp!][30lp!][75lp!]", ""));
+				"[grow][75lp!][35lp!][75lp!]", ""));
 		// // Atmospheric preferences
 		sub.setBorder(BorderFactory.createTitledBorder(trans
 				.get("simedtdlg.border.Atmoscond")));
@@ -222,7 +222,7 @@ public class LaunchPreferencesPanel extends PreferencesPanel {
 		spin.setEditor(new SpinnerEditor(spin));
 		spin.setToolTipText(tip);
 		isa.addEnableComponent(spin, false);
-		sub.add(spin, "w 65lp!");
+		sub.add(spin, "growx");
 
 		unit = new UnitSelector(m);
 		unit.setToolTipText(tip);
@@ -249,7 +249,7 @@ public class LaunchPreferencesPanel extends PreferencesPanel {
 		spin.setEditor(new SpinnerEditor(spin));
 		spin.setToolTipText(tip);
 		isa.addEnableComponent(spin, false);
-		sub.add(spin, "w 65lp!");
+		sub.add(spin, "growx");
 
 		unit = new UnitSelector(m);
 		unit.setToolTipText(tip);
@@ -284,7 +284,7 @@ public class LaunchPreferencesPanel extends PreferencesPanel {
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		spin.setToolTipText(tip);
-		sub.add(spin, "w 65lp!");
+		sub.add(spin, "growx");
 
 		label = new JLabel(Chars.DEGREE + " " + trans.get("CompassRose.lbl.north"));
 		label.setToolTipText(tip);
@@ -305,7 +305,7 @@ public class LaunchPreferencesPanel extends PreferencesPanel {
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		spin.setToolTipText(tip);
-		sub.add(spin, "w 65lp!");
+		sub.add(spin, "growx");
 
 		label = new JLabel(Chars.DEGREE + " " + trans.get("CompassRose.lbl.east"));
 		label.setToolTipText(tip);
@@ -328,7 +328,7 @@ public class LaunchPreferencesPanel extends PreferencesPanel {
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		spin.setToolTipText(tip);
-		sub.add(spin, "w 65lp!");
+		sub.add(spin, "growx");
 
 		unit = new UnitSelector(m);
 		unit.setToolTipText(tip);
@@ -358,7 +358,7 @@ public class LaunchPreferencesPanel extends PreferencesPanel {
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		spin.setToolTipText(tip);
-		sub.add(spin, "w 65lp!");
+		sub.add(spin, "growx");
 
 		unit = new UnitSelector(m);
 		unit.setToolTipText(tip);
@@ -393,7 +393,7 @@ public class LaunchPreferencesPanel extends PreferencesPanel {
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		spin.setToolTipText(tip);
-		sub.add(spin, "w 65lp!");
+		sub.add(spin, "growx");
 
 		unit = new UnitSelector(m);
 		unit.setToolTipText(tip);
@@ -421,7 +421,7 @@ public class LaunchPreferencesPanel extends PreferencesPanel {
 		JSpinner directionSpin = new JSpinner(m.getSpinnerModel());
 		directionSpin.setEditor(new SpinnerEditor(directionSpin));
 		directionSpin.setToolTipText(tip);
-		sub.add(directionSpin, "w 65lp!");
+		sub.add(directionSpin, "growx");
 
 		unit = new UnitSelector(m);
 		unit.setToolTipText(tip);

--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationConditionsPanel.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationConditionsPanel.java
@@ -169,7 +169,7 @@ public class SimulationConditionsPanel extends JPanel {
 		
 		//// Temperature and pressure
 		sub = new JPanel(new MigLayout("fill, gap rel unrel",
-				"[grow][65lp!][30lp!][75lp!]", ""));
+				"[grow][75lp!][35lp!][75lp!]", ""));
 		//// Atmospheric conditions
 		sub.setBorder(BorderFactory.createTitledBorder(trans.get("simedtdlg.border.Atmoscond")));
 		this.add(sub, "growx, aligny 0, gapright para");
@@ -204,7 +204,7 @@ public class SimulationConditionsPanel extends JPanel {
 		spin.setEditor(new SpinnerEditor(spin));
 		spin.setToolTipText(tip);
 		isa.addEnableComponent(spin, false);
-		sub.add(spin, "w 65lp!");
+		sub.add(spin, "growx");
 		
 		unit = new UnitSelector(m);
 		unit.setToolTipText(tip);
@@ -231,7 +231,7 @@ public class SimulationConditionsPanel extends JPanel {
 		spin.setEditor(new SpinnerEditor(spin));
 		spin.setToolTipText(tip);
 		isa.addEnableComponent(spin, false);
-		sub.add(spin, "w 65lp!");
+		sub.add(spin, "growx");
 		
 		unit = new UnitSelector(m);
 		unit.setToolTipText(tip);


### PR DESCRIPTION
This PR fixes #2003. The temperature and pressure in the launch site settings now have a 2 decimal resolution. For the pressure, `bar` and `atm` remain the same, since that was already good at 0.001 resolution. The resolution of `Pa` is still at integers, that's accurate enough.