### PR TITLE
[#2256] Use fixed width for warnings panel

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
@@ -145,14 +145,14 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 					worstToggle.setSelected(false);
 			}
 		});
-		panel.add(worstToggle, "");
+		panel.add(worstToggle);
 
 
 		warningList = new JList<>();
 		JScrollPane scrollPane = new JScrollPane(warningList);
 		////Warnings:
 		scrollPane.setBorder(BorderFactory.createTitledBorder(trans.get("componentanalysisdlg.TitledBorder.warnings")));
-		panel.add(scrollPane, "gap paragraph, spany 4, wmin 300lp, grow, height :100lp:, wrap");
+		panel.add(scrollPane, "gap paragraph, spany 4, w 300lp, grow, height :100lp:, wrap");
 
 		////Angle of attack:
 		panel.add(new JLabel(trans.get("componentanalysisdlg.lbl.angleofattack")), "width 120lp!");


### PR DESCRIPTION
This PR fixes #2256 by fixing the width of the warnings panel in the component analysis dialog.