### PR TITLE
[#2329] Apply component tooltip to panel

### DIFF
--- a/swing/src/net/sf/openrocket/gui/main/componenttree/ComponentTree.java
+++ b/swing/src/net/sf/openrocket/gui/main/componenttree/ComponentTree.java
@@ -42,9 +42,5 @@ public class ComponentTree extends BasicTree {
 		
 		// Enable tooltips for this component
 		ToolTipManager.sharedInstance().registerComponent(this);
-		
 	}
-	
-
-
 }

--- a/swing/src/net/sf/openrocket/gui/main/componenttree/ComponentTreeRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/main/componenttree/ComponentTreeRenderer.java
@@ -7,6 +7,7 @@ import java.awt.Font;
 import java.util.List;
 
 import javax.swing.BorderFactory;
+import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JTree;
@@ -88,6 +89,8 @@ public class ComponentTreeRenderer extends DefaultTreeCellRenderer {
 			textLabel.setForeground(GUIUtil.getUITheme().getComponentTreeForegroundColor());
 		}
 
+		applyToolTipText(components, c, panel);
+
 		comp = panel;
 
 		// Add mass/CG/CD overridden icons
@@ -116,24 +119,26 @@ public class ComponentTreeRenderer extends DefaultTreeCellRenderer {
 			}
 			
 			// Make sure the tooltip also works on the override icons
-			if (components != null && components.size() > 1 && components.contains(c)) {
-				p.setToolTipText(getToolTipMultipleComponents(components));
-			} else {
-				p.setToolTipText(getToolTipSingleComponent(c));
-			}
+			applyToolTipText(components, c, p);
 
 			Font originalFont = tree.getFont();
 			p.setFont(originalFont);
 			comp = p;
 		}
 
-		if (components != null && components.size() > 1 && components.contains(c)) {
-			this.setToolTipText(getToolTipMultipleComponents(components));
-		} else {
-			this.setToolTipText(getToolTipSingleComponent(c));
-		}
+		applyToolTipText(components, c, this);
 
 		return comp;
+	}
+
+	private void applyToolTipText(List<RocketComponent> components, RocketComponent c, JComponent comp) {
+		String tooltipText;
+		if (components != null && components.size() > 1 && components.contains(c)) {
+			tooltipText = getToolTipMultipleComponents(components);
+		} else {
+			tooltipText = getToolTipSingleComponent(c);
+		}
+		comp.setToolTipText(tooltipText);
 	}
 
 	private static String getToolTipSingleComponent(RocketComponent c) {


### PR DESCRIPTION
This PR fixes #2329. Component tooltips are back :)
<img width="431" alt="image" src="https://github.com/openrocket/openrocket/assets/11031519/26a8a685-bc87-4f22-bcdd-42affbb512fc">
