### PR TITLE
Tell user about zero-area fins and keep them from crashing simulation with NaN error

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -1882,6 +1882,7 @@ Warning.PODSET_FORWARD = In-line podset forward of parent airframe component
 Warning.PODSET_OVERLAP = In-line podset overlaps parent airframe component
 Warning.THICK_FIN = Thick fins may not simulate accurately.
 Warning.JAGGED_EDGED_FIN = Jagged-edged fin predictions may be inaccurate.
+Warning.ZERO_AREA_FIN = Fins with zero area will not affect aerodynamics
 Warning.LISTENERS_AFFECTED = Listeners modified the flight simulation
 Warning.RECOVERY_DEPLOYMENT_WHILE_BURNING = Recovery device opened while motor still burning.
 Warning.FILE_INVALID_PARAMETER = Invalid parameter encountered, ignoring.

--- a/core/src/net/sf/openrocket/aerodynamics/Warning.java
+++ b/core/src/net/sf/openrocket/aerodynamics/Warning.java
@@ -382,6 +382,10 @@ public abstract class Warning {
 	////Jagged-edged fin predictions may be inaccurate.
 	public static final Warning JAGGED_EDGED_FIN = new Other(trans.get("Warning.JAGGED_EDGED_FIN"));
 	
+	/** A <code>Warning</code> that the fins have a zero area. */
+	////Fins with no area will not affect aerodynamics
+	public static final Warning ZERO_AREA_FIN = new Other(trans.get("Warning.ZERO_AREA_FIN"));
+	
 	/** A <code>Warning</code> that simulation listeners have affected the simulation */
 	////Listeners modified the flight simulation
 	public static final Warning LISTENERS_AFFECTED = new Other(trans.get("Warning.LISTENERS_AFFECTED"));

--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/FinSetCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/FinSetCalc.java
@@ -84,7 +84,9 @@ public class FinSetCalc extends RocketComponentCalc {
 	public void calculateNonaxialForces(FlightConditions conditions, Transformation transform,
 			AerodynamicForces forces, WarningSet warnings) {
 		
-		if (span < 0.001) {
+		warnings.addAll(geometryWarnings);
+		
+		if (finArea < MathUtil.EPSILON) {
 			forces.setCm(0);
 			forces.setCN(0);
 			forces.setCNa(0);
@@ -96,12 +98,6 @@ public class FinSetCalc extends RocketComponentCalc {
 			forces.setCyaw(0);
 			return;
 		}
-
-		if ((bodyRadius > 0) && (thickness > bodyRadius / 2)){
-			// Add warnings  (radius/2 == diameter/4)
-			warnings.add(Warning.THICK_FIN);
-		}
-		warnings.addAll(geometryWarnings);
 		
 		//////// Calculate CNa.  /////////
 		
@@ -241,17 +237,26 @@ public class FinSetCalc extends RocketComponentCalc {
 		
 		Coordinate[] points = component.getFinPoints();
 		
-		// Check for jagged edges
+		// Check geometry
 		geometryWarnings.clear();
 		boolean down = false;
 		for (int i = 1; i < points.length; i++) {
 			if ((points[i].y > points[i - 1].y + 0.001) && down) {
-				geometryWarnings.add(Warning.JAGGED_EDGED_FIN);
+				geometryWarnings.add(Warning.JAGGED_EDGED_FIN, component.toString());
 				break;
 			}
 			if (points[i].y < points[i - 1].y - 0.001) {
 				down = true;
 			}
+		}
+
+		if (finArea < MathUtil.EPSILON) {
+			geometryWarnings.add(Warning.ZERO_AREA_FIN, component.toString());
+		}
+
+		if ((bodyRadius > 0) && (thickness > bodyRadius / 2)){
+			// Add warnings  (radius/2 == diameter/4)
+			geometryWarnings.add(Warning.THICK_FIN, component.toString());
 		}
 		
 		// Calculate the chord lead and trail positions and length
@@ -365,7 +370,6 @@ public class FinSetCalc extends RocketComponentCalc {
 		macLead *= dy;
 		area *= dy;
 		rollSum *= dy;
-		
 		macLength /= area;
 		macSpan /= area;
 		macLead /= area;
@@ -614,6 +618,11 @@ public class FinSetCalc extends RocketComponentCalc {
 
 	@Override
 	public double calculateFrictionCD(FlightConditions conditions, double componentCf, WarningSet warnings) {
+		// a fin with 0 area contributes no drag
+		if (finArea < MathUtil.EPSILON) {
+			return 0.0;
+		}
+		
 		double cd = componentCf * (1 + 2 * thickness / macLength) * 2 * finArea / conditions.getRefArea();
 		return cd;
 	}
@@ -622,6 +631,11 @@ public class FinSetCalc extends RocketComponentCalc {
 	public double calculatePressureCD(FlightConditions conditions,
 									  double stagnationCD, double baseCD, WarningSet warnings) {
 		
+		// a fin with 0 area contributes no drag
+		if (finArea < MathUtil.EPSILON) {
+			return 0.0;
+		}
+
 		double mach = conditions.getMach();
 		double cd = 0;
 		


### PR DESCRIPTION
Warn that fins with zero area will not affect aerodynamics
Keep fins with zero area from getting NaN errors

Fixes #2032