### PR TITLE
[#2307] Add dedicated undo actions + fix multi-comp editing for motors & recovery settings

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/RecoveryDevice.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/RecoveryDevice.java
@@ -30,8 +30,7 @@ public abstract class RecoveryDevice extends MassObject implements FlightConfigu
 	private FlightConfigurableParameterSet<DeploymentConfiguration> deploymentConfigurations;
 	
 	public RecoveryDevice() {
-		this.deploymentConfigurations =
-				new FlightConfigurableParameterSet<DeploymentConfiguration>( new DeploymentConfiguration());
+		this.deploymentConfigurations = new FlightConfigurableParameterSet<>( new DeploymentConfiguration());
 		defaultMaterial = (Material.Surface) Application.getPreferences().getDefaultComponentMaterial(RecoveryDevice.class, Material.Type.SURFACE);
 		setMaterial(Application.getPreferences().getDefaultComponentMaterial(RecoveryDevice.class, Material.Type.SURFACE));
 	}
@@ -148,7 +147,7 @@ public abstract class RecoveryDevice extends MassObject implements FlightConfigu
 	@Override
 	protected RocketComponent copyWithOriginalID() {
 		RecoveryDevice copy = (RecoveryDevice) super.copyWithOriginalID();
-		copy.deploymentConfigurations = new FlightConfigurableParameterSet<DeploymentConfiguration>(deploymentConfigurations);
+		copy.deploymentConfigurations = new FlightConfigurableParameterSet<>(deploymentConfigurations);
 		return copy;
 	}
 

--- a/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/DeploymentSelectionDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/DeploymentSelectionDialog.java
@@ -4,6 +4,7 @@ import java.awt.Dialog;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
 
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
@@ -46,6 +47,8 @@ public class DeploymentSelectionDialog extends JDialog {
 	private final JSpinner altSpinner;
 	private final UnitSelector altUnit;
 	private final JSlider altSlider;
+
+	private boolean isOverrideDefault;
 	
 	public DeploymentSelectionDialog(Window parent, final Rocket rocket, final FlightConfigurationId id, final RecoveryDevice component) {
 		super(parent, trans.get("edtmotorconfdlg.title.Selectdeploymentconf"), Dialog.ModalityType.APPLICATION_MODAL);
@@ -59,7 +62,9 @@ public class DeploymentSelectionDialog extends JDialog {
 		panel.add(defaultButton, "span, gapleft para, wrap rel");
 		String str = trans.get("DeploymentSelectionDialog.opt.override");
 		str = str.replace("{0}", descriptor.format(rocket, id));
-		final JRadioButton overrideButton = new JRadioButton(str, false);
+		final JRadioButton overrideButton = new JRadioButton(str);
+		overrideButton.addItemListener(e -> isOverrideDefault = e.getStateChange() == ItemEvent.SELECTED);
+		overrideButton.setSelected(false);
 		panel.add(overrideButton, "span, gapleft para, wrap para");
 		
 		ButtonGroup buttonGroup = new ButtonGroup();
@@ -156,6 +161,12 @@ public class DeploymentSelectionDialog extends JDialog {
 		altUnit.setEnabled(enabled);
 		altSlider.setEnabled(enabled);
 	}
-	
-	
+
+	/**
+	 * Returns true if this dialog was used to override the default configuration.
+	 * @return true if this dialog was used to override the default configuration.
+	 */
+	public boolean isOverrideDefault() {
+		return isOverrideDefault;
+	}
 }

--- a/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/DeploymentSelectionDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/DeploymentSelectionDialog.java
@@ -66,8 +66,7 @@ public class DeploymentSelectionDialog extends JDialog {
 		buttonGroup.add(defaultButton);
 		buttonGroup.add(overrideButton);
 		
-		// Select the button based on current configuration.  If the configuration is overridden
-		// The the overrideButton is selected.
+		// Select the button based on current configuration.  If the configuration is overridden, the overrideButton is selected.
 		boolean isOverridden = !component.getDeploymentConfigurations().isDefault(id);
 		if (isOverridden) {
 			overrideButton.setSelected(true);
@@ -77,7 +76,7 @@ public class DeploymentSelectionDialog extends JDialog {
 		//// Deploys at:
 		panel.add(new JLabel(trans.get("ParachuteCfg.lbl.Deploysat")), "");
 		
-		final JComboBox<DeployEvent> deployEvent = new JComboBox<DeployEvent>(new EnumModel<DeployEvent>(newConfiguration, "DeployEvent"));
+		final JComboBox<DeployEvent> deployEvent = new JComboBox<DeployEvent>(new EnumModel<>(newConfiguration, "DeployEvent"));
 		if( (component.getStageNumber() + 1 ) == rocket.getStageCount() ){
 			//	This is the bottom stage:  Restrict deployment options.
 		    deployEvent.removeItem( DeployEvent.LOWER_STAGE_SEPARATION );
@@ -147,7 +146,7 @@ public class DeploymentSelectionDialog extends JDialog {
 		
 		this.setContentPane(panel);
 		GUIUtil.setDisposableDialogOptions(this, okButton);
-		// TODO: closes wrong, doesn't use okButton action
+		GUIUtil.installEscapeCloseButtonOperation(this, okButton);
 	}
 	
 	private void updateState() {

--- a/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/DeploymentSelectionDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/DeploymentSelectionDialog.java
@@ -47,11 +47,9 @@ public class DeploymentSelectionDialog extends JDialog {
 	private final UnitSelector altUnit;
 	private final JSlider altSlider;
 	
-	public DeploymentSelectionDialog(Window parent, final Rocket rocket, final RecoveryDevice component) {
+	public DeploymentSelectionDialog(Window parent, final Rocket rocket, final FlightConfigurationId id, final RecoveryDevice component) {
 		super(parent, trans.get("edtmotorconfdlg.title.Selectdeploymentconf"), Dialog.ModalityType.APPLICATION_MODAL);
-		
-		final FlightConfigurationId id = rocket.getSelectedConfiguration().getFlightConfigurationID();
-		
+
 		newConfiguration = component.getDeploymentConfigurations().get(id).clone();
 		
 		JPanel panel = new JPanel(new MigLayout("fill"));
@@ -149,6 +147,7 @@ public class DeploymentSelectionDialog extends JDialog {
 		
 		this.setContentPane(panel);
 		GUIUtil.setDisposableDialogOptions(this, okButton);
+		// TODO: closes wrong, doesn't use okButton action
 	}
 	
 	private void updateState() {

--- a/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/IgnitionSelectionDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/IgnitionSelectionDialog.java
@@ -4,6 +4,7 @@ import java.awt.Dialog;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
 import java.util.Iterator;
 
 import javax.swing.ButtonGroup;
@@ -44,6 +45,8 @@ public class IgnitionSelectionDialog extends JDialog {
 	
 	private IgnitionEvent startIgnitionEvent;
 	private double startIgnitionDelay;
+
+	private boolean isOverrideDefault;
 	
 	public IgnitionSelectionDialog(Window parent, final FlightConfigurationId curFCID, MotorMount _mount) {
 		super(parent, trans.get("edtmotorconfdlg.title.Selectignitionconf"), Dialog.ModalityType.APPLICATION_MODAL);
@@ -62,15 +65,16 @@ public class IgnitionSelectionDialog extends JDialog {
 		Rocket rkt = ((RocketComponent)_mount).getRocket();
 		str = str.replace("{0}", descriptor.format(rkt, curFCID));
 		
-		final JRadioButton overrideButton = new JRadioButton(str, !isDefault);
+		final JRadioButton overrideButton = new JRadioButton(str);
+		overrideButton.addItemListener(e -> isOverrideDefault = e.getStateChange() == ItemEvent.SELECTED);
+		overrideButton.setSelected(!isDefault);
 		panel.add(overrideButton, "span, gapleft para, wrap para");
 		
 		ButtonGroup buttonGroup = new ButtonGroup();
 		buttonGroup.add(defaultButton);
 		buttonGroup.add(overrideButton);
 		
-		// Select the button based on current configuration.  If the configuration is overridden
-		// The the overrideButton is selected.
+		// Select the button based on current configuration.  If the configuration is overridden the overrideButton is selected.
 		boolean isOverridden = !isDefault;
 		if (isOverridden) {
 			overrideButton.setSelected(true);
@@ -114,18 +118,11 @@ public class IgnitionSelectionDialog extends JDialog {
 					// and change all remaining configs
 					// this seems like odd behavior to me, but it matches the text on the UI dialog popup. -teyrana (equipoise@gmail.com) 
 					Iterator<MotorConfiguration> iter = curMount.getMotorIterator();
-					while( iter.hasNext() ){
+					while(iter.hasNext() ) {
 						MotorConfiguration next = iter.next();
-						next.setIgnitionDelay( cid);
-						next.setIgnitionEvent( cie);
+						next.setIgnitionDelay(cid);
+						next.setIgnitionEvent(cie);
 					}
-					
-//					System.err.println("setting default motor ignition ("+defaultMotorInstance.getMotorID().toString()+") to: ");
-//					System.err.println("    event: "+defaultMotorInstance.getIgnitionEvent().name+" w/delay: "+defaultMotorInstance.getIgnitionDelay());
-//				}else {
-//					System.err.println("setting motor ignition to.... new values: ");
-//					//destMotorInstance.setIgnitionEvent((IgnitionEvent)eventBox.getSelectedItem());
-//					System.err.println("    "+curMotorInstance.getIgnitionEvent()+" w/ "+curMotorInstance.getIgnitionDelay());
 				}
 				IgnitionSelectionDialog.this.setVisible(false);
 			}
@@ -150,5 +147,14 @@ public class IgnitionSelectionDialog extends JDialog {
 		this.setContentPane(panel);
 		
 		GUIUtil.setDisposableDialogOptions(this, okButton);
+		GUIUtil.installEscapeCloseButtonOperation(this, okButton);
+	}
+
+	/**
+	 * Returns true if this dialog was used to override the default configuration.
+	 * @return true if this dialog was used to override the default configuration.
+	 */
+	public boolean isOverrideDefault() {
+		return isOverrideDefault;
 	}
 }

--- a/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/SeparationSelectionDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/SeparationSelectionDialog.java
@@ -4,6 +4,7 @@ import java.awt.Dialog;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
 
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
@@ -38,11 +39,12 @@ public class SeparationSelectionDialog extends JDialog {
 	private RocketDescriptor descriptor = Application.getInjector().getInstance(RocketDescriptor.class);
 	
 	private StageSeparationConfiguration newConfiguration;
+
+	private boolean isOverrideDefault;
 	
-	public SeparationSelectionDialog(Window parent, final Rocket rocket, final AxialStage stage) {
+	public SeparationSelectionDialog(Window parent, final Rocket rocket, final AxialStage stage, FlightConfigurationId id) {
 		super(parent, trans.get("edtmotorconfdlg.title.Selectseparationconf"), Dialog.ModalityType.APPLICATION_MODAL);
-		final FlightConfigurationId id = rocket.getSelectedConfiguration().getFlightConfigurationID();
-		
+
 		newConfiguration = stage.getSeparationConfigurations().get(id);
 		if( stage.getSeparationConfigurations().isDefault( newConfiguration )){
 			newConfiguration = newConfiguration.clone();
@@ -59,7 +61,9 @@ public class SeparationSelectionDialog extends JDialog {
 		panel.add(defaultButton, "span, gapleft para, wrap rel");
 		String str = trans.get("SeparationSelectionDialog.opt.override");
 		str = str.replace("{0}", descriptor.format(rocket, id));
-		final JRadioButton overrideButton = new JRadioButton(str, false);
+		final JRadioButton overrideButton = new JRadioButton(str);
+		overrideButton.addItemListener(e -> isOverrideDefault = e.getStateChange() == ItemEvent.SELECTED);
+		overrideButton.setSelected(false);
 		panel.add(overrideButton, "span, gapleft para, wrap para");
 		
 		ButtonGroup buttonGroup = new ButtonGroup();
@@ -123,5 +127,14 @@ public class SeparationSelectionDialog extends JDialog {
 		this.setContentPane(panel);
 		
 		GUIUtil.setDisposableDialogOptions(this, okButton);
+		GUIUtil.installEscapeCloseButtonOperation(this, okButton);
+	}
+
+	/**
+	 * Returns true if this dialog was used to override the default configuration.
+	 * @return true if this dialog was used to override the default configuration.
+	 */
+	public boolean isOverrideDefault() {
+		return isOverrideDefault;
 	}
 }

--- a/swing/src/net/sf/openrocket/gui/main/FlightConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/FlightConfigurationPanel.java
@@ -237,12 +237,29 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 		List<FlightConfigurationId> fcIds = getSelectedConfigurationIds();
 		if (fcIds == null) return;
 		FlightConfigurationId initFcId = fcIds.get(0);
-		new RenameConfigDialog(SwingUtilities.getWindowAncestor(this), rocket, initFcId).setVisible(true);
+		String initName = rocket.getFlightConfiguration(initFcId).getNameRaw();
+
+		// Launch the rename dialog
+		RenameConfigDialog dialog = new RenameConfigDialog(SwingUtilities.getWindowAncestor(this), rocket, initFcId);
+		dialog.setVisible(true);
+
+		// Get the name of the (potentially renamed) config
 		String newName = rocket.getFlightConfiguration(initFcId).getNameRaw();
+
+		document.addUndoPosition("Rename configuration(s)");
+
+		boolean update = !newName.equals(initName);
 		for (int i = 1; i < fcIds.size(); i++) {
-			rocket.getFlightConfiguration(fcIds.get(i)).setName(newName);
+			FlightConfiguration config = rocket.getFlightConfiguration(fcIds.get(i));
+			if (!config.getNameRaw().equals(newName)) {
+				update = true;
+				config.setName(newName);
+			}
 		}
-		configurationChanged(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
+
+		if (update) {
+			configurationChanged(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
+		}
 	}
 	
 	private void removeConfigurationAction() {

--- a/swing/src/net/sf/openrocket/gui/main/FlightConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/FlightConfigurationPanel.java
@@ -88,15 +88,15 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 		tabs = new JTabbedPane();
 		
 		//// Motor tabs
-		motorConfigurationPanel = new MotorConfigurationPanel(this, rocket);
+		motorConfigurationPanel = new MotorConfigurationPanel(this, document, rocket);
 		tabs.add(trans.get("edtmotorconfdlg.lbl.Motortab"), motorConfigurationPanel);
 		
 		//// Recovery tab
-		recoveryConfigurationPanel = new RecoveryConfigurationPanel(this, rocket);
+		recoveryConfigurationPanel = new RecoveryConfigurationPanel(this, document, rocket);
 		tabs.add(trans.get("edtmotorconfdlg.lbl.Recoverytab"), recoveryConfigurationPanel);
 		
 		//// Stage tab
-		separationConfigurationPanel = new SeparationConfigurationPanel(this, rocket);
+		separationConfigurationPanel = new SeparationConfigurationPanel(this, document, rocket);
 		tabs.add(trans.get("edtmotorconfdlg.lbl.Stagetab"), separationConfigurationPanel);
 
 		//// New configuration
@@ -239,14 +239,14 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 		FlightConfigurationId initFcId = fcIds.get(0);
 		String initName = rocket.getFlightConfiguration(initFcId).getNameRaw();
 
+		document.addUndoPosition("Rename configuration(s)");
+
 		// Launch the rename dialog
 		RenameConfigDialog dialog = new RenameConfigDialog(SwingUtilities.getWindowAncestor(this), rocket, initFcId);
 		dialog.setVisible(true);
 
 		// Get the name of the (potentially renamed) config
 		String newName = rocket.getFlightConfiguration(initFcId).getNameRaw();
-
-		document.addUndoPosition("Rename configuration(s)");
 
 		boolean update = !newName.equals(initName);
 		for (int i = 1; i < fcIds.size(); i++) {
@@ -266,6 +266,8 @@ public class FlightConfigurationPanel extends JPanel implements StateChangeListe
 		List<FlightConfigurationId> fcIds = getSelectedConfigurationIds();
 		if (fcIds == null || fcIds.size() == 0)
 			return;
+
+		document.addUndoPosition("Remove configuration(s)");
 
 		for (FlightConfigurationId fcId : fcIds) {
 			document.removeFlightConfigurationAndSimulations(fcId);

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
@@ -22,6 +22,7 @@ import javax.swing.event.ListSelectionListener;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 
+import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.gui.main.FlightConfigurationPanel;
 import net.sf.openrocket.gui.util.SwingPreferences;
 import net.sf.openrocket.util.ArrayList;
@@ -51,12 +52,14 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 	protected RocketDescriptor descriptor = Application.getInjector().getInstance(RocketDescriptor.class);
 
 	protected final FlightConfigurationPanel flightConfigurationPanel;
+	protected final OpenRocketDocument document;
 	protected final Rocket rocket;
 	protected final JTable table;
 	
-	public FlightConfigurablePanel(final FlightConfigurationPanel flightConfigurationPanel, Rocket rocket) {
+	public FlightConfigurablePanel(final FlightConfigurationPanel flightConfigurationPanel, OpenRocketDocument document, Rocket rocket) {
 		super(new MigLayout("fill"));
 		this.flightConfigurationPanel = flightConfigurationPanel;
+		this.document = document;
 		this.rocket = rocket;
 		table = doTableInitialization();
 

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
@@ -253,7 +253,10 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 				if (tableValue instanceof Pair) {
 					@SuppressWarnings("unchecked")
 					Pair<String, T> selectedComponent = (Pair<String, T>) tableValue;
-					components.add(selectedComponent.getV());
+					T comp = selectedComponent.getV();
+					if (!components.contains(comp)) {
+						components.add(comp);
+					}
 				}
 			}
 		}
@@ -292,11 +295,17 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 				@SuppressWarnings("unchecked")
 				Pair<FlightConfigurationId, T> selectedComponent = (Pair<FlightConfigurationId, T>) tableValue;
 				FlightConfigurationId fcid = selectedComponent.getU();
-				Ids.add(fcid);
+				if (!Ids.contains(fcid)) {
+					Ids.add(fcid);
+				}
 			} else if (tableValue instanceof FlightConfigurationId) {
-				Ids.add((FlightConfigurationId) tableValue);
+				if (!Ids.contains(tableValue)) {
+					Ids.add((FlightConfigurationId) tableValue);
+				}
 			} else {
-				Ids.add(FlightConfigurationId.ERROR_FCID);
+				if (!Ids.contains(FlightConfigurationId.ERROR_FCID)) {
+					Ids.add(FlightConfigurationId.ERROR_FCID);
+				}
 			}
 		}
 

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/MotorConfigurationPanel.java
@@ -28,6 +28,7 @@ import javax.swing.event.TableModelEvent;
 import javax.swing.event.TableModelListener;
 
 import net.miginfocom.swing.MigLayout;
+import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.gui.dialogs.flightconfiguration.IgnitionSelectionDialog;
 import net.sf.openrocket.gui.dialogs.flightconfiguration.MotorMountConfigurationPanel;
 import net.sf.openrocket.gui.dialogs.motor.MotorChooserDialog;
@@ -49,7 +50,7 @@ import net.sf.openrocket.util.Chars;
 
 @SuppressWarnings("serial")
 public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount> {
-	
+
 	private static final String NONE = trans.get("edtmotorconfdlg.tbl.None");
 
 	private final JButton selectMotorButton, deleteMotorButton, selectIgnitionButton, resetIgnitionButton;
@@ -64,8 +65,8 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 	private final JPopupMenu popupMenuFull;		// popup menu containing all the options
 
 
-	public MotorConfigurationPanel(final FlightConfigurationPanel flightConfigurationPanel, Rocket rocket) {
-		super(flightConfigurationPanel, rocket);
+	public MotorConfigurationPanel(final FlightConfigurationPanel flightConfigurationPanel, OpenRocketDocument document, Rocket rocket) {
+		super(flightConfigurationPanel, document, rocket);
 
 		motorChooserDialog = new MotorChooserDialog(SwingUtilities.getWindowAncestor(flightConfigurationPanel));
 
@@ -306,6 +307,9 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 
         double initDelay = initMount.getMotorConfig(initFcId).getEjectionDelay();
 
+		document.addUndoPosition("Select motor");
+
+		// Open the motor chooser dialog
 		motorChooserDialog.setMotorMountAndConfig(initFcId, initMount);
 		motorChooserDialog.open();
 
@@ -343,6 +347,8 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
             return;
         }
 
+		document.addUndoPosition("Delete motor(s)");
+
 		for (MotorMount mount : mounts) {
 			for (FlightConfigurationId fcId : fcIds) {
 				mount.setMotorConfig(null, fcId);
@@ -366,6 +372,8 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 		MotorConfiguration initConfig = initMount.getMotorConfig(initFcId);
 		IgnitionEvent initialIgnitionEvent = initConfig.getIgnitionEvent();
 		double initialIgnitionDelay = initConfig.getIgnitionDelay();
+
+		document.addUndoPosition("Select ignition");
 
 		// this call also performs the update changes
 		IgnitionSelectionDialog ignitionDialog = new IgnitionSelectionDialog(
@@ -409,6 +417,8 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 		if ((mounts == null) || (fcIds == null) || mounts.size() == 0 || fcIds.size() == 0) {
 			return;
 		}
+
+		document.addUndoPosition("Reset ignition");
 
 		boolean update = false;
 		for (MotorMount mount : mounts) {

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
@@ -171,7 +171,7 @@ public class RecoveryConfigurationPanel extends FlightConfigurablePanel<Recovery
 			return;
 		}
 
-		boolean update = false;
+		// Get the device and fcid that will be used in the config dialog
 		RecoveryDevice initDevice = devices.get(0);
 		FlightConfigurationId initFcId = fcIds.get(0);
 
@@ -179,32 +179,30 @@ public class RecoveryConfigurationPanel extends FlightConfigurablePanel<Recovery
 		JDialog d = new DeploymentSelectionDialog(SwingUtilities.getWindowAncestor(this), rocket, initDevice);
 		d.setVisible(true);
 
-		if (!initialConfig.equals(initDevice.getDeploymentConfigurations().get(initFcId))) {
-			update = true;
-		}
+		final DeploymentConfiguration modifiedConfig = initDevice.getDeploymentConfigurations().get(initFcId);
+		boolean update = !initialConfig.equals(modifiedConfig);
 
-		double deployDelay = initDevice.getDeploymentConfigurations().get(initFcId).getDeployDelay();
-		double deployAltitude = initDevice.getDeploymentConfigurations().get(initFcId).getDeployAltitude();
-		DeployEvent deployEvent = initDevice.getDeploymentConfigurations().get(initFcId).getDeployEvent();
+		double deployDelay = modifiedConfig.getDeployDelay();
+		double deployAltitude = modifiedConfig.getDeployAltitude();
+		DeployEvent deployEvent = modifiedConfig.getDeployEvent();
 
-		for (int i = 0; i < devices.size(); i++) {
-			for (int j = 0; j < fcIds.size(); j++) {
-				if ((i == 0) && (j == 0)) break;
+		for (RecoveryDevice device : devices) {
+			for (FlightConfigurationId fcId : fcIds) {
+				// Skip the config that was used for the config dialog (it has already been modified)
+				if ((device == initDevice) && (fcId == initFcId))
+					continue;
 
-				final RecoveryDevice device = devices.get(i);
-				final FlightConfigurationId fcId = fcIds.get(j);
-				DeploymentConfiguration config = device.getDeploymentConfigurations().get(fcId).copy(fcId);
-				initialConfig = config.copy(fcId);
+				DeploymentConfiguration currentConfig = device.getDeploymentConfigurations().get(fcId);
 
-				config.setDeployDelay(deployDelay);
-				config.setDeployAltitude(deployAltitude);
-				config.setDeployEvent(deployEvent);
-
-				device.getDeploymentConfigurations().set(fcId, config);
-
-				if (!initialConfig.equals(device.getDeploymentConfigurations().get(fcId))) {
-					update = true;
+				if (currentConfig.equals(modifiedConfig)) {
+					continue;
 				}
+
+				update = true;
+
+				currentConfig.setDeployDelay(deployDelay);
+				currentConfig.setDeployAltitude(deployAltitude);
+				currentConfig.setDeployEvent(deployEvent);
 			}
 		}
 

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
@@ -21,6 +21,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 
+import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.formatting.RocketDescriptor;
 import net.sf.openrocket.gui.dialogs.flightconfiguration.DeploymentSelectionDialog;
 import net.sf.openrocket.gui.main.FlightConfigurationPanel;
@@ -42,8 +43,8 @@ public class RecoveryConfigurationPanel extends FlightConfigurablePanel<Recovery
 	private final JPopupMenu popupMenuFull;		// popup menu containing all the options
 
 
-	public RecoveryConfigurationPanel(FlightConfigurationPanel flightConfigurationPanel, Rocket rocket) {
-		super(flightConfigurationPanel,rocket);
+	public RecoveryConfigurationPanel(FlightConfigurationPanel flightConfigurationPanel, OpenRocketDocument document, Rocket rocket) {
+		super(flightConfigurationPanel, document, rocket);
 
 		JScrollPane scroll = new JScrollPane(table);
 		this.add(scroll, "span, grow, pushy, wrap");
@@ -176,7 +177,11 @@ public class RecoveryConfigurationPanel extends FlightConfigurablePanel<Recovery
 		FlightConfigurationId initFcId = fcIds.get(0);
 
 		DeploymentConfiguration initialConfig = initDevice.getDeploymentConfigurations().get(initFcId).copy(initFcId);
-		JDialog d = new DeploymentSelectionDialog(SwingUtilities.getWindowAncestor(this), rocket, initDevice);
+
+		document.addUndoPosition("Select deployment");
+
+		// Open the configuration dialog
+		JDialog d = new DeploymentSelectionDialog(SwingUtilities.getWindowAncestor(this), rocket, initFcId, initDevice);
 		d.setVisible(true);
 
 		final DeploymentConfiguration modifiedConfig = initDevice.getDeploymentConfigurations().get(initFcId);
@@ -220,6 +225,8 @@ public class RecoveryConfigurationPanel extends FlightConfigurablePanel<Recovery
 		if ((devices == null) || (fcIds == null) || (devices.size() == 0) || fcIds.size() == 0) {
 			return;
 		}
+
+		document.addUndoPosition("Reset deployment");
 
 		boolean update = false;
 		for (RecoveryDevice device : devices) {

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/RecoveryConfigurationPanel.java
@@ -181,7 +181,7 @@ public class RecoveryConfigurationPanel extends FlightConfigurablePanel<Recovery
 		document.addUndoPosition("Select deployment");
 
 		// Open the configuration dialog
-		JDialog d = new DeploymentSelectionDialog(SwingUtilities.getWindowAncestor(this), rocket, initFcId, initDevice);
+		DeploymentSelectionDialog d = new DeploymentSelectionDialog(SwingUtilities.getWindowAncestor(this), rocket, initFcId, initDevice);
 		d.setVisible(true);
 
 		final DeploymentConfiguration modifiedConfig = initDevice.getDeploymentConfigurations().get(initFcId);
@@ -190,12 +190,18 @@ public class RecoveryConfigurationPanel extends FlightConfigurablePanel<Recovery
 		double deployDelay = modifiedConfig.getDeployDelay();
 		double deployAltitude = modifiedConfig.getDeployAltitude();
 		DeployEvent deployEvent = modifiedConfig.getDeployEvent();
+		boolean isOverrideDefault = d.isOverrideDefault();
 
 		for (RecoveryDevice device : devices) {
 			for (FlightConfigurationId fcId : fcIds) {
 				// Skip the config that was used for the config dialog (it has already been modified)
 				if ((device == initDevice) && (fcId == initFcId))
 					continue;
+
+				// It could be that the current config is the default config, but the user has selected to override it.
+				if (isOverrideDefault && !device.getDeploymentConfigurations().containsId(fcId)) {
+					device.getDeploymentConfigurations().set(fcId, device.getDeploymentConfigurations().getDefault().clone());
+				}
 
 				DeploymentConfiguration currentConfig = device.getDeploymentConfigurations().get(fcId);
 

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/SeparationConfigurationPanel.java
@@ -21,6 +21,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 
+import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.formatting.RocketDescriptor;
 import net.sf.openrocket.gui.dialogs.flightconfiguration.SeparationSelectionDialog;
 import net.sf.openrocket.gui.main.FlightConfigurationPanel;
@@ -47,8 +48,8 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialS
 	private final JPopupMenu popupMenuFull;		// popup menu containing all the options
 
 
-	public SeparationConfigurationPanel(FlightConfigurationPanel flightConfigurationPanel, Rocket rocket) {
-		super(flightConfigurationPanel,rocket);
+	public SeparationConfigurationPanel(FlightConfigurationPanel flightConfigurationPanel, OpenRocketDocument document, Rocket rocket) {
+		super(flightConfigurationPanel, document, rocket);
 		
 		JScrollPane scroll = new JScrollPane(table);
 		this.add(scroll, "span, grow, pushy, wrap");
@@ -187,6 +188,8 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialS
 		// Store the initial configuration so we can check later whether something changed
 		StageSeparationConfiguration initialConfig = initStage.getSeparationConfigurations().get(initFcId).copy(initFcId);
 
+		document.addUndoPosition("Select separation");
+
 		// Launch the separation config dialog
 		JDialog d = new SeparationSelectionDialog(SwingUtilities.getWindowAncestor(this), rocket, initStage);
 		d.setVisible(true);
@@ -198,7 +201,7 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialS
 		double separationDelay = initStage.getSeparationConfigurations().get(initFcId).getSeparationDelay();
 		SeparationEvent separationEvent= initStage.getSeparationConfigurations().get(initFcId).getSeparationEvent();
 
-		// Parse all stages anc flight configurations to check whether we need to update
+		// Parse all stages and flight configurations to check whether we need to update
 		for (int i = 0; i < stages.size(); i++) {
 			for (int j = 0; j < fcIds.size(); j++) {
 				if ((i == 0) && (j == 0)) break;
@@ -235,6 +238,8 @@ public class SeparationConfigurationPanel extends FlightConfigurablePanel<AxialS
 		if ((stages == null) || (fcIds == null) || (stages.size() == 0) || (fcIds.size() == 0)) {
 			return;
 		}
+
+		document.addUndoPosition("Reset separation");
 
 		boolean update = false;
 		for (AxialStage stage : stages) {

--- a/swing/src/net/sf/openrocket/gui/util/GUIUtil.java
+++ b/swing/src/net/sf/openrocket/gui/util/GUIUtil.java
@@ -165,6 +165,25 @@ public class GUIUtil {
 		installEscapeCloseOperation(dialog, null);
 	}
 
+	public static void installEscapeCloseButtonOperation(final JDialog dialog, final JButton buttonToClick) {
+		Action triggerButtonAndClose = new AbstractAction() {
+			private static final long serialVersionUID = 9196153713666242274L;
+
+			@Override
+			public void actionPerformed(ActionEvent event) {
+				log.info(Markers.USER_MARKER, "Closing dialog " + dialog);
+
+				if (buttonToClick != null) {
+					buttonToClick.doClick();  // Programmatically "press" the button
+				}
+
+				dialog.dispatchEvent(new WindowEvent(dialog, WindowEvent.WINDOW_CLOSING));
+			}
+		};
+
+		installEscapeCloseOperation(dialog, triggerButtonAndClose);
+	}
+
 	/**
 	 * Add the correct action to close a JDialog when the ESC key is pressed.
 	 * The dialog is closed by sending it a WINDOW_CLOSING event.


### PR DESCRIPTION
This PR fixes #2307. Every config action in the motors & recovery tab now has a dedicated undo action (select motor, delete motor, select ignition, reset ignition, select deployment, reset deployment, select separation and reset separation).

Whilst working on this PR, I also found some pretty serious bugs in multi-comp editing the motors, recovery and stages. An example bug:
1. Open 'Three-stage rocket'
2. Go to recovery tab, select middle and first config, change deployment to 1 s
3. All configs change, instead of only first 2

This PR fixes those bugs for each tab.