### PR TITLE
[#2150] Don't let illegal file format be a silent warning

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -2284,11 +2284,11 @@ IgnitionSelectionDialog.opt.default = Change all configurations using the defaul
 IgnitionSelectionDialog.opt.override = Override for the {0} flight configuration only
 
 DeploymentSelectionDialog.opt.title = Which flight configurations are affected:
-DeploymentSelectionDialog.opt.default = Change all configuration using the default deployment event
+DeploymentSelectionDialog.opt.default = Change all configurations using the default deployment event
 DeploymentSelectionDialog.opt.override = Override for the {0} flight configuration only
 
 SeparationSelectionDialog.opt.title = Which flight configurations are affected:
-SeparationSelectionDialog.opt.default = Change all configuration using the default separation event
+SeparationSelectionDialog.opt.default = Change all configurations using the default separation event
 SeparationSelectionDialog.opt.override = Override for the {0} flight configuration only
 
 MotorConfigurationPanel.description = <b>Select the motors and motor ignition events of the selected flight configuration.</b><br> <em>Motor mounts:</em> Select which components function as motor mounts.<br> <em>Motor configurations:</em> Select the motor and ignition event for each motor mount.

--- a/core/src/net/sf/openrocket/file/motor/RASPMotorLoader.java
+++ b/core/src/net/sf/openrocket/file/motor/RASPMotorLoader.java
@@ -94,7 +94,8 @@ public class RASPMotorLoader extends AbstractMotorLoader {
 				// desig diam len delays prop.w tot.w manufacturer
 				pieces = split(line);
 				if (pieces.length != 7) {
-					throw new IOException("Illegal file format.");
+					throw new IOException("Illegal file format. Motor header line must contain 7 fields:<br>" +
+							"&nbsp designation diameter length delays propellantWeight totalWeight manufacturer");
 				}
 				
 				designation = pieces[0];
@@ -140,7 +141,8 @@ public class RASPMotorLoader extends AbstractMotorLoader {
 						thrust.add(Double.parseDouble(buf[1]));
 						
 					} else {
-						throw new IOException("Illegal file format.");
+						throw new IOException("Illegal file format.<br>" +
+								"Data should only have 2 entries: a time and thrust value.");
 					}
 				}
 				
@@ -158,7 +160,8 @@ public class RASPMotorLoader extends AbstractMotorLoader {
 			
 		} catch (NumberFormatException e) {
 			
-			throw new IOException("Illegal file format.");
+			throw new IOException("Illegal file format. Could not convert value to a number.<br" +
+					">Verify that each number is correctly formatted.");
 			
 		}
 		

--- a/swing/src/net/sf/openrocket/database/MotorDatabaseLoader.java
+++ b/swing/src/net/sf/openrocket/database/MotorDatabaseLoader.java
@@ -27,6 +27,7 @@ import net.sf.openrocket.util.Pair;
 
 import javax.swing.JDialog;
 import javax.swing.JOptionPane;
+import javax.swing.SwingUtilities;
 
 /**
  * An asynchronous database loader that loads the internal thrust curves
@@ -140,21 +141,26 @@ public class MotorDatabaseLoader extends AsynchronousDatabaseLoader {
 	 */
 	private void loadFile(GeneralMotorLoader loader, Pair<File, InputStream> f) {
 		try {
-			List<ThrustCurveMotor.Builder> motors = loader.load(f.getV(), f.getU().getName());
 			try {
+				List<ThrustCurveMotor.Builder> motors = loader.load(f.getV(), f.getU().getName());
 				addMotorsFromBuilders(motors);
 			}
-			catch (IllegalArgumentException e) {
+			catch (IllegalArgumentException | IOException e) {
 				Translator trans = Application.getTranslator();
 				String fullPath = f.getU().getPath();
 				String message = "<html><body><p style='width: 400px;'><i>" + e.getMessage() +
 						"</i>.<br><br>" + MessageFormat.format( trans.get("MotorDbLoaderDlg.message1"), fullPath) +
 						"<br>" + trans.get("MotorDbLoaderDlg.message2") + "</p></body></html>";
-				JOptionPane pane = new JOptionPane(message, JOptionPane.WARNING_MESSAGE);
-				JDialog dialog = pane.createDialog(null, trans.get("MotorDbLoaderDlg.title"));
-				dialog.setModalityType(Dialog.ModalityType.MODELESS);
-				dialog.setAlwaysOnTop(true);
-				dialog.setVisible(true);
+				SwingUtilities.invokeLater(new Runnable() {
+					@Override
+					public void run() {
+						JOptionPane pane = new JOptionPane(message, JOptionPane.WARNING_MESSAGE);
+						JDialog dialog = pane.createDialog(null, trans.get("MotorDbLoaderDlg.title"));
+						dialog.setModalityType(Dialog.ModalityType.MODELESS);
+						dialog.setAlwaysOnTop(true);
+						dialog.setVisible(true);
+					}
+				});
 			}
 			f.getV().close();
 		} catch (Exception e) {


### PR DESCRIPTION
This PR fixes #2150 by showing a warning dialog when a thrust curve file has an illegal file format.

There is still a discussion in #2150 about how to handle a motor designation with a dash.