### PR TITLE
[#2295] Use component color for sticker edge mode

### DIFF
--- a/swing/src/net/sf/openrocket/gui/figure3d/RealisticRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/RealisticRenderer.java
@@ -21,7 +21,6 @@ import net.sf.openrocket.util.Color;
 import com.jogamp.opengl.util.texture.Texture;
 
 public class RealisticRenderer extends RocketRenderer {
-	private final float[] colorClear = { 0, 0, 0, 0 };
 	private final float[] colorWhite = { 1, 1, 1, 1 };
 	private final float[] color = new float[4];
 	
@@ -165,7 +164,7 @@ public class RealisticRenderer extends RocketRenderer {
 			gl.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_S, toEdgeMode(t.getEdgeMode()));
 			
 			
-			gl.glTexParameterfv(GL.GL_TEXTURE_2D, GL2.GL_TEXTURE_BORDER_COLOR, colorClear, 0);
+			gl.glTexParameterfv(GL.GL_TEXTURE_2D, GL2.GL_TEXTURE_BORDER_COLOR, convertedColor, 0);
 			gl.glMaterialfv(GL.GL_FRONT, GLLightingFunc.GL_DIFFUSE, colorWhite, 0);
 			gl.glMaterialfv(GL.GL_FRONT, GLLightingFunc.GL_AMBIENT, colorWhite, 0);
 			


### PR DESCRIPTION
This PR fixes #2295.

<img width="1578" alt="image" src="https://github.com/openrocket/openrocket/assets/11031519/1f0898f2-492a-47df-b0b4-4f9d3fb015ab">

Drawback is that the opacity of the color has no effect, but I already spent too much time trying to fix it, so I'll leave that as is for now.