### PR TITLE
Decrease lower-limit of FOV

### DIFF
--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettings.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettings.java
@@ -113,7 +113,7 @@ public class PhotoSettings extends AbstractChangeSource implements FlameSettings
 	}
 	
 	public void setFov(double fov) {
-		this.fov = MathUtil.clamp(fov, 1, Math.PI);
+		this.fov = MathUtil.clamp(fov, 0, Math.PI);
 		fireChangeEvent();
 	}
 	

--- a/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettingsConfig.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/photo/PhotoSettingsConfig.java
@@ -223,10 +223,10 @@ public class PhotoSettingsConfig extends JTabbedPane {
 
 				/// FoV
 				add(new JLabel(trans.get("PhotoSettingsConfig.lbl.fov")));
-				DoubleModel fovModel = new DoubleModel(p, "Fov", UnitGroup.UNITS_ANGLE, Math.PI * 57.3/180, Math.PI * 160/180);
+				DoubleModel fovModel = new DoubleModel(p, "Fov", UnitGroup.UNITS_ANGLE, Math.PI * 10/180, Math.PI * 160/180);
 				add(new EditableSpinner(fovModel.getSpinnerModel()), "growx");
 				add(new UnitSelector(fovModel), "growx");
-				add(new BasicSlider(fovModel.getSliderModel(Math.PI * 57.3/180, Math.PI * 160/180)), "wrap");
+				add(new BasicSlider(fovModel.getSliderModel()), "wrap");
 			}
 		});
 


### PR DESCRIPTION
For some reason, the FOV in PhotoStudio was limited to 1 rad (57.3 °). I don't see immediate issues with decreasing this limit, so this PR decreases the limit to 10°.


https://user-images.githubusercontent.com/11031519/221654214-b8082660-4961-4f8e-857e-ab1bf2e60403.mp4

