### PR TITLE
[#2107] Don't render decals on component edges

### DIFF
--- a/swing/src/net/sf/openrocket/gui/figure3d/RealisticRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/RealisticRenderer.java
@@ -101,15 +101,15 @@ public class RealisticRenderer extends RocketRenderer {
 
 			render(gl, geom, Surface.INSIDE, innerApp, true, alpha);
 			if (((InsideColorComponent) c).getInsideColorComponentHandler().isEdgesSameAsInside()) {
-				render(gl, geom, Surface.EDGES, innerApp, true, alpha);
+				render(gl, geom, Surface.EDGES, innerApp, false, alpha);
 			}
 			else {
-				render(gl, geom, Surface.EDGES, app, true, alpha);
+				render(gl, geom, Surface.EDGES, app, false, alpha);
 			}
 		}
 	    else {
 			render(gl, geom, Surface.INSIDE, app, true, alpha);
-			render(gl, geom, Surface.EDGES, app, true, alpha);
+			render(gl, geom, Surface.EDGES, app, false, alpha);
 		}
 		render(gl, geom, Surface.OUTSIDE, app, true, alpha);
 


### PR DESCRIPTION
This PR fixes #2107. Decals are now not rendered on component edges anymore.