### PR TITLE
[#2084] Include parts details for pods and boosters

### DIFF
--- a/swing/src/net/sf/openrocket/gui/print/visitor/PartsDetailVisitorStrategy.java
+++ b/swing/src/net/sf/openrocket/gui/print/visitor/PartsDetailVisitorStrategy.java
@@ -8,6 +8,7 @@ import java.util.Set;
 
 import javax.swing.ImageIcon;
 
+import net.sf.openrocket.rocketcomponent.ComponentAssembly;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -150,18 +151,20 @@ public class PartsDetailVisitorStrategy {
     private void handle (RocketComponent component) {
         //This ugly if-then-else construct is not object oriented.  Originally it was an elegant, and very OO savy, design
         //using the Visitor pattern.  Unfortunately, it was misunderstood and was removed.
-        if (component instanceof AxialStage) {
+        if (component instanceof ComponentAssembly) {
             try {
                 if (grid != null) {
                     document.add(grid);
                 }
-                document.add(ITextHelper.createPhrase(component.getName()));
+                if (level > 1) {
+                    Chunk tab = new Chunk(new VerticalPositionMark(), (level - 1) * 10, false);
+                    document.add(tab);
+                }
+                document.add(ITextHelper.createPhrase(component.getComponentName() + ": " +  component.getName()));
                 grid = new PdfPTable(TABLE_COLUMNS);
                 grid.setWidthPercentage(100);
                 grid.setHorizontalAlignment(Element.ALIGN_LEFT);
-            }
-            catch (DocumentException e) {
-            }
+            } catch (DocumentException ignored) { }
 
             List<RocketComponent> rc = component.getChildren();
             goDeep(rc);


### PR DESCRIPTION
This PR fixes #2084. Pods and booster components are now included in the parts details.
Export results for "Pods--airframes and winglets" example design:
![test1](https://user-images.githubusercontent.com/11031519/221732756-70538d96-3a8b-4ecf-9e52-da6f71b9414f.jpg)
![test2](https://user-images.githubusercontent.com/11031519/221732766-67674c87-ca0d-4a26-bec3-af2f7d725dad.jpg)
