### PR TITLE
[#2217] Fix mass issues for fin sets (+ CM of launch lug and rail buttons)

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/ExternalComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/ExternalComponent.java
@@ -102,7 +102,7 @@ public abstract class ExternalComponent extends RocketComponent {
 	 */
 	@Override
 	public double getComponentMass() {
-		return material.getDensity() * getComponentVolume() * getInstanceCount();
+		return material.getDensity() * getComponentVolume();
 	}
 	
 	/**

--- a/core/src/net/sf/openrocket/rocketcomponent/LaunchLug.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/LaunchLug.java
@@ -228,9 +228,12 @@ public class LaunchLug extends Tube implements AnglePositionable, BoxBounded, Li
 	
 	@Override
 	public Coordinate getComponentCG() {
+		final double parentRadius = parent instanceof SymmetricComponent ?
+				((SymmetricComponent) parent).getRadius(getAxialOffset()) : 0;
+
 		final double CMx = length / 2 + (instanceSeparation * (instanceCount-1)) / 2;
-		final double CMy = Math.cos(this.angleOffsetRad)*getOuterRadius();
-		final double CMz = Math.sin(this.angleOffsetRad)*getOuterRadius();
+		final double CMy = Math.cos(this.angleOffsetRad) * (parentRadius + getOuterRadius());
+		final double CMz = Math.sin(this.angleOffsetRad) * (parentRadius + getOuterRadius());
 		return new Coordinate(CMx, CMy, CMz, getComponentMass());
 	}
 	

--- a/core/src/net/sf/openrocket/rocketcomponent/LaunchLug.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/LaunchLug.java
@@ -215,7 +215,7 @@ public class LaunchLug extends Tube implements AnglePositionable, BoxBounded, Li
 	
 	@Override
 	public double getComponentVolume() {
-		return length * Math.PI * (MathUtil.pow2(radius) - MathUtil.pow2(radius - thickness));
+		return length * Math.PI * (MathUtil.pow2(radius) - MathUtil.pow2(radius - thickness)) * getInstanceCount();
 	}
 	
 	@Override

--- a/core/src/net/sf/openrocket/rocketcomponent/RailButton.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RailButton.java
@@ -304,7 +304,8 @@ public class RailButton extends ExternalComponent implements AnglePositionable, 
 		final double volInner = Math.PI*Math.pow( innerDiameter_m/2, 2)*getInnerHeight();
 		final double volStandoff = Math.PI*Math.pow( outerDiameter_m/2, 2)* baseHeight_m;
 		final double volScrew = 2f/3 * Math.PI * MathUtil.pow2(outerDiameter_m/2) * screwHeight_m;
-		return volOuter + volInner + volStandoff + volScrew;
+		final double volInstance = volOuter + volInner + volStandoff + volScrew;
+		return volInstance * getInstanceCount();
 	}
 	
 	@Override

--- a/core/src/net/sf/openrocket/rocketcomponent/RailButton.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RailButton.java
@@ -381,14 +381,16 @@ public class RailButton extends ExternalComponent implements AnglePositionable, 
 		final double flangeCM = this.totalHeight_m - getFlangeHeight()/2;
 		final double screwCM = this.totalHeight_m + 4 * this.screwHeight_m / (3 * Math.PI);
 		final double heightCM = (massBase*baseCM + massInner*innerCM + massFlange*flangeCM + massScrew*screwCM)/totalMass;
+		final double parentRadius = parent instanceof SymmetricComponent ?
+				((SymmetricComponent) parent).getRadius(getAxialOffset()) : 0;
 
 		if (heightCM > this.totalHeight_m + this.screwHeight_m) {
 			throw new BugException(" bug found while computing the CG of a RailButton: "+this.getName()+"\n height of CG: "+heightCM);
 		}
 
 		final double CMx = (instanceSeparation * (instanceCount-1)) / 2;
-		final double CMy = Math.cos(this.angleOffsetRad)*heightCM;
-		final double CMz = Math.sin(this.angleOffsetRad)*heightCM;
+		final double CMy = Math.cos(this.angleOffsetRad) * (parentRadius + heightCM);
+		final double CMz = Math.sin(this.angleOffsetRad) * (parentRadius + heightCM);
 		
 		return new Coordinate( CMx, CMy, CMz, getComponentMass());
 	}

--- a/core/test/net/sf/openrocket/masscalc/MassCalculatorTest.java
+++ b/core/test/net/sf/openrocket/masscalc/MassCalculatorTest.java
@@ -65,7 +65,7 @@ public class MassCalculatorTest extends BaseTestCase {
 		assertEquals(" Alpha III Empty Mass is incorrect: ", expRocketDryMass, actualRocketDryMass, EPSILON);
 
 		double expCMx = 0.1917685523;
-		double expCMy = -0.00006340812673;		// Slight offset due to launch lug
+		double expCMy = -0.000317040634;		// Slight offset due to launch lug
 		Coordinate expCM = new Coordinate(expCMx, expCMy, 0, expRocketDryMass);
 		assertEquals("Simple Rocket CM.x is incorrect: ", expCM.x, actualRocketDryCM.x, EPSILON);
 		assertEquals("Simple Rocket CM.y is incorrect: ", expCM.y, actualRocketDryCM.y, EPSILON);
@@ -73,7 +73,7 @@ public class MassCalculatorTest extends BaseTestCase {
 		assertEquals("Simple Rocket CM is incorrect: ", expCM, actualRocketDryCM);
 
 
-		double expMOIrot = 1.8763734635622462E-5;
+		double expMOIrot = 1.888136072268211E-5;
 		double expMOIlong = 1.7808603404853048E-4;
 
 		double actualMOIrot = actualStructure.getRotationalInertia();
@@ -118,7 +118,7 @@ public class MassCalculatorTest extends BaseTestCase {
 		assertEquals(" Alpha III Total Mass (with motor: " + desig + ") is incorrect: ", expRocketLaunchMass, actualRocketLaunchMass, EPSILON);
 
 		double expCMx = 0.20996455968266833;
-		double expCMy = -0.00003845163503;		// Slight offset due to launch lug
+		double expCMy = -0.00019225817513303;		// Slight offset due to launch lug
 		Coordinate expCM = new Coordinate(expCMx, expCMy, 0, expRocketLaunchMass);
 		assertEquals("Simple Rocket CM.x is incorrect: ", expCM.x, actualRocketLaunchCM.x, EPSILON);
 		assertEquals("Simple Rocket CM.y is incorrect: ", expCM.y, actualRocketLaunchCM.y, EPSILON);

--- a/core/test/net/sf/openrocket/masscalc/MassCalculatorTest.java
+++ b/core/test/net/sf/openrocket/masscalc/MassCalculatorTest.java
@@ -1269,5 +1269,37 @@ public class MassCalculatorTest extends BaseTestCase {
 		assertEquals(0.02, bodyTube.getMass(), EPSILON);
 		assertEquals(0.02, bodyTube.getSectionMass(), EPSILON);
 	}
+
+
+	@Test
+	public void testTubeFinMass() {
+		Rocket rocket = OpenRocketDocumentFactory.createNewRocket().getRocket();
+		AxialStage stage = rocket.getStage(0);
+		BodyTube bodyTube = new BodyTube();
+		stage.addChild(bodyTube);
+		TubeFinSet tubeFinSet = new TubeFinSet();
+		tubeFinSet.setOuterRadius(0.04);
+		tubeFinSet.setThickness(0.002);
+		tubeFinSet.setLength(0.1);
+		tubeFinSet.setInstanceCount(3);
+		bodyTube.addChild(tubeFinSet);
+
+		assertEquals(0.0001470265, tubeFinSet.getComponentVolume(), EPSILON);
+		assertEquals(0.0999780446, tubeFinSet.getComponentMass(), EPSILON);
+		assertEquals(0.0999780446, tubeFinSet.getMass(), EPSILON);
+
+		tubeFinSet.setInstanceCount(4);
+
+		assertEquals(0.000196035, tubeFinSet.getComponentVolume(), EPSILON);
+		assertEquals(0.133304059, tubeFinSet.getComponentMass(), EPSILON);
+		assertEquals(0.133304059, tubeFinSet.getMass(), EPSILON);
+
+		tubeFinSet.setMassOverridden(true);
+		tubeFinSet.setOverrideMass(0.02);
+
+		assertEquals(0.133304059, tubeFinSet.getComponentMass(), EPSILON);
+		assertEquals(0.02, tubeFinSet.getMass(), EPSILON);
+	}
+
 	
 }

--- a/core/test/net/sf/openrocket/rocketcomponent/LaunchLugTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/LaunchLugTest.java
@@ -39,7 +39,7 @@ public class LaunchLugTest extends BaseTestCase {
 	public void testLaunchLugLocationAtAngles() {
 		Rocket rocket = TestRockets.makeEstesAlphaIII();
 		
-		BodyTube body= (BodyTube)rocket.getChild(0).getChild(1);
+		BodyTube body = (BodyTube)rocket.getChild(0).getChild(1);
 		LaunchLug lug = (LaunchLug)rocket.getChild(0).getChild(1).getChild(1);
 		double startAngle = Math.PI/2;
 		lug.setAngleOffset( startAngle );
@@ -67,6 +67,7 @@ public class LaunchLugTest extends BaseTestCase {
 	@Test
 	public void testCMSingleInstance() {
 		BodyTube bodyTube = new BodyTube();
+		bodyTube.setOuterRadius(0.025);
 		LaunchLug lug = new LaunchLug();
 		lug.setLength(0.1);
 		lug.setOuterRadius(0.02);
@@ -75,7 +76,7 @@ public class LaunchLugTest extends BaseTestCase {
 		// Test normal CG
 		Coordinate CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.05, CG.x, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong y value: ", -0.02, CG.y, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong y value: ", -0.045, CG.y, EPSILON);
 		assertEquals(" LaunchLug CG has the wrong z value: ", 0, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.008331504, CG.weight, EPSILON);
 
@@ -84,14 +85,14 @@ public class LaunchLugTest extends BaseTestCase {
 		CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.05, CG.x, EPSILON);
 		assertEquals(" LaunchLug CG has the wrong y value: ", 0, CG.y, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong z value: ", 0.02, CG.z, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong z value: ", 0.045, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.008331504, CG.weight, EPSILON);
 
 		lug.setAngleOffset(-Math.PI / 3);
 		CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.05, CG.x, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong y value: ", 0.01, CG.y, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong z value: ", -0.0173205, CG.z, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong y value: ", 0.0225, CG.y, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong z value: ", -0.03897114, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.008331504, CG.weight, EPSILON);
 
 
@@ -102,7 +103,7 @@ public class LaunchLugTest extends BaseTestCase {
 
 		CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.025, CG.x, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong y value: ", 0.015, CG.y, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong y value: ", 0.04, CG.y, EPSILON);
 		assertEquals(" LaunchLug CG has the wrong z value: ", 0, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.00309761, CG.weight, EPSILON);
 
@@ -111,20 +112,21 @@ public class LaunchLugTest extends BaseTestCase {
 		CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.025, CG.x, EPSILON);
 		assertEquals(" LaunchLug CG has the wrong y value: ", 0, CG.y, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong z value: ", 0.015, CG.z, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong z value: ", 0.04, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.00309761, CG.weight, EPSILON);
 
 		lug.setAngleOffset(-Math.PI / 3);
 		CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.025, CG.x, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong y value: ", 0.0075, CG.y, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong z value: ", -0.01299038, CG.z, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong y value: ", 0.02, CG.y, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong z value: ", -0.034641016, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.00309761, CG.weight, EPSILON);
 	}
 
 	@Test
 	public void testCMSingleInstanceOverride() {
 		BodyTube bodyTube = new BodyTube();
+		bodyTube.setOuterRadius(0.025);
 		LaunchLug lug = new LaunchLug();
 		lug.setLength(0.1);
 		lug.setOuterRadius(0.02);
@@ -135,7 +137,7 @@ public class LaunchLugTest extends BaseTestCase {
 		// Test normal CG
 		Coordinate CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.0123, CG.x, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong y value: ", -0.02, CG.y, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong y value: ", -0.045, CG.y, EPSILON);
 		assertEquals(" LaunchLug CG has the wrong z value: ", 0, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.008331504, CG.weight, EPSILON);
 
@@ -144,14 +146,14 @@ public class LaunchLugTest extends BaseTestCase {
 		CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.0123, CG.x, EPSILON);
 		assertEquals(" LaunchLug CG has the wrong y value: ", 0, CG.y, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong z value: ", 0.02, CG.z, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong z value: ", 0.045, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.008331504, CG.weight, EPSILON);
 
 		lug.setAngleOffset(-Math.PI / 3);
 		CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.0123, CG.x, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong y value: ", 0.01, CG.y, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong z value: ", -0.0173205, CG.z, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong y value: ", 0.0225, CG.y, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong z value: ", -0.03897114, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.008331504, CG.weight, EPSILON);
 
 
@@ -165,7 +167,7 @@ public class LaunchLugTest extends BaseTestCase {
 
 		CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.0321, CG.x, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong y value: ", 0.015, CG.y, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong y value: ", 0.04, CG.y, EPSILON);
 		assertEquals(" LaunchLug CG has the wrong z value: ", 0, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.1, CG.weight, EPSILON);
 
@@ -174,20 +176,21 @@ public class LaunchLugTest extends BaseTestCase {
 		CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.0321, CG.x, EPSILON);
 		assertEquals(" LaunchLug CG has the wrong y value: ", 0, CG.y, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong z value: ", 0.015, CG.z, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong z value: ", 0.04, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.1, CG.weight, EPSILON);
 
 		lug.setAngleOffset(-Math.PI / 3);
 		CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.0321, CG.x, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong y value: ", 0.0075, CG.y, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong z value: ", -0.01299038, CG.z, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong y value: ", 0.02, CG.y, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong z value: ", -0.034641016, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.1, CG.weight, EPSILON);
 	}
 
 	@Test
 	public void testCMMultipleInstances() {
 		BodyTube bodyTube = new BodyTube();
+		bodyTube.setOuterRadius(0.025);
 		LaunchLug lug = new LaunchLug();
 		lug.setLength(0.1);
 		lug.setOuterRadius(0.02);
@@ -198,7 +201,7 @@ public class LaunchLugTest extends BaseTestCase {
 		// Test normal CG
 		Coordinate CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.25, CG.x, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong y value: ", -0.02, CG.y, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong y value: ", -0.045, CG.y, EPSILON);
 		assertEquals(" LaunchLug CG has the wrong z value: ", 0, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.024994512, CG.weight, EPSILON);
 
@@ -207,14 +210,14 @@ public class LaunchLugTest extends BaseTestCase {
 		CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.25, CG.x, EPSILON);
 		assertEquals(" LaunchLug CG has the wrong y value: ", 0, CG.y, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong z value: ", 0.02, CG.z, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong z value: ", 0.045, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.024994512, CG.weight, EPSILON);
 
 		lug.setAngleOffset(-Math.PI / 3);
 		CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.25, CG.x, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong y value: ", 0.01, CG.y, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong z value: ", -0.0173205, CG.z, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong y value: ", 0.0225, CG.y, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong z value: ", -0.03897114, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.024994512, CG.weight, EPSILON);
 
 
@@ -227,7 +230,7 @@ public class LaunchLugTest extends BaseTestCase {
 
 		CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.1, CG.x, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong y value: ", 0.015, CG.y, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong y value: ", 0.04, CG.y, EPSILON);
 		assertEquals(" LaunchLug CG has the wrong z value: ", 0, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.00619522, CG.weight, EPSILON);
 
@@ -236,20 +239,21 @@ public class LaunchLugTest extends BaseTestCase {
 		CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.1, CG.x, EPSILON);
 		assertEquals(" LaunchLug CG has the wrong y value: ", 0, CG.y, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong z value: ", 0.015, CG.z, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong z value: ", 0.04, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.00619522, CG.weight, EPSILON);
 
 		lug.setAngleOffset(-Math.PI / 3);
 		CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.1, CG.x, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong y value: ", 0.0075, CG.y, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong z value: ", -0.01299038, CG.z, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong y value: ", 0.02, CG.y, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong z value: ", -0.034641016, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.00619522, CG.weight, EPSILON);
 	}
 
 	@Test
 	public void testCMMultipleInstancesOverride() {
 		BodyTube bodyTube = new BodyTube();
+		bodyTube.setOuterRadius(0.025);
 		LaunchLug lug = new LaunchLug();
 		lug.setLength(0.1);
 		lug.setOuterRadius(0.02);
@@ -262,7 +266,7 @@ public class LaunchLugTest extends BaseTestCase {
 		// Test normal CG
 		Coordinate CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.0123, CG.x, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong y value: ", -0.02, CG.y, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong y value: ", -0.045, CG.y, EPSILON);
 		assertEquals(" LaunchLug CG has the wrong z value: ", 0, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.024994512, CG.weight, EPSILON);
 
@@ -271,14 +275,14 @@ public class LaunchLugTest extends BaseTestCase {
 		CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.0123, CG.x, EPSILON);
 		assertEquals(" LaunchLug CG has the wrong y value: ", 0, CG.y, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong z value: ", 0.02, CG.z, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong z value: ", 0.045, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.024994512, CG.weight, EPSILON);
 
 		lug.setAngleOffset(-Math.PI / 3);
 		CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.0123, CG.x, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong y value: ", 0.01, CG.y, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong z value: ", -0.0173205, CG.z, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong y value: ", 0.0225, CG.y, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong z value: ", -0.03897114, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.024994512, CG.weight, EPSILON);
 
 
@@ -294,7 +298,7 @@ public class LaunchLugTest extends BaseTestCase {
 
 		CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.0321, CG.x, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong y value: ", 0.015, CG.y, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong y value: ", 0.04, CG.y, EPSILON);
 		assertEquals(" LaunchLug CG has the wrong z value: ", 0, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.2, CG.weight, EPSILON);
 
@@ -303,14 +307,14 @@ public class LaunchLugTest extends BaseTestCase {
 		CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.0321, CG.x, EPSILON);
 		assertEquals(" LaunchLug CG has the wrong y value: ", 0, CG.y, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong z value: ", 0.015, CG.z, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong z value: ", 0.04, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.2, CG.weight, EPSILON);
 
 		lug.setAngleOffset(-Math.PI / 3);
 		CG = lug.getCG();
 		assertEquals(" LaunchLug CG has the wrong x value: ", 0.0321, CG.x, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong y value: ", 0.0075, CG.y, EPSILON);
-		assertEquals(" LaunchLug CG has the wrong z value: ", -0.01299038, CG.z, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong y value: ", 0.02, CG.y, EPSILON);
+		assertEquals(" LaunchLug CG has the wrong z value: ", -0.034641016, CG.z, EPSILON);
 		assertEquals(" LaunchLug CM has the wrong value: ", 0.2, CG.weight, EPSILON);
 	}
 	

--- a/core/test/net/sf/openrocket/rocketcomponent/RailButtonTest.java
+++ b/core/test/net/sf/openrocket/rocketcomponent/RailButtonTest.java
@@ -13,6 +13,7 @@ public class RailButtonTest extends BaseTestCase {
     @Test
     public void testCMSingleInstance() {
         BodyTube bodyTube = new BodyTube();
+        bodyTube.setOuterRadius(0.025);
         RailButton button = new RailButton();
         button.setOuterDiameter(0.05);
         button.setTotalHeight(0.05);
@@ -21,7 +22,7 @@ public class RailButtonTest extends BaseTestCase {
         // Test normal CG
         Coordinate CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0, CG.x, EPSILON);
-        assertEquals(" RailButton CG has the wrong y value: ", -0.025, CG.y, EPSILON);
+        assertEquals(" RailButton CG has the wrong y value: ", -0.05, CG.y, EPSILON);
         assertEquals(" RailButton CG has the wrong z value: ", 0, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.014435995, CG.weight, EPSILON);
 
@@ -30,14 +31,14 @@ public class RailButtonTest extends BaseTestCase {
         CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0, CG.x, EPSILON);
         assertEquals(" RailButton CG has the wrong y value: ", 0, CG.y, EPSILON);
-        assertEquals(" RailButton CG has the wrong z value: ", 0.025, CG.z, EPSILON);
+        assertEquals(" RailButton CG has the wrong z value: ", 0.05, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.014435995, CG.weight, EPSILON);
 
         button.setAngleOffset(-Math.PI / 3);
         CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0, CG.x, EPSILON);
-        assertEquals(" RailButton CG has the wrong y value: ", 0.0125, CG.y, EPSILON);
-        assertEquals(" RailButton CG has the wrong z value: ", -0.02165064, CG.z, EPSILON);
+        assertEquals(" RailButton CG has the wrong y value: ", 0.025, CG.y, EPSILON);
+        assertEquals(" RailButton CG has the wrong z value: ", -0.04330127, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.014435995, CG.weight, EPSILON);
 
 
@@ -48,7 +49,7 @@ public class RailButtonTest extends BaseTestCase {
 
         CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0, CG.x, EPSILON);
-        assertEquals(" RailButton CG has the wrong y value: ", 0.01, CG.y, EPSILON);
+        assertEquals(" RailButton CG has the wrong y value: ", 0.035, CG.y, EPSILON);
         assertEquals(" RailButton CG has the wrong z value: ", 0, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.003930195, CG.weight, EPSILON);
 
@@ -57,20 +58,21 @@ public class RailButtonTest extends BaseTestCase {
         CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0, CG.x, EPSILON);
         assertEquals(" RailButton CG has the wrong y value: ", 0, CG.y, EPSILON);
-        assertEquals(" RailButton CG has the wrong z value: ", 0.01, CG.z, EPSILON);
+        assertEquals(" RailButton CG has the wrong z value: ", 0.035, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.003930195, CG.weight, EPSILON);
 
         button.setAngleOffset(-Math.PI / 3);
         CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0, CG.x, EPSILON);
-        assertEquals(" RailButton CG has the wrong y value: ", 0.005, CG.y, EPSILON);
-        assertEquals(" RailButton CG has the wrong z value: ", -0.00866025, CG.z, EPSILON);
+        assertEquals(" RailButton CG has the wrong y value: ", 0.0175, CG.y, EPSILON);
+        assertEquals(" RailButton CG has the wrong z value: ", -0.03031089, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.003930195, CG.weight, EPSILON);
     }
 
     @Test
     public void testCMSingleInstanceOverride() {
         BodyTube bodyTube = new BodyTube();
+        bodyTube.setOuterRadius(0.025);
         RailButton button = new RailButton();
         button.setOuterDiameter(0.05);
         button.setTotalHeight(0.05);
@@ -81,7 +83,7 @@ public class RailButtonTest extends BaseTestCase {
         // Test normal CG
         Coordinate CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0.0123, CG.x, EPSILON);
-        assertEquals(" RailButton CG has the wrong y value: ", -0.025, CG.y, EPSILON);
+        assertEquals(" RailButton CG has the wrong y value: ", -0.05, CG.y, EPSILON);
         assertEquals(" RailButton CG has the wrong z value: ", 0, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.014435995, CG.weight, EPSILON);
 
@@ -90,14 +92,14 @@ public class RailButtonTest extends BaseTestCase {
         CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0.0123, CG.x, EPSILON);
         assertEquals(" RailButton CG has the wrong y value: ", 0, CG.y, EPSILON);
-        assertEquals(" RailButton CG has the wrong z value: ", 0.025, CG.z, EPSILON);
+        assertEquals(" RailButton CG has the wrong z value: ", 0.05, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.014435995, CG.weight, EPSILON);
 
         button.setAngleOffset(-Math.PI / 3);
         CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0.0123, CG.x, EPSILON);
-        assertEquals(" RailButton CG has the wrong y value: ", 0.0125, CG.y, EPSILON);
-        assertEquals(" RailButton CG has the wrong z value: ", -0.02165064, CG.z, EPSILON);
+        assertEquals(" RailButton CG has the wrong y value: ", 0.025, CG.y, EPSILON);
+        assertEquals(" RailButton CG has the wrong z value: ", -0.04330127, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.014435995, CG.weight, EPSILON);
 
 
@@ -111,7 +113,7 @@ public class RailButtonTest extends BaseTestCase {
 
         CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0.0321, CG.x, EPSILON);
-        assertEquals(" RailButton CG has the wrong y value: ", 0.01, CG.y, EPSILON);
+        assertEquals(" RailButton CG has the wrong y value: ", 0.035, CG.y, EPSILON);
         assertEquals(" RailButton CG has the wrong z value: ", 0, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.1, CG.weight, EPSILON);
 
@@ -120,20 +122,21 @@ public class RailButtonTest extends BaseTestCase {
         CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0.0321, CG.x, EPSILON);
         assertEquals(" RailButton CG has the wrong y value: ", 0, CG.y, EPSILON);
-        assertEquals(" RailButton CG has the wrong z value: ", 0.01, CG.z, EPSILON);
+        assertEquals(" RailButton CG has the wrong z value: ", 0.035, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.1, CG.weight, EPSILON);
 
         button.setAngleOffset(-Math.PI / 3);
         CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0.0321, CG.x, EPSILON);
-        assertEquals(" RailButton CG has the wrong y value: ", 0.005, CG.y, EPSILON);
-        assertEquals(" RailButton CG has the wrong z value: ", -0.00866025, CG.z, EPSILON);
+        assertEquals(" RailButton CG has the wrong y value: ", 0.0175, CG.y, EPSILON);
+        assertEquals(" RailButton CG has the wrong z value: ", -0.03031089, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.1, CG.weight, EPSILON);
     }
 
     @Test
     public void testCMMultipleInstances() {
         BodyTube bodyTube = new BodyTube();
+        bodyTube.setOuterRadius(0.025);
         RailButton button = new RailButton();
         button.setOuterDiameter(0.05);
         button.setTotalHeight(0.05);
@@ -144,7 +147,7 @@ public class RailButtonTest extends BaseTestCase {
         // Test normal CG
         Coordinate CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0.2, CG.x, EPSILON);
-        assertEquals(" RailButton CG has the wrong y value: ", -0.025, CG.y, EPSILON);
+        assertEquals(" RailButton CG has the wrong y value: ", -0.05, CG.y, EPSILON);
         assertEquals(" RailButton CG has the wrong z value: ", 0, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.043307985, CG.weight, EPSILON);
 
@@ -153,14 +156,14 @@ public class RailButtonTest extends BaseTestCase {
         CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0.2, CG.x, EPSILON);
         assertEquals(" RailButton CG has the wrong y value: ", 0, CG.y, EPSILON);
-        assertEquals(" RailButton CG has the wrong z value: ", 0.025, CG.z, EPSILON);
+        assertEquals(" RailButton CG has the wrong z value: ", 0.05, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.043307985, CG.weight, EPSILON);
 
         button.setAngleOffset(-Math.PI / 3);
         CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0.2, CG.x, EPSILON);
-        assertEquals(" RailButton CG has the wrong y value: ", 0.0125, CG.y, EPSILON);
-        assertEquals(" RailButton CG has the wrong z value: ", -0.02165064, CG.z, EPSILON);
+        assertEquals(" RailButton CG has the wrong y value: ", 0.025, CG.y, EPSILON);
+        assertEquals(" RailButton CG has the wrong z value: ", -0.04330127, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.043307985, CG.weight, EPSILON);
 
 
@@ -173,7 +176,7 @@ public class RailButtonTest extends BaseTestCase {
 
         CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0.075, CG.x, EPSILON);
-        assertEquals(" RailButton CG has the wrong y value: ", 0.01, CG.y, EPSILON);
+        assertEquals(" RailButton CG has the wrong y value: ", 0.035, CG.y, EPSILON);
         assertEquals(" RailButton CG has the wrong z value: ", 0, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.00786039, CG.weight, EPSILON);
 
@@ -182,20 +185,21 @@ public class RailButtonTest extends BaseTestCase {
         CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0.075, CG.x, EPSILON);
         assertEquals(" RailButton CG has the wrong y value: ", 0, CG.y, EPSILON);
-        assertEquals(" RailButton CG has the wrong z value: ", 0.01, CG.z, EPSILON);
+        assertEquals(" RailButton CG has the wrong z value: ", 0.035, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.00786039, CG.weight, EPSILON);
 
         button.setAngleOffset(-Math.PI / 3);
         CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0.075, CG.x, EPSILON);
-        assertEquals(" RailButton CG has the wrong y value: ", 0.005, CG.y, EPSILON);
-        assertEquals(" RailButton CG has the wrong z value: ", -0.00866025, CG.z, EPSILON);
+        assertEquals(" RailButton CG has the wrong y value: ", 0.0175, CG.y, EPSILON);
+        assertEquals(" RailButton CG has the wrong z value: ", -0.03031089, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.00786039, CG.weight, EPSILON);
     }
 
     @Test
     public void testCMMultipleInstancesOverride() {
         BodyTube bodyTube = new BodyTube();
+        bodyTube.setOuterRadius(0.025);
         RailButton button = new RailButton();
         button.setOuterDiameter(0.05);
         button.setTotalHeight(0.05);
@@ -208,7 +212,7 @@ public class RailButtonTest extends BaseTestCase {
         // Test normal CG
         Coordinate CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0.0123, CG.x, EPSILON);
-        assertEquals(" RailButton CG has the wrong y value: ", -0.025, CG.y, EPSILON);
+        assertEquals(" RailButton CG has the wrong y value: ", -0.05, CG.y, EPSILON);
         assertEquals(" RailButton CG has the wrong z value: ", 0, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.043307985, CG.weight, EPSILON);
 
@@ -217,14 +221,14 @@ public class RailButtonTest extends BaseTestCase {
         CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0.0123, CG.x, EPSILON);
         assertEquals(" RailButton CG has the wrong y value: ", 0, CG.y, EPSILON);
-        assertEquals(" RailButton CG has the wrong z value: ", 0.025, CG.z, EPSILON);
+        assertEquals(" RailButton CG has the wrong z value: ", 0.05, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.043307985, CG.weight, EPSILON);
 
         button.setAngleOffset(-Math.PI / 3);
         CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0.0123, CG.x, EPSILON);
-        assertEquals(" RailButton CG has the wrong y value: ", 0.0125, CG.y, EPSILON);
-        assertEquals(" RailButton CG has the wrong z value: ", -0.02165064, CG.z, EPSILON);
+        assertEquals(" RailButton CG has the wrong y value: ", 0.025, CG.y, EPSILON);
+        assertEquals(" RailButton CG has the wrong z value: ", -0.04330127, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.043307985, CG.weight, EPSILON);
 
 
@@ -240,7 +244,7 @@ public class RailButtonTest extends BaseTestCase {
 
         CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0.0321, CG.x, EPSILON);
-        assertEquals(" RailButton CG has the wrong y value: ", 0.01, CG.y, EPSILON);
+        assertEquals(" RailButton CG has the wrong y value: ", 0.035, CG.y, EPSILON);
         assertEquals(" RailButton CG has the wrong z value: ", 0, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.2, CG.weight, EPSILON);
 
@@ -249,14 +253,14 @@ public class RailButtonTest extends BaseTestCase {
         CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0.0321, CG.x, EPSILON);
         assertEquals(" RailButton CG has the wrong y value: ", 0, CG.y, EPSILON);
-        assertEquals(" RailButton CG has the wrong z value: ", 0.01, CG.z, EPSILON);
+        assertEquals(" RailButton CG has the wrong z value: ", 0.035, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.2, CG.weight, EPSILON);
 
         button.setAngleOffset(-Math.PI / 3);
         CG = button.getCG();
         assertEquals(" RailButton CG has the wrong x value: ", 0.0321, CG.x, EPSILON);
-        assertEquals(" RailButton CG has the wrong y value: ", 0.005, CG.y, EPSILON);
-        assertEquals(" RailButton CG has the wrong z value: ", -0.00866025, CG.z, EPSILON);
+        assertEquals(" RailButton CG has the wrong y value: ", 0.0175, CG.y, EPSILON);
+        assertEquals(" RailButton CG has the wrong z value: ", -0.03031089, CG.z, EPSILON);
         assertEquals(" RailButton CM has the wrong value: ", 0.2, CG.weight, EPSILON);
     }
     


### PR DESCRIPTION
This PR fixes #2217. The was caused by PR #2053 - I didn't realize that componentVolume was that of all the instances instead of a single instance.

Additionally, I noticed an issues with launch lugs and rial buttons where the y and z location of the CG wasn't right. If you created a new design with just a body tube and rail button/launch lug and overdid the mass of the body tube to 0, the CG should be located solely at the rail button/launch lug, which wasn't the case. This is now fixed. 