### PR TITLE
Don't use selected row, but target row for preset selection

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/WelcomeDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/WelcomeDialog.java
@@ -61,6 +61,7 @@ public class WelcomeDialog extends JDialog {
         textPane.setContentType("text/html");
         textPane.setMargin(new Insets(10, 10, 10, 10));
         textPane.putClientProperty(JTextPane.HONOR_DISPLAY_PROPERTIES, true);
+        textPane.setBorder(GUIUtil.getUITheme().getBorder());
 
         String sb = "<html>" +
                 MarkdownUtil.toHtml(releaseNotes) + "<br><br>" +

--- a/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetTable.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetTable.java
@@ -74,14 +74,13 @@ public class ComponentPresetTable extends JTable {
 			@Override
 			public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
 				// Only support favorite
-				if ( columnIndex != 0 ) {
+				if (columnIndex != 0) {
 					return;
 				}
-				int selectedRow = ComponentPresetTable.this.getSelectedRow();
 				ComponentPreset preset = ComponentPresetTable.this.presets.get(rowIndex);
 				Application.getComponentPresetDao().setFavorite(preset, presetType, (Boolean) aValue);
 				ComponentPresetTable.this.updateFavorites();
-				ComponentPresetTable.this.setRowSelectionInterval(selectedRow, selectedRow);
+				ComponentPresetTable.this.setRowSelectionInterval(rowIndex, rowIndex);
 			}
 
 			@Override


### PR DESCRIPTION
One of our beta testers found a bug: if you use the dark theme, open the component preset dialog and then click a checkbox without having a row previously selected, OR would throw an exception.