### PR TITLE
Check for 0 mass when running simulation

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -636,6 +636,8 @@ RK4SimulationStepper.error.valuesTooLarge = Simulation values exceeded limits.  
 
 SimulationModifierTree.OptimizationParameters = Optimization Parameters
 
+SimulationStepper.error.totalMassZero = Total mass of active states is 0
+
 ! SimulationExportPanel
 SimExpPan.border.Vartoexport = Variables to export
 SimExpPan.border.Stage = Stage to export

--- a/core/src/net/sf/openrocket/simulation/AbstractEulerStepper.java
+++ b/core/src/net/sf/openrocket/simulation/AbstractEulerStepper.java
@@ -3,10 +3,12 @@ package net.sf.openrocket.simulation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.models.atmosphere.AtmosphericConditions;
 import net.sf.openrocket.rocketcomponent.InstanceMap;
 import net.sf.openrocket.rocketcomponent.RecoveryDevice;
 import net.sf.openrocket.simulation.exception.SimulationException;
+import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.util.Coordinate;
 import net.sf.openrocket.util.GeodeticComputationStrategy;
 import net.sf.openrocket.util.MathUtil;
@@ -14,6 +16,7 @@ import net.sf.openrocket.util.WorldCoordinate;
 
 public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 	private static final Logger log = LoggerFactory.getLogger(AbstractEulerStepper.class);
+	private static final Translator trans = Application.getTranslator();
 	
 	private static final double RECOVERY_TIME_STEP = 0.5;
 
@@ -46,12 +49,15 @@ public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 		double dynP = (0.5 * atmosphere.getDensity() * airSpeed.length2());
 		double dragForce = getCD() * dynP * status.getConfiguration().getReferenceArea();
 
-		// n.b. this is constant, and could be calculated once at the beginning of this simulation branch...
 		double rocketMass = calculateStructureMass(status).getMass();
 		double motorMass = calculateMotorMass(status).getMass();
 		
 		double mass = rocketMass + motorMass;
 
+		if (mass < MathUtil.EPSILON) {
+			throw new SimulationException(trans.get("SimulationStepper.error.totalMassZero"));
+		}
+		
 		// Compute drag acceleration
 		Coordinate linearAcceleration;
 		if (airSpeed.length() > 0.001) {

--- a/core/src/net/sf/openrocket/simulation/RK4SimulationStepper.java
+++ b/core/src/net/sf/openrocket/simulation/RK4SimulationStepper.java
@@ -329,6 +329,10 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 		store.motorMass = calculateMotorMass(status);
 		store.rocketMass = structureMassData.add( store.motorMass );
 
+		if (store.rocketMass.getMass() < MathUtil.EPSILON) {
+			throw new SimulationException(trans.get("SimulationStepper.error.totalMassZero"));
+		}
+		
 		// Calculate the forces from the aerodynamic coefficients
 		
 		double dynP = (0.5 * store.flightConditions.getAtmosphericConditions().getDensity() *


### PR DESCRIPTION
It would have been more aesthetically pleasing to just check at the start of each simulation branch, but a buggy simulation listener could cause the mass to be zero at a later time in the branch.

Also, removed comment in AbstractEulerStepper claiming mass could be calculated once at the start of the branch, due to possibility of simulation listeners.

Fixes #2196 