### PR TITLE
[#2096] Update values after auto is set

### DIFF
--- a/core/src/net/sf/openrocket/file/openrocket/importt/DocumentConfig.java
+++ b/core/src/net/sf/openrocket/file/openrocket/importt/DocumentConfig.java
@@ -389,7 +389,7 @@ class DocumentConfig {
 		
 		// MassObject
 		setters.put("MassObject:packedlength", new DoubleSetter(
-				Reflection.findMethod(MassObject.class, "setLengthNoAuto", double.class)));
+				Reflection.findMethod(MassObject.class, "setLength", double.class)));
 		setters.put("MassObject:packedradius", new DoubleSetter(
 				Reflection.findMethod(MassObject.class, "setRadius", double.class),
 				"auto", " ",

--- a/core/src/net/sf/openrocket/file/openrocket/savers/BodyTubeSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/savers/BodyTubeSaver.java
@@ -23,7 +23,7 @@ public class BodyTubeSaver extends SymmetricComponentSaver {
 		net.sf.openrocket.rocketcomponent.BodyTube tube = (net.sf.openrocket.rocketcomponent.BodyTube) c;
 
 		if (tube.isOuterRadiusAutomatic()) {
-			elements.add("<radius>auto " + tube.getOuterRadiusNoAutomatic() + "</radius>");
+			elements.add("<radius>auto " + tube.getOuterRadius() + "</radius>");
 		}
 		else
 			elements.add("<radius>" + tube.getOuterRadius() + "</radius>");

--- a/core/src/net/sf/openrocket/file/openrocket/savers/MassObjectSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/savers/MassObjectSaver.java
@@ -13,11 +13,11 @@ public class MassObjectSaver extends InternalComponentSaver {
 
 		MassObject mass = (MassObject) c;
 
-		elements.add("<packedlength>" + mass.getLengthNoAuto() + "</packedlength>");
+		elements.add("<packedlength>" + mass.getLength() + "</packedlength>");
 		if (mass.isRadiusAutomatic()) {
-			elements.add("<packedradius>auto " + mass.getRadiusNoAuto() + "</packedradius>");
+			elements.add("<packedradius>auto " + mass.getRadius() + "</packedradius>");
 		} else {
-			elements.add("<packedradius>" + mass.getRadiusNoAuto() + "</packedradius>");
+			elements.add("<packedradius>" + mass.getRadius() + "</packedradius>");
 		}
 		elements.add("<radialposition>" + mass.getRadialPosition() + "</radialposition>");
 		elements.add("<radialdirection>" + (mass.getRadialDirection() * 180.0 / Math.PI)

--- a/core/src/net/sf/openrocket/file/openrocket/savers/NoseConeSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/savers/NoseConeSaver.java
@@ -27,7 +27,7 @@ public class NoseConeSaver extends TransitionSaver {
 		super.addParams(c, elements);
 
 		if (noseCone.isBaseRadiusAutomatic())
-			elements.add("<aftradius>auto " + noseCone.getBaseRadiusNoAutomatic() + "</aftradius>");
+			elements.add("<aftradius>auto " + noseCone.getBaseRadius() + "</aftradius>");
 		else
 			elements.add("<aftradius>" + noseCone.getBaseRadius() + "</aftradius>");
 

--- a/core/src/net/sf/openrocket/file/openrocket/savers/TransitionSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/savers/TransitionSaver.java
@@ -46,12 +46,12 @@ public class TransitionSaver extends SymmetricComponentSaver {
 		}
 
 		if (trans.isForeRadiusAutomatic())
-			elements.add("<foreradius>auto " + trans.getForeRadiusNoAutomatic() + "</foreradius>");
+			elements.add("<foreradius>auto " + trans.getForeRadius() + "</foreradius>");
 		else
 			elements.add("<foreradius>" + trans.getForeRadius() + "</foreradius>");
 		
 		if (trans.isAftRadiusAutomatic())
-			elements.add("<aftradius>auto " + trans.getAftRadiusNoAutomatic() + "</aftradius>");
+			elements.add("<aftradius>auto " + trans.getAftRadius() + "</aftradius>");
 		else
 			elements.add("<aftradius>" + trans.getAftRadius() + "</aftradius>");
 		

--- a/core/src/net/sf/openrocket/rocketcomponent/BodyTube.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/BodyTube.java
@@ -75,35 +75,35 @@ public class BodyTube extends SymmetricComponent implements BoxBounded, MotorMou
 	@Override
 	public double getOuterRadius() {
 		if (autoRadius) {
-			// Return auto radius from front or rear
-			double r = -1;
-			SymmetricComponent c = this.getPreviousSymmetricComponent();
-			// Don't use the radius of a component who already has its auto diameter enabled
-			if (c != null && !c.usesNextCompAutomatic()) {
-				r = c.getFrontAutoRadius();
-				refComp = c;
-			}
-			if (r < 0) {
-				c = this.getNextSymmetricComponent();
-				// Don't use the radius of a component who already has its auto diameter enabled
-				if (c != null && !c.usesPreviousCompAutomatic()) {
-					r = c.getRearAutoRadius();
-					refComp = c;
-				}
-			}
-			if (r < 0)
-				r = DEFAULT_RADIUS;
-			return r;
+			outerRadius = getAutoOuterRadius();
 		}
 		return outerRadius;
 	}
 
 	/**
-	 * Return the outer radius that was manually entered, so not the value that the component received from automatic
-	 * outer radius.
+	 * Returns the automatic outer radius, taken from the previous/next component. Returns the default radius if there
+	 * is no previous/next component.
 	 */
-	public double getOuterRadiusNoAutomatic() {
-		return outerRadius;
+	private double getAutoOuterRadius() {
+		// Return auto radius from front or rear
+		double r = -1;
+		SymmetricComponent c = this.getPreviousSymmetricComponent();
+		// Don't use the radius of a component who already has its auto diameter enabled
+		if (c != null && !c.usesNextCompAutomatic()) {
+			r = c.getFrontAutoRadius();
+			refComp = c;
+		}
+		if (r < 0) {
+			c = this.getNextSymmetricComponent();
+			// Don't use the radius of a component who already has its auto diameter enabled
+			if (c != null && !c.usesPreviousCompAutomatic()) {
+				r = c.getRearAutoRadius();
+				refComp = c;
+			}
+		}
+		if (r < 0)
+			r = DEFAULT_RADIUS;
+		return r;
 	}
 	
 	/**

--- a/core/src/net/sf/openrocket/rocketcomponent/NoseCone.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/NoseCone.java
@@ -53,14 +53,6 @@ public class NoseCone extends Transition implements InsideColorComponent {
 	}
 
 	/**
-	 * Returns the raw base radius of the nose cone (independent of whether the nose cone is flipped or not).
-	 * This method should be used over {@link #getAftRadiusNoAutomatic()} because it works for both normal and flipped nose cones.
-	 */
-	public double getBaseRadiusNoAutomatic() {
-		return isFlipped ? getForeRadiusNoAutomatic() : getAftRadiusNoAutomatic();
-	}
-
-	/**
 	 * Sets the base radius of the nose cone (independent of whether the nose cone is flipped or not).
 	 * This method should be used over {@link #setAftRadius(double)} because it works for both normal and flipped nose cones.
 	 */
@@ -203,7 +195,7 @@ public class NoseCone extends Transition implements InsideColorComponent {
 		boolean previousByPass = isBypassComponentChangeEvent();
 		setBypassChangeEvent(true);
 		if (flipped) {
-			setForeRadius(getAftRadiusNoAutomatic());
+			setForeRadius(getAftRadius());
 			setForeRadiusAutomatic(isAftRadiusAutomatic(), sanityCheck);
 			setForeShoulderLength(getAftShoulderLength());
 			setForeShoulderRadius(getAftShoulderRadius());
@@ -212,7 +204,7 @@ public class NoseCone extends Transition implements InsideColorComponent {
 
 			resetAftRadius();
 		} else {
-			setAftRadius(getForeRadiusNoAutomatic());
+			setAftRadius(getForeRadius());
 			setAftRadiusAutomatic(isForeRadiusAutomatic(), sanityCheck);
 			setAftShoulderLength(getForeShoulderLength());
 			setAftShoulderRadius(getForeShoulderRadius());

--- a/core/src/net/sf/openrocket/rocketcomponent/Transition.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Transition.java
@@ -77,7 +77,7 @@ public class Transition extends SymmetricComponent implements InsideColorCompone
 	@Override
 	public double getForeRadius() {
 		if (isForeRadiusAutomatic()) {
-			return getAutoForeRadius();
+			foreRadius = getAutoForeRadius();
 		}
 		return foreRadius;
 	}
@@ -93,14 +93,6 @@ public class Transition extends SymmetricComponent implements InsideColorCompone
 		} else {
 			return DEFAULT_RADIUS;
 		}
-	}
-
-	/**
-	 * Return the fore radius that was manually entered, so not the value that the component received from automatic
-	 * fore radius.
-	 */
-	public double getForeRadiusNoAutomatic() {
-		return foreRadius;
 	}
 
 	/**
@@ -174,7 +166,7 @@ public class Transition extends SymmetricComponent implements InsideColorCompone
 	@Override
 	public double getAftRadius() {
 		if (isAftRadiusAutomatic()) {
-			return getAutoAftRadius();
+			aftRadius = getAutoAftRadius();
 		}
 		return aftRadius;
 	}
@@ -190,14 +182,6 @@ public class Transition extends SymmetricComponent implements InsideColorCompone
 		} else {
 			return DEFAULT_RADIUS;
 		}
-	}
-
-	/**
-	 * Return the aft radius that was manually entered, so not the value that the component received from automatic
-	 * zft radius.
-	 */
-	public double getAftRadiusNoAutomatic() {
-		return aftRadius;
 	}
 
 	/**

--- a/core/test/net/sf/openrocket/rocketcomponent/MassObjectTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/MassObjectTest.java
@@ -21,20 +21,14 @@ public class MassObjectTest extends BaseTestCase {
             mo.setLength(0.1);
             Assert.assertEquals(String.format(" No auto %s incorrect radius", mo.getClass().getName()),
                     0.1, mo.getRadius(), MathUtil.EPSILON);
-            Assert.assertEquals(String.format(" No auto %s incorrect no auto radius", mo.getClass().getName()),
-                    0.1, mo.getRadiusNoAuto(),MathUtil.EPSILON);
             Assert.assertEquals(String.format(" No auto %s incorrect length", mo.getClass().getName()),
                     0.1, mo.getLength(), MathUtil.EPSILON);
-            Assert.assertEquals(String.format(" No auto %s incorrect no auto length", mo.getClass().getName()),
-                    0.1, mo.getLengthNoAuto(), MathUtil.EPSILON);
             Assert.assertEquals(String.format(" No auto %s incorrect CG", mo.getClass().getName()),
                     0.05, mo.getComponentCG().x, MathUtil.EPSILON);
 
-            mo.setLengthNoAuto(0.1);
+            mo.setLength(0.1);
             Assert.assertEquals(String.format(" No auto 2 %s incorrect length", mo.getClass().getName()),
                     0.1, mo.getLength(), MathUtil.EPSILON);
-            Assert.assertEquals(String.format(" No auto 2 %s incorrect no auto length", mo.getClass().getName()),
-                    0.1, mo.getLengthNoAuto(), MathUtil.EPSILON);
             Assert.assertEquals(String.format(" No auto %s incorrect CG", mo.getClass().getName()),
                     0.05, mo.getComponentCG().x, MathUtil.EPSILON);
 
@@ -46,12 +40,8 @@ public class MassObjectTest extends BaseTestCase {
             mo.setRadiusAutomatic(true);
             Assert.assertEquals(String.format(" Auto 1 %s incorrect radius", mo.getClass().getName()),
                     0.05, mo.getRadius(), MathUtil.EPSILON);
-            Assert.assertEquals(String.format(" Auto 1 %s incorrect no auto radius", mo.getClass().getName()),
-                    0.1, mo.getRadiusNoAuto(), MathUtil.EPSILON);
             Assert.assertEquals(String.format(" Auto 1 %s incorrect length", mo.getClass().getName()),
                     0.4, mo.getLength(), MathUtil.EPSILON);
-            Assert.assertEquals(String.format(" Auto 1 %s incorrect no auto length", mo.getClass().getName()),
-                    0.1, mo.getLengthNoAuto(), MathUtil.EPSILON);
             Assert.assertEquals(String.format(" Auto 1 %s incorrect CG", mo.getClass().getName()),
                     0.2, mo.getComponentCG().x, MathUtil.EPSILON);
 
@@ -59,12 +49,8 @@ public class MassObjectTest extends BaseTestCase {
             parent.setInnerRadius(0.1);
             Assert.assertEquals(String.format(" Auto 2 %s incorrect radius", mo.getClass().getName()),
                     0.1, mo.getRadius(), MathUtil.EPSILON);
-            Assert.assertEquals(String.format(" Auto 2 %s incorrect no auto radius", mo.getClass().getName()),
-                    0.1, mo.getRadiusNoAuto(), MathUtil.EPSILON);
             Assert.assertEquals(String.format(" Auto 2 %s incorrect length", mo.getClass().getName()),
                     0.1, mo.getLength(), MathUtil.EPSILON);
-            Assert.assertEquals(String.format(" Auto 2 %s incorrect no auto length", mo.getClass().getName()),
-                    0.1, mo.getLengthNoAuto(), MathUtil.EPSILON);
             Assert.assertEquals(String.format(" Auto 2 %s incorrect CG", mo.getClass().getName()),
                     0.05, mo.getComponentCG().x, MathUtil.EPSILON);
 
@@ -73,26 +59,18 @@ public class MassObjectTest extends BaseTestCase {
             mo.setLength(0.075);
             Assert.assertEquals(String.format(" Auto 3 %s incorrect radius", mo.getClass().getName()),
                     0.075, mo.getRadius(), MathUtil.EPSILON);
-            Assert.assertEquals(String.format(" Auto 3 %s incorrect no auto radius", mo.getClass().getName()),
-                    0.1, mo.getRadiusNoAuto(), MathUtil.EPSILON);
             Assert.assertEquals(String.format(" Auto 3 %s incorrect length", mo.getClass().getName()),
                     0.075, mo.getLength(), MathUtil.EPSILON);
-            Assert.assertEquals(String.format(" Auto 3 %s incorrect no auto length", mo.getClass().getName()),
-                    0.0422, mo.getLengthNoAuto(), 0.001);
             Assert.assertEquals(String.format(" Auto 3 %s incorrect CG", mo.getClass().getName()),
                     0.0375, mo.getComponentCG().x, MathUtil.EPSILON);
 
-            mo.setLengthNoAuto(0.05);
+            mo.setLength(0.05);
             Assert.assertEquals(String.format(" Auto 4 %s incorrect radius", mo.getClass().getName()),
                     0.075, mo.getRadius(), MathUtil.EPSILON);
-            Assert.assertEquals(String.format(" Auto 4 %s incorrect no auto radius", mo.getClass().getName()),
-                    0.1, mo.getRadiusNoAuto(), MathUtil.EPSILON);
             Assert.assertEquals(String.format(" Auto 4 %s incorrect length", mo.getClass().getName()),
-                    0.0889, mo.getLength(), 0.001);
-            Assert.assertEquals(String.format(" Auto 4 %s incorrect no auto length", mo.getClass().getName()),
-                    0.05, mo.getLengthNoAuto(), MathUtil.EPSILON);
+                    0.05, mo.getLength(), 0.001);
             Assert.assertEquals(String.format(" Auto 4 %s incorrect CG", mo.getClass().getName()),
-                    0.044444444444, mo.getComponentCG().x, MathUtil.EPSILON);
+                    0.025, mo.getComponentCG().x, MathUtil.EPSILON);
         }
     }
 }

--- a/core/test/net/sf/openrocket/rocketcomponent/NoseConeTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/NoseConeTest.java
@@ -31,8 +31,8 @@ public class NoseConeTest extends BaseTestCase {
         assertEquals(0.06, noseCone.getLength(), EPSILON);
         assertEquals(0.1, noseCone.getAftRadius(), EPSILON);
         assertEquals(0.1, noseCone.getBaseRadius(), EPSILON);
-        assertEquals(0.1, noseCone.getAftRadiusNoAutomatic(), EPSILON);
-        assertEquals(0.1, noseCone.getBaseRadiusNoAutomatic(), EPSILON);
+        assertEquals(0.1, noseCone.getAftRadius(), EPSILON);
+        assertEquals(0.1, noseCone.getBaseRadius(), EPSILON);
         assertEquals(0.01, noseCone.getAftShoulderLength(), EPSILON);
         assertEquals(0.01, noseCone.getShoulderLength(), EPSILON);
         assertEquals(0.05, noseCone.getAftShoulderRadius(), EPSILON);
@@ -44,7 +44,7 @@ public class NoseConeTest extends BaseTestCase {
         assertFalse(noseCone.isAftRadiusAutomatic());
 
         assertEquals(0, noseCone.getForeRadius(), EPSILON);
-        assertEquals(0, noseCone.getForeRadiusNoAutomatic(), EPSILON);
+        assertEquals(0, noseCone.getForeRadius(), EPSILON);
         assertEquals(0, noseCone.getForeShoulderLength(), EPSILON);
         assertEquals(0, noseCone.getForeShoulderRadius(), EPSILON);
         assertEquals(0, noseCone.getForeShoulderThickness(), EPSILON);
@@ -60,8 +60,8 @@ public class NoseConeTest extends BaseTestCase {
 
         assertEquals(0.2, noseCone.getAftRadius(), EPSILON);
         assertEquals(0.2, noseCone.getBaseRadius(), EPSILON);
-        assertEquals(0.2, noseCone.getAftRadiusNoAutomatic(), EPSILON);
-        assertEquals(0.2, noseCone.getBaseRadiusNoAutomatic(), EPSILON);
+        assertEquals(0.2, noseCone.getAftRadius(), EPSILON);
+        assertEquals(0.2, noseCone.getBaseRadius(), EPSILON);
         assertEquals(0.03, noseCone.getAftShoulderLength(), EPSILON);
         assertEquals(0.03, noseCone.getShoulderLength(), EPSILON);
         assertEquals(0.04, noseCone.getAftShoulderRadius(), EPSILON);
@@ -73,7 +73,7 @@ public class NoseConeTest extends BaseTestCase {
         assertFalse(noseCone.isAftRadiusAutomatic());
 
         assertEquals(0, noseCone.getForeRadius(), EPSILON);
-        assertEquals(0, noseCone.getForeRadiusNoAutomatic(), EPSILON);
+        assertEquals(0, noseCone.getForeRadius(), EPSILON);
         assertEquals(0, noseCone.getForeShoulderLength(), EPSILON);
         assertEquals(0, noseCone.getForeShoulderRadius(), EPSILON);
         assertEquals(0, noseCone.getForeShoulderThickness(), EPSILON);
@@ -99,8 +99,8 @@ public class NoseConeTest extends BaseTestCase {
         assertEquals(0.06, noseCone.getLength(), EPSILON);
         assertEquals(0.1, noseCone.getForeRadius(), EPSILON);
         assertEquals(0.1, noseCone.getBaseRadius(), EPSILON);
-        assertEquals(0.1, noseCone.getForeRadiusNoAutomatic(), EPSILON);
-        assertEquals(0.1, noseCone.getBaseRadiusNoAutomatic(), EPSILON);
+        assertEquals(0.1, noseCone.getForeRadius(), EPSILON);
+        assertEquals(0.1, noseCone.getBaseRadius(), EPSILON);
         assertEquals(0.01, noseCone.getForeShoulderLength(), EPSILON);
         assertEquals(0.01, noseCone.getShoulderLength(), EPSILON);
         assertEquals(0.05, noseCone.getForeShoulderRadius(), EPSILON);
@@ -112,7 +112,7 @@ public class NoseConeTest extends BaseTestCase {
         assertFalse(noseCone.isForeRadiusAutomatic());
 
         assertEquals(0, noseCone.getAftRadius(), EPSILON);
-        assertEquals(0, noseCone.getAftRadiusNoAutomatic(), EPSILON);
+        assertEquals(0, noseCone.getAftRadius(), EPSILON);
         assertEquals(0, noseCone.getAftShoulderLength(), EPSILON);
         assertEquals(0, noseCone.getAftShoulderRadius(), EPSILON);
         assertEquals(0, noseCone.getAftShoulderThickness(), EPSILON);
@@ -128,8 +128,8 @@ public class NoseConeTest extends BaseTestCase {
 
         assertEquals(0.2, noseCone.getForeRadius(), EPSILON);
         assertEquals(0.2, noseCone.getBaseRadius(), EPSILON);
-        assertEquals(0.2, noseCone.getForeRadiusNoAutomatic(), EPSILON);
-        assertEquals(0.2, noseCone.getBaseRadiusNoAutomatic(), EPSILON);
+        assertEquals(0.2, noseCone.getForeRadius(), EPSILON);
+        assertEquals(0.2, noseCone.getBaseRadius(), EPSILON);
         assertEquals(0.03, noseCone.getForeShoulderLength(), EPSILON);
         assertEquals(0.03, noseCone.getShoulderLength(), EPSILON);
         assertEquals(0.04, noseCone.getForeShoulderRadius(), EPSILON);
@@ -141,7 +141,7 @@ public class NoseConeTest extends BaseTestCase {
         assertFalse(noseCone.isForeRadiusAutomatic());
 
         assertEquals(0, noseCone.getAftRadius(), EPSILON);
-        assertEquals(0, noseCone.getAftRadiusNoAutomatic(), EPSILON);
+        assertEquals(0, noseCone.getAftRadius(), EPSILON);
         assertEquals(0, noseCone.getAftShoulderLength(), EPSILON);
         assertEquals(0, noseCone.getAftShoulderRadius(), EPSILON);
         assertEquals(0, noseCone.getAftShoulderThickness(), EPSILON);
@@ -153,8 +153,8 @@ public class NoseConeTest extends BaseTestCase {
 
         assertEquals(0.2, noseCone.getAftRadius(), EPSILON);
         assertEquals(0.2, noseCone.getBaseRadius(), EPSILON);
-        assertEquals(0.2, noseCone.getAftRadiusNoAutomatic(), EPSILON);
-        assertEquals(0.2, noseCone.getBaseRadiusNoAutomatic(), EPSILON);
+        assertEquals(0.2, noseCone.getAftRadius(), EPSILON);
+        assertEquals(0.2, noseCone.getBaseRadius(), EPSILON);
         assertEquals(0.03, noseCone.getAftShoulderLength(), EPSILON);
         assertEquals(0.03, noseCone.getShoulderLength(), EPSILON);
         assertEquals(0.04, noseCone.getAftShoulderRadius(), EPSILON);
@@ -166,7 +166,7 @@ public class NoseConeTest extends BaseTestCase {
         assertFalse(noseCone.isAftRadiusAutomatic());
 
         assertEquals(0, noseCone.getForeRadius(), EPSILON);
-        assertEquals(0, noseCone.getForeRadiusNoAutomatic(), EPSILON);
+        assertEquals(0, noseCone.getForeRadius(), EPSILON);
         assertEquals(0, noseCone.getForeShoulderLength(), EPSILON);
         assertEquals(0, noseCone.getForeShoulderRadius(), EPSILON);
         assertEquals(0, noseCone.getForeShoulderThickness(), EPSILON);
@@ -180,7 +180,7 @@ public class NoseConeTest extends BaseTestCase {
         AxialStage stage = rocket.getStage(0);
 
         NoseCone noseCone = new NoseCone(Transition.Shape.CONICAL, 0.06, 0.01);
-        BodyTube tube1 = new BodyTube(0.06, 0.02);
+        BodyTube tube1 = new BodyTube(0.06, 0.023);
         tube1.setOuterRadiusAutomatic(false);
         BodyTube tube2 = new BodyTube(0.06, 0.03);
         tube2.setOuterRadiusAutomatic(false);
@@ -197,11 +197,11 @@ public class NoseConeTest extends BaseTestCase {
         assertFalse(noseCone.isAftRadiusAutomatic());
         assertFalse(noseCone.isBaseRadiusAutomatic());
         assertFalse(noseCone.isForeRadiusAutomatic());
-        assertEquals(noseCone.getAftRadius(), noseCone.getAftRadiusNoAutomatic(), EPSILON);
-        assertEquals(noseCone.getBaseRadius(), noseCone.getBaseRadiusNoAutomatic(), EPSILON);
-        assertEquals(noseCone.getForeRadius(), noseCone.getForeRadiusNoAutomatic(), EPSILON);
-        assertEquals(0.01, noseCone.getAftRadiusNoAutomatic(), EPSILON);
-        assertEquals(0, noseCone.getForeRadiusNoAutomatic(), EPSILON);
+        assertEquals(noseCone.getAftRadius(), noseCone.getAftRadius(), EPSILON);
+        assertEquals(noseCone.getBaseRadius(), noseCone.getBaseRadius(), EPSILON);
+        assertEquals(noseCone.getForeRadius(), noseCone.getForeRadius(), EPSILON);
+        assertEquals(0.01, noseCone.getAftRadius(), EPSILON);
+        assertEquals(0, noseCone.getForeRadius(), EPSILON);
 
         noseCone.setAftRadiusAutomatic(true, true);
         assertFalse(noseCone.isAftRadiusAutomatic());
@@ -222,10 +222,10 @@ public class NoseConeTest extends BaseTestCase {
         assertFalse(noseCone.isAftRadiusAutomatic());
         assertFalse(noseCone.isBaseRadiusAutomatic());
         assertFalse(noseCone.isForeRadiusAutomatic());
-        assertEquals(noseCone.getAftRadius(), noseCone.getAftRadiusNoAutomatic(), EPSILON);
-        assertEquals(noseCone.getBaseRadius(), noseCone.getBaseRadiusNoAutomatic(), EPSILON);
-        assertEquals(noseCone.getForeRadius(), noseCone.getForeRadiusNoAutomatic(), EPSILON);
-        assertEquals(0, noseCone.getForeRadiusNoAutomatic(), EPSILON);
+        assertEquals(noseCone.getAftRadius(), noseCone.getAftRadius(), EPSILON);
+        assertEquals(noseCone.getBaseRadius(), noseCone.getBaseRadius(), EPSILON);
+        assertEquals(noseCone.getForeRadius(), noseCone.getForeRadius(), EPSILON);
+        assertEquals(0, noseCone.getForeRadius(), EPSILON);
 
         noseCone.setAftRadiusAutomatic(true, true);
         assertFalse(noseCone.usesPreviousCompAutomatic());
@@ -238,24 +238,24 @@ public class NoseConeTest extends BaseTestCase {
         assertTrue(noseCone.isBaseRadiusAutomatic());
         assertFalse(noseCone.isForeRadiusAutomatic());
         assertEquals(tube1.getForeRadius(), noseCone.getAftRadius(), EPSILON);
-        assertEquals(0.01, noseCone.getAftRadiusNoAutomatic(), EPSILON);
+        assertEquals(0.023, noseCone.getAftRadius(), EPSILON);
         assertEquals(tube1.getForeRadius(), noseCone.getBaseRadius(), EPSILON);
-        assertEquals(0.01, noseCone.getBaseRadiusNoAutomatic(), EPSILON);
-        assertEquals(noseCone.getForeRadius(), noseCone.getForeRadiusNoAutomatic(), EPSILON);
-        assertEquals(0, noseCone.getForeRadiusNoAutomatic(), EPSILON);
+        assertEquals(0.023, noseCone.getBaseRadius(), EPSILON);
+        assertEquals(noseCone.getForeRadius(), noseCone.getForeRadius(), EPSILON);
+        assertEquals(0, noseCone.getForeRadius(), EPSILON);
 
         noseCone.setAftRadiusAutomatic(false, true);
-        assertEquals(noseCone.getAftRadius(), noseCone.getAftRadiusNoAutomatic(), EPSILON);
-        assertEquals(noseCone.getBaseRadius(), noseCone.getBaseRadiusNoAutomatic(), EPSILON);
-        assertEquals(noseCone.getForeRadius(), noseCone.getForeRadiusNoAutomatic(), EPSILON);
-        assertEquals(0, noseCone.getForeRadiusNoAutomatic(), EPSILON);
+        assertEquals(noseCone.getAftRadius(), noseCone.getAftRadius(), EPSILON);
+        assertEquals(noseCone.getBaseRadius(), noseCone.getBaseRadius(), EPSILON);
+        assertEquals(noseCone.getForeRadius(), noseCone.getForeRadius(), EPSILON);
+        assertEquals(0, noseCone.getForeRadius(), EPSILON);
 
         noseCone.setBaseRadiusAutomatic(true);
-        assertEquals(0.01, noseCone.getAftRadiusNoAutomatic(), EPSILON);
+        assertEquals(0.023, noseCone.getAftRadius(), EPSILON);
         assertEquals(tube1.getForeRadius(), noseCone.getBaseRadius(), EPSILON);
-        assertEquals(0.01, noseCone.getBaseRadiusNoAutomatic(), EPSILON);
-        assertEquals(noseCone.getForeRadius(), noseCone.getForeRadiusNoAutomatic(), EPSILON);
-        assertEquals(0, noseCone.getForeRadiusNoAutomatic(), EPSILON);
+        assertEquals(0.023, noseCone.getBaseRadius(), EPSILON);
+        assertEquals(noseCone.getForeRadius(), noseCone.getForeRadius(), EPSILON);
+        assertEquals(0, noseCone.getForeRadius(), EPSILON);
 
         noseCone.setForeRadiusAutomatic(true, true);
         assertFalse(noseCone.isForeRadiusAutomatic());
@@ -274,11 +274,11 @@ public class NoseConeTest extends BaseTestCase {
         assertTrue(noseCone.isBaseRadiusAutomatic());
         assertFalse(noseCone.isForeRadiusAutomatic());
         assertEquals(tube1.getForeRadius(), noseCone.getAftRadius(), EPSILON);
-        assertEquals(0.01, noseCone.getAftRadiusNoAutomatic(), EPSILON);
+        assertEquals(0.023, noseCone.getAftRadius(), EPSILON);
         assertEquals(tube1.getForeRadius(), noseCone.getBaseRadius(), EPSILON);
-        assertEquals(0.01, noseCone.getBaseRadiusNoAutomatic(), EPSILON);
-        assertEquals(noseCone.getForeRadius(), noseCone.getForeRadiusNoAutomatic(), EPSILON);
-        assertEquals(0, noseCone.getForeRadiusNoAutomatic(), EPSILON);
+        assertEquals(0.023, noseCone.getBaseRadius(), EPSILON);
+        assertEquals(noseCone.getForeRadius(), noseCone.getForeRadius(), EPSILON);
+        assertEquals(0, noseCone.getForeRadius(), EPSILON);
 
         // Do a flip
         noseCone.setFlipped(true);
@@ -311,11 +311,11 @@ public class NoseConeTest extends BaseTestCase {
         assertFalse(noseCone.isAftRadiusAutomatic());
         assertFalse(noseCone.isBaseRadiusAutomatic());
         assertFalse(noseCone.isForeRadiusAutomatic());
-        assertEquals(noseCone.getAftRadius(), noseCone.getAftRadiusNoAutomatic(), EPSILON);
-        assertEquals(noseCone.getBaseRadius(), noseCone.getBaseRadiusNoAutomatic(), EPSILON);
-        assertEquals(noseCone.getForeRadius(), noseCone.getForeRadiusNoAutomatic(), EPSILON);
-        assertEquals(0, noseCone.getAftRadiusNoAutomatic(), EPSILON);
-        assertEquals(0.01, noseCone.getForeRadiusNoAutomatic(), EPSILON);
+        assertEquals(noseCone.getAftRadius(), noseCone.getAftRadius(), EPSILON);
+        assertEquals(noseCone.getBaseRadius(), noseCone.getBaseRadius(), EPSILON);
+        assertEquals(noseCone.getForeRadius(), noseCone.getForeRadius(), EPSILON);
+        assertEquals(0, noseCone.getAftRadius(), EPSILON);
+        assertEquals(0.01, noseCone.getForeRadius(), EPSILON);
 
         noseCone.setAftRadiusAutomatic(true, true);
         assertFalse(noseCone.isAftRadiusAutomatic());
@@ -336,10 +336,10 @@ public class NoseConeTest extends BaseTestCase {
         assertFalse(noseCone.isAftRadiusAutomatic());
         assertFalse(noseCone.isBaseRadiusAutomatic());
         assertFalse(noseCone.isForeRadiusAutomatic());
-        assertEquals(noseCone.getAftRadius(), noseCone.getAftRadiusNoAutomatic(), EPSILON);
-        assertEquals(noseCone.getBaseRadius(), noseCone.getBaseRadiusNoAutomatic(), EPSILON);
-        assertEquals(noseCone.getForeRadius(), noseCone.getForeRadiusNoAutomatic(), EPSILON);
-        assertEquals(0, noseCone.getAftRadiusNoAutomatic(), EPSILON);
+        assertEquals(noseCone.getAftRadius(), noseCone.getAftRadius(), EPSILON);
+        assertEquals(noseCone.getBaseRadius(), noseCone.getBaseRadius(), EPSILON);
+        assertEquals(noseCone.getForeRadius(), noseCone.getForeRadius(), EPSILON);
+        assertEquals(0, noseCone.getAftRadius(), EPSILON);
 
         noseCone.setBaseRadiusAutomatic(true);
         assertTrue(noseCone.usesPreviousCompAutomatic());
@@ -352,25 +352,25 @@ public class NoseConeTest extends BaseTestCase {
         assertTrue(noseCone.isBaseRadiusAutomatic());
         assertTrue(noseCone.isForeRadiusAutomatic());
         assertEquals(tube1.getAftRadius(), noseCone.getForeRadius(), EPSILON);
-        assertEquals(0.01, noseCone.getForeRadiusNoAutomatic(), EPSILON);
+        assertEquals(0.02, noseCone.getForeRadius(), EPSILON);
         assertEquals(tube1.getAftRadius(), noseCone.getBaseRadius(), EPSILON);
-        assertEquals(0.01, noseCone.getBaseRadiusNoAutomatic(), EPSILON);
-        assertEquals(noseCone.getAftRadius(), noseCone.getAftRadiusNoAutomatic(), EPSILON);
-        assertEquals(0, noseCone.getAftRadiusNoAutomatic(), EPSILON);
+        assertEquals(0.02, noseCone.getBaseRadius(), EPSILON);
+        assertEquals(noseCone.getAftRadius(), noseCone.getAftRadius(), EPSILON);
+        assertEquals(0, noseCone.getAftRadius(), EPSILON);
 
         noseCone.setForeRadiusAutomatic(false, true);
-        assertEquals(noseCone.getAftRadius(), noseCone.getAftRadiusNoAutomatic(), EPSILON);
-        assertEquals(noseCone.getBaseRadius(), noseCone.getBaseRadiusNoAutomatic(), EPSILON);
-        assertEquals(noseCone.getForeRadius(), noseCone.getForeRadiusNoAutomatic(), EPSILON);
-        assertEquals(0.01, noseCone.getForeRadiusNoAutomatic(), EPSILON);
+        assertEquals(noseCone.getAftRadius(), noseCone.getAftRadius(), EPSILON);
+        assertEquals(noseCone.getBaseRadius(), noseCone.getBaseRadius(), EPSILON);
+        assertEquals(noseCone.getForeRadius(), noseCone.getForeRadius(), EPSILON);
+        assertEquals(0.02, noseCone.getForeRadius(), EPSILON);
 
         noseCone.setBaseRadiusAutomatic(true);
         assertEquals(tube1.getAftRadius(), noseCone.getForeRadius(), EPSILON);
-        assertEquals(0.01, noseCone.getForeRadiusNoAutomatic(), EPSILON);
+        assertEquals(0.02, noseCone.getForeRadius(), EPSILON);
         assertEquals(tube1.getAftRadius(), noseCone.getBaseRadius(), EPSILON);
-        assertEquals(0.01, noseCone.getBaseRadiusNoAutomatic(), EPSILON);
-        assertEquals(noseCone.getAftRadius(), noseCone.getAftRadiusNoAutomatic(), EPSILON);
-        assertEquals(0, noseCone.getAftRadiusNoAutomatic(), EPSILON);
+        assertEquals(0.02, noseCone.getBaseRadius(), EPSILON);
+        assertEquals(noseCone.getAftRadius(), noseCone.getAftRadius(), EPSILON);
+        assertEquals(0, noseCone.getAftRadius(), EPSILON);
 
         assertTrue(noseCone.isForeRadiusAutomatic());
         assertTrue(noseCone.isBaseRadiusAutomatic());
@@ -389,10 +389,10 @@ public class NoseConeTest extends BaseTestCase {
         assertTrue(noseCone.isBaseRadiusAutomatic());
         assertTrue(noseCone.isForeRadiusAutomatic());
         assertEquals(tube1.getAftRadius(), noseCone.getForeRadius(), EPSILON);
-        assertEquals(0.01, noseCone.getForeRadiusNoAutomatic(), EPSILON);
+        assertEquals(0.02, noseCone.getForeRadius(), EPSILON);
         assertEquals(tube1.getForeRadius(), noseCone.getBaseRadius(), EPSILON);
-        assertEquals(0.01, noseCone.getBaseRadiusNoAutomatic(), EPSILON);
-        assertEquals(noseCone.getAftRadius(), noseCone.getAftRadiusNoAutomatic(), EPSILON);
+        assertEquals(0.02, noseCone.getBaseRadius(), EPSILON);
+        assertEquals(noseCone.getAftRadius(), noseCone.getAftRadius(), EPSILON);
         assertEquals(0, noseCone.getAftRadius(), EPSILON);
     }
 }

--- a/swing/src/net/sf/openrocket/gui/dialogs/ScaleDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/ScaleDialog.java
@@ -136,10 +136,8 @@ public class ScaleDialog extends JDialog {
 		SCALERS_NO_OFFSET.put(FreeformFinSet.class, list);
 		
 		// MassObject
-		list = new ArrayList<>(1);
-		list.add(new MassObjectScaler());
-		SCALERS_NO_OFFSET.put(MassObject.class, list);
 		addScaler(MassObject.class, "Radius", "isRadiusAutomatic", SCALERS_NO_OFFSET);
+		addScaler(MassObject.class, "Length", SCALERS_NO_OFFSET);
 		addScaler(MassObject.class, "RadialPosition", SCALERS_OFFSET);
 		
 		// MassComponent
@@ -719,25 +717,6 @@ public class ScaleDialog extends JDialog {
 			}
 		}
 		
-	}
-
-	private static class MassObjectScaler implements Scaler {
-		@Override
-		public void scale(RocketComponent component, double multiplier, boolean scaleMass) {
-			if (scaleMass) {
-				MassObject c = (MassObject) component;
-				if (c.isRadiusAutomatic()) {
-					double volume = Math.PI * Math.pow(c.getRadiusNoAuto(), 2) * c.getLengthNoAuto();
-					double scaledVolume = volume * MathUtil.pow3(multiplier);
-					c.setRadius(c.getRadiusNoAuto() * multiplier);
-					c.setLengthNoAuto(scaledVolume / (Math.PI * Math.pow(c.getRadiusNoAuto(), 2)));
-					c.setRadiusAutomatic(true);
-				} else {
-					c.setLength(c.getLength() * multiplier);
-				}
-			}
-		}
-
 	}
 	
 	private static class FreeformFinSetScaler implements Scaler {


### PR DESCRIPTION
This PR fixes #2096. After checking the "Automatic" checkbox on any rocket component setting, that setting will remain saved, even after unchecking the 'Automatic" checkbox.