### PR TITLE
[#2051] Sanitize some XML content

### DIFF
--- a/core/src/net/sf/openrocket/file/openrocket/OpenRocketSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/OpenRocketSaver.java
@@ -627,7 +627,7 @@ public class OpenRocketSaver extends RocketSaver {
 	private void writeElement(String element, Object content) throws IOException {
 		if (content == null)
 			content = "";
-		writeln("<" + element + ">" + content + "</" + element + ">");
+		writeln("<" + element + ">" + TextUtil.escapeXML(content) + "</" + element + ">");
 	}
 	
 	

--- a/core/src/net/sf/openrocket/file/openrocket/savers/RocketComponentSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/savers/RocketComponentSaver.java
@@ -40,8 +40,9 @@ public class RocketComponentSaver {
 		ComponentPreset preset = c.getPresetComponent();
 		if (preset != null) {
 			elements.add("<preset type=\"" + preset.getType() +
-					"\" manufacturer=\"" + preset.getManufacturer().getSimpleName() +
-					"\" partno=\"" + preset.getPartNo() + "\" digest=\"" + preset.getDigest() + "\"/>");
+					"\" manufacturer=\"" + TextUtil.escapeXML(preset.getManufacturer().getSimpleName()) +
+					"\" partno=\"" + TextUtil.escapeXML(preset.getPartNo()) + "\" digest=\"" +
+					preset.getDigest() + "\"/>");
 		}
 
 		// Save outside appearance

--- a/core/src/net/sf/openrocket/util/TextUtil.java
+++ b/core/src/net/sf/openrocket/util/TextUtil.java
@@ -156,7 +156,11 @@ public class TextUtil {
 	 * 
 	 * The result is both valid XML and HTML 2.0.  The majority of characters are left unchanged.
 	 */
-	public static String escapeXML(String s) {
+	public static String escapeXML(Object obj) {
+		if (obj == null) {
+			return "";
+		}
+		String s = obj.toString();
 		StringBuilder sb = new StringBuilder(s.length());
 		
 		for (int i = 0; i < s.length(); i++) {


### PR DESCRIPTION
This PR fixes #2051 by sanitizing some of the XML content when saving a .ork file.

Note: it is not possible to open files already saved with quotes, it is only possible to avoid this issue from happening in the future by sanitizing the XML content before saving it.

Steps to reproduce:
1. Add a body tube, go to its parts library
2. Search for "38mm Motor Mount tube 11" and apply it to the body tube
3. Save the file and close it
4. Open it again