### PR TITLE
[#2179] Fix mount name column text being cut off too early

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/MotorMountConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/MotorMountConfigurationPanel.java
@@ -25,7 +25,7 @@ public class MotorMountConfigurationPanel extends JPanel {
 		table.setShowVerticalLines(false);
 		table.setRowSelectionAllowed(false);
 		table.setColumnSelectionAllowed(false);
-		table.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
+		table.setAutoResizeMode(JTable.AUTO_RESIZE_LAST_COLUMN);
 		table.setAutoCreateColumnsFromModel(false);
 		
 		TableColumnModel columnModel = table.getColumnModel();


### PR DESCRIPTION
This PR fixes #2179.
<img width="249" alt="image" src="https://user-images.githubusercontent.com/11031519/230506351-b34a8089-c2fa-47db-98d6-9ed836d48075.png">
