### PR TITLE
If stage separation occurs before clearing launch rail, warn the user

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -2023,6 +2023,7 @@ Warning.TUBE_SEPARATION = Space between tube fins may not simulate accurately.
 Warning.TUBE_OVERLAP = Overlapping tube fins may not simulate accurately.
 Warning.EMPTY_BRANCH = Simulation branch contains no data
 Warning.SEPARATION_ORDER = Stages separated in an unreasonable order
+Warning.EARLY_SEPARATION = Stages separated before clearing launch rod/rail
 
 ! Scale dialog
 ScaleDialog.lbl.scaleRocket = Entire rocket

--- a/core/src/net/sf/openrocket/logging/Warning.java
+++ b/core/src/net/sf/openrocket/logging/Warning.java
@@ -386,7 +386,11 @@ public abstract class Warning extends Message {
 	public static final Warning TUBE_SEPARATION = new Other(trans.get("Warning.TUBE_SEPARATION"));
 	public static final Warning TUBE_OVERLAP = new Other(trans.get("Warning.TUBE_OVERLAP"));
 
+	/** A <code>Warning</code> that stage separation occurred at other than the last stage */
 	public static final Warning SEPARATION_ORDER = new Other(trans.get("Warning.SEPARATION_ORDER"));
+
+	/** A <code>Warning</code> that stage separation occurred before the rocket cleared the launch rod or rail */
+	public static final Warning EARLY_SEPARATION = new Other(trans.get("Warning.EARLY_SEPARATION"));
 
 	public static final Warning EMPTY_BRANCH = new Other(trans.get("Warning.EMPTY_BRANCH"));
 }

--- a/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
+++ b/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
@@ -485,6 +485,11 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 						currentStatus.getWarnings().add(Warning.SEPARATION_ORDER);
 					}
 
+					// If I haven't cleared the rail yet, flag a warning
+					if (!currentStatus.isLaunchRodCleared()) {
+						currentStatus.getWarnings().add(Warning.EARLY_SEPARATION);
+					}	
+
 					// Create a new simulation branch for the booster
 					SimulationStatus boosterStatus = new SimulationStatus(currentStatus);
 					


### PR DESCRIPTION
Fixes #2239 

This is actually a bit more general than called for in the feature request; it doesn't just warn about a stage separation before launch, it warns if the separation occurs before leaving the launch rail.