### PR TITLE
[#2270] Only check axial stages for upper stage, not boosters

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/AxialStage.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/AxialStage.java
@@ -170,14 +170,14 @@ public class AxialStage extends ComponentAssembly implements FlightConfigurableC
 	 * @return	the previous stage in the rocket
 	 */
 	public AxialStage getUpperStage() {
-		if( null == this.parent ) {
+		if (this.parent == null) {
 			return null; 
-		}else if(Rocket.class.isAssignableFrom(this.parent.getClass()) ){
-			final int thisIndex = getStageNumber();
-			if( 0 < thisIndex ){
-				return (AxialStage)parent.getChild(thisIndex-1);
+		} else if (Rocket.class.isAssignableFrom(this.parent.getClass())) {
+			final int thisIndex = parent.getChildPosition(this);
+			if (thisIndex > 0) {
+				return (AxialStage) parent.getChild(thisIndex-1);
 			}
-		}else {
+		} else {
 			return this.parent.getStage();
 		}
 		return null;


### PR DESCRIPTION
This PR fixes #2270. The issue was that when checking for the upper stage, the stage number was used to find the previous stage index. In the case of #2270, because there are boosters in the sustainer, the previous (upper) stage index was that of one of the boosters instead of the sustainer. So, this PR just checks for the index of the current stage relative to the rocket.