### PR TITLE
[#2244 & #2249] Copy default sep config instead of creating new one

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/AxialStage.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/AxialStage.java
@@ -207,10 +207,10 @@ public class AxialStage extends ComponentAssembly implements FlightConfigurableC
 	public StageSeparationConfiguration getSeparationConfiguration() {
 		FlightConfiguration flConfig = getRocket().getSelectedConfiguration();
 		StageSeparationConfiguration sepConfig = getSeparationConfigurations().get(flConfig.getId());
-		// to ensure the configuration is distinct, and we're not modifying the default
+		// To ensure the configuration is distinct, and we're not modifying the default
 		if ((sepConfig == getSeparationConfigurations().getDefault())
 				&& (flConfig.getId() != FlightConfigurationId.DEFAULT_VALUE_FCID)) {
-			sepConfig = new StageSeparationConfiguration();
+			sepConfig = sepConfig.copy(flConfig.getId());
 			getSeparationConfigurations().set(flConfig.getId(), sepConfig);
 		}
 		return sepConfig;

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
@@ -181,10 +181,13 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialS
 		}
 
 		boolean update = false;
-		AxialStage initStage = stages.get(0);
-		FlightConfigurationId initFcId = fcIds.get(0);
+		AxialStage initStage = stages.get(0);			// Arbitrary choice of stage (all stages should have the same settings due to multi-comp editing)
+		FlightConfigurationId initFcId = rocket.getSelectedConfiguration().getId();		// The SeparationSelectionDialog should apply its separation settings to the selected configuration
 
+		// Store the initial configuration so we can check later whether something changed
 		StageSeparationConfiguration initialConfig = initStage.getSeparationConfigurations().get(initFcId).copy(initFcId);
+
+		// Launch the separation config dialog
 		JDialog d = new SeparationSelectionDialog(SwingUtilities.getWindowAncestor(this), rocket, initStage);
 		d.setVisible(true);
 
@@ -195,6 +198,7 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialS
 		double separationDelay = initStage.getSeparationConfigurations().get(initFcId).getSeparationDelay();
 		SeparationEvent separationEvent= initStage.getSeparationConfigurations().get(initFcId).getSeparationEvent();
 
+		// Parse all stages anc flight configurations to check whether we need to update
 		for (int i = 0; i < stages.size(); i++) {
 			for (int j = 0; j < fcIds.size(); j++) {
 				if ((i == 0) && (j == 0)) break;
@@ -205,7 +209,7 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialS
 				initialConfig = config.copy(fcId);
 
 				if (stage.getSeparationConfigurations().isDefault(config)) {
-					config = config.clone();
+					config = config.copy(fcId);
 				}
 
 				config.setSeparationDelay(separationDelay);


### PR DESCRIPTION
This PR fixes #2244. The issue was that there was a check that verifies whether you're editing the default flight config, and if so OR would create a new flight config. This PR now clones the default config, which retains the separation settings.

Additionally, this PR fixes #2249.