### PR TITLE
[#2222] Fix file association Open Recent

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -13,6 +13,15 @@ Release Notes
 
 </div>
 
+<div id="23.xx">
+
+OpenRocket 23.xx
+------------------------
+
+Here, the release notes for the next release will be documented.
+
+</div>
+
 <div id="22.02">
 
 OpenRocket 22.02 (2023-02-08)

--- a/core/resources/build.properties
+++ b/core/resources/build.properties
@@ -1,6 +1,6 @@
 
 # The OpenRocket build version
-build.version=22.02
+build.version=23.xx
 
 # The copyright year for the build. Displayed in the about dialog.
 # Will show as Copyright 2013-${build.copyright}

--- a/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
+++ b/swing/src/net/sf/openrocket/gui/main/BasicFrame.java
@@ -1259,7 +1259,11 @@ public class BasicFrame extends JFrame {
 	 */
 	public static BasicFrame open(File file, Window parent) {
 		OpenFileWorker worker = new OpenFileWorker(file);
-		return open(worker, file.getName(), parent, false);
+		BasicFrame frame = open(worker, file.getName(), parent, false);
+		if (frame != null) {
+			MRUDesignFile.getInstance().addFile(file.getAbsolutePath());
+		}
+		return frame;
 	}
 
 

--- a/swing/src/net/sf/openrocket/startup/OSXSetup.java
+++ b/swing/src/net/sf/openrocket/startup/OSXSetup.java
@@ -6,8 +6,10 @@ import java.awt.desktop.OpenFilesHandler;
 import java.awt.desktop.PreferencesHandler;
 import java.awt.desktop.QuitHandler;
 import java.awt.desktop.AppReopenedListener;
+import java.io.File;
 
 import net.sf.openrocket.communication.UpdateInfoRetriever;
+import net.sf.openrocket.gui.main.MRUDesignFile;
 import net.sf.openrocket.gui.util.DummyFrameMenuOSX;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,8 +42,9 @@ final class OSXSetup {
 	 * The handler for file associations
 	 */
 	public static final OpenFilesHandler OPEN_FILE_HANDLER = (e) -> {
-		log.info("Opening file from association: " + e.getFiles().get(0));
-		BasicFrame.open(e.getFiles().get(0), BasicFrame.lastFrameInstance);
+		File associateFile = e.getFiles().get(0);
+		log.info("Opening file from association: " + associateFile);
+		BasicFrame.open(associateFile, BasicFrame.lastFrameInstance);
 	};
 	
 	/**


### PR DESCRIPTION
This PR fixes #2222. Opening a file with the file association should now also cause that file to open in the recent design files.