### PR TITLE
[#2171] Compute position based on active components

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RocketComponent.java
@@ -1338,8 +1338,19 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 		if( 0 == thisIndex ) {
 			this.position = this.position.setX(0.);
 		}else if( 0 < thisIndex ) {
-			RocketComponent referenceComponent = parent.getChild( thisIndex - 1 );
-		
+			int idx = thisIndex - 1;
+			RocketComponent referenceComponent = parent.getChild(idx);
+			while (!getRocket().getSelectedConfiguration().isComponentActive(referenceComponent) && idx > 0) {
+				idx--;
+				referenceComponent = parent.getChild(idx);
+			}
+
+			// If previous components are inactive, set this as the new reference point
+			if (!getRocket().getSelectedConfiguration().isComponentActive(referenceComponent)) {
+				this.position = this.position.setX(0.);
+				return;
+			}
+
 			double refLength = referenceComponent.getLength();
 			double refRelX = referenceComponent.getPosition().x;
 

--- a/core/test/net/sf/openrocket/masscalc/MassCalculatorTest.java
+++ b/core/test/net/sf/openrocket/masscalc/MassCalculatorTest.java
@@ -998,7 +998,7 @@ public class MassCalculatorTest extends BaseTestCase {
 		double expTotalMass = overrideMass;
 		assertEquals(" Booster Launch Mass is incorrect: ", expTotalMass, calcTotalMass, EPSILON);
 
-		double expCMx = 6.484;
+		double expCMx = 5.92;
 		Coordinate expCM = new Coordinate(expCMx, 0, 0, expTotalMass);
 		assertEquals(" Booster Launch CM.x is incorrect: ", expCM.x, boosterSetCM.x, EPSILON);
 		assertEquals(" Booster Launch CM.y is incorrect: ", expCM.y, boosterSetCM.y, EPSILON);
@@ -1052,7 +1052,7 @@ public class MassCalculatorTest extends BaseTestCase {
 		double expTotalMass = 3.3565872;
 		assertEquals(" Booster Launch Mass is incorrect: ", expTotalMass, boosterData.getMass(), EPSILON);
 
-		double expCMx = 0.847508988;
+		double expCMx = 0.2835089882645608;
 		Coordinate expCM = new Coordinate(expCMx, 0, 0, expTotalMass);
 		assertEquals(" Booster Launch CM.x is incorrect: ", expCM.x, boosterCM.x, EPSILON);
 		assertEquals(" Booster Launch CM.y is incorrect: ", expCM.y, boosterCM.y, EPSILON);
@@ -1099,7 +1099,7 @@ public class MassCalculatorTest extends BaseTestCase {
 		double calcTotalMass = structure.getMass();
 		assertEquals(" Booster Launch Mass is incorrect: ", expMass, calcTotalMass, EPSILON);
 
-		final double expCMx = 1.1191303646438673;
+		final double expCMx = 0.5551303646438673;
 		Coordinate expCM = new Coordinate(expCMx, 0, 0, expMass);
 		assertEquals(" Booster Launch CM.x is incorrect: ", expCM.x, structure.getCM().x, EPSILON);
 		assertEquals(" Booster Launch CM.y is incorrect: ", expCM.y, structure.getCM().y, EPSILON);

--- a/core/test/net/sf/openrocket/simulation/DisableStageTest.java
+++ b/core/test/net/sf/openrocket/simulation/DisableStageTest.java
@@ -42,7 +42,7 @@ public class DisableStageTest extends BaseTestCase {
             }
         }
 
-        //// Test re-enableing the stage.
+        //// Test re-enabling the stage.
         Rocket rocketOriginal = TestRockets.makeEstesAlphaIII();
 
         Simulation simOriginal = new Simulation(rocketOriginal);
@@ -81,7 +81,7 @@ public class DisableStageTest extends BaseTestCase {
 
         compareSims(simRemoved, simDisabled, delta);
 
-        //// Test re-enableing the stage.
+        //// Test re-enabling the stage.
         Rocket rocketOriginal = TestRockets.makeBeta();
         Simulation simOriginal = new Simulation(rocketOriginal);
         simOriginal.setFlightConfigurationId(TestRockets.TEST_FCID_1);
@@ -173,7 +173,7 @@ public class DisableStageTest extends BaseTestCase {
 
         compareSims(simRemoved, simDisabled, delta);
 
-        //// Test re-enableing the stage.
+        //// Test re-enabling the stage.
         Rocket rocketOriginal = TestRockets.makeFalcon9Heavy();
 		TestRockets.addCoreFins(rocketOriginal);
 		
@@ -232,7 +232,7 @@ public class DisableStageTest extends BaseTestCase {
             }
         }
 
-        //// Test re-enableing the stage.
+        //// Test re-enabling the stage.
         Rocket rocketOriginal = TestRockets.makeFalcon9Heavy();
 		TestRockets.addCoreFins(rocketOriginal);
 		


### PR DESCRIPTION
This PR fixes #2171 by computing a rocket component's position only based on active components.


https://user-images.githubusercontent.com/11031519/230635048-00e8fa69-b921-4058-ae63-897e6dc47153.mov

