### PR TITLE
Fix error in sim loading, add unit test, refine loading a bit.

### DIFF
--- a/core/src/net/sf/openrocket/file/openrocket/importt/OpenRocketLoader.java
+++ b/core/src/net/sf/openrocket/file/openrocket/importt/OpenRocketLoader.java
@@ -61,7 +61,7 @@ public class OpenRocketLoader extends AbstractRocketLoader {
 		}
 		
 		// If we saved data for a simulation before, we'll use that as our default option this time
-		boolean saveData = false;
+		// Also, updaet all the sims' modIDs to agree with flight config
 		for (Simulation s : doc.getSimulations()) {
 			s.syncModID();		// The config's modID can be out of sync with the simulation's after the whole loading process
 			if (s.getStatus() == Simulation.Status.EXTERNAL ||
@@ -79,8 +79,6 @@ public class OpenRocketLoader extends AbstractRocketLoader {
 				continue;
 
 			doc.getDefaultStorageOptions().setSaveSimulationData(true);
-			break;
-
 		}
 
 		doc.getDefaultStorageOptions().setExplicitlySet(false);

--- a/core/test/net/sf/openrocket/file/openrocket/OpenRocketSaverTest.java
+++ b/core/test/net/sf/openrocket/file/openrocket/OpenRocketSaverTest.java
@@ -22,6 +22,7 @@ import net.sf.openrocket.database.motor.MotorDatabase;
 import net.sf.openrocket.database.motor.ThrustCurveMotorSetDatabase;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.document.OpenRocketDocumentFactory;
+import net.sf.openrocket.document.Simulation;
 import net.sf.openrocket.document.StorageOptions;
 import net.sf.openrocket.file.GeneralRocketLoader;
 import net.sf.openrocket.file.RocketLoadException;
@@ -264,7 +265,64 @@ public class OpenRocketSaverTest {
 		
 		// TODO: fix estimateFileSize so that it's a lot more accurate
 	}
-	
+
+	/**
+	 * Test sim status with/without sim data in file.
+	 */
+	@Test
+	public void TestSimStatus() {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		OpenRocketDocument rocketDoc = OpenRocketDocumentFactory.createDocumentFromRocket(rocket);
+		
+		// Hook up some simulations.
+		// First sim will not have options set
+		Simulation sim1 = new Simulation(rocket);
+		rocketDoc.addSimulation(sim1);
+
+		// Second sim has options, but hasn't been simulated
+		Simulation sim2 = new Simulation(rocket);
+        sim2.getOptions().setISAAtmosphere(true);
+        sim2.getOptions().setTimeStep(0.05);
+        sim2.setFlightConfigurationId(TestRockets.TEST_FCID_0);
+		rocketDoc.addSimulation(sim2);
+
+		// Third sim has been executed
+		Simulation sim3 = new Simulation(rocket);
+        sim3.getOptions().setISAAtmosphere(true);
+        sim3.getOptions().setTimeStep(0.05);
+        sim3.setFlightConfigurationId(TestRockets.TEST_FCID_0);
+		try {
+			sim3.simulate();
+		} catch (Exception e) {
+			fail(e.toString());
+		}
+		rocketDoc.addSimulation(sim3);
+
+		// Fourth sim has been executed, then configuration changed
+		Simulation sim4 = new Simulation(rocket);
+        sim4.getOptions().setISAAtmosphere(true);
+        sim4.getOptions().setTimeStep(0.05);
+        sim4.setFlightConfigurationId(TestRockets.TEST_FCID_0);
+		try {
+			sim4.simulate();
+		} catch (Exception e) {
+			fail(e.toString());
+		}
+        sim4.getOptions().setTimeStep(0.1);
+		rocketDoc.addSimulation(sim4);
+
+		// save, then load document
+		StorageOptions options = new StorageOptions();
+		options.setSaveSimulationData(true);
+
+		File file = saveRocket(rocketDoc, options);
+		OpenRocketDocument rocketDocLoaded = loadRocket(file.getPath());
+		
+		assertEquals(Simulation.Status.CANT_RUN, rocketDocLoaded.getSimulations().get(0).getStatus());
+		assertEquals(Simulation.Status.NOT_SIMULATED, rocketDocLoaded.getSimulations().get(1).getStatus());
+		assertEquals(Simulation.Status.LOADED, rocketDocLoaded.getSimulations().get(2).getStatus());		
+		assertEquals(Simulation.Status.OUTDATED, rocketDocLoaded.getSimulations().get(3).getStatus());
+	}
 	
 	////////////////////////////////
 	// Tests for File Version 1.7 // 
@@ -276,7 +334,8 @@ public class OpenRocketSaverTest {
 		assertEquals(108, getCalculatedFileVersion(rocketDoc));
 	}
 	
-	
+
+	////////////////////////////////
 	/*
 	 * Utility Functions
 	 */


### PR DESCRIPTION
(see discussion of sim loading error at https://discord.com/channels/1073297014814691328/1078123170088878130/1080633494604107796)

The problem with nearly all the sims being marked as "out of date" was that a single loop was being used both to determine whether any of the sims had been saved with data, and to mark them as current.  I exited when a sim with data was identified; all the sims needed to be updated.  Loop isn't exiting early now.

Added a unit test to determine whether a sim was stored in a state in which it couldn't be run (I'm not sure that can happen in practice), runnable but not run, current, or out of date.  

Refined sim loading a bit to identify when loaded data was out of date when it was stored, and mark it out of date.