### PR TITLE
[#2267] Check for nose cone base radius for massObject auto radius

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/MassObject.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/MassObject.java
@@ -109,7 +109,7 @@ public abstract class MassObject extends InternalComponent {
 			return radius;
 		}
 		if (parent instanceof NoseCone) {
-			return ((NoseCone) parent).getAftRadius();
+			return ((NoseCone) parent).getBaseRadius();
 		} else if (parent instanceof Transition) {
 			double foreRadius = ((Transition) parent).getForeRadius();
 			double aftRadius = ((Transition) parent).getAftRadius();


### PR DESCRIPTION
This PR fixes #2267. The issue was that the auto radius method should've checked the nose cone base radius, not the aft radius.