### PR TITLE
Remove capability to not compute and save "extra" simulation parameters

### DIFF
--- a/core/src/net/sf/openrocket/simulation/AbstractEulerStepper.java
+++ b/core/src/net/sf/openrocket/simulation/AbstractEulerStepper.java
@@ -126,7 +126,6 @@ public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 
 		// Store data
 		FlightDataBranch data = status.getFlightData();
-		boolean extra = status.getSimulationConditions().isCalculateExtras();
 		data.addPoint();
 		
 		data.setValue(FlightDataType.TYPE_TIME, status.getSimulationTime());
@@ -135,24 +134,23 @@ public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 		data.setValue(FlightDataType.TYPE_POSITION_Y, status.getRocketPosition().y);
 
 		airSpeed = status.getRocketVelocity().add(windSpeed);
-		if (extra) {
-			data.setValue(FlightDataType.TYPE_POSITION_XY,
-					MathUtil.hypot(status.getRocketPosition().x, status.getRocketPosition().y));
-			data.setValue(FlightDataType.TYPE_POSITION_DIRECTION,
-					Math.atan2(status.getRocketPosition().y, status.getRocketPosition().x));
-			
-			data.setValue(FlightDataType.TYPE_VELOCITY_XY,
-					MathUtil.hypot(status.getRocketVelocity().x, status.getRocketVelocity().y));
-			data.setValue(FlightDataType.TYPE_ACCELERATION_XY,
-					MathUtil.hypot(linearAcceleration.x, linearAcceleration.y));
-			
-			data.setValue(FlightDataType.TYPE_ACCELERATION_TOTAL, linearAcceleration.length());
-			
-			double Re = airSpeed.length() *
-					status.getConfiguration().getLengthAerodynamic() /
-					atmosphere.getKinematicViscosity();
-			data.setValue(FlightDataType.TYPE_REYNOLDS_NUMBER, Re);
-		}
+
+		data.setValue(FlightDataType.TYPE_POSITION_XY,
+					  MathUtil.hypot(status.getRocketPosition().x, status.getRocketPosition().y));
+		data.setValue(FlightDataType.TYPE_POSITION_DIRECTION,
+					  Math.atan2(status.getRocketPosition().y, status.getRocketPosition().x));
+		
+		data.setValue(FlightDataType.TYPE_VELOCITY_XY,
+					  MathUtil.hypot(status.getRocketVelocity().x, status.getRocketVelocity().y));
+		data.setValue(FlightDataType.TYPE_ACCELERATION_XY,
+					  MathUtil.hypot(linearAcceleration.x, linearAcceleration.y));
+		
+		data.setValue(FlightDataType.TYPE_ACCELERATION_TOTAL, linearAcceleration.length());
+		
+		double Re = airSpeed.length() *
+			status.getConfiguration().getLengthAerodynamic() /
+			atmosphere.getKinematicViscosity();
+		data.setValue(FlightDataType.TYPE_REYNOLDS_NUMBER, Re);
 		
 
 		data.setValue(FlightDataType.TYPE_LATITUDE, status.getRocketWorldPosition().getLatitudeRad());

--- a/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
+++ b/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
@@ -523,7 +523,7 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 				currentStatus.setApogeeReached(true);
 				currentStatus.getFlightData().addEvent(event);
 				// This apogee event might be the optimum if recovery has not already happened.
-				if (currentStatus.getSimulationConditions().isCalculateExtras() && currentStatus.getDeployedRecoveryDevices().size() == 0) {
+				if (currentStatus.getDeployedRecoveryDevices().size() == 0) {
 					currentStatus.getFlightData().setOptimumAltitude(currentStatus.getMaxAlt());
 					currentStatus.getFlightData().setTimeToOptimumAltitude(currentStatus.getMaxAltTime());
 				}
@@ -559,7 +559,7 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 					
 					// If we haven't already reached apogee, then we need to compute the actual coast time
 					// to determine the optimum altitude.
-					if (currentStatus.getSimulationConditions().isCalculateExtras() && !currentStatus.isApogeeReached()) {
+					if (!currentStatus.isApogeeReached()) {
 						FlightData coastStatus = computeCoastTime();
 
 						currentStatus.getFlightData().setOptimumAltitude(coastStatus.getMaxAltitude());

--- a/core/src/net/sf/openrocket/simulation/RK4SimulationStepper.java
+++ b/core/src/net/sf/openrocket/simulation/RK4SimulationStepper.java
@@ -551,7 +551,6 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 	private void storeData(RK4SimulationStatus status, DataStore store) {
 		
 		FlightDataBranch data = status.getFlightData();
-		boolean extra = status.getSimulationConditions().isCalculateExtras();
 		
 		data.addPoint();
 		data.setValue(FlightDataType.TYPE_TIME, status.getSimulationTime());
@@ -565,28 +564,26 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 			data.setValue(FlightDataType.TYPE_CORIOLIS_ACCELERATION, store.coriolisAcceleration.length());
 		}
 		
-		if (extra) {
-			data.setValue(FlightDataType.TYPE_POSITION_XY,
-					MathUtil.hypot(status.getRocketPosition().x, status.getRocketPosition().y));
-			data.setValue(FlightDataType.TYPE_POSITION_DIRECTION,
-					Math.atan2(status.getRocketPosition().y, status.getRocketPosition().x));
+		data.setValue(FlightDataType.TYPE_POSITION_XY,
+					  MathUtil.hypot(status.getRocketPosition().x, status.getRocketPosition().y));
+		data.setValue(FlightDataType.TYPE_POSITION_DIRECTION,
+					  Math.atan2(status.getRocketPosition().y, status.getRocketPosition().x));
+		
+		data.setValue(FlightDataType.TYPE_VELOCITY_XY,
+					  MathUtil.hypot(status.getRocketVelocity().x, status.getRocketVelocity().y));
+		
+		if (store.linearAcceleration != null) {
+			data.setValue(FlightDataType.TYPE_ACCELERATION_XY,
+						  MathUtil.hypot(store.linearAcceleration.x, store.linearAcceleration.y));
 			
-			data.setValue(FlightDataType.TYPE_VELOCITY_XY,
-					MathUtil.hypot(status.getRocketVelocity().x, status.getRocketVelocity().y));
+			data.setValue(FlightDataType.TYPE_ACCELERATION_TOTAL, store.linearAcceleration.length());
+		}
 			
-			if (store.linearAcceleration != null) {
-				data.setValue(FlightDataType.TYPE_ACCELERATION_XY,
-						MathUtil.hypot(store.linearAcceleration.x, store.linearAcceleration.y));
-				
-				data.setValue(FlightDataType.TYPE_ACCELERATION_TOTAL, store.linearAcceleration.length());
-			}
-			
-			if (store.flightConditions != null) {
-				double Re = (store.flightConditions.getVelocity() *
-						status.getConfiguration().getLengthAerodynamic() /
-						store.flightConditions.getAtmosphericConditions().getKinematicViscosity());
-				data.setValue(FlightDataType.TYPE_REYNOLDS_NUMBER, Re);
-			}
+		if (store.flightConditions != null) {
+			double Re = (store.flightConditions.getVelocity() *
+						 status.getConfiguration().getLengthAerodynamic() /
+						 store.flightConditions.getAtmosphericConditions().getKinematicViscosity());
+			data.setValue(FlightDataType.TYPE_REYNOLDS_NUMBER, Re);
 		}
 		
 		data.setValue(FlightDataType.TYPE_VELOCITY_Z, status.getRocketVelocity().z);
@@ -664,16 +661,13 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 			data.setValue(FlightDataType.TYPE_AOA, store.flightConditions.getAOA());
 		}
 		
-
-		if (extra) {
-			Coordinate c = status.getRocketOrientationQuaternion().rotateZ();
-			double theta = Math.atan2(c.z, MathUtil.hypot(c.x, c.y));
-			double phi = Math.atan2(c.y, c.x);
-			if (phi < -(Math.PI - 0.0001))
-				phi = Math.PI;
-			data.setValue(FlightDataType.TYPE_ORIENTATION_THETA, theta);
-			data.setValue(FlightDataType.TYPE_ORIENTATION_PHI, phi);
-		}
+		Coordinate c = status.getRocketOrientationQuaternion().rotateZ();
+		double theta = Math.atan2(c.z, MathUtil.hypot(c.x, c.y));
+		double phi = Math.atan2(c.y, c.x);
+		if (phi < -(Math.PI - 0.0001))
+			phi = Math.PI;
+		data.setValue(FlightDataType.TYPE_ORIENTATION_THETA, theta);
+		data.setValue(FlightDataType.TYPE_ORIENTATION_PHI, phi);
 		
 		data.setValue(FlightDataType.TYPE_WIND_VELOCITY, store.windSpeed);
 		

--- a/core/src/net/sf/openrocket/simulation/SimulationConditions.java
+++ b/core/src/net/sf/openrocket/simulation/SimulationConditions.java
@@ -59,10 +59,6 @@ public class SimulationConditions implements Monitorable, Cloneable {
 	private double timeStep = RK4SimulationStepper.RECOMMENDED_TIME_STEP;
 	private double maximumAngleStep = RK4SimulationStepper.RECOMMENDED_ANGLE_STEP;
 	
-	/* Whether to calculate additional data or only primary simulation figures */
-	private boolean calculateExtras = true;
-	
-	
 	private List<SimulationListener> simulationListeners = new ArrayList<SimulationListener>();
 	
 	
@@ -255,18 +251,6 @@ public class SimulationConditions implements Monitorable, Cloneable {
 		this.maximumAngleStep = maximumAngle;
 		this.modID++;
 	}
-	
-	
-	public boolean isCalculateExtras() {
-		return calculateExtras;
-	}
-	
-	
-	public void setCalculateExtras(boolean calculateExtras) {
-		this.calculateExtras = calculateExtras;
-		this.modID++;
-	}
-	
 	
 	
 	public int getRandomSeed() {

--- a/core/src/net/sf/openrocket/simulation/SimulationOptions.java
+++ b/core/src/net/sf/openrocket/simulation/SimulationOptions.java
@@ -80,9 +80,6 @@ public class SimulationOptions implements ChangeSource, Cloneable {
 	
 	private int randomSeed = new Random().nextInt();
 	
-	private boolean calculateExtras = true;
-	
-	
 	private List<EventListener> listeners = new ArrayList<EventListener>();
 	
 	public SimulationOptions() {
@@ -353,23 +350,6 @@ public class SimulationOptions implements ChangeSource, Cloneable {
 		fireChangeEvent();
 	}
 	
-	
-	
-	public boolean getCalculateExtras() {
-		return calculateExtras;
-	}
-	
-	
-	
-	public void setCalculateExtras(boolean calculateExtras) {
-		if (this.calculateExtras == calculateExtras)
-			return;
-		this.calculateExtras = calculateExtras;
-		fireChangeEvent();
-	}
-	
-	
-	
 	public int getRandomSeed() {
 		return randomSeed;
 	}
@@ -468,10 +448,6 @@ public class SimulationOptions implements ChangeSource, Cloneable {
 			isChanged = true;
 			this.windTurbulence = src.windTurbulence;
 		}
-		if (this.calculateExtras != src.calculateExtras) {
-			isChanged = true;
-			this.calculateExtras = src.calculateExtras;
-		}
 		if (this.timeStep != src.timeStep) {
 			isChanged = true;
 			this.timeStep = src.timeStep;
@@ -511,8 +487,7 @@ public class SimulationOptions implements ChangeSource, Cloneable {
 				MathUtil.equals(this.timeStep, o.timeStep) &&
 				MathUtil.equals(this.windAverage, o.windAverage) &&
 				MathUtil.equals(this.windTurbulence, o.windTurbulence) &&
-				MathUtil.equals(this.windDirection, o.windDirection) &&
-				this.calculateExtras == o.calculateExtras && this.randomSeed == o.randomSeed);
+				MathUtil.equals(this.windDirection, o.windDirection));
 	}
 	
 	/**
@@ -581,8 +556,6 @@ public class SimulationOptions implements ChangeSource, Cloneable {
 		conditions.setTimeStep(getTimeStep());
 		conditions.setMaximumAngleStep(getMaximumStepAngle());
 		
-		conditions.setCalculateExtras(getCalculateExtras());
-		
 		return conditions;
 	}
 
@@ -605,7 +578,6 @@ public class SimulationOptions implements ChangeSource, Cloneable {
 			.concat(String.format("    launchPressure:  %f\n", launchPressure))
 			.concat(String.format("    timeStep:  %f\n", timeStep))
 			.concat(String.format("    maximumAngle:  %f\n", maximumAngle))
-			.concat(String.format("    calculateExtras:  %b\n", calculateExtras))
 			.concat("]\n");
 	}
 	


### PR DESCRIPTION
The simulation status identifies some simulation parameters (such as rocket orientation angles) as "extra", and checks whether a simulation option for calculating these extras is set before calculating and saving them.  I can't find any way to set this variable to anything other than "true" (I've got a hunch it went away back when we got rid of the option to only save "primary figures", but haven't checked).  Anyway, it appears to do nothing, so this gets rid of it and always calculates and saves these extras.