### PR TITLE
Fix component preset table column popup menu

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
@@ -22,8 +22,12 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 import javax.swing.RowFilter;
+import javax.swing.event.ChangeEvent;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.TableColumnModelEvent;
+import javax.swing.event.TableColumnModelListener;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableModel;
 
@@ -245,12 +249,41 @@ public class ComponentPresetChooserDialog extends JDialog {
 		panel.add(showLegacyCheckBox, "wrap");
 		
 		showLegacyCheckBox.addItemListener(new ItemListener() {
-				@Override
-				public void itemStateChanged(ItemEvent e) {
-					updateFilters();
-					tm.setColumnVisible(legacyColumn, showLegacyCheckBox.isSelected());
+			@Override
+			public void itemStateChanged(ItemEvent e) {
+				updateFilters();
+				tm.setColumnVisible(legacyColumn, showLegacyCheckBox.isSelected());
+			}
+		});
+
+		// When the legacy column changes visibility (by right-clicking on the column header and toggling the legacy header checkbox),
+		// update the main legacy checkbox
+		tm.addColumnModelListener(new TableColumnModelListener() {
+			@Override
+			public void columnAdded(TableColumnModelEvent e) {
+				TableColumn column = tm.getColumn(e.getToIndex());
+				if (column == legacyColumn) {
+					showLegacyCheckBox.setSelected(true);
 				}
-			});			
+			}
+
+			@Override
+			public void columnRemoved(TableColumnModelEvent e) {
+				// Use 'getFromIndex' since the column has been removed
+				if (e.getFromIndex() == legacyColumnIndex) {
+					showLegacyCheckBox.setSelected(false);
+				}
+			}
+
+			@Override
+			public void columnMoved(TableColumnModelEvent e) {}
+
+			@Override
+			public void columnMarginChanged(ChangeEvent e) {}
+
+			@Override
+			public void columnSelectionChanged(ListSelectionEvent e) {}
+		});
 		
 		if(component instanceof SymmetricComponent) {
 			final SymmetricComponent curSym = (SymmetricComponent) component;

--- a/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
@@ -251,10 +251,17 @@ public class ComponentPresetChooserDialog extends JDialog {
 		showLegacyCheckBox.addItemListener(new ItemListener() {
 			@Override
 			public void itemStateChanged(ItemEvent e) {
-				updateFilters();
-				tm.setColumnVisible(legacyColumn, showLegacyCheckBox.isSelected());
+				boolean selected = e != null && e.getStateChange() == ItemEvent.SELECTED;
+				if (tm.isColumnVisible(legacyColumn) == selected) {
+					// No change
+					return;
+				}
 
-				if (showLegacyCheckBox.isSelected()) {
+				updateFilters();
+
+				tm.setColumnVisible(legacyColumn, selected);
+
+				if (selected) {
 					// Let's say the optimal width is 100 (you can adjust this as needed)
 					int optimalWidth = 50;
 					legacyColumn.setPreferredWidth(optimalWidth);

--- a/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetChooserDialog.java
@@ -253,6 +253,12 @@ public class ComponentPresetChooserDialog extends JDialog {
 			public void itemStateChanged(ItemEvent e) {
 				updateFilters();
 				tm.setColumnVisible(legacyColumn, showLegacyCheckBox.isSelected());
+
+				if (showLegacyCheckBox.isSelected()) {
+					// Let's say the optimal width is 100 (you can adjust this as needed)
+					int optimalWidth = 50;
+					legacyColumn.setPreferredWidth(optimalWidth);
+				}
 			}
 		});
 

--- a/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetTable.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetTable.java
@@ -7,6 +7,7 @@ import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Set;
 
@@ -45,6 +46,7 @@ public class ComponentPresetTable extends JTable {
 	private final AbstractTableModel tableModel;
 	private final XTableColumnModel tableColumnModel;
 	private final ComponentPresetTableColumn[] columns;
+	private final List<TableColumn> hiddenColumns;
 
 	public ComponentPresetTable(final ComponentPreset.Type presetType, List<ComponentPreset> presets, List<TypedKey<?>> visibleColumnKeys) {
 		super();
@@ -54,7 +56,7 @@ public class ComponentPresetTable extends JTable {
 		this.columns = new ComponentPresetTableColumn[ComponentPreset.ORDERED_KEY_LIST.size() + 1];
 
 
-		tableModel = new AbstractTableModel() {
+		this.tableModel = new AbstractTableModel() {
 			final ComponentPresetTableColumn[] myColumns = columns;
 
 			@Override
@@ -97,17 +99,16 @@ public class ComponentPresetTable extends JTable {
 		};
 
 
-		sorter = new TableRowSorter<TableModel>(tableModel);
-
-		tableColumnModel = new XTableColumnModel();
+		this.sorter = new TableRowSorter<TableModel>(tableModel);
+		this.tableColumnModel = new XTableColumnModel();
 
 		/*
 		 * Set up the Column Table model, and customize the sorting.
 		 */
-		columns[0] = new ComponentPresetTableColumn.Favorite(0);
-		tableColumnModel.addColumn(columns[0]);
+		this.columns[0] = new ComponentPresetTableColumn.Favorite(0);
+		this.tableColumnModel.addColumn(columns[0]);
 
-		List<TableColumn> hiddenColumns = new ArrayList<TableColumn>();
+		this.hiddenColumns = new ArrayList<>();
 		{
 			int index = 1;
 			for (final TypedKey<?> key : ComponentPreset.ORDERED_KEY_LIST) {
@@ -144,7 +145,7 @@ public class ComponentPresetTable extends JTable {
 					});
 				}
 
-				if (visibleColumnKeys.indexOf(key) < 0) {
+				if (!visibleColumnKeys.contains(key)) {
 					hiddenColumns.add(columns[index]);
 				}
 				index++;
@@ -156,10 +157,10 @@ public class ComponentPresetTable extends JTable {
 		this.setModel(tableModel);
 		this.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 		this.setRowSorter(sorter);
-		sorter.toggleSortOrder(2);        // Sort by the first column (manufacturer) by default
+		this.sorter.toggleSortOrder(2);        // Sort by the first column (manufacturer) by default
 
-		for (TableColumn hiddenColumn : hiddenColumns) {
-			tableColumnModel.setColumnVisible(hiddenColumn, false);
+		for (TableColumn hiddenColumn : this.hiddenColumns) {
+			this.tableColumnModel.setColumnVisible(hiddenColumn, false);
 		}
 
 		JTableHeader header = this.getTableHeader();
@@ -185,7 +186,7 @@ public class ComponentPresetTable extends JTable {
 	}
 
 	public XTableColumnModel getXColumnModel() {
-		return tableColumnModel;
+		return this.tableColumnModel;
 	}
 
 	public void setRowFilter(RowFilter<? super TableModel, ? super Integer> filter) {
@@ -231,6 +232,9 @@ public class ComponentPresetTable extends JTable {
 				}
 			}
 			for (TableColumn c : columns) {
+				if (hiddenColumns.contains(c)) {
+					continue;
+				}
 				JCheckBoxMenuItem item = new ToggleColumnMenuItem(c);
 				this.add(item);
 			}

--- a/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetTable.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetTable.java
@@ -1,5 +1,7 @@
 package net.sf.openrocket.gui.dialogs.preset;
 
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.MouseAdapter;
@@ -7,13 +9,14 @@ import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Enumeration;
 import java.util.List;
 import java.util.Set;
 
+import javax.swing.ButtonGroup;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JMenu;
 import javax.swing.JPopupMenu;
+import javax.swing.JRadioButtonMenuItem;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.RowFilter;
@@ -286,33 +289,38 @@ public class ComponentPresetTable extends JTable {
 			}
 		}
 
-		private class UnitSelectorMenuItem extends JMenu implements ItemListener {
+		private class UnitSelectorMenuItem extends JMenu {
 			ComponentPresetTableColumn.DoubleWithUnit col;
+			ButtonGroup buttonGroup; // To group the radio buttons
 
 			UnitSelectorMenuItem(ComponentPresetTableColumn.DoubleWithUnit col) {
 				super(trans.get("ComponentPresetChooserDialog.menu.units"));
 				this.col = col;
+
+				buttonGroup = new ButtonGroup(); // Create a new ButtonGroup to hold the radio buttons
+
 				UnitGroup group = col.unitGroup;
 				Unit selectedUnit = col.selectedUnit;
+
 				for (Unit u : group.getUnits()) {
-					JCheckBoxMenuItem item = new JCheckBoxMenuItem(u.toString());
+					JRadioButtonMenuItem item = new JRadioButtonMenuItem(u.toString());
+
 					if (u == selectedUnit) {
 						item.setSelected(true);
 					}
-					item.addItemListener(this);
-					this.add(item);
+
+					item.addActionListener(new ActionListener() {
+						@Override
+						public void actionPerformed(ActionEvent e) {
+							col.selectedUnit = u;
+							ComponentPresetTable.this.tableModel.fireTableDataChanged();
+						}
+					});
+
+					buttonGroup.add(item); // Add the radio button to the button group
+					this.add(item);       // Add the radio button to the menu
 				}
-
 			}
-
-			@Override
-			public void itemStateChanged(ItemEvent e) {
-				JCheckBoxMenuItem item = (JCheckBoxMenuItem) e.getItem();
-				String val = item.getText();
-				col.selectedUnit = col.unitGroup.findApproximate(val);
-				ComponentPresetTable.this.tableModel.fireTableDataChanged();
-			}
-
 		}
 	}
 }

--- a/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetTable.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preset/ComponentPresetTable.java
@@ -51,11 +51,12 @@ public class ComponentPresetTable extends JTable {
 		this.presets = presets;
 		this.presetType = presetType;
 		this.favorites = Application.getPreferences().getComponentFavorites(presetType);
-		this.columns = new ComponentPresetTableColumn[ComponentPreset.ORDERED_KEY_LIST.size()+1];
+		this.columns = new ComponentPresetTableColumn[ComponentPreset.ORDERED_KEY_LIST.size() + 1];
 
 
 		tableModel = new AbstractTableModel() {
 			final ComponentPresetTableColumn[] myColumns = columns;
+
 			@Override
 			public int getRowCount() {
 				return ComponentPresetTable.this.presets.size();
@@ -68,7 +69,7 @@ public class ComponentPresetTable extends JTable {
 
 			@Override
 			public Object getValueAt(int rowIndex, int columnIndex) {
-				return myColumns[columnIndex].getValueFromPreset(favorites,ComponentPresetTable.this.presets.get(rowIndex));
+				return myColumns[columnIndex].getValueFromPreset(favorites, ComponentPresetTable.this.presets.get(rowIndex));
 			}
 
 			@Override
@@ -109,25 +110,25 @@ public class ComponentPresetTable extends JTable {
 		List<TableColumn> hiddenColumns = new ArrayList<TableColumn>();
 		{
 			int index = 1;
-			for (final TypedKey<?> key: ComponentPreset.ORDERED_KEY_LIST ) {
-				if ( key.getType() == Double.class && key.getUnitGroup() != null ) {
-					columns[index] = new ComponentPresetTableColumn.DoubleWithUnit((TypedKey<Double>)key,index);
+			for (final TypedKey<?> key : ComponentPreset.ORDERED_KEY_LIST) {
+				if (key.getType() == Double.class && key.getUnitGroup() != null) {
+					columns[index] = new ComponentPresetTableColumn.DoubleWithUnit((TypedKey<Double>) key, index);
 				} else {
-					columns[index] = new ComponentPresetTableColumn.Parameter(key,index);
+					columns[index] = new ComponentPresetTableColumn.Parameter(key, index);
 				}
 				tableColumnModel.addColumn(columns[index]);
-				if ( key == ComponentPreset.PARTNO ) {
+				if (key == ComponentPreset.PARTNO) {
 					sorter.setComparator(index, new AlphanumComparator());
-				} else if ( key.getType() == Double.class ) {
-					sorter.setComparator(index,  new Comparator<Value>() {
+				} else if (key.getType() == Double.class) {
+					sorter.setComparator(index, new Comparator<Value>() {
 
 						@Override
 						public int compare(Value o1, Value o2) {
 							return Double.compare(o1.getValue(), o2.getValue());
 						}
-						
+
 					});
-				} else if ( key.getType() == Boolean.class ) {
+				} else if (key.getType() == Boolean.class) {
 					sorter.setComparator(index, new Comparator<Boolean>() {
 
 						@Override
@@ -140,42 +141,43 @@ public class ComponentPresetTable extends JTable {
 								return 0;
 							}
 						}
-						});
+					});
 				}
-				
-				if ( visibleColumnKeys.indexOf(key) < 0 ) {
+
+				if (visibleColumnKeys.indexOf(key) < 0) {
 					hiddenColumns.add(columns[index]);
 				}
-				index ++;
-				}
+				index++;
+			}
 		}
 
 		this.setAutoCreateColumnsFromModel(false);
-		this.setColumnModel( tableColumnModel );
+		this.setColumnModel(tableColumnModel);
 		this.setModel(tableModel);
 		this.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 		this.setRowSorter(sorter);
-		sorter.toggleSortOrder(2);		// Sort by the first column (manufacturer) by default
+		sorter.toggleSortOrder(2);        // Sort by the first column (manufacturer) by default
 
-		for ( TableColumn hiddenColumn : hiddenColumns ) {
+		for (TableColumn hiddenColumn : hiddenColumns) {
 			tableColumnModel.setColumnVisible(hiddenColumn, false);
 		}
 
 		JTableHeader header = this.getTableHeader();
-		
+
 		header.setReorderingAllowed(true);
 
-		header.addMouseListener( new MouseAdapter() {
+		header.addMouseListener(new MouseAdapter() {
 
 			@Override
 			public void mousePressed(MouseEvent e) {
-				if ( e.isPopupTrigger() ) {
+				if (e.isPopupTrigger()) {
 					doPopup(e);
 				}
 			}
+
 			@Override
 			public void mouseReleased(MouseEvent e) {
-				if ( e.isPopupTrigger() ) {
+				if (e.isPopupTrigger()) {
 					doPopup(e);
 				}
 			}
@@ -186,49 +188,49 @@ public class ComponentPresetTable extends JTable {
 		return tableColumnModel;
 	}
 
-	public void setRowFilter( RowFilter<? super TableModel ,? super Integer> filter ) {
-		sorter.setRowFilter( filter );
+	public void setRowFilter(RowFilter<? super TableModel, ? super Integer> filter) {
+		sorter.setRowFilter(filter);
 	}
 
-	public void updateData( List<ComponentPreset> myPresets ) {
+	public void updateData(List<ComponentPreset> myPresets) {
 		this.presets = myPresets;
 		this.favorites = Application.getPreferences().getComponentFavorites(presetType);
 		this.tableModel.fireTableDataChanged();
 	}
-	
+
 	public void updateFavorites() {
 		this.favorites = Application.getPreferences().getComponentFavorites(presetType);
 		this.tableModel.fireTableDataChanged();
 	}
 
-	private void doPopup(MouseEvent evt ) {
-		
+	private void doPopup(MouseEvent evt) {
+
 		// Figure out what column header was clicked on.
-		int colIndex = tableColumnModel.getColumnIndexAtX( evt.getX() );
+		int colIndex = tableColumnModel.getColumnIndexAtX(evt.getX());
 		ComponentPresetTableColumn colClicked = null;
-		if ( colIndex >=0 ) {
+		if (colIndex >= 0) {
 			colClicked = (ComponentPresetTableColumn) tableColumnModel.getColumn(colIndex);
 		}
-		
+
 		JPopupMenu columnMenu = new ColumnPopupMenu(colClicked, colIndex);
-		columnMenu.show(evt.getComponent(),evt.getX(),evt.getY());
+		columnMenu.show(evt.getComponent(), evt.getX(), evt.getY());
 	}
 
 	private class ColumnPopupMenu extends JPopupMenu {
 
 		ColumnPopupMenu(ComponentPresetTableColumn colClicked, int colClickedIndex) {
-			if ( colClickedIndex >= 0 ) {
+			if (colClickedIndex >= 0) {
 				JCheckBoxMenuItem item = new SortAscColumnMenuItem(colClickedIndex);
 				this.add(item);
 				item = new SortDescColumnMenuItem(colClickedIndex);
 				this.add(item);
 				this.addSeparator();
-				if ( colClicked instanceof ComponentPresetTableColumn.DoubleWithUnit ) {
-					this.add( new UnitSelectorMenuItem( (ComponentPresetTableColumn.DoubleWithUnit) colClicked ));
+				if (colClicked instanceof ComponentPresetTableColumn.DoubleWithUnit) {
+					this.add(new UnitSelectorMenuItem((ComponentPresetTableColumn.DoubleWithUnit) colClicked));
 					this.addSeparator();
 				}
 			}
-			for( TableColumn c: columns ) {
+			for (TableColumn c : columns) {
 				JCheckBoxMenuItem item = new ToggleColumnMenuItem(c);
 				this.add(item);
 			}
@@ -237,67 +239,74 @@ public class ComponentPresetTable extends JTable {
 
 		private class SortAscColumnMenuItem extends JCheckBoxMenuItem implements ItemListener {
 			private int columnClicked;
+
 			SortAscColumnMenuItem(int columnClicked) {
-				super( trans.get("ComponentPresetChooserDialog.menu.sortAsc") );
+				super(trans.get("ComponentPresetChooserDialog.menu.sortAsc"));
 				this.addItemListener(this);
 				this.columnClicked = columnClicked;
 			}
+
 			@Override
 			public void itemStateChanged(ItemEvent e) {
-				sorter.setSortKeys( Collections.singletonList( new SortKey(columnClicked, SortOrder.ASCENDING)));
+				sorter.setSortKeys(Collections.singletonList(new SortKey(columnClicked, SortOrder.ASCENDING)));
 			}
 		}
-		
+
 		private class SortDescColumnMenuItem extends JCheckBoxMenuItem implements ItemListener {
 			private int columnClicked;
+
 			SortDescColumnMenuItem(int columnClicked) {
-				super( trans.get("ComponentPresetChooserDialog.menu.sortDesc") );
+				super(trans.get("ComponentPresetChooserDialog.menu.sortDesc"));
 				this.addItemListener(this);
 				this.columnClicked = columnClicked;
 			}
+
 			@Override
 			public void itemStateChanged(ItemEvent e) {
-				sorter.setSortKeys( Collections.singletonList( new SortKey(columnClicked, SortOrder.DESCENDING)));
+				sorter.setSortKeys(Collections.singletonList(new SortKey(columnClicked, SortOrder.DESCENDING)));
 			}
 		}
-		
+
 		private class ToggleColumnMenuItem extends JCheckBoxMenuItem implements ItemListener {
 			TableColumn col;
-			ToggleColumnMenuItem( TableColumn col ) {
-				super( String.valueOf(col.getHeaderValue()), tableColumnModel.isColumnVisible(col));
+
+			ToggleColumnMenuItem(TableColumn col) {
+				super(String.valueOf(col.getHeaderValue()), tableColumnModel.isColumnVisible(col));
 				this.addItemListener(this);
 				this.col = col;
 			}
+
 			@Override
 			public void itemStateChanged(ItemEvent e) {
 				tableColumnModel.setColumnVisible(col, !tableColumnModel.isColumnVisible(col));
 			}
 		}
-		
+
 		private class UnitSelectorMenuItem extends JMenu implements ItemListener {
 			ComponentPresetTableColumn.DoubleWithUnit col;
-			UnitSelectorMenuItem( ComponentPresetTableColumn.DoubleWithUnit col ) {
+
+			UnitSelectorMenuItem(ComponentPresetTableColumn.DoubleWithUnit col) {
 				super(trans.get("ComponentPresetChooserDialog.menu.units"));
 				this.col = col;
 				UnitGroup group = col.unitGroup;
 				Unit selectedUnit = col.selectedUnit;
-				for( Unit u : group.getUnits() ) {
-					JCheckBoxMenuItem item = new JCheckBoxMenuItem( u.toString() );
-					if ( u == selectedUnit ) {
+				for (Unit u : group.getUnits()) {
+					JCheckBoxMenuItem item = new JCheckBoxMenuItem(u.toString());
+					if (u == selectedUnit) {
 						item.setSelected(true);
 					}
 					item.addItemListener(this);
 					this.add(item);
 				}
-				
+
 			}
+
 			@Override
 			public void itemStateChanged(ItemEvent e) {
 				JCheckBoxMenuItem item = (JCheckBoxMenuItem) e.getItem();
 				String val = item.getText();
 				col.selectedUnit = col.unitGroup.findApproximate(val);
 				ComponentPresetTable.this.tableModel.fireTableDataChanged();
-				return;
 			}
 
 		}

--- a/swing/src/net/sf/openrocket/gui/util/GUIUtil.java
+++ b/swing/src/net/sf/openrocket/gui/util/GUIUtil.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -56,6 +57,7 @@ import javax.swing.event.ChangeListener;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableColumnModel;
 import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
 import javax.swing.table.TableModel;
 import javax.swing.tree.DefaultMutableTreeNode;
@@ -404,23 +406,24 @@ public class GUIUtil {
 
 	public static void rememberTableColumnWidths(final JTable table, String keyName) {
 		final String key = keyName == null ? table.getClass().getName() : keyName;
-		for (int i = 0; i < table.getColumnCount(); i++) {
-			final int column = i;
-			table.getColumnModel().getColumn(i).addPropertyChangeListener(new PropertyChangeListener() {
+		Enumeration<TableColumn> columns = table.getColumnModel().getColumns();
+		while (columns.hasMoreElements()) {
+			TableColumn column = columns.nextElement();
+			column.addPropertyChangeListener(new PropertyChangeListener() {
 				@Override
 				public void propertyChange(PropertyChangeEvent evt) {
 					if (evt.getPropertyName().equals("width")) {
-						log.debug("Storing width of " + table.getName() + "-" + table.getColumnName(column) + ": " + table.getColumnModel().getColumn(column).getWidth());
+						log.debug("Storing width of " + table.getName() + "-" + column + ": " + column.getWidth());
 						((SwingPreferences) Application.getPreferences()).setTableColumnWidth(
-								key, column, table.getColumnModel().getColumn(column).getWidth());
+								key, column.getModelIndex(), column.getWidth());
 					}
 				}
 			});
 
 			final Integer width = ((SwingPreferences) Application.getPreferences()).getTableColumnWidth(
-					key, column);
+					key, column.getModelIndex());
 			if (width != null) {
-				table.getColumnModel().getColumn(column).setPreferredWidth(width);
+				column.setPreferredWidth(width);
 			}
 		}
 	}

--- a/swing/src/net/sf/openrocket/gui/util/GUIUtil.java
+++ b/swing/src/net/sf/openrocket/gui/util/GUIUtil.java
@@ -424,12 +424,32 @@ public class GUIUtil {
 					key, column.getModelIndex());
 			if (width != null) {
 				column.setPreferredWidth(width);
+			} else {
+				column.setPreferredWidth(getOptimalColumnWidth(table, column.getModelIndex()));
 			}
 		}
 	}
 
 	public static void rememberTableColumnWidths(final JTable table) {
 		rememberTableColumnWidths(table, null);
+	}
+
+	public static int getOptimalColumnWidth(JTable table, int columnIndex) {
+		TableColumn column = table.getColumnModel().getColumn(columnIndex);
+		Component headerRenderer = table.getTableHeader().getDefaultRenderer()
+				.getTableCellRendererComponent(table, column.getHeaderValue(), false, false, 0, columnIndex);
+
+		int maxWidth = headerRenderer.getPreferredSize().width;
+
+		for (int row = 0; row < table.getRowCount(); row++) {
+			Component renderer = table.getCellRenderer(row, columnIndex)
+					.getTableCellRendererComponent(table, table.getValueAt(row, columnIndex), false, false, row, columnIndex);
+			maxWidth = Math.max(maxWidth, renderer.getPreferredSize().width);
+		}
+
+		// Optional: Add some padding
+		int padding = 5;  // adjust this value as needed
+		return maxWidth + padding;
 	}
 	
 	


### PR DESCRIPTION
In the component preset table, you can right-click the header to hide/show columns and change the units. However, the columns displayed were not correct; every column from each different rocket component was displayed:
<img width="1285" alt="image" src="https://github.com/openrocket/openrocket/assets/11031519/587bcfe2-c11f-4d0d-975b-e33ffdb2337f">
(notice screw entries etc.)

Additionally, in dark mode, the units used checkboxes, so you could select multiple units (does not make sense):
<img width="289" alt="image" src="https://github.com/openrocket/openrocket/assets/11031519/ff46c039-1de9-486f-80dd-c9cc99780431">


---

Fix after this PR:
<img width="1090" alt="image" src="https://github.com/openrocket/openrocket/assets/11031519/054bae3f-d8cc-4043-817f-c1a943c525b4">

Correct units:
<img width="276" alt="image" src="https://github.com/openrocket/openrocket/assets/11031519/0992e3f2-1bf9-44f9-b184-694a9505447e">
