### PR TITLE
[#2072] Apply designation/common name choice to other parts

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -1378,6 +1378,7 @@ TCMotorSelPan.lbl.Ejectionchargedelay = Ejection charge delay:
 TCMotorSelPan.equalsIgnoreCase.None = None
 TCMotorSelPan.lbl.NumberofsecondsorNone = (Number of seconds or \"None\")
 TCMotorSelPan.lbl.Designation = Designation:
+TCMotorSelPan.lbl.CommonName = Common name:
 TCMotorSelPan.lbl.Totalimpulse = Total impulse:
 TCMotorSelPan.lbl.Avgthrust = Avg. thrust:
 TCMotorSelPan.lbl.Maxthrust = Max. thrust:

--- a/core/src/net/sf/openrocket/formatting/MotorConfigurationSubstitutor.java
+++ b/core/src/net/sf/openrocket/formatting/MotorConfigurationSubstitutor.java
@@ -12,6 +12,7 @@ import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
 import net.sf.openrocket.rocketcomponent.MotorMount;
 import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
+import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.ArrayList;
 import net.sf.openrocket.util.Chars;
 
@@ -93,7 +94,7 @@ public class MotorConfigurationSubstitutor implements RocketSubstitutor {
                 Motor motor = inst.getMotor();
 
                 if (mount.isMotorMount() && config.isComponentActive(mount) && (motor != null)) {
-                    String motorDesignation = motor.getDesignation(inst.getEjectionDelay());
+                    String motorDesignation = motor.getMotorName(inst.getEjectionDelay());
                     String manufacturer = "";
                     if (motor instanceof ThrustCurveMotor) {
                         manufacturer = ((ThrustCurveMotor) motor).getManufacturer().getDisplayName();

--- a/core/src/net/sf/openrocket/motor/Motor.java
+++ b/core/src/net/sf/openrocket/motor/Motor.java
@@ -1,5 +1,7 @@
 package net.sf.openrocket.motor;
 
+import net.sf.openrocket.startup.Application;
+
 public interface Motor {
 	
 	/**
@@ -110,6 +112,24 @@ public interface Motor {
 	 * @return		 designation with delay.
 	 */
 	public String getDesignation(double delay);
+
+	/**
+	 * Returns the motor name, based on whether the preference is to use the designation or common name.
+	 * @return the motor designation, if the preference is to use the designation, otherwise the common name.
+	 */
+	public default String getMotorName() {
+		boolean useDesignation = Application.getPreferences().getMotorNameColumn();
+		return useDesignation ? getDesignation() : getCommonName();
+	}
+
+	/**
+	 * Returns the motor name, including a delay, based on whether the preference is to use the designation or common name.
+	 * @return the motor designation, including a delay, if the preference is to use the designation, otherwise the common name.
+	 */
+	public default String getMotorName(double delay) {
+		boolean useDesignation = Application.getPreferences().getMotorNameColumn();
+		return useDesignation ? getDesignation(delay) : getCommonName(delay);
+	}
 	
 	
 	/**

--- a/core/src/net/sf/openrocket/motor/MotorConfiguration.java
+++ b/core/src/net/sf/openrocket/motor/MotorConfiguration.java
@@ -7,7 +7,6 @@ import net.sf.openrocket.rocketcomponent.InnerTube;
 import net.sf.openrocket.rocketcomponent.MotorMount;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.startup.Application;
-import net.sf.openrocket.util.ArrayList;
 import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.Inertia;
 
@@ -68,11 +67,11 @@ public class MotorConfiguration implements FlightConfigurableParameter<MotorConf
 		return ignitionOveride;
 	}
 
-	public String toMotorCommonName(){
+	public String toMotorName(){
 		if( motor == null ){
 			return trans.get("empty");
 		}else{
-			return this.motor.getCommonName(this.getEjectionDelay());
+			return this.motor.getMotorName(this.getEjectionDelay());
 		}
 	}
 	
@@ -273,7 +272,7 @@ public class MotorConfiguration implements FlightConfigurableParameter<MotorConf
 	}
 
 	public String toDescription(){
-		return ( this.toMotorCommonName()+
+		return ( this.toMotorName()+
 				" in: "+mount.getDebugName()+
 				" ign@: "+this.toIgnitionDescription() );
 	}
@@ -289,7 +288,7 @@ public class MotorConfiguration implements FlightConfigurableParameter<MotorConf
 				mount.getDebugName(),
 				fcid.toShortKey(),
 				mid.toDebug(),
-				toMotorCommonName(),
+				toMotorName(),
 				toIgnitionDescription() ));
 		
 		return buf.toString();

--- a/core/src/net/sf/openrocket/motor/MotorConfigurationSet.java
+++ b/core/src/net/sf/openrocket/motor/MotorConfigurationSet.java
@@ -58,7 +58,7 @@ public class MotorConfigurationSet extends FlightConfigurableParameterSet<MotorC
 					loopFCID.toShortKey(),
 					curConfig.getFCID().toShortKey(),
 					curConfig.getMID().toShortKey(),
-					curConfig.toMotorCommonName(),
+					curConfig.toMotorName(),
 					curConfig.toIgnitionDescription() ));
 						
 		}

--- a/core/src/net/sf/openrocket/startup/Preferences.java
+++ b/core/src/net/sf/openrocket/startup/Preferences.java
@@ -590,6 +590,22 @@ public abstract class Preferences implements ChangeSource {
 	}
 
 	/**
+	 * Check whether to display the common name (false), or designation (true) in the motor selection table "Name" column
+	 * @return true to display designation, false to display common name
+	 */
+	public boolean getMotorNameColumn() {
+		return getBoolean(net.sf.openrocket.startup.Preferences.MOTOR_NAME_COLUMN, true);
+	}
+
+	/**
+	 * Set whether to display the common name, or designation in the motor selection table "Name" column
+	 * @param value if true, display designation, if false, display common name
+	 */
+	public void setMotorNameColumn(boolean value) {
+		putBoolean(net.sf.openrocket.startup.Preferences.MOTOR_NAME_COLUMN, value);
+	}
+
+	/**
 	 * Return the OpenRocket unique ID.
 	 *
 	 * @return	a random ID string that stays constant between OpenRocket executions

--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/MotorHolder.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/MotorHolder.java
@@ -22,7 +22,7 @@ class MotorHolder {
 	
 	@Override
 	public String toString() {
-		return motor.getCommonName();
+		return motor.getMotorName();
 	}
 	
 	@Override

--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/MotorInformationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/MotorInformationPanel.java
@@ -52,6 +52,7 @@ class MotorInformationPanel extends JPanel {
 	private ThrustCurveMotor selectedMotor;
 
 	private final JLabel designationLabel;
+	private final JLabel commonNameLabel;
 	private final JLabel totalImpulseLabel;
 	private final JLabel classificationLabel;
 	private final JLabel avgThrustLabel;
@@ -82,6 +83,11 @@ class MotorInformationPanel extends JPanel {
 			this.add(new JLabel(trans.get("TCMotorSelPan.lbl.Designation")));
 			designationLabel = new JLabel();
 			this.add(designationLabel, "wrap");
+
+			//// Common name
+			this.add(new JLabel(trans.get("TCMotorSelPan.lbl.CommonName")));
+			commonNameLabel = new JLabel();
+			this.add(commonNameLabel, "wrap");
 		
 			//// Total impulse:
 			this.add(new JLabel(trans.get("TCMotorSelPan.lbl.Totalimpulse")));
@@ -230,6 +236,7 @@ class MotorInformationPanel extends JPanel {
 		selectedMotor = null;
 		selectedMotorSet = null;
 		designationLabel.setText("");
+		commonNameLabel.setText("");
 		totalImpulseLabel.setText("");
 		totalImpulseLabel.setToolTipText(null);
 		classificationLabel.setText("");
@@ -262,6 +269,7 @@ class MotorInformationPanel extends JPanel {
 
 		// Update thrust curve data
 		designationLabel.setText(selectedMotor.getDesignation());
+		commonNameLabel.setText(selectedMotor.getCommonName());
 		double impulse = selectedMotor.getTotalImpulseEstimate();
 		MotorClass mc = MotorClass.getMotorClass(impulse);
 		totalImpulseLabel.setText(UnitGroup.UNITS_IMPULSE.getDefaultUnit().toStringUnit(impulse));

--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorSelectionPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorSelectionPanel.java
@@ -248,6 +248,8 @@ public class ThrustCurveMotorSelectionPanel extends JPanel implements MotorSelec
 					if (selectedRow >= 0) {
 						table.setRowSelectionInterval(selectedRow, selectedRow);
 					}
+					curveSelectionBox.revalidate();
+					curveSelectionBox.repaint();
 				}
 			});
 			designation.addActionListener(new ActionListener() {
@@ -259,6 +261,8 @@ public class ThrustCurveMotorSelectionPanel extends JPanel implements MotorSelec
 					if (selectedRow >= 0) {
 						table.setRowSelectionInterval(selectedRow, selectedRow);
 					}
+					curveSelectionBox.revalidate();
+					curveSelectionBox.repaint();
 				}
 			});
 

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
@@ -507,7 +507,7 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 				throw new NullPointerException("Motor has a null mount... this should never happen: "+curMotorInstance.getID());
 			}
 
-			String str = motor.getCommonName(curMotorInstance.getEjectionDelay());
+			String str = motor.getMotorName(curMotorInstance.getEjectionDelay());
 			int count = mount.getInstanceCount();
 			if (count > 1) {
 				str = "" + count + Chars.TIMES + " " + str;

--- a/swing/src/net/sf/openrocket/gui/util/SwingPreferences.java
+++ b/swing/src/net/sf/openrocket/gui/util/SwingPreferences.java
@@ -362,23 +362,6 @@ public class SwingPreferences extends net.sf.openrocket.startup.Preferences {
 		// TODO: MEDIUM:  Motor fill color (settable?)
 		return new Color(0, 0, 0, 100);
 	}
-
-
-	/**
-	 * Check whether to display the common name (false), or designation (true) in the motor selection table "Name" column
-	 * @return true to display designation, false to display common name
-	 */
-	public boolean getMotorNameColumn() {
-		return getBoolean(net.sf.openrocket.startup.Preferences.MOTOR_NAME_COLUMN, true);
-	}
-
-	/**
-	 * Set whether to display the common name, or designation in the motor selection table "Name" column
-	 * @param value if true, display designation, if false, display common name
-	 */
-	public void setMotorNameColumn(boolean value) {
-		putBoolean(net.sf.openrocket.startup.Preferences.MOTOR_NAME_COLUMN, value);
-	}
 	
 	
 	public static int getMaxThreadCount() {


### PR DESCRIPTION
This PR fixes #2072. Selecting either "common name" or "manufacturer's designation" in the motor selection table will now also update other parts of OR.


https://user-images.githubusercontent.com/11031519/221307406-3fac9769-776d-48f1-a904-45d7322e0f75.mp4

