### PR TITLE
[#2341] Sanitize OBJ export groupnames

### DIFF
--- a/core/src/net/sf/openrocket/file/wavefrontobj/export/OBJExporterFactory.java
+++ b/core/src/net/sf/openrocket/file/wavefrontobj/export/OBJExporterFactory.java
@@ -154,6 +154,7 @@ public class OBJExporterFactory {
 
             // Component exporting
             String groupName = idx + "_" + component.getName();
+            groupName = sanitizeGroupName(groupName);
             handleComponent(obj, this.configuration, this.options.getTransformer(), component, groupName,
                     materials.get(obj), this.options.getLOD(), options, warnings);
 
@@ -291,6 +292,20 @@ public class OBJExporterFactory {
         addChildComponentToList(this.configuration.getRocket(), components, sortedComponents);
 
         return sortedComponents;
+    }
+
+    /**
+     * Sanitize the group name by replacing illegal characters with underscores.
+     * @param groupName the group name to sanitize
+     * @return the sanitized group name
+     */
+    private static String sanitizeGroupName(String groupName) {
+        Character c = FileUtils.getIllegalFilenameChar(groupName);
+        while (c != null) {
+            groupName = groupName.replace(c, '_');
+            c = FileUtils.getIllegalFilenameChar(groupName);
+        }
+        return groupName;
     }
 
     private void addChildComponentToList(RocketComponent parent, Set<RocketComponent> components, Set<RocketComponent> sortedComponents) {

--- a/core/src/net/sf/openrocket/util/FileUtils.java
+++ b/core/src/net/sf/openrocket/util/FileUtils.java
@@ -9,31 +9,29 @@ import java.io.OutputStream;
 import java.nio.file.Paths;
 
 public abstract class FileUtils {
+	private static final char[] ILLEGAL_CHARS = new char[] { '/', '\\', ':', '*', '?', '"', '<', '>', '|' };
 
-	public static void copy( InputStream is, OutputStream os ) throws IOException {
-		
-		if ( ! (os instanceof BufferedOutputStream ) ) {
+	public static void copy(InputStream is, OutputStream os) throws IOException {
+		if (!(os instanceof BufferedOutputStream)) {
 			os = new BufferedOutputStream(os);
 		}
 		
-		if ( ! (is instanceof BufferedInputStream ) ) {
+		if (!(is instanceof BufferedInputStream)) {
 			is = new BufferedInputStream(is);
 		}
 		
 		byte[] buffer = new byte[1024];
 		int bytesRead = 0;
 		
-		while( (bytesRead = is.read(buffer)) > 0 ) {
-			os.write(buffer,0,bytesRead);
+		while( (bytesRead = is.read(buffer)) > 0) {
+			os.write(buffer, 0, bytesRead);
 		}
 		os.flush();
 	}
 	
-	public static byte[] readBytes( InputStream is ) throws IOException {
-
+	public static byte[] readBytes(InputStream is) throws IOException {
 		ByteArrayOutputStream bos = new ByteArrayOutputStream(1024);
-
-		copy( is, bos );
+		copy(is, bos);
 
 		return bos.toByteArray();
 
@@ -59,6 +57,24 @@ public abstract class FileUtils {
 	 */
 	public static String getFileNameFromPath(String pathString) {
 		return Paths.get(pathString).getFileName().toString();
+	}
+
+
+	/**
+	 * Returns an illegal character if one is found in the filename, otherwise returns null.
+	 * @param filename The filename to check
+	 * @return The illegal character, or null if none is found
+	 */
+	public static Character getIllegalFilenameChar(String filename) {
+		if (filename == null || filename.isEmpty()) {
+			return null;
+		}
+		for (char c : ILLEGAL_CHARS) {
+			if (filename.indexOf(c) >= 0) {
+				return c;
+			}
+		}
+		return null;
 	}
 
 }

--- a/swing/src/net/sf/openrocket/gui/widgets/SaveFileChooser.java
+++ b/swing/src/net/sf/openrocket/gui/widgets/SaveFileChooser.java
@@ -2,6 +2,7 @@ package net.sf.openrocket.gui.widgets;
 
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
+import net.sf.openrocket.util.FileUtils;
 
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
@@ -12,7 +13,6 @@ import java.util.regex.PatternSyntaxException;
 public class SaveFileChooser extends JFileChooser {
     private static final Translator trans = Application.getTranslator();
 
-    private static final char[] ILLEGAL_CHARS = new char[] { '/', '\\', ':', '*', '?', '"', '<', '>', '|' };
 
     private File cwd = null;
     private File currentFile = null;
@@ -30,7 +30,7 @@ public class SaveFileChooser extends JFileChooser {
         if (file.getParentFile() != getCurrentDirectory()) {
             cwd = getCurrentDirectory();
             fileName = getFilenameInput(currentFile, cwd);
-            if (getIllegalChar(fileName) != null) {
+            if (FileUtils.getIllegalFilenameChar(fileName) != null) {
                 return;
             }
         }
@@ -42,7 +42,7 @@ public class SaveFileChooser extends JFileChooser {
 
     @Override
     public void approveSelection() {
-        Character c = getIllegalChar(fileName);
+        Character c = FileUtils.getIllegalFilenameChar(fileName);
         if (c != null) {
             // Illegal character found
             JOptionPane.showMessageDialog(getParent(),
@@ -55,23 +55,6 @@ public class SaveFileChooser extends JFileChooser {
             setCurrentDirectory(cwd);
             super.approveSelection();
         }
-    }
-
-    /**
-     * Returns an illegal character if one is found in the filename, otherwise returns null.
-     * @param filename The filename to check
-     * @return The illegal character, or null if none is found
-     */
-    private Character getIllegalChar(String filename) {
-        if (filename == null || filename.isEmpty()) {
-            return null;
-        }
-        for (char c : ILLEGAL_CHARS) {
-            if (filename.indexOf(c) >= 0) {
-                return c;
-            }
-        }
-        return null;
     }
 
     /**


### PR DESCRIPTION
This PR fixes #2341 by sanitizing the group names before exportin.