### PR TITLE
[#2148] Apply sim changes when window closes & [#1826] Fill in gaps in multi-sim editing

### DIFF
--- a/core/src/net/sf/openrocket/simulation/SimulationOptions.java
+++ b/core/src/net/sf/openrocket/simulation/SimulationOptions.java
@@ -442,10 +442,6 @@ public class SimulationOptions implements ChangeSource, Cloneable {
 			isChanged = true;
 			this.launchLongitude = src.launchLongitude;
 		}
-		if (this.launchPressure != src.launchPressure) {
-			isChanged = true;
-			this.launchPressure = src.launchPressure;
-		}
 		if (this.launchRodAngle != src.launchRodAngle) {
 			isChanged = true;
 			this.launchRodAngle = src.launchRodAngle;
@@ -458,18 +454,25 @@ public class SimulationOptions implements ChangeSource, Cloneable {
 			isChanged = true;
 			this.launchRodLength = src.launchRodLength;
 		}
+		if (this.launchIntoWind != src.launchIntoWind) {
+			isChanged = true;
+			this.launchIntoWind = src.launchIntoWind;
+		}
+		if (this.useISA != src.useISA) {
+			isChanged = true;
+			this.useISA = src.useISA;
+		}
 		if (this.launchTemperature != src.launchTemperature) {
 			isChanged = true;
 			this.launchTemperature = src.launchTemperature;
 		}
+		if (this.launchPressure != src.launchPressure) {
+			isChanged = true;
+			this.launchPressure = src.launchPressure;
+		}
 		if (this.maximumAngle != src.maximumAngle) {
 			isChanged = true;
 			this.maximumAngle = src.maximumAngle;
-		}
-		this.maximumAngle = src.maximumAngle;
-		if (this.timeStep != src.timeStep) {
-			isChanged = true;
-			this.timeStep = src.timeStep;
 		}
 		if (this.windAverage != src.windAverage) {
 			isChanged = true;
@@ -486,6 +489,14 @@ public class SimulationOptions implements ChangeSource, Cloneable {
 		if (this.calculateExtras != src.calculateExtras) {
 			isChanged = true;
 			this.calculateExtras = src.calculateExtras;
+		}
+		if (this.timeStep != src.timeStep) {
+			isChanged = true;
+			this.timeStep = src.timeStep;
+		}
+		if (this.geodeticComputation != src.geodeticComputation) {
+			isChanged = true;
+			this.geodeticComputation = src.geodeticComputation;
 		}
 		
 		if (isChanged) {

--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -1284,34 +1284,24 @@ public class BasicFrame extends JFrame {
 		////	Handle the document
 		OpenRocketDocument doc = null;
 		try {
-
 			doc = worker.get();
-
 		} catch (ExecutionException e) {
-
 			Throwable cause = e.getCause();
-
 			if (cause instanceof FileNotFoundException) {
-
 				log.warn("File not found", cause);
 				JOptionPane.showMessageDialog(parent,
 						"File not found: " + displayName,
 						"Error opening file", JOptionPane.ERROR_MESSAGE);
 				return null;
-
 			} else if (cause instanceof RocketLoadException) {
-
 				log.warn("Error loading the file", cause);
 				JOptionPane.showMessageDialog(parent,
 						"Unable to open file '" + displayName + "': "
 								+ cause.getMessage(),
 								"Error opening file", JOptionPane.ERROR_MESSAGE);
 				return null;
-
 			} else {
-
 				throw new BugException("Unknown error when opening file", e);
-
 			}
 
 		} catch (InterruptedException e) {
@@ -1321,7 +1311,6 @@ public class BasicFrame extends JFrame {
 		if (doc == null) {
 			throw new BugException("Document loader returned null");
 		}
-
 
 		////	Show warnings
 		WarningSet warnings = worker.getRocketLoader().getWarnings();

--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -515,12 +515,12 @@ public class BasicFrame extends JFrame {
 		fileMenu.add(item);
 
 		////	Edit
-		fileMenu = new JMenu(trans.get("main.menu.edit"));
-		fileMenu.setMnemonic(KeyEvent.VK_E);
+		JMenu editMenu = new JMenu(trans.get("main.menu.edit"));
+		editMenu.setMnemonic(KeyEvent.VK_E);
 
 		////	Rocket editing
-		fileMenu.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.edit.desc"));
-		menubar.add(fileMenu);
+		editMenu.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.edit.desc"));
+		menubar.add(editMenu);
 
 		Action action = UndoRedoAction.newUndoAction(document);
 		item = new JMenuItem(action);
@@ -530,7 +530,7 @@ public class BasicFrame extends JFrame {
 		////	Undo the previous operation
 		item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.edit.undo.desc"));
 
-		fileMenu.add(item);
+		editMenu.add(item);
 
 		action = UndoRedoAction.newRedoAction(document);
 		item = new JMenuItem(action);
@@ -539,42 +539,42 @@ public class BasicFrame extends JFrame {
 
 		////	Redo the previously undone operation
 		item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.edit.redo.desc"));
-		fileMenu.add(item);
+		editMenu.add(item);
 
-		fileMenu.addSeparator();
+		editMenu.addSeparator();
 
 
 		item = new JMenuItem(actions.getEditAction());
-		fileMenu.add(item);
+		editMenu.add(item);
 
 		item = new JMenuItem(actions.getCutAction());
-		fileMenu.add(item);
+		editMenu.add(item);
 
 		item = new JMenuItem(actions.getCopyAction());
-		fileMenu.add(item);
+		editMenu.add(item);
 
 		item = new JMenuItem(actions.getPasteAction());
-		fileMenu.add(item);
+		editMenu.add(item);
 
 		item = new JMenuItem(actions.getDuplicateAction());
-		fileMenu.add(item);
+		editMenu.add(item);
 
 		item = new JMenuItem(actions.getDeleteAction());
-		fileMenu.add(item);
+		editMenu.add(item);
 
-		fileMenu.addSeparator();
+		editMenu.addSeparator();
 
 		JMenu subMenu = new JMenu(trans.get("RocketActions.Select"));
-		fileMenu.add(subMenu);
+		editMenu.add(subMenu);
 		item = new JMenuItem(actions.getSelectSameColorAction());
 		subMenu.add(item);
 		item = new JMenuItem(actions.getDeselectAllAction());
 		subMenu.add(item);
 
-		fileMenu.addSeparator();
+		editMenu.addSeparator();
 
 		item = new JMenuItem(actions.getScaleAction());
-		fileMenu.add(item);
+		editMenu.add(item);
 
 
 		////	Preferences
@@ -590,7 +590,7 @@ public class BasicFrame extends JFrame {
 				PreferencesDialog.showPreferences(BasicFrame.this);
 			}
 		});
-		fileMenu.add(item);
+		editMenu.add(item);
 
 		////	Edit Component Preset File
 		if (System.getProperty("openrocket.preseteditor.fileMenu") != null) {
@@ -605,13 +605,13 @@ public class BasicFrame extends JFrame {
 					dialog.setVisible(true);
 				}
 			});
-			fileMenu.add(item);
+			editMenu.add(item);
 		}
 
 
 		//	Tools
-		fileMenu = new JMenu(trans.get("main.menu.tools"));
-		menubar.add(fileMenu);
+		JMenu toolsMenu = new JMenu(trans.get("main.menu.tools"));
+		menubar.add(toolsMenu);
 
 		////	Component analysis
 		item = new JMenuItem(trans.get("main.menu.tools.componentAnalysis"), KeyEvent.VK_C);
@@ -625,7 +625,7 @@ public class BasicFrame extends JFrame {
 				ComponentAnalysisDialog.showDialog(rocketpanel);
 			}
 		});
-		fileMenu.add(item);
+		toolsMenu.add(item);
 
 		////	Optimize
 		item = new JMenuItem(trans.get("main.menu.tools.optimization"), KeyEvent.VK_O);
@@ -641,7 +641,7 @@ public class BasicFrame extends JFrame {
 				}
 			}
 		});
-		fileMenu.add(item);
+		toolsMenu.add(item);
 
 		////	Custom expressions
 		item = new JMenuItem(trans.get("main.menu.tools.customExpressions"), KeyEvent.VK_E);
@@ -653,7 +653,7 @@ public class BasicFrame extends JFrame {
 				new CustomExpressionDialog(document, BasicFrame.this).setVisible(true);
 			}
 		});
-		fileMenu.add(item);
+		toolsMenu.add(item);
 
 		item = new JMenuItem(trans.get("PhotoFrame.title"), KeyEvent.VK_P);
 		item.getAccessibleContext().setAccessibleDescription(trans.get("PhotoFrame.desc"));
@@ -665,7 +665,7 @@ public class BasicFrame extends JFrame {
 				pa.setVisible(true);
 			}
 		});
-		fileMenu.add(item);
+		toolsMenu.add(item);
 
 		////	Debug
 		//	//	(shown if openrocket.debug.fileMenu is defined)

--- a/swing/src/net/sf/openrocket/gui/main/ExampleDesignFileAction.java
+++ b/swing/src/net/sf/openrocket/gui/main/ExampleDesignFileAction.java
@@ -107,7 +107,7 @@ public final class ExampleDesignFileAction extends JMenu {
     /**
      * When a user clicks on one of the recently used design files, open it.
      *
-     * @param file the design file name (absolute path)
+     * @param example the design file name (absolute path)
      *
      * @return the action to open a design file
      */

--- a/swing/src/net/sf/openrocket/gui/main/SimulationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/SimulationPanel.java
@@ -662,7 +662,7 @@ public class SimulationPanel extends JPanel {
 
 		@Override
 		public void updateEnabledState() {
-			setEnabled(simulationTable.getSelectedRowCount() == 1);
+			setEnabled(simulationTable.getSelectedRowCount() > 0);
 		}
 	}
 

--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationEditDialog.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationEditDialog.java
@@ -5,6 +5,9 @@ import java.awt.CardLayout;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
 
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -42,6 +45,8 @@ public class SimulationEditDialog extends JDialog {
 	JPanel cards;
 	private final static String EDITMODE = "EDIT";
 	private final static String PLOTMODE = "PLOT";
+
+	private WindowListener applyChangesToSimsListener;
 	
 	public SimulationEditDialog(Window parent, final OpenRocketDocument document, Simulation... sims) {
 		//// Edit simulation
@@ -59,6 +64,14 @@ public class SimulationEditDialog extends JDialog {
 		this.pack();
 		
 		this.setLocationByPlatform(true);
+
+		this.applyChangesToSimsListener = new WindowAdapter() {
+			@Override
+			public void windowClosed(WindowEvent e) {
+				copyChangesToAllSims();
+			}
+		};
+		this.addWindowListener(applyChangesToSimsListener);
 		
 		GUIUtil.setDisposableDialogOptions(this, null);
 	}
@@ -75,12 +88,14 @@ public class SimulationEditDialog extends JDialog {
 		CardLayout cl = (CardLayout) (cards.getLayout());
 		cl.show(cards, EDITMODE);
 		cards.validate();
+		this.addWindowListener(applyChangesToSimsListener);
 	}
 	
 	public void setPlotMode() {
 		if (!allowsPlotMode()) {
 			return;
 		}
+		this.removeWindowListener(applyChangesToSimsListener);
 		setTitle(trans.get("simplotpanel.title.Plotsim"));
 		CardLayout cl = (CardLayout) (cards.getLayout());
 		cl.show(cards, PLOTMODE);
@@ -223,7 +238,6 @@ public class SimulationEditDialog extends JDialog {
 		close.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				copyChangesToAllSims();
 				SimulationEditDialog.this.dispose();
 			}
 		});


### PR DESCRIPTION
This PR fixes #2148 and fixes #1826. Now, when closing the edit sim dialog in **any way** (clicking the close button, hitting the escape key, x-button in top-left of the window) applies the simulation options to all selected simulation.

The fix for #1826 is that multi-sim editing had some gaps, namely:
- The checkbox for "Always launch directly up-wind"
- The checkbox for "Use ISA"
- Geodetic calculations

These are now fixed.