### PR TITLE
[#2098] Use higher precision for inches lengths

### DIFF
--- a/core/src/net/sf/openrocket/unit/InchUnit.java
+++ b/core/src/net/sf/openrocket/unit/InchUnit.java
@@ -4,9 +4,21 @@ package net.sf.openrocket.unit;
  * Special unit for inches, which always provides 3-decimal precision.
  */
 public class InchUnit extends GeneralUnit {
+	private final double precision;
 	
 	public InchUnit(double multiplier, String unit) {
+		this(multiplier, unit, 1);
+	}
+
+	/**
+	 *
+	 * @param multiplier
+	 * @param unit
+	 * @param precision The precision of the unit, in inches.
+	 */
+	public InchUnit(double multiplier, String unit, double precision) {
 		super(multiplier, unit);
+		this.precision = precision;
 	}
 	
 	
@@ -15,6 +27,16 @@ public class InchUnit extends GeneralUnit {
 		double mul = 1000.0;
 		val = Math.rint(val * mul) / mul;
 		return val;
+	}
+
+	@Override
+	public double getNextValue(double value) {
+		return value + precision;
+	}
+
+	@Override
+	public double getPreviousValue(double value) {
+		return value - precision;
 	}
 	
 }

--- a/core/src/net/sf/openrocket/unit/UnitGroup.java
+++ b/core/src/net/sf/openrocket/unit/UnitGroup.java
@@ -123,7 +123,7 @@ public class UnitGroup {
 		UNITS_LENGTH.addUnit(new GeneralUnit(0.001, "mm"));
 		UNITS_LENGTH.addUnit(new GeneralUnit(0.01, "cm"));
 		UNITS_LENGTH.addUnit(new GeneralUnit(1, "m"));
-		UNITS_LENGTH.addUnit(new InchUnit(0.0254, "in"));
+		UNITS_LENGTH.addUnit(new InchUnit(0.0254, "in", 0.1));
 		UNITS_LENGTH.addUnit(new FractionalUnit(0.0254, "in/64", "in", 64, 1d / 16d, 0.5d / 64d));
 		UNITS_LENGTH.addUnit(new GeneralUnit(0.3048, "ft"));
 		


### PR DESCRIPTION
This PR fixes #2098. Lengths in inches now have a 0.1" precision instead of 1".