### PR TITLE
[Enhancement] Add better warning that data will be plotted in time order

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -767,8 +767,6 @@ simplotpanel.but.NewYaxisplottype = New Y axis plot type
 simplotpanel.lbl.Axis = Axis:
 simplotpanel.but.ttip.Deletethisplot = Delete this plot
 simplotpanel.Desc = The data will be plotted in time order even if the X axis type is not time.
-! Fix this name
-simplotpanel.Warning = The data is plotted in time order even though the X axis type is not time. 
 simplotpanel.OptionPane.lbl1 = A maximum of 15 plots is allowed.
 simplotpanel.OptionPane.lbl2 = Cannot add plot
 simplotpanel.AUTO_NAME = Auto
@@ -1506,6 +1504,7 @@ TCMotorSelPan.btn.close = Close
 ! PlotDialog
 PlotDialog.CheckBox.Showdatapoints = Show data points
 PlotDialog.lbl.Chart = left click drag to zoom area. mouse wheel to zoom. ctrl-mouse wheel to zoom x axis only. ctrl-left click drag to pan.  right click drag to zoom dynamically.
+PlotDialog.lbl.timeSeriesWarning = The data is plotted in time order even though the X axis type is not time. 
 PlotDialog.btn.exportImage = Export Image
 
 ComponentTree.ttip.massoverride = mass overriden

--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -767,6 +767,8 @@ simplotpanel.but.NewYaxisplottype = New Y axis plot type
 simplotpanel.lbl.Axis = Axis:
 simplotpanel.but.ttip.Deletethisplot = Delete this plot
 simplotpanel.Desc = The data will be plotted in time order even if the X axis type is not time.
+! Fix this name
+simplotpanel.Warning = The data is plotted in time order even though the X axis type is not time. 
 simplotpanel.OptionPane.lbl1 = A maximum of 15 plots is allowed.
 simplotpanel.OptionPane.lbl2 = Cannot add plot
 simplotpanel.AUTO_NAME = Auto

--- a/swing/src/net/sf/openrocket/gui/components/DescriptionArea.java
+++ b/swing/src/net/sf/openrocket/gui/components/DescriptionArea.java
@@ -18,6 +18,9 @@ import java.io.FileOutputStream;
 import javax.swing.JTextPane;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
+import javax.swing.text.SimpleAttributeSet;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.StyledDocument;
 import javax.swing.JEditorPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -188,6 +191,7 @@ public class DescriptionArea extends JScrollPane {
 			}
 			
 		});
+		setForeground(editorPane.getForeground());
 		editorPane.scrollRectToVisible(new Rectangle(0, 0, 1, 1));
 	}
 
@@ -206,11 +210,19 @@ public class DescriptionArea extends JScrollPane {
 	public void setBackground(Color color) {
 		if (editorPane == null) return;
 		editorPane.setBackground(color);
+		StyledDocument styledDocument = (StyledDocument) editorPane.getDocument();
+		SimpleAttributeSet attributeSet = new SimpleAttributeSet();
+		StyleConstants.setForeground(attributeSet, color);
+		styledDocument.setCharacterAttributes(0, styledDocument.getLength(), attributeSet, false);
 	}
 
 	public void setForeground(Color color) {
 		if (editorPane == null) return;
 		editorPane.setForeground(color);
+		StyledDocument styledDocument = (StyledDocument) editorPane.getDocument();
+		SimpleAttributeSet attributeSet = new SimpleAttributeSet();
+		StyleConstants.setForeground(attributeSet, color);
+		styledDocument.setCharacterAttributes(0, styledDocument.getLength(), attributeSet, false);
 	}
 	
 }

--- a/swing/src/net/sf/openrocket/gui/components/DescriptionArea.java
+++ b/swing/src/net/sf/openrocket/gui/components/DescriptionArea.java
@@ -202,5 +202,15 @@ public class DescriptionArea extends JScrollPane {
 			editorPane.setFont(font);
 		}
 	}
+
+	public void setBackground(Color color) {
+		if (editorPane == null) return;
+		editorPane.setBackground(color);
+	}
+
+	public void setForeground(Color color) {
+		if (editorPane == null) return;
+		editorPane.setForeground(color);
+	}
 	
 }

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
@@ -76,10 +76,7 @@ public class SimulationPlotDialog extends JDialog {
 
 		// Add warning if X axis type is not time
 		if (config.getDomainAxisType() != FlightDataType.TYPE_TIME) {
-			// TODO: LOW: This translation message doesn't use the proper tense (simple future when it would be present)
-			// There is currently no translation message representing this dialog. 
-			// Such a message should be added, and this code should be updated to use it. 
-			JLabel msg = new StyledLabel(trans.get("simplotpanel.Desc"), -2);
+			JLabel msg = new StyledLabel(trans.get("simplotpanel.Warning"), -2);
 			msg.setForeground(Color.DARK_RED.toAWTColor());
 			panel.add(msg, "wrap");
 		}

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
@@ -76,7 +76,7 @@ public class SimulationPlotDialog extends JDialog {
 
 		// Add warning if X axis type is not time
 		if (config.getDomainAxisType() != FlightDataType.TYPE_TIME) {
-			JLabel msg = new StyledLabel(trans.get("simplotpanel.Warning"), -2);
+			JLabel msg = new StyledLabel(trans.get("PlotDialog.lbl.timeSeriesWarning"), -2);
 			msg.setForeground(Color.DARK_RED.toAWTColor());
 			panel.add(msg, "wrap");
 		}

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
@@ -28,8 +28,10 @@ import net.sf.openrocket.gui.util.Icons;
 import net.sf.openrocket.gui.util.SwingPreferences;
 import net.sf.openrocket.gui.widgets.SaveFileChooser;
 import net.sf.openrocket.l10n.Translator;
+import net.sf.openrocket.simulation.FlightDataType;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.startup.Preferences;
+import net.sf.openrocket.util.Color;
 import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 import org.jfree.chart.ChartPanel;
@@ -71,6 +73,16 @@ public class SimulationPlotDialog extends JDialog {
 		//// Description text
 		JLabel label = new StyledLabel(trans.get("PlotDialog.lbl.Chart"), -2);
 		panel.add(label, "wrap");
+
+		// Add warning if X axis type is not time
+		if (config.getDomainAxisType() != FlightDataType.TYPE_TIME) {
+			// TODO: LOW: This translation message doesn't use the proper tense (simple future when it would be present)
+			// There is currently no translation message representing this dialog. 
+			// Such a message should be added, and this code should be updated to use it. 
+			JLabel msg = new StyledLabel(trans.get("simplotpanel.Desc"), -2);
+			msg.setForeground(Color.DARK_RED.toAWTColor());
+			panel.add(msg, "wrap");
+		}
 		
 		//// Show data points
 		final JCheckBox check = new JCheckBox(trans.get("PlotDialog.CheckBox.Showdatapoints"));

--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationPlotPanel.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationPlotPanel.java
@@ -1,6 +1,5 @@
 package net.sf.openrocket.gui.simulation;
 
-import java.awt.Color;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -41,6 +40,7 @@ import net.sf.openrocket.simulation.FlightEvent;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.startup.Preferences;
 import net.sf.openrocket.unit.Unit;
+import net.sf.openrocket.util.Color;
 import net.sf.openrocket.util.Utils;
 import net.sf.openrocket.gui.widgets.SelectColorButton;
 
@@ -205,8 +205,7 @@ public class SimulationPlotPanel extends JPanel {
 		//// The data will be plotted in time order even if the X axis type is not time.
 		simPlotPanelDesc = new DescriptionArea("", 2, -2f, false);
 		simPlotPanelDesc.setVisible(false);
-		simPlotPanelDesc.setForeground(Color.RED);
-		
+		simPlotPanelDesc.setForeground(Color.DARK_RED.toAWTColor());
 		simPlotPanelDesc.setViewportBorder(BorderFactory.createEmptyBorder());
 		this.add(simPlotPanelDesc, "width 1px, growx 1, wrap unrel");
 		

--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationPlotPanel.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationPlotPanel.java
@@ -1,5 +1,6 @@
 package net.sf.openrocket.gui.simulation;
 
+import java.awt.Color;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -105,7 +106,8 @@ public class SimulationPlotPanel extends JPanel {
 	
 	
 	private int modifying = 0;
-	
+
+	private DescriptionArea simPlotPanelDesc;	
 	
 	public SimulationPlotPanel(final Simulation simulation) {
 		super(new MigLayout("fill"));
@@ -170,6 +172,14 @@ public class SimulationPlotPanel extends JPanel {
 				if (modifying > 0)
 					return;
 				FlightDataType type = (FlightDataType) domainTypeSelector.getSelectedItem();
+				if (type == FlightDataType.TYPE_TIME) {
+					simPlotPanelDesc.setVisible(false);
+					simPlotPanelDesc.setText("");
+				}
+				else {
+					simPlotPanelDesc.setVisible(true);
+					simPlotPanelDesc.setText(trans.get("simplotpanel.Desc"));
+				}
 				configuration.setDomainAxisType(type);
 				domainUnitSelector.setUnitGroup(type.getUnitGroup());
 				domainUnitSelector.setSelectedUnit(configuration.getDomainAxisUnit());
@@ -193,9 +203,13 @@ public class SimulationPlotPanel extends JPanel {
 		this.add(domainUnitSelector, "width 40lp, gapright para");
 		
 		//// The data will be plotted in time order even if the X axis type is not time.
-		DescriptionArea desc = new DescriptionArea(trans.get("simplotpanel.Desc"), 2, -2f);
-		desc.setViewportBorder(BorderFactory.createEmptyBorder());
-		this.add(desc, "width 1px, growx 1, wrap unrel");
+		simPlotPanelDesc = new DescriptionArea("", 2, -2f, false);
+		simPlotPanelDesc.setVisible(false);
+		simPlotPanelDesc.setForeground(Color.RED);
+		
+		simPlotPanelDesc.setViewportBorder(BorderFactory.createEmptyBorder());
+		this.add(simPlotPanelDesc, "width 1px, growx 1, wrap unrel");
+		
 		
 		
 		


### PR DESCRIPTION
Fixes #2161 
The plot dialog warns that all data is plotted in time order regardless of X axis type, but this warning is easy to miss.
The message was removed by default and on changing to an X axis type other than time, a red warning will appear.

[Here is a jar file for testing](https://drive.google.com/file/d/1YJp7lEhRgSuI3k13kbFqVgx6vLZBWWz-/view?usp=share_link)