### PR TITLE
[#2141] Reset window position if out-of-screen

### DIFF
--- a/swing/src/net/sf/openrocket/gui/util/SwingPreferences.java
+++ b/swing/src/net/sf/openrocket/gui/util/SwingPreferences.java
@@ -2,7 +2,11 @@ package net.sf.openrocket.gui.util;
 
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -386,15 +390,41 @@ public class SwingPreferences extends net.sf.openrocket.startup.Preferences {
 		} catch (NumberFormatException e) {
 			return null;
 		}
-		return new Point(x, y);
+
+		// If position was on a screen that is not available anymore
+		Point p = new Point(x, y);
+		if (!isPointOnScreen(p)) {
+			return null;
+		}
+
+		return p;
 	}
 	
 	public void setWindowPosition(Class<?> c, Point p) {
 		PREFNODE.node("windows").put("position." + c.getCanonicalName(), "" + p.x + "," + p.y);
 		storeVersion();
 	}
-	
-	
+
+	/**
+	 * Checks whether the point is present on any of the current monitor screens.
+	 * Can return false if point was e.g. referenced on a secondary monitor that doesn't exist anymore.
+	 * @param p point to check
+	 * @return true if point is present on any of the current screens, false otherwise
+	 */
+	private boolean isPointOnScreen(Point p) {
+		GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+		GraphicsDevice[] screens = ge.getScreenDevices();
+
+		for (GraphicsDevice screen : screens) {
+			GraphicsConfiguration gc = screen.getDefaultConfiguration();
+			Rectangle bounds = gc.getBounds();
+			if (bounds.contains(p)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	
 	
 	public Dimension getWindowSize(Class<?> c) {


### PR DESCRIPTION
This PR fixes #2141.

Steps to reproduce the original bug:
1. Open "A simple model rocket"
2. Go to the simulations tab, and plot simulation 1
3. Move the plot window to a secondary monitor screen
4. Close the plot window
5. Re-plot simulation 1, you will see that the window remains on the secondary monitor screen
6. Unplug the secondary monitor screen
7. Re-plot simulation 1 again
8. Plot window can be gone

Steps to verify the solution = same as the bug steps, but in step 8, the plot window should be centered on the screen again.

Note: this is now implemented as a general solution. For every window that has window location remembrance enabled, OR will first check whether the window is positioned on an existing screen. If not, it will reset the position.