### PR TITLE
[#2276] Don't check for inline if grandparent is this component

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
@@ -852,8 +852,8 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 			(!MathUtil.equals(this.parent.getRadiusMethod().getRadius(this.parent.parent, this, this.parent.getRadiusOffset()), 0)))
 			return false;
 		
-		if ((candidate.parent instanceof RingInstanceable) &&
-			(!MathUtil.equals(candidate.parent.getRadiusMethod().getRadius(candidate.parent.parent, candidate, candidate.parent.getRadiusOffset()), 0)))
+		if ((candidate.parent instanceof RingInstanceable) && ((candidate.parent.parent == this) ||
+			(!MathUtil.equals(candidate.parent.getRadiusMethod().getRadius(candidate.parent.parent, candidate, candidate.parent.getRadiusOffset()), 0))))
 			return false;
 
 		return true;

--- a/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/SymmetricComponent.java
@@ -849,12 +849,20 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 		// have a radial offset of 0 from their centerline, we are in line.
 
 		if ((this.parent instanceof RingInstanceable) &&
-			(!MathUtil.equals(this.parent.getRadiusMethod().getRadius(this.parent.parent, this, this.parent.getRadiusOffset()), 0)))
+			(!MathUtil.equals(this.parent.getRadiusMethod().getRadius(
+					this.parent.parent, this, this.parent.getRadiusOffset()), 0)))
 			return false;
 		
-		if ((candidate.parent instanceof RingInstanceable) && ((candidate.parent.parent == this) ||
-			(!MathUtil.equals(candidate.parent.getRadiusMethod().getRadius(candidate.parent.parent, candidate, candidate.parent.getRadiusOffset()), 0))))
-			return false;
+		if (candidate.parent instanceof RingInstanceable) {
+			// We need to check if the grandparent of the candidate is a body tube and if the outer radius is automatic.
+			// If so, then this would cause an infinite loop when checking the radius of the radiusMethod.
+			if (candidate.parent.parent == this && (this.isAftRadiusAutomatic() || this.isForeRadiusAutomatic())) {
+				return false;
+			} else {
+				return MathUtil.equals(candidate.parent.getRadiusMethod().getRadius(
+						candidate.parent.parent, candidate, candidate.parent.getRadiusOffset()), 0);
+			}
+		}
 
 		return true;
 	}


### PR DESCRIPTION
This PR fixes #2276. It was a sneaky bug... Basically, if `getAutoRadius` was called on a body tube, which eventually ended in the `inline` call, and `candidate.parent.parent` was this component, then the `getRadius` method would cause an infinite loop (stackoverflow), because it calls `getAutoRadius`.