### PR TITLE
[#2208] Fix manufacturers' list in dark theme

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/MotorFilterPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/MotorFilterPanel.java
@@ -1,5 +1,6 @@
 package net.sf.openrocket.gui.dialogs.motor.thrustcurve;
 
+import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
@@ -16,6 +17,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSpinner;
+import javax.swing.border.Border;
 import javax.swing.border.TitledBorder;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
@@ -144,26 +146,25 @@ public abstract class MotorFilterPanel extends JPanel {
 
 		// Manufacturer selection
 		JPanel sub = new JPanel(new MigLayout("fill"));
-		TitledBorder border = BorderFactory.createTitledBorder(trans.get("TCurveMotorCol.MANUFACTURER"));
+		Border templateBorder = GUIUtil.getUITheme().getBorder();
+		TitledBorder border = BorderFactory.createTitledBorder(templateBorder);
+		border.setTitle(trans.get("TCurveMotorCol.MANUFACTURER"));
 		GUIUtil.changeFontStyle(border, Font.BOLD);
 		sub.setBorder(border);
 
 		this.setBorder(BorderFactory.createEmptyBorder(1, 1, 1, 1));
 
-		List<Manufacturer> manufacturers = new ArrayList<Manufacturer>();
-		for (Manufacturer m : allManufacturers) {
-			manufacturers.add(m);
-		}
+        List<Manufacturer> manufacturers = new ArrayList<>(allManufacturers);
 
-		Collections.sort(manufacturers, new Comparator<Manufacturer>() {
-			@Override
-			public int compare(Manufacturer o1, Manufacturer o2) {
-				return o1.getSimpleName().compareTo( o2.getSimpleName());
-			}
+		manufacturers.sort(new Comparator<Manufacturer>() {
+            @Override
+            public int compare(Manufacturer o1, Manufacturer o2) {
+                return o1.getSimpleName().compareTo(o2.getSimpleName());
+            }
 
-		});
+        });
 
-		manufacturerCheckList = new CheckList.Builder().<Manufacturer>build();
+		manufacturerCheckList = new CheckList.Builder().build();
 		manufacturerCheckList.setData(manufacturers);
 
 		manufacturerCheckList.setUncheckedItems(unselectedManusFromPreferences);
@@ -213,7 +214,8 @@ public abstract class MotorFilterPanel extends JPanel {
 		// Total Impulse selection
 		{
 			sub = new JPanel(new MigLayout("fill"));
-			border = BorderFactory.createTitledBorder(trans.get("TCurveMotorCol.TOTAL_IMPULSE"));
+			border = BorderFactory.createTitledBorder(templateBorder);
+			border.setTitle(trans.get("TCurveMotorCol.TOTAL_IMPULSE"));
 			GUIUtil.changeFontStyle(border, Font.BOLD);
 			sub.setBorder(border);
 
@@ -240,7 +242,8 @@ public abstract class MotorFilterPanel extends JPanel {
 
 		// Motor Dimensions
 		sub = new JPanel(new MigLayout("fill"));
-		TitledBorder diameterTitleBorder = BorderFactory.createTitledBorder(trans.get("TCMotorSelPan.MotorSize"));
+		TitledBorder diameterTitleBorder = BorderFactory.createTitledBorder(templateBorder);
+		diameterTitleBorder.setTitle(trans.get("TCMotorSelPan.MotorSize"));
 		GUIUtil.changeFontStyle(diameterTitleBorder, Font.BOLD);
 		sub.setBorder(diameterTitleBorder);
 

--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/MotorFilterPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/MotorFilterPanel.java
@@ -185,7 +185,12 @@ public abstract class MotorFilterPanel extends JPanel {
 			}
 		});
 
-		sub.add(new JScrollPane(manufacturerCheckList.getList()), "grow, pushy, wrap");
+		JScrollPane scrollPane = new JScrollPane(manufacturerCheckList.getList());
+		Border border1 = GUIUtil.getUITheme().getBorder();
+		if (border1 != null) {
+			scrollPane.setBorder(border1);
+		}
+		sub.add(scrollPane, "grow, pushy, wrap");
 
 		JButton clearMotors = new SelectColorButton(trans.get("TCMotorSelPan.btn.checkNone"));
 		clearMotors.addActionListener( new ActionListener() {

--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/MotorInformationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/MotorInformationPanel.java
@@ -159,6 +159,7 @@ class MotorInformationPanel extends JPanel {
 
 
 			comment = new JTextArea(5, 5);
+			comment.setBorder(GUIUtil.getUITheme().getBorder());
 			GUIUtil.changeFontSize(comment, -2);
 			withCommentFont = comment.getFont();
 			noCommentFont = withCommentFont.deriveFont(Font.ITALIC);

--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorSelectionPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorSelectionPanel.java
@@ -45,6 +45,7 @@ import javax.swing.event.RowSorterListener;
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
 
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.util.StateChangeListener;
 import org.jfree.chart.ChartColor;
 import org.slf4j.Logger;
@@ -335,7 +336,7 @@ public class ThrustCurveMotorSelectionPanel extends JPanel implements MotorSelec
 			nrOfMotorsLabel = new StyledLabel(-2f, StyledLabel.Style.ITALIC);
 			nrOfMotorsLabel.setToolTipText(trans.get("TCMotorSelPan.lbl.ttip.nrOfMotors"));
 			updateNrOfMotors();
-			nrOfMotorsLabel.setForeground(Color.darkGray);
+			nrOfMotorsLabel.setForeground(GUIUtil.getUITheme().getDimTextColor());
 			panel.add(nrOfMotorsLabel, "gapleft para, spanx, wrap");
 			sorter.addRowSorterListener(new RowSorterListener() {
 				@Override

--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorSelectionPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorSelectionPanel.java
@@ -332,11 +332,10 @@ public class ThrustCurveMotorSelectionPanel extends JPanel implements MotorSelec
 
 		// Number of motors
 		{
-			nrOfMotorsLabel = new JLabel();
+			nrOfMotorsLabel = new StyledLabel(-2f, StyledLabel.Style.ITALIC);
 			nrOfMotorsLabel.setToolTipText(trans.get("TCMotorSelPan.lbl.ttip.nrOfMotors"));
 			updateNrOfMotors();
 			nrOfMotorsLabel.setForeground(Color.darkGray);
-			nrOfMotorsLabel.setFont(new Font(Font.SANS_SERIF, Font.ITALIC, 11));
 			panel.add(nrOfMotorsLabel, "gapleft para, spanx, wrap");
 			sorter.addRowSorterListener(new RowSorterListener() {
 				@Override

--- a/swing/src/net/sf/openrocket/gui/util/CheckListRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/util/CheckListRenderer.java
@@ -33,10 +33,8 @@ package net.sf.openrocket.gui.util;
 
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.Rectangle;
 import java.io.Serializable;
 
-import javax.swing.DefaultListCellRenderer;
 import javax.swing.Icon;
 import javax.swing.JCheckBox;
 import javax.swing.JList;
@@ -49,7 +47,7 @@ import javax.swing.border.EmptyBorder;
 public class CheckListRenderer extends JCheckBox implements ListCellRenderer, Serializable {
 		
 	private static final Border NO_FOCUS_BORDER = new EmptyBorder(1, 1, 1, 1);
-	private static final Border SAFE_NO_FOCUS_BORDER = NO_FOCUS_BORDER; // may change in the feature
+	private static final Border SAFE_NO_FOCUS_BORDER = NO_FOCUS_BORDER; // may change in the future
 	
 	/**
 	 * Constructs a default renderer object for an item in a list.
@@ -160,68 +158,6 @@ public class CheckListRenderer extends JCheckBox implements ListCellRenderer, Se
 			
 			super.firePropertyChange(propertyName, oldValue, newValue);
 		}
-	}
-	
-	// Methods below are overridden for performance reasons.
-	
-	@Override
-	public void validate() {
-	}
-	
-	@Override
-	public void invalidate() {
-	}
-	
-	@Override
-	public void repaint() {
-	}
-	
-	@Override
-	public void revalidate() {
-	}
-	
-	@Override
-	public void repaint(long tm, int x, int y, int width, int height) {
-	}
-	
-	@Override
-	public void repaint(Rectangle r) {
-	}
-	
-	@Override
-	public void firePropertyChange(String propertyName, byte oldValue, byte newValue) {
-	}
-	
-	@Override
-	public void firePropertyChange(String propertyName, char oldValue, char newValue) {
-	}
-	
-	@Override
-	public void firePropertyChange(String propertyName, short oldValue, short newValue) {
-	}
-	
-	@Override
-	public void firePropertyChange(String propertyName, int oldValue, int newValue) {
-	}
-	
-	@Override
-	public void firePropertyChange(String propertyName, long oldValue, long newValue) {
-	}
-	
-	@Override
-	public void firePropertyChange(String propertyName, float oldValue, float newValue) {
-	}
-	
-	@Override
-	public void firePropertyChange(String propertyName, double oldValue, double newValue) {
-	}
-	
-	@Override
-	public void firePropertyChange(String propertyName, boolean oldValue, boolean newValue) {
-	}
-	
-	@SuppressWarnings("serial")
-	public static class UIResource extends DefaultListCellRenderer implements javax.swing.plaf.UIResource {
 	}
 	
 }


### PR DESCRIPTION
This PR fixes #2298.
<img width="1093" alt="image" src="https://github.com/openrocket/openrocket/assets/11031519/9ae44866-7e9b-4a44-85ea-9bc23976b9fb">

I also fixed an issue where the "Number of motors" text below the motor table was not shown + I added borders around some of the widgets.