### PR TITLE
Railbutton pressure drag tweaks

### DIFF
--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/RailButtonCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/RailButtonCalc.java
@@ -58,48 +58,56 @@ public class RailButtonCalc extends RocketComponentCalc {
 		final double notchArea = (button.getOuterDiameter() - button.getInnerDiameter()) * button.getInnerHeight();
 		final double refArea = outerArea - notchArea;
 
-		// accumulate Cd contribution from each rail button
+		// accumulate Cd contribution from each rail button.  If velocity is 0 just set CDmul to a value previously
+		// competed for velocity MathUtil.EPSILON and skip the loop to avoid division by 0
 		double CDmul = 0.0;
-		for (int i = 0; i < button.getInstanceCount(); i++) {
-			
-			// compute boundary layer height at button location.  I can't find a good reference for the
-			// formula, e.g. https://aerospaceengineeringblog.com/boundary-layers/ simply says it's the
-			// "scientific consensus".
-			double x = (button.toAbsolute(instanceOffsets[i]))[0].x;   // location of button
-			double rex = calculateReynoldsNumber(x, conditions);       // Reynolds number of button location
-			double del = 0.37 * x / Math.pow(rex, 0.2);                // Boundary layer thickness
-
-			// compute mean airspeed over button
-			// this assumes airspeed changes linearly through boundary layer
-			// and that all parts of the railbutton contribute equally to Cd,
-			// neither of which is true but both are plenty close enough for our purposes
-
-			double mach;
-			if (buttonHt > del) {
-				// Case 1:  button extends beyond boundary layer
-				// Mean velocity is 1/2 rocket velocity up to limit of boundary layer,
-				// full velocity after that
-				mach = (buttonHt - 0.5*del) * conditions.getMach()/buttonHt;
-			} else {
-				// Case 2:  button is entirely within boundary layer
-				mach = MathUtil.map(buttonHt/2.0, 0, del, 0, conditions.getMach());
+		if (conditions.getMach() > MathUtil.EPSILON) {
+			for (int i = 0; i < button.getInstanceCount(); i++) {
+				
+				// compute boundary layer height at button location.  I can't find a good reference for the
+				// formula, e.g. https://aerospaceengineeringblog.com/boundary-layers/ simply says it's the
+				// "scientific consensus".
+				double x = (button.toAbsolute(instanceOffsets[i]))[0].x;   // location of button
+				double rex = calculateReynoldsNumber(x, conditions);       // Reynolds number of button location
+				double del = 0.37 * x / Math.pow(rex, 0.2);                // Boundary layer thickness
+				
+				// compute mean airspeed over button
+				// this assumes airspeed changes linearly through boundary layer
+				// and that all parts of the railbutton contribute equally to Cd,
+				// neither of which is true but both are plenty close enough for our purposes
+				
+				double mach;
+				if (buttonHt > del) {
+					// Case 1:  button extends beyond boundary layer
+					// Mean velocity is 1/2 rocket velocity up to limit of boundary layer,
+					// full velocity after that
+					mach = (buttonHt - 0.5*del) * conditions.getMach()/buttonHt;
+				} else {
+					// Case 2:  button is entirely within boundary layer
+					mach = MathUtil.map(buttonHt/2.0, 0, del, 0, conditions.getMach());
+				}
+				
+				// look up Cd as function of speed.  It's pretty constant as a function of Reynolds
+				// number when slow, so we can just use a function of Mach number
+				double cd = MathUtil.interpolate(cdDomain, cdRange, mach);
+				
+				// Since later drag force calculations don't consider boundary layer, compute "effective Cd"
+				// based on rocket velocity
+				cd = cd * MathUtil.pow2(mach)/MathUtil.pow2(conditions.getMach());
+				
+				// add to CDmul
+				CDmul += cd;
+				
 			}
 
-			// look up Cd as function of speed.  It's pretty constant as a function of Reynolds
-			// number when slow, so we can just use a function of Mach number
-			double cd = MathUtil.interpolate(cdDomain, cdRange, mach);
-
-			// Since later drag force calculations don't consider boundary layer, compute "effective Cd"
-			// based on rocket velocity
-			cd = cd * MathUtil.pow2(mach)/MathUtil.pow2(conditions.getMach());
+			// since we'll be multiplying by the instance count up in BarrowmanCalculator,
+			// we want to return the mean CD instead of the total
+			CDmul /= button.getInstanceCount();
 			
-			// add to CDmul
-			CDmul += cd;
-		}
-
-		// since we'll be multiplying by the instance count up in BarrowmanCalculator,
-		// we want to return the mean CD instead of the total
-		CDmul /= button.getInstanceCount();
+			} else {
+			// value at velocity of MathUtil.EPSILON
+				CDmul = 8.786395072609939E-4;
+			}
 		
 		return CDmul * stagnationCD * refArea / conditions.getRefArea();
 	}

--- a/core/src/net/sf/openrocket/aerodynamics/barrowman/RailButtonCalc.java
+++ b/core/src/net/sf/openrocket/aerodynamics/barrowman/RailButtonCalc.java
@@ -96,6 +96,10 @@ public class RailButtonCalc extends RocketComponentCalc {
 			// add to CDmul
 			CDmul += cd;
 		}
+
+		// since we'll be multiplying by the instance count up in BarrowmanCalculator,
+		// we want to return the mean CD instead of the total
+		CDmul /= button.getInstanceCount();
 		
 		return CDmul * stagnationCD * refArea / conditions.getRefArea();
 	}

--- a/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java
+++ b/core/test/net/sf/openrocket/aerodynamics/BarrowmanCalculatorTest.java
@@ -26,6 +26,7 @@ import net.sf.openrocket.rocketcomponent.Transition;
 import net.sf.openrocket.rocketcomponent.TrapezoidFinSet;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.Coordinate;
+import net.sf.openrocket.util.MathUtil;
 import net.sf.openrocket.util.TestRockets;
 
 public class BarrowmanCalculatorTest {
@@ -499,7 +500,8 @@ public class BarrowmanCalculatorTest {
 	}
 
 	/**
-	 * Tests railbutton drag.  Really is testing instancing more than actual drag calculations
+	 * Tests railbutton drag.  Really is testing instancing more than actual drag calculations, and making
+	 * sure we don't divide by 0 when not moving
 	 */
 	@Test
 	public void testRailButtonDrag() {
@@ -519,6 +521,8 @@ public class BarrowmanCalculatorTest {
 		final FlightConfiguration config = rocket.getSelectedConfiguration();
 		final FlightConditions conditions = new FlightConditions(config);
 		final BarrowmanCalculator calc = new BarrowmanCalculator();
+
+		// part 1:  instancing
 		
 		// Put two individual railbuttons and get their CD
 		final RailButton button1 = new RailButton();
@@ -548,7 +552,16 @@ public class BarrowmanCalculatorTest {
 		final double pairCD = pairForces.getCD();
 
 		assertEquals("two individual railbuttons should have same CD as a pair", individualCD, pairCD, EPSILON);
+
+		// part 2: test at Mach 0
+		conditions.setMach(MathUtil.EPSILON);
+		final AerodynamicForces epsForces = calc.getAerodynamicForces(config, conditions, warnings);
+		final double epsCD = epsForces.getCD();
+
+		conditions.setMach(0);
+		final AerodynamicForces zeroForces = calc.getAerodynamicForces(config, conditions, warnings);
+		final double zeroCD = zeroForces.getCD();
+		assertEquals("drag at mach 0 should equal drag at mach MathUtil.EPSILON", epsCD, zeroCD, EPSILON);
 	}
-		
 }
 	


### PR DESCRIPTION
Railbutton pressure drag ended up being multiplied by number of railbuttons because pressure drag was computing total pressure drag for all railbuttons, then it got multiplied by number of railbuttons elsewhere.  Compute average pressure drag instead, so total railbutton drag is correct.

Check for very small velocities and avoid division by 0 by setting pressure drag multiplier to a fixed number in that case.

Add unit tests to both of the above.

Fixes #2115 