### PR TITLE
[#2344] Optimize UI color fetching

### DIFF
--- a/swing/src/net/sf/openrocket/file/wavefrontobj/OBJOptionChooser.java
+++ b/swing/src/net/sf/openrocket/file/wavefrontobj/OBJOptionChooser.java
@@ -5,6 +5,7 @@ import net.sf.openrocket.file.wavefrontobj.export.OBJExportOptions;
 import net.sf.openrocket.gui.SpinnerEditor;
 import net.sf.openrocket.gui.adaptors.DoubleModel;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.rocketcomponent.ComponentAssembly;
 import net.sf.openrocket.rocketcomponent.Rocket;
@@ -27,6 +28,7 @@ import javax.swing.JToggleButton;
 import javax.swing.UIManager;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
+import java.awt.Color;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -63,6 +65,12 @@ public class OBJOptionChooser extends JPanel {
     //private boolean isProgrammaticallyChanging = false;
 
     private int totallyNormalCounter = 0;
+
+    private static Color darkWarningColor;
+
+    static {
+        initColors();
+    }
 
     public OBJOptionChooser(JComponent parent, OBJExportOptions opts, List<RocketComponent> selectedComponents, Rocket rocket) {
         super(new MigLayout("hidemode 3"));
@@ -305,13 +313,22 @@ public class OBJOptionChooser extends JPanel {
         loadOptions(opts);
     }
 
+    private static void initColors() {
+        updateColors();
+        UITheme.Theme.addUIThemeChangeListener(OBJOptionChooser::updateColors);
+    }
+
+    private static void updateColors() {
+        darkWarningColor = GUIUtil.getUITheme().getDarkWarningColor();
+    }
+
     /**
      * Highlight the given button and un-highlight the other button.
      * @param highlightButton The button to highlight
      * @param loserButton The button to un-highlight
      */
     private void highlightButton(JButton highlightButton, JButton loserButton) {
-        highlightButton.setBorder(BorderFactory.createLineBorder(GUIUtil.getUITheme().getDarkWarningColor()));
+        highlightButton.setBorder(BorderFactory.createLineBorder(darkWarningColor));
         loserButton.setBorder(UIManager.getBorder("Button.border"));
     }
 

--- a/swing/src/net/sf/openrocket/gui/components/BasicTree.java
+++ b/swing/src/net/sf/openrocket/gui/components/BasicTree.java
@@ -1,6 +1,7 @@
 package net.sf.openrocket.gui.components;
 
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 
 import java.awt.BasicStroke;
 import java.awt.Color;
@@ -16,6 +17,12 @@ import javax.swing.tree.TreePath;
 
 @SuppressWarnings("serial")
 public class BasicTree extends JTree {
+	private static Color backgroundColor;
+
+	static {
+		initColors();
+	}
+
 	public BasicTree() {
 		super();
 		setDefaultOptions();
@@ -37,10 +44,18 @@ public class BasicTree extends JTree {
 		plainUI.setLeftChildIndent(15);
 		
 
-		this.setBackground(GUIUtil.getUITheme().getBackgroundColor());
+		this.setBackground(backgroundColor);
 		this.setShowsRootHandles(false);
 	}
-	
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(BasicTree::updateColors);
+	}
+
+	private static void updateColors() {
+		backgroundColor = GUIUtil.getUITheme().getBackgroundColor();
+	}
 	
 	/**
 	 * Expand the entire tree structure.  All nodes will be visible after the call.

--- a/swing/src/net/sf/openrocket/gui/components/DescriptionArea.java
+++ b/swing/src/net/sf/openrocket/gui/components/DescriptionArea.java
@@ -1,6 +1,7 @@
 package net.sf.openrocket.gui.components;
 
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.gui.util.URLUtil;
 
 import java.awt.Color;
@@ -16,6 +17,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 
 import javax.swing.JTextPane;
+import javax.swing.border.Border;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
 import javax.swing.text.SimpleAttributeSet;
@@ -33,6 +35,12 @@ public class DescriptionArea extends JScrollPane {
 	private final JEditorPane editorPane;
 
 	private final float size;
+
+	private static Border border;
+
+	static {
+		initColors();
+	}
 	
 	
 	/**
@@ -177,10 +185,19 @@ public class DescriptionArea extends JScrollPane {
 		dim.height = lineheight * rows + extraheight + 2;
 		this.setPreferredSize(dim);
 
-		editorPane.setBorder(GUIUtil.getUITheme().getBorder());
+		editorPane.setBorder(border);
 		
 		this.setViewportView(editorPane);
 		this.setText(text);
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(DescriptionArea::updateColors);
+	}
+
+	private static void updateColors() {
+		border = GUIUtil.getUITheme().getBorder();
 	}
 	
 	public void setText(String txt) {

--- a/swing/src/net/sf/openrocket/gui/components/URLLabel.java
+++ b/swing/src/net/sf/openrocket/gui/components/URLLabel.java
@@ -1,5 +1,6 @@
 package net.sf.openrocket.gui.components;
 
+import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.Desktop;
 import java.awt.event.MouseAdapter;
@@ -9,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.gui.util.URLUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +23,12 @@ import org.slf4j.LoggerFactory;
  */
 public class URLLabel extends SelectableLabel {
 	private static final Logger log = LoggerFactory.getLogger(URLLabel.class);
+
+	private static Color URLColor;
+
+	static {
+		initColors();
+	}
 
 	/**
 	 * Create a label showing the url it will direct to.
@@ -48,7 +56,7 @@ public class URLLabel extends SelectableLabel {
 			Map<TextAttribute, Object> map = new HashMap<TextAttribute, Object>();
 			map.put(TextAttribute.UNDERLINE, TextAttribute.UNDERLINE_ON);
 			this.setFont(this.getFont().deriveFont(map));
-			this.setForeground(GUIUtil.getUITheme().getURLColor());
+			this.setForeground(URLColor);
 			
 			this.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 			
@@ -65,5 +73,14 @@ public class URLLabel extends SelectableLabel {
 			});
 
 		}
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(URLLabel::updateColors);
+	}
+
+	private static void updateColors() {
+		URLColor = GUIUtil.getUITheme().getURLColor();
 	}
 }

--- a/swing/src/net/sf/openrocket/gui/configdialog/InnerTubeConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/InnerTubeConfig.java
@@ -41,6 +41,7 @@ import net.sf.openrocket.gui.components.BasicSlider;
 import net.sf.openrocket.gui.components.DescriptionArea;
 import net.sf.openrocket.gui.components.UnitSelector;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.gui.widgets.SelectColorButton;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.material.Material;
@@ -467,15 +468,15 @@ class ClusterSelectionPanel extends JPanel {
 	private static final int MOTOR_DIAMETER = 10;
 
 	private static final Color SELECTED_COLOR;
-	private static final Color UNSELECTED_COLOR;
+	private static Color UNSELECTED_COLOR;
 	private static final Color MOTOR_FILL_COLOR;
 	private static final Color MOTOR_BORDER_COLOR;
 
 	static {
 		SELECTED_COLOR = Color.RED;
-		UNSELECTED_COLOR = GUIUtil.getUITheme().getBackgroundColor();
 		MOTOR_FILL_COLOR = Color.GREEN;
 		MOTOR_BORDER_COLOR = Color.BLACK;
+		initColors();
 	}
 
 	public ClusterSelectionPanel(Clusterable component) {
@@ -493,6 +494,15 @@ class ClusterSelectionPanel extends JPanel {
 				add(button);
 		}
 
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(ClusterSelectionPanel::updateColors);
+	}
+
+	private static void updateColors() {
+		UNSELECTED_COLOR = GUIUtil.getUITheme().getBackgroundColor();
 	}
 
 

--- a/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
@@ -100,6 +100,7 @@ public class RocketComponentConfig extends JPanel {
 	private boolean allMassive;			// Checks whether all listener components, and this component, are massive
 
 	private static Color darkWarningColor;
+	private static Color multiCompEditColor;
 	private static Border border;
 
 	static {
@@ -203,6 +204,7 @@ public class RocketComponentConfig extends JPanel {
 
 	private static void updateColors() {
 		darkWarningColor = GUIUtil.getUITheme().getDarkWarningColor();
+		multiCompEditColor = GUIUtil.getUITheme().getMultiCompEditColor();
 		border = GUIUtil.getUITheme().getBorder();
 	}
 
@@ -270,7 +272,7 @@ public class RocketComponentConfig extends JPanel {
 
 		//// Multi-comp edit label
 		multiCompEditLabel = new StyledLabel(" ", -1, Style.BOLD);
-		multiCompEditLabel.setFontColor(new Color(170, 0, 100));
+		multiCompEditLabel.setFontColor(multiCompEditColor);
 		buttonPanel.add(multiCompEditLabel, "split 2");
 
 		//// Mass:

--- a/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RocketComponentConfig.java
@@ -30,6 +30,7 @@ import javax.swing.JTabbedPane;
 import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
+import javax.swing.border.Border;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
@@ -49,6 +50,7 @@ import net.sf.openrocket.gui.components.UnitSelector;
 import net.sf.openrocket.gui.dialogs.preset.ComponentPresetChooserDialog;
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.gui.util.Icons;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.gui.widgets.IconToggleButton;
 import net.sf.openrocket.gui.widgets.SelectColorButton;
 import net.sf.openrocket.l10n.Translator;
@@ -96,6 +98,13 @@ public class RocketComponentConfig extends JPanel {
 
 	private boolean allSameType;		// Checks whether all listener components are of the same type as <component>
 	private boolean allMassive;			// Checks whether all listener components, and this component, are massive
+
+	private static Color darkWarningColor;
+	private static Border border;
+
+	static {
+		initColors();
+	}
 
 	public RocketComponentConfig(OpenRocketDocument document, RocketComponent component, JDialog parent) {
 		setLayout(new MigLayout("fill, gap 4!, ins panel, hidemode 3", "[]:5[]", "[growprio 5]5![fill, grow, growprio 500]5![growprio 5]"));
@@ -185,6 +194,16 @@ public class RocketComponentConfig extends JPanel {
 		addButtons();
 
 		updateFields();
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(RocketComponentConfig::updateColors);
+	}
+
+	private static void updateColors() {
+		darkWarningColor = GUIUtil.getUITheme().getDarkWarningColor();
+		border = GUIUtil.getUITheme().getBorder();
 	}
 
 	/**
@@ -506,7 +525,7 @@ public class RocketComponentConfig extends JPanel {
 			StyledLabel labelMassOverriddenBy = new StyledLabel(
 					String.format(trans.get("RocketCompCfg.lbl.MassOverriddenBy"), component.getMassOverriddenBy().getName()),
 					0, StyledLabel.Style.BOLD);
-			labelMassOverriddenBy.setFontColor(GUIUtil.getUITheme().getDarkWarningColor());
+			labelMassOverriddenBy.setFontColor(darkWarningColor);
 			labelMassOverriddenBy.setToolTipText(
 					String.format(trans.get("RocketCompCfg.lbl.MassOverriddenBy.ttip"), component.getMassOverriddenBy().getName()));
 			checkboxes.add(labelMassOverriddenBy, "gapleft 25lp, wrap");
@@ -569,7 +588,7 @@ public class RocketComponentConfig extends JPanel {
 			StyledLabel labelCGOverriddenBy = new StyledLabel(
 					String.format(trans.get("RocketCompCfg.lbl.CGOverriddenBy"), component.getCGOverriddenBy().getName()),
 					0, StyledLabel.Style.BOLD);
-			labelCGOverriddenBy.setFontColor(GUIUtil.getUITheme().getDarkWarningColor());
+			labelCGOverriddenBy.setFontColor(darkWarningColor);
 			labelCGOverriddenBy.setToolTipText(
 					String.format(trans.get("RocketCompCfg.lbl.CGOverriddenBy.ttip"), component.getCGOverriddenBy().getName()));
 			checkboxes.add(labelCGOverriddenBy, "gapleft 25lp, wrap");
@@ -663,7 +682,7 @@ public class RocketComponentConfig extends JPanel {
 			StyledLabel labelCDOverriddenBy = new StyledLabel(
 					String.format(trans.get("RocketCompCfg.lbl.CDOverriddenBy"), component.getCDOverriddenBy().getName()),
 					0, StyledLabel.Style.BOLD);
-			labelCDOverriddenBy.setFontColor(GUIUtil.getUITheme().getDarkWarningColor());
+			labelCDOverriddenBy.setFontColor(darkWarningColor);
 			labelCDOverriddenBy.setToolTipText(
 					String.format(trans.get("RocketCompCfg.lbl.CDOverriddenBy"), component.getCDOverriddenBy().getName()));
 			checkboxes.add(labelCDOverriddenBy, "gapleft 25lp, wrap");
@@ -719,7 +738,7 @@ public class RocketComponentConfig extends JPanel {
 		commentTextArea.setLineWrap(true);
 		commentTextArea.setWrapStyleWord(true);
 		commentTextArea.setEditable(true);
-		commentTextArea.setBorder(GUIUtil.getUITheme().getBorder());
+		commentTextArea.setBorder(border);
 		GUIUtil.setTabToFocusing(commentTextArea);
 		commentTextArea.addFocusListener(textFieldListener);
 		commentTextArea.addKeyListener(new TextComponentSelectionKeyListener(commentTextArea));

--- a/swing/src/net/sf/openrocket/gui/configdialog/RocketConfig.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/RocketConfig.java
@@ -16,10 +16,12 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
+import javax.swing.border.Border;
 
 import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
@@ -34,6 +36,12 @@ public class RocketConfig extends RocketComponentConfig {
 	private JTextArea revisionTextArea;
 	
 	private final Rocket rocket;
+
+	private static Border border;
+
+	static {
+		initColors();
+	}
 	
 	public RocketConfig(OpenRocketDocument d, RocketComponent c, JDialog parent) {
 		super(d, c, parent);
@@ -55,7 +63,7 @@ public class RocketConfig extends RocketComponentConfig {
 		designerTextArea.setLineWrap(true);
 		designerTextArea.setWrapStyleWord(true);
 		designerTextArea.setEditable(true);
-		designerTextArea.setBorder(GUIUtil.getUITheme().getBorder());
+		designerTextArea.setBorder(border);
 		GUIUtil.setTabToFocusing(designerTextArea);
 		designerTextArea.addFocusListener(textFieldListener);
 		this.add(new JScrollPane(designerTextArea), "wmin 400lp, height 60lp:60lp:, grow 30, wrap para");
@@ -70,7 +78,7 @@ public class RocketConfig extends RocketComponentConfig {
 		revisionTextArea.setLineWrap(true);
 		revisionTextArea.setWrapStyleWord(true);
 		revisionTextArea.setEditable(true);
-		revisionTextArea.setBorder(GUIUtil.getUITheme().getBorder());
+		revisionTextArea.setBorder(border);
 		GUIUtil.setTabToFocusing(revisionTextArea);
 		revisionTextArea.addFocusListener(textFieldListener);
 		
@@ -79,6 +87,15 @@ public class RocketConfig extends RocketComponentConfig {
 
 		addButtons();
 		addEasterEgg();
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(RocketConfig::updateColors);
+	}
+
+	private static void updateColors() {
+		border = GUIUtil.getUITheme().getBorder();
 	}
 
 	/**

--- a/swing/src/net/sf/openrocket/gui/customexpression/CustomExpressionPanel.java
+++ b/swing/src/net/sf/openrocket/gui/customexpression/CustomExpressionPanel.java
@@ -1,5 +1,6 @@
 package net.sf.openrocket.gui.customexpression;
 
+import java.awt.Color;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -15,10 +16,12 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
+import javax.swing.border.Border;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.gui.util.SwingPreferences;
+import net.sf.openrocket.gui.util.UITheme;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +45,13 @@ public class CustomExpressionPanel extends JPanel {
 
 	private JPanel expressionSelectorPanel;
 	private OpenRocketDocument doc;
-	
+
+	private static Border border;
+
+	static {
+		initColors();
+	}
+
 	public CustomExpressionPanel(final OpenRocketDocument doc, final JDialog parentDialog) {
 		super(new MigLayout("fill"));
 		this.doc = doc;
@@ -51,7 +60,7 @@ public class CustomExpressionPanel extends JPanel {
 		expressionSelectorPanel.setToolTipText(trans.get("customExpressionPanel.lbl.CalcNote"));
 		
 		JScrollPane scroll = new JScrollPane(expressionSelectorPanel);
-		expressionSelectorPanel.setBorder(GUIUtil.getUITheme().getBorder());
+		expressionSelectorPanel.setBorder(border);
 		
 		//Border bdr = BorderFactory.createTitledBorder(trans.get("customExpressionPanel.lbl.CustomExpressions"));
 		//scroll.setBorder(bdr);
@@ -131,7 +140,16 @@ public class CustomExpressionPanel extends JPanel {
 		
 		updateExpressions();
 	}
-	
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(CustomExpressionPanel::updateColors);
+	}
+
+	private static void updateColors() {
+		border = GUIUtil.getUITheme().getBorder();
+	}
+
 	/*
 	 * Update the expressionSelectorPanel
 	 */
@@ -171,10 +189,24 @@ public class CustomExpressionPanel extends JPanel {
 	 * A JPanel which configures a single expression
 	 */
 	private class SingleExpression extends JPanel {
+		private static Color backgroundColor;
+
+		private static void initColors() {
+			updateColors();
+			UITheme.Theme.addUIThemeChangeListener(SingleExpression::updateColors);
+		}
+
+		static {
+			initColors();
+		}
+
+		private static void updateColors() {
+			backgroundColor = GUIUtil.getUITheme().getBackgroundColor();
+		}
 
 		// Convenience method to make the labels consistent
 		private JLabel setLabelStyle(JLabel l) {
-			l.setBackground(GUIUtil.getUITheme().getBackgroundColor());
+			l.setBackground(backgroundColor);
 			l.setOpaque(true);
 			l.setBorder(BorderFactory.createRaisedBevelBorder());
 			l.setText(" " + l.getText() + " ");
@@ -192,7 +224,7 @@ public class CustomExpressionPanel extends JPanel {
 			JLabel symbolLabel = new JLabel(trans.get("customExpression.Symbol") + " :");
 			JLabel symbol = new JLabel(expression.getSymbol());
 			symbol = setLabelStyle(symbol);
-			symbol.setBackground(GUIUtil.getUITheme().getBackgroundColor());
+			symbol.setBackground(backgroundColor);
 			
 			JLabel unitLabel = new JLabel(trans.get("customExpression.Units") + " :");
 			UnitSelector unitSelector = new UnitSelector(expression.getType().getUnitGroup());

--- a/swing/src/net/sf/openrocket/gui/dialogs/BugReportDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/BugReportDialog.java
@@ -29,6 +29,7 @@ import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.components.URLLabel;
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.gui.util.SwingPreferences;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.logging.LogLevelBufferLogger;
 import net.sf.openrocket.logging.LogLine;
@@ -47,6 +48,12 @@ public class BugReportDialog extends JDialog {
 	
 	private static final Translator trans = Application.getTranslator();
 	private static final SwingPreferences preferences = (SwingPreferences) Application.getPreferences();
+
+	private static Color darkWarningColor;
+
+	static {
+		initColors();
+	}
 	
 	
 	public BugReportDialog(Window parent, String labelText, final String message, final boolean sendIfUnchanged) {
@@ -102,6 +109,15 @@ public class BugReportDialog extends JDialog {
 		this.setLocationRelativeTo(parent);
 		
 		GUIUtil.setDisposableDialogOptions(this, close);
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(BugReportDialog::updateColors);
+	}
+
+	private static void updateColors() {
+		darkWarningColor = GUIUtil.getUITheme().getDarkWarningColor();
 	}
 	
 	/**
@@ -178,7 +194,7 @@ public class BugReportDialog extends JDialog {
 	private static void addBugReportInformation(StringBuilder sb) {
 		sb.append("<html>---------- Bug report ----------\n");
 		sb.append('\n');
-		Color color = GUIUtil.getUITheme().getDarkWarningColor();
+		Color color = darkWarningColor;
 		sb.append(String.format("<b style='color:rgb(%d, %d, %d)'>Please include a description about what actions you were " +
 				"performing when the exception occurred:</b>\n", color.getRed(), color.getGreen(), color.getBlue()));
 		sb.append("<i>(You can edit text directly in this window)</i>\n");

--- a/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
@@ -33,6 +33,7 @@ import javax.swing.ListSelectionModel;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
+import javax.swing.border.Border;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.table.DefaultTableCellRenderer;
@@ -41,6 +42,7 @@ import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.aerodynamics.AerodynamicCalculator;
 import net.sf.openrocket.aerodynamics.AerodynamicForces;
 import net.sf.openrocket.aerodynamics.FlightConditions;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.logging.Warning;
 import net.sf.openrocket.logging.WarningSet;
 import net.sf.openrocket.gui.adaptors.Column;
@@ -97,6 +99,12 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 	private final List<AerodynamicForces> dragData = new ArrayList<AerodynamicForces>();
 	private final List<AerodynamicForces> rollData = new ArrayList<AerodynamicForces>();
 
+	private static Border border;
+
+	static {
+		initColors();
+	}
+
 
 	public ComponentAnalysisDialog(final RocketPanel rocketPanel) {
 		////Component analysis
@@ -150,7 +158,7 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 
 		warningList = new JList<>();
 		JScrollPane scrollPane = new JScrollPane(warningList);
-		warningList.setBorder(GUIUtil.getUITheme().getBorder());
+		warningList.setBorder(border);
 		////Warnings:
 		scrollPane.setBorder(BorderFactory.createTitledBorder(trans.get("componentanalysisdlg.TitledBorder.warnings")));
 		panel.add(scrollPane, "gap paragraph, spany 4, w 300lp, grow, height :100lp:, wrap");
@@ -499,6 +507,14 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 	}
 
 
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(ComponentAnalysisDialog::updateColors);
+	}
+
+	private static void updateColors() {
+		border = GUIUtil.getUITheme().getBorder();
+	}
 
 	/**
 	 * Updates the data in the table and fires a table data change event.
@@ -626,12 +642,27 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 		private final List<?> data;
 		protected final int decimalPlaces;
 
+		private static Color backgroundColor;
+
+		static {
+			initColors();
+		}
+
 		public CustomCellRenderer(List<?> data, int decimalPlaces) {
 			super();
 			this.decimalPlaces = decimalPlaces;
 			this.data = data;
 			this.normalFont = getFont();
 			this.boldFont = normalFont.deriveFont(Font.BOLD);
+		}
+
+		private static void initColors() {
+			updateColors();
+			UITheme.Theme.addUIThemeChangeListener(CustomCellRenderer::updateColors);
+		}
+
+		private static void updateColors() {
+			backgroundColor = GUIUtil.getUITheme().getBackgroundColor();
 		}
 
 		@Override
@@ -647,7 +678,7 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 			}
 
 			label.setOpaque(true);
-			label.setBackground(GUIUtil.getUITheme().getBackgroundColor());
+			label.setBackground(backgroundColor);
 			label.setHorizontalAlignment(SwingConstants.LEFT);
 
 			if ((row < 0) || (row >= data.size()))

--- a/swing/src/net/sf/openrocket/gui/dialogs/DebugLogDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/DebugLogDialog.java
@@ -32,12 +32,14 @@ import javax.swing.ListSelectionModel;
 import javax.swing.RowFilter;
 import javax.swing.SwingUtilities;
 import javax.swing.Timer;
+import javax.swing.border.Border;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
 
+import net.sf.openrocket.gui.util.UITheme;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,6 +111,12 @@ public class DebugLogDialog extends JDialog {
 	private final SelectableLabel locationLabel;
 	private final SelectableLabel messageLabel;
 	private final JTextArea stackTraceLabel;
+
+	private static Border border;
+
+	static {
+		initColors();
+	}
 	
 	public DebugLogDialog(Window parent) {
 		//// OpenRocket debug log
@@ -343,7 +351,7 @@ public class DebugLogDialog extends JDialog {
 		bottomPanel.add(new JLabel(trans.get("debuglogdlg.lbl.Stacktrace")), "wrap rel");
 		stackTraceLabel = new JTextArea(8, 80);
 		stackTraceLabel.setEditable(false);
-		stackTraceLabel.setBorder(GUIUtil.getUITheme().getBorder());
+		stackTraceLabel.setBorder(border);
 		GUIUtil.changeFontSize(stackTraceLabel, -2);
 		bottomPanel.add(new JScrollPane(stackTraceLabel), "grow, pushy 200, growprioy 200");
 		
@@ -385,7 +393,16 @@ public class DebugLogDialog extends JDialog {
 		setLocationRelativeTo(parent);
 		followBox.requestFocus();
 	}
-	
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(DebugLogDialog::updateColors);
+	}
+
+	private static void updateColors() {
+		border = GUIUtil.getUITheme().getBorder();
+	}
+
 	private void updateSelected(int row) {
 		if (row < 0) {
 			

--- a/swing/src/net/sf/openrocket/gui/dialogs/ErrorWarningDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/ErrorWarningDialog.java
@@ -4,6 +4,7 @@ import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.util.BetterListCellRenderer;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.logging.Error;
 import net.sf.openrocket.logging.ErrorSet;
 import net.sf.openrocket.logging.Warning;
@@ -16,6 +17,8 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSeparator;
 import javax.swing.ListSelectionModel;
+import javax.swing.border.Border;
+import java.awt.Color;
 import java.awt.Component;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -25,12 +28,30 @@ import java.awt.event.MouseEvent;
  */
 @SuppressWarnings("serial")
 public abstract class ErrorWarningDialog {
+    private static Border border;
+    private static Color darkWarningColor;
+    private static Color textSelectionForegroundColor;
+
+    static {
+        initColors();
+    }
+
+    private static void initColors() {
+        updateColors();
+        UITheme.Theme.addUIThemeChangeListener(ErrorWarningDialog::updateColors);
+    }
+
+    private static void updateColors() {
+        border = GUIUtil.getUITheme().getBorder();
+        darkWarningColor = GUIUtil.getUITheme().getDarkWarningColor();
+        textSelectionForegroundColor = GUIUtil.getUITheme().getTextSelectionForegroundColor();
+    }
 
     public static void showErrorsAndWarnings(Component parent, Object message, String title, ErrorSet errors, WarningSet warnings) {
         JPanel content = new JPanel(new MigLayout("ins 0, fillx"));
 
         StyledLabel label = new StyledLabel("Errors");
-        label.setFontColor(GUIUtil.getUITheme().getDarkWarningColor());
+        label.setFontColor(darkWarningColor);
         content.add(label, "wrap, gaptop 15lp");
 
         Error[] e = errors.toArray(new Error[0]);
@@ -38,7 +59,7 @@ public abstract class ErrorWarningDialog {
         errorList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         errorList.setCellRenderer(new ErrorListCellRenderer());
         JScrollPane errorPane = new JScrollPane(errorList);
-        errorList.setBorder(GUIUtil.getUITheme().getBorder());
+        errorList.setBorder(border);
         content.add(errorPane, "wrap, growx");
 
         // Deselect items if clicked on blank region
@@ -60,7 +81,7 @@ public abstract class ErrorWarningDialog {
         final JList<Warning> warningList = new JList<>(w);
         warningList.setCellRenderer(new BetterListCellRenderer());
         JScrollPane warningPane = new JScrollPane(warningList);
-        warningList.setBorder(GUIUtil.getUITheme().getBorder());
+        warningList.setBorder(border);
         content.add(warningPane, "wrap, growx");
 
         // Deselect items if clicked on blank region
@@ -87,9 +108,9 @@ public abstract class ErrorWarningDialog {
 
             // Text color
             if (isSelected) {
-                label.setForeground(GUIUtil.getUITheme().getTextSelectionForegroundColor());
+                label.setForeground(textSelectionForegroundColor);
             } else {
-                label.setForeground(GUIUtil.getUITheme().getDarkWarningColor());
+                label.setForeground(darkWarningColor);
             }
 
             return label;

--- a/swing/src/net/sf/openrocket/gui/dialogs/UpdateInfoDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/UpdateInfoDialog.java
@@ -1,5 +1,6 @@
 package net.sf.openrocket.gui.dialogs;
 
+import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Insets;
@@ -32,6 +33,7 @@ import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.gui.util.Icons;
 import net.sf.openrocket.gui.util.SwingPreferences;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.gui.util.URLUtil;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.startup.Application;
@@ -50,6 +52,12 @@ public class UpdateInfoDialog extends JDialog {
 	private static final Logger log = LoggerFactory.getLogger(UpdateInfoDialog.class);
 	private static final Translator trans = Application.getTranslator();
 	private final SwingPreferences preferences = (SwingPreferences) Application.getPreferences();
+
+	private static Color textColor;
+
+	static {
+		initColors();
+	}
 
 	public UpdateInfoDialog(UpdateInfo info) {
 		//// OpenRocket update available
@@ -74,7 +82,7 @@ public class UpdateInfoDialog extends JDialog {
 
 		// Release information box
 		final JTextPane textPane = new JTextPane();
-		textPane.setBorder(BorderFactory.createLineBorder(GUIUtil.getUITheme().getTextColor()));
+		textPane.setBorder(BorderFactory.createLineBorder(textColor));
 		textPane.setEditable(false);
 		textPane.setContentType("text/html");
 		textPane.setMargin(new Insets(10, 10, 40, 10));
@@ -199,6 +207,15 @@ public class UpdateInfoDialog extends JDialog {
 		this.pack();
 		this.setLocationRelativeTo(null);
 		GUIUtil.setDisposableDialogOptions(this, btnLater);
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(UpdateInfoDialog::updateColors);
+	}
+
+	private static void updateColors() {
+		textColor = GUIUtil.getUITheme().getTextColor();
 	}
 
 	/**

--- a/swing/src/net/sf/openrocket/gui/dialogs/WarningDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/WarningDialog.java
@@ -6,21 +6,37 @@ import javax.swing.BorderFactory;
 import javax.swing.JList;
 import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
+import javax.swing.border.Border;
 
 import net.sf.openrocket.gui.util.BetterListCellRenderer;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.logging.Warning;
 import net.sf.openrocket.logging.WarningSet;
 
 @SuppressWarnings("serial")
 public abstract class WarningDialog {
+	private static Border border;
+
+	static {
+		initColors();
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(WarningDialog::updateColors);
+	}
+
+	private static void updateColors() {
+		border = GUIUtil.getUITheme().getBorder();
+	}
+
 	public static void showWarnings(Component parent, Object message, String title, WarningSet warnings) {
-		
 		Warning[] w = warnings.toArray(new Warning[0]);
 		final JList<Warning> list = new JList<Warning>(w);
 		list.setCellRenderer(new BetterListCellRenderer());
 		JScrollPane pane = new JScrollPane(list);
-		pane.setBorder(GUIUtil.getUITheme().getBorder());
+		pane.setBorder(border);
 		
 		JOptionPane.showMessageDialog(parent, new Object[] { message, pane }, 
 				title, JOptionPane.WARNING_MESSAGE);

--- a/swing/src/net/sf/openrocket/gui/dialogs/WelcomeDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/WelcomeDialog.java
@@ -4,6 +4,7 @@ import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.gui.util.Icons;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.gui.util.URLUtil;
 import net.sf.openrocket.gui.widgets.SelectColorButton;
 import net.sf.openrocket.l10n.Translator;
@@ -20,9 +21,9 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextPane;
+import javax.swing.border.Border;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
-import java.awt.Desktop;
 import java.awt.Dimension;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
@@ -34,6 +35,12 @@ import java.awt.event.ActionListener;
 public class WelcomeDialog extends JDialog {
     private static final Translator trans = Application.getTranslator();
     private static final Logger log = LoggerFactory.getLogger(WelcomeDialog.class);
+
+    private static Border border;
+
+    static {
+        initColors();
+    }
 
     /**
      * @param releaseNotes the release notes to display for the current version
@@ -82,7 +89,7 @@ public class WelcomeDialog extends JDialog {
         textPane.setCaretPosition(0);	// Scroll to the top
 
         JScrollPane scrollPane = new JScrollPane(textPane);
-        scrollPane.setBorder(GUIUtil.getUITheme().getBorder());
+        scrollPane.setBorder(border);
         panel.add(scrollPane, "skip 1, left, spanx, grow, push, gapbottom 6px, wrap");
 
         // Don't show this dialog again
@@ -113,5 +120,14 @@ public class WelcomeDialog extends JDialog {
         this.pack();
         this.setLocationRelativeTo(null);
         GUIUtil.setDisposableDialogOptions(this, closeBtn);
+    }
+
+    private static void initColors() {
+        updateColors();
+        UITheme.Theme.addUIThemeChangeListener(WelcomeDialog::updateColors);
+    }
+
+    private static void updateColors() {
+        border = GUIUtil.getUITheme().getBorder();
     }
 }

--- a/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/RenameConfigDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/flightconfiguration/RenameConfigDialog.java
@@ -1,5 +1,6 @@
 package net.sf.openrocket.gui.dialogs.flightconfiguration;
 
+import java.awt.Color;
 import java.awt.Dialog;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
@@ -15,6 +16,7 @@ import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.configdialog.CommonStrings;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.rocketcomponent.FlightConfigurationId;
 import net.sf.openrocket.rocketcomponent.Rocket;
@@ -24,6 +26,12 @@ import net.sf.openrocket.gui.widgets.SelectColorButton;
 public class RenameConfigDialog extends JDialog {
 	private static final long serialVersionUID = -5423008694485357248L;
 	private static final Translator trans = Application.getTranslator();
+
+	private static Color dimTextColor;
+
+	static {
+		initColors();
+	}
 
 	public RenameConfigDialog(final Window parent, final Rocket rocket, final FlightConfigurationId fcid) {
 		super(parent, trans.get("RenameConfigDialog.title"), Dialog.ModalityType.APPLICATION_MODAL);
@@ -73,11 +81,20 @@ public class RenameConfigDialog extends JDialog {
 				+ trans.get("RenameConfigDialog.lbl.infoCases")
 				+ trans.get("RenameConfigDialog.lbl.infoCombination");
 		StyledLabel info = new StyledLabel(text, -2);
-		info.setFontColor(GUIUtil.getUITheme().getDimTextColor());
+		info.setFontColor(dimTextColor);
 		panel.add(info, "spanx, growx, wrap");
 		
 		this.add(panel);
 		
 		GUIUtil.setDisposableDialogOptions(this, okButton);
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(RenameConfigDialog::updateColors);
+	}
+
+	private static void updateColors() {
+		dimTextColor = GUIUtil.getUITheme().getDimTextColor();
 	}
 }

--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/MotorFilterPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/MotorFilterPanel.java
@@ -34,6 +34,7 @@ import net.sf.openrocket.gui.components.UnitSelector;
 import net.sf.openrocket.gui.util.CheckList;
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.gui.util.SwingPreferences;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.gui.widgets.MultiSlider;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.motor.Manufacturer;
@@ -118,6 +119,12 @@ public abstract class MotorFilterPanel extends JPanel {
 	private final MultiSlider lengthSlider;
 	private final MultiSlider diameterSlider;
 
+	private static Border border;
+
+	static {
+		initColors();
+	}
+
 	public MotorFilterPanel(Collection<Manufacturer> allManufacturers, MotorRowFilter filter ) {
 		super(new MigLayout("fill", "[grow]"));
 		this.filter = filter;
@@ -146,7 +153,7 @@ public abstract class MotorFilterPanel extends JPanel {
 
 		// Manufacturer selection
 		JPanel sub = new JPanel(new MigLayout("fill"));
-		Border templateBorder = GUIUtil.getUITheme().getBorder();
+		Border templateBorder = border;
 		TitledBorder border = BorderFactory.createTitledBorder(templateBorder);
 		border.setTitle(trans.get("TCurveMotorCol.MANUFACTURER"));
 		GUIUtil.changeFontStyle(border, Font.BOLD);
@@ -186,9 +193,8 @@ public abstract class MotorFilterPanel extends JPanel {
 		});
 
 		JScrollPane scrollPane = new JScrollPane(manufacturerCheckList.getList());
-		Border border1 = GUIUtil.getUITheme().getBorder();
-		if (border1 != null) {
-			scrollPane.setBorder(border1);
+		if (border != null) {
+			scrollPane.setBorder(border);
 		}
 		sub.add(scrollPane, "grow, pushy, wrap");
 
@@ -366,6 +372,15 @@ public abstract class MotorFilterPanel extends JPanel {
 		}
 		this.add(sub, "grow,wrap");
 
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(MotorFilterPanel::updateColors);
+	}
+
+	private static void updateColors() {
+		border = GUIUtil.getUITheme().getBorder();
 	}
 
 	public void setMotorMount( MotorMount mount ) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/MotorInformationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/MotorInformationPanel.java
@@ -15,7 +15,9 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
+import javax.swing.border.Border;
 
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.util.StringUtils;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartPanel;
@@ -42,8 +44,10 @@ class MotorInformationPanel extends JPanel {
 	private static final int ZOOM_ICON_POSITION_NEGATIVE_X = 50;
 	private static final int ZOOM_ICON_POSITION_POSITIVE_Y = 12;
 
-	private static final Color NO_COMMENT_COLOR = GUIUtil.getUITheme().getDimTextColor();
-	private static final Color WITH_COMMENT_COLOR = GUIUtil.getUITheme().getTextColor();
+	private static Color NO_COMMENT_COLOR;
+	private static Color WITH_COMMENT_COLOR;
+	private static Color textColor;
+	private static Border border;
 
 	// Motors in set
 	private List<ThrustCurveMotor> selectedMotorSet;
@@ -73,6 +77,10 @@ class MotorInformationPanel extends JPanel {
 	private final JFreeChart chart;
 	private final ChartPanel chartPanel;
 	private final JLabel zoomIcon;
+
+	static {
+		initColors();
+	}
 
 	public MotorInformationPanel() {
 		super(new MigLayout("fill"));
@@ -159,7 +167,7 @@ class MotorInformationPanel extends JPanel {
 
 
 			comment = new JTextArea(5, 5);
-			comment.setBorder(GUIUtil.getUITheme().getBorder());
+			comment.setBorder(border);
 			GUIUtil.changeFontSize(comment, -2);
 			withCommentFont = comment.getFont();
 			noCommentFont = withCommentFont.deriveFont(Font.ITALIC);
@@ -191,7 +199,7 @@ class MotorInformationPanel extends JPanel {
 
 			//// Thrust curve:
 			TextTitle title = new TextTitle(trans.get("TCMotorSelPan.title.Thrustcurve"), this.getFont());
-			title.setPaint(GUIUtil.getUITheme().getTextColor());
+			title.setPaint(textColor);
 			chart.setTitle(title);
 			chart.setBackgroundPaint(this.getBackground());
 			plot.setBackgroundPaint(Color.WHITE);
@@ -238,6 +246,18 @@ class MotorInformationPanel extends JPanel {
 
 			this.add(layer, "width 300:300:, height 180:180:, grow, spanx");
 		}
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(MotorInformationPanel::updateColors);
+	}
+
+	private static void updateColors() {
+		NO_COMMENT_COLOR = GUIUtil.getUITheme().getDimTextColor();
+		WITH_COMMENT_COLOR = GUIUtil.getUITheme().getTextColor();
+		textColor = GUIUtil.getUITheme().getTextColor();
+		border = GUIUtil.getUITheme().getBorder();
 	}
 	
 	public void clearData() {

--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorSelectionPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorSelectionPanel.java
@@ -111,6 +111,12 @@ public class ThrustCurveMotorSelectionPanel extends JPanel implements MotorSelec
 	private ThrustCurveMotorSet selectedMotorSet;
 	private double selectedDelay;
 
+	private static Color dimTextColor;
+
+	static {
+		initColors();
+	}
+
 	public ThrustCurveMotorSelectionPanel( final FlightConfigurationId fcid, MotorMount mount ) {
 		this();
 		setMotorMountAndConfig( fcid, mount );
@@ -336,7 +342,7 @@ public class ThrustCurveMotorSelectionPanel extends JPanel implements MotorSelec
 			nrOfMotorsLabel = new StyledLabel(-2f, StyledLabel.Style.ITALIC);
 			nrOfMotorsLabel.setToolTipText(trans.get("TCMotorSelPan.lbl.ttip.nrOfMotors"));
 			updateNrOfMotors();
-			nrOfMotorsLabel.setForeground(GUIUtil.getUITheme().getDimTextColor());
+			nrOfMotorsLabel.setForeground(dimTextColor);
 			panel.add(nrOfMotorsLabel, "gapleft para, spanx, wrap");
 			sorter.addRowSorterListener(new RowSorterListener() {
 				@Override
@@ -398,6 +404,15 @@ public class ThrustCurveMotorSelectionPanel extends JPanel implements MotorSelec
 		hideUnavailableBox.getActionListeners()[0].actionPerformed(null);
 		hideSimilarBox.getActionListeners()[0].actionPerformed(null);
 
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(ThrustCurveMotorSelectionPanel::updateColors);
+	}
+
+	private static void updateColors() {
+		dimTextColor = GUIUtil.getUITheme().getDimTextColor();
 	}
 
 	public void setMotorMountAndConfig( final FlightConfigurationId _fcid,  MotorMount mountToEdit ) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/optimization/SimulationModifierTree.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/optimization/SimulationModifierTree.java
@@ -1,5 +1,6 @@
 package net.sf.openrocket.gui.dialogs.optimization;
 
+import java.awt.Color;
 import java.awt.Component;
 import java.awt.Font;
 import java.util.Enumeration;
@@ -17,6 +18,7 @@ import javax.swing.tree.TreePath;
 import net.sf.openrocket.gui.components.BasicTree;
 import net.sf.openrocket.gui.main.ComponentIcons;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.optimization.rocketoptimization.SimulationModifier;
 import net.sf.openrocket.rocketcomponent.Rocket;
@@ -38,6 +40,15 @@ public class SimulationModifierTree extends BasicTree {
 	private final List<SimulationModifier> selectedModifiers;
 	private static final Translator trans = Application.getTranslator();
 
+	private static Color textColor;
+	private static Color dimTextColor;
+	private static Color textSelectionForegroundColor;
+	private static Color textSelectionBackgroundColor;
+
+	static {
+		initColors();
+	}
+
 	/**
 	 * Sole constructor.
 	 * 
@@ -56,6 +67,18 @@ public class SimulationModifierTree extends BasicTree {
 		ToolTipManager.sharedInstance().registerComponent(this);
 		
 		expandComponents();
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(SimulationModifierTree::updateColors);
+	}
+
+	private static void updateColors() {
+		textColor = GUIUtil.getUITheme().getTextColor();
+		dimTextColor = GUIUtil.getUITheme().getDimTextColor();
+		textSelectionForegroundColor = GUIUtil.getUITheme().getTextSelectionForegroundColor();
+		textSelectionBackgroundColor = GUIUtil.getUITheme().getTextSelectionBackgroundColor();
 	}
 	
 	
@@ -157,7 +180,7 @@ public class SimulationModifierTree extends BasicTree {
 			
 			// Set text color/style
 			if (object instanceof RocketComponent) {
-				setForeground(GUIUtil.getUITheme().getDimTextColor());
+				setForeground(dimTextColor);
 				setFont(componentFont);
 				
 				// Set tooltip
@@ -171,21 +194,21 @@ public class SimulationModifierTree extends BasicTree {
 					this.setToolTipText(null);
 				}
 			} else if (object instanceof String) {
-				setForeground(GUIUtil.getUITheme().getDimTextColor());
+				setForeground(dimTextColor);
 				setFont(stringFont);
 			} else if (object instanceof SimulationModifier) {
 				
 				if (selectedModifiers.contains(object)) {
-					setForeground(GUIUtil.getUITheme().getDimTextColor());
+					setForeground(dimTextColor);
 					setFont(stringFont);
 				} else {
 					if (tree.getSelectionRows() != null &&
 							IntStream.of(tree.getSelectionRows()).anyMatch(r -> r == row)) {
-						setForeground(GUIUtil.getUITheme().getTextSelectionForegroundColor());
-						setBackground(GUIUtil.getUITheme().getTextSelectionBackgroundColor());
+						setForeground(textSelectionForegroundColor);
+						setBackground(textSelectionBackgroundColor);
 						setOpaque(true);
 					} else {
-						setForeground(GUIUtil.getUITheme().getTextColor());
+						setForeground(textColor);
 					}
 					setFont(modifierFont);
 				}

--- a/swing/src/net/sf/openrocket/gui/dialogs/preferences/LaunchPreferencesPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preferences/LaunchPreferencesPanel.java
@@ -1,5 +1,6 @@
 package net.sf.openrocket.gui.dialogs.preferences;
 
+import java.awt.Color;
 import java.awt.LayoutManager;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
@@ -24,6 +25,7 @@ import net.sf.openrocket.gui.components.BasicSlider;
 import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.components.UnitSelector;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.models.atmosphere.ExtendedISAModel;
 import net.sf.openrocket.simulation.SimulationOptions;
 import net.sf.openrocket.unit.UnitGroup;
@@ -31,6 +33,11 @@ import net.sf.openrocket.util.Chars;
 import net.sf.openrocket.util.StateChangeListener;
 
 public class LaunchPreferencesPanel extends PreferencesPanel {
+	private static Color darkWarningColor;
+
+	static {
+		initColors();
+	}
 
 	public LaunchPreferencesPanel(JDialog parent, LayoutManager layout) {
 		super(parent, layout);
@@ -44,7 +51,7 @@ public class LaunchPreferencesPanel extends PreferencesPanel {
 		StyledLabel warning = new StyledLabel(String.format(
 				"<html>%s</html>", trans.get("pref.dlg.lbl.launchWarning")),
 				0.5f, StyledLabel.Style.BOLD);
-		warning.setFontColor(GUIUtil.getUITheme().getDarkWarningColor());
+		warning.setFontColor(darkWarningColor);
 		warning.setToolTipText(trans.get("pref.dlg.lbl.launchWarning.ttip"));
 		add(warning, "spanx, growx 0, gapbottom para, wrap");
 
@@ -449,6 +456,15 @@ public class LaunchPreferencesPanel extends PreferencesPanel {
 		intoWind.addEnableComponent(unit, false);
 		intoWind.addEnableComponent(directionSlider, false);
 
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(LaunchPreferencesPanel::updateColors);
+	}
+
+	private static void updateColors() {
+		darkWarningColor = GUIUtil.getUITheme().getDarkWarningColor();
 	}
 
 	private String getIntensityDescription(double i) {

--- a/swing/src/net/sf/openrocket/gui/dialogs/preferences/SimulationPreferencesPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/preferences/SimulationPreferencesPanel.java
@@ -1,5 +1,6 @@
 package net.sf.openrocket.gui.dialogs.preferences;
 
+import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
@@ -18,6 +19,7 @@ import net.sf.openrocket.gui.components.BasicSlider;
 import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.components.UnitSelector;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.simulation.RK4SimulationStepper;
 import net.sf.openrocket.unit.UnitGroup;
 import net.sf.openrocket.util.GeodeticComputationStrategy;
@@ -25,6 +27,12 @@ import net.sf.openrocket.gui.widgets.SelectColorButton;
 
 public class SimulationPreferencesPanel extends PreferencesPanel {
 	private static final long serialVersionUID = 7983195730016979888L;
+
+	private static Color darkWarningColor;
+
+	static {
+		initColors();
+	}
 
 	/*
 	 * private GeodeticComputationStrategy geodeticComputation =
@@ -85,7 +93,7 @@ public class SimulationPreferencesPanel extends PreferencesPanel {
 		StyledLabel warning = new StyledLabel(String.format(
 				"<html>%s</html>", trans.get("pref.dlg.lbl.launchWarning")),
 				0, StyledLabel.Style.BOLD);
-		warning.setFontColor(GUIUtil.getUITheme().getDarkWarningColor());
+		warning.setFontColor(darkWarningColor);
 		warning.setToolTipText(trans.get("pref.dlg.lbl.launchWarning.ttip"));
 		subsub.add(warning, "spanx, wrap para");
 
@@ -294,4 +302,13 @@ public class SimulationPreferencesPanel extends PreferencesPanel {
 	 * public void fireContentsChanged() { super.fireContentsChanged(this, 0,
 	 * getSize()); } }
 	 */
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(SimulationPreferencesPanel::updateColors);
+	}
+
+	private static void updateColors() {
+		darkWarningColor = GUIUtil.getUITheme().getDarkWarningColor();
+	}
 }

--- a/swing/src/net/sf/openrocket/gui/figure3d/RocketFigure3d.java
+++ b/swing/src/net/sf/openrocket/gui/figure3d/RocketFigure3d.java
@@ -35,6 +35,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.event.MouseInputAdapter;
 
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,13 +99,19 @@ public class RocketFigure3d extends JPanel implements GLEventListener {
 	float[] lightPosition = new float[] { 1, 4, 1, 0 };
 	
 	RocketRenderer rr = new FigureRenderer();
+
+	private static Color backgroundColor;
+
+	static {
+		initColors();
+	}
 	
 	public RocketFigure3d(final OpenRocketDocument document) {
 		this.document = document;
 		this.rkt = document.getRocket();
 		this.setLayout(new BorderLayout());
-		
-		//Only initialize GL if 3d is enabled.
+
+		// Only initialize GL if 3d is enabled.
 		if (is3dEnabled()) {
 			//Fixes a linux / X bug: Splash must be closed before GL Init
 			SplashScreen splash = Splash.getSplashScreen();
@@ -113,6 +120,15 @@ public class RocketFigure3d extends JPanel implements GLEventListener {
 			
 			initGLCanvas();
 		}
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(RocketFigure3d::updateColors);
+	}
+
+	private static void updateColors() {
+		backgroundColor = GUIUtil.getUITheme().getBackgroundColor();
 	}
 	
 	public void flushTextureCaches() {
@@ -289,7 +305,6 @@ public class RocketFigure3d extends JPanel implements GLEventListener {
 		GL2 gl = drawable.getGL().getGL2();
 		GLU glu = new GLU();
 
-		Color backgroundColor = GUIUtil.getUITheme().getBackgroundColor();
 		gl.glClearColor(backgroundColor.getRed()/255f, backgroundColor.getGreen()/255f,
 				backgroundColor.getBlue()/255f, backgroundColor.getAlpha()/255f);
 		gl.glClear(GL.GL_COLOR_BUFFER_BIT | GL.GL_DEPTH_BUFFER_BIT);

--- a/swing/src/net/sf/openrocket/gui/figureelements/CGCaret.java
+++ b/swing/src/net/sf/openrocket/gui/figureelements/CGCaret.java
@@ -1,6 +1,7 @@
 package net.sf.openrocket.gui.figureelements;
 
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 
 import java.awt.Color;
 import java.awt.geom.Area;
@@ -19,11 +20,26 @@ public class CGCaret extends Caret {
 	
 	private static Area caret = null;
 
+	private static Color CGColor;
+
+	static {
+		initColors();
+	}
+
 	/**
 	 * Create a new CGCaret at the specified coordinates.
 	 */
 	public CGCaret(double x, double y) {
 		super(x,y);
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(CGCaret::updateColors);
+	}
+
+	private static void updateColors() {
+		CGColor = GUIUtil.getUITheme().getCGColor();
 	}
 
 	/**
@@ -58,7 +74,7 @@ public class CGCaret extends Caret {
 	 */
 	@Override
 	protected Color getColor() {
-		return GUIUtil.getUITheme().getCGColor();
+		return CGColor;
 	}
 
 }

--- a/swing/src/net/sf/openrocket/gui/figureelements/CPCaret.java
+++ b/swing/src/net/sf/openrocket/gui/figureelements/CPCaret.java
@@ -1,6 +1,7 @@
 package net.sf.openrocket.gui.figureelements;
 
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 
 import java.awt.Color;
 import java.awt.geom.Area;
@@ -18,11 +19,26 @@ public class CPCaret extends Caret {
 	
 	private static Area caret = null;
 
+	private static Color CPColor;
+
+	static {
+		initColors();
+	}
+
 	/**
 	 * Create a new CPCaret at the specified coordinates.
 	 */
 	public CPCaret(double x, double y) {
 		super(x,y);
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(CPCaret::updateColors);
+	}
+
+	private static void updateColors() {
+		CPColor = GUIUtil.getUITheme().getCPColor();
 	}
 
 	/**
@@ -53,6 +69,6 @@ public class CPCaret extends Caret {
 	 */
 	@Override
 	protected Color getColor() {
-		return GUIUtil.getUITheme().getCPColor();
+		return CPColor;
 	}
 }

--- a/swing/src/net/sf/openrocket/gui/figureelements/RocketInfo.java
+++ b/swing/src/net/sf/openrocket/gui/figureelements/RocketInfo.java
@@ -3,6 +3,7 @@ package net.sf.openrocket.gui.figureelements;
 import static net.sf.openrocket.util.Chars.ALPHA;
 import static net.sf.openrocket.util.Chars.THETA;
 
+import java.awt.Color;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
@@ -12,6 +13,7 @@ import java.awt.geom.Rectangle2D;
 
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.gui.util.SwingPreferences;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.logging.Warning;
 import net.sf.openrocket.logging.WarningSet;
 import net.sf.openrocket.l10n.Translator;
@@ -64,12 +66,34 @@ public class RocketInfo implements FigureElement {
 	private Graphics2D g2 = null;
 	private float line = 0;
 	private float x1, x2, y1, y2;
-	
+
+	private static Color textColor;
+	private static Color dimTextColor;
+	private static Color warningColor;
+	private static Color flightDataTextActiveColor;
+	private static Color flightDataTextInactiveColor;
+
+	static {
+		initColors();
+	}
 	
 	public RocketInfo(FlightConfiguration configuration) {
 		this.configuration = configuration;
 		this.stabilityUnits = UnitGroup.stabilityUnits(configuration);
 		this.secondaryStabilityUnits = UnitGroup.secondaryStabilityUnits(configuration);
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(RocketInfo::updateColors);
+	}
+
+	private static void updateColors() {
+		textColor = GUIUtil.getUITheme().getTextColor();
+		dimTextColor = GUIUtil.getUITheme().getDimTextColor();
+		warningColor = GUIUtil.getUITheme().getWarningColor();
+		flightDataTextActiveColor = GUIUtil.getUITheme().getFlightDataTextActiveColor();
+		flightDataTextInactiveColor = GUIUtil.getUITheme().getFlightDataTextInactiveColor();
 	}
 	
 	
@@ -176,7 +200,7 @@ public class RocketInfo implements FigureElement {
 
 		GlyphVector massLineWithoutMotors = createText(massTextWithoutMotors);
 
-		g2.setColor(GUIUtil.getUITheme().getTextColor());
+		g2.setColor(textColor);
 
 		g2.drawGlyphVector(name, x1, y1);
 		g2.drawGlyphVector(lengthLine, x1, y1+line);
@@ -234,7 +258,7 @@ public class RocketInfo implements FigureElement {
 		unitWidth = unitWidth + spaceWidth;
 		stabUnitWidth = stabUnitWidth + spaceWidth;
 
-		g2.setColor(GUIUtil.getUITheme().getTextColor());
+		g2.setColor(textColor);
 
 		// Draw the stability, CG & CP values (and units)
 		g2.drawGlyphVector(stabValue, (float)(x2-stabRect.getWidth()), y1);
@@ -261,7 +285,7 @@ public class RocketInfo implements FigureElement {
 			atPos = (float)(x2 - atTextRect.getWidth());
 		}
 		
-		g2.setColor(GUIUtil.getUITheme().getDimTextColor());
+		g2.setColor(dimTextColor);
 		g2.drawGlyphVector(atText, atPos, y1 + 3*line);
 
 	}
@@ -411,7 +435,7 @@ public class RocketInfo implements FigureElement {
 		
 
 		float y = y2 - line * (texts.length-1);
-		g2.setColor(GUIUtil.getUITheme().getWarningColor());
+		g2.setColor(warningColor);
 
 		for (GlyphVector v: texts) {
 			Rectangle2D rect = v.getVisualBounds();
@@ -427,7 +451,7 @@ public class RocketInfo implements FigureElement {
 		if (calculatingData) {
 			//// Calculating...
 			GlyphVector calculating = createText(trans.get("RocketInfo.Calculating"));
-			g2.setColor(GUIUtil.getUITheme().getTextColor());
+			g2.setColor(textColor);
 			g2.drawGlyphVector(calculating, x1, (float)(y2-height));
 		}
 	}
@@ -485,17 +509,17 @@ public class RocketInfo implements FigureElement {
 		width += 5;
 
 		if (!calculatingData) 
-			g2.setColor(GUIUtil.getUITheme().getFlightDataTextActiveColor());
+			g2.setColor(flightDataTextActiveColor);
 		else
-			g2.setColor(GUIUtil.getUITheme().getFlightDataTextInactiveColor());
+			g2.setColor(flightDataTextInactiveColor);
 
-		g2.drawGlyphVector(apogee, (float)x1, (float)(y2-2*line));
-		g2.drawGlyphVector(maxVelocity, (float)x1, (float)(y2-line));
-		g2.drawGlyphVector(maxAcceleration, (float)x1, (float)(y2));
+		g2.drawGlyphVector(apogee, x1, y2-2*line);
+		g2.drawGlyphVector(maxVelocity, x1, y2-line);
+		g2.drawGlyphVector(maxAcceleration, x1, y2);
 
-		g2.drawGlyphVector(apogeeValue, (float)(x1+width), (float)(y2-2*line));
-		g2.drawGlyphVector(velocityValue, (float)(x1+width), (float)(y2-line));
-		g2.drawGlyphVector(accelerationValue, (float)(x1+width), (float)(y2));
+		g2.drawGlyphVector(apogeeValue, (float)(x1+width), y2-2*line);
+		g2.drawGlyphVector(velocityValue, (float)(x1+width), y2-line);
+		g2.drawGlyphVector(accelerationValue, (float)(x1+width), y2);
 		
 		return 3*line;
 	}

--- a/swing/src/net/sf/openrocket/gui/help/tours/SlideSetManager.java
+++ b/swing/src/net/sf/openrocket/gui/help/tours/SlideSetManager.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import javax.swing.text.html.StyleSheet;
 
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.util.BugException;
 
 /**
@@ -32,7 +33,12 @@ public class SlideSetManager {
 	
 	private final String baseDir;
 	private final Map<String, SlideSet> slideSets = new LinkedHashMap<String, SlideSet>();
-	
+
+	private static Color textColor;
+
+	static {
+		initColors();
+	}
 	
 	/**
 	 * Sole constructor.
@@ -44,6 +50,15 @@ public class SlideSetManager {
 			baseDir = baseDir + "/";
 		}
 		this.baseDir = baseDir;
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(SlideSetManager::updateColors);
+	}
+
+	private static void updateColors() {
+		textColor = GUIUtil.getUITheme().getTextColor();
 	}
 	
 	
@@ -132,7 +147,6 @@ public class SlideSetManager {
 		try {
 			
 			StyleSheet ss = new StyleSheet();
-			Color textColor = GUIUtil.getUITheme().getTextColor();
 			ss.addRule(String.format("p { color: rgb(%d, %d, %d, %d)",
 					textColor.getRed(), textColor.getGreen(), textColor.getBlue(), textColor.getAlpha()));
 			InputStreamReader reader = new InputStreamReader(in, "UTF-8");

--- a/swing/src/net/sf/openrocket/gui/help/tours/SlideShowComponent.java
+++ b/swing/src/net/sf/openrocket/gui/help/tours/SlideShowComponent.java
@@ -7,12 +7,14 @@ import javax.swing.JEditorPane;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
 import javax.swing.JTextPane;
+import javax.swing.border.Border;
 import javax.swing.event.HyperlinkListener;
 import javax.swing.text.html.HTMLDocument;
 import javax.swing.text.html.StyleSheet;
 
 import net.sf.openrocket.gui.components.ImageDisplayComponent;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 
 /**
  * Component that displays a single slide, with the image on top and
@@ -30,10 +32,16 @@ public class SlideShowComponent extends JSplitPane {
 	private final ImageDisplayComponent imageDisplay;
 	private final JEditorPane textPane;
 
+	private static Border border;
+
+	static {
+		initColors();
+	}
+
 	
 	public SlideShowComponent() {
 		super(VERTICAL_SPLIT);
-		
+
 		imageDisplay = new ImageDisplayComponent();
 		imageDisplay.setPreferredSize(new Dimension(WIDTH, HEIGHT_IMAGE));
 		this.setLeftComponent(imageDisplay);
@@ -45,10 +53,19 @@ public class SlideShowComponent extends JSplitPane {
 		textPane.setPreferredSize(new Dimension(WIDTH, HEIGHT_TEXT));
 		
 		JScrollPane scrollPanel = new JScrollPane(textPane);
-		textPane.setBorder(GUIUtil.getUITheme().getBorder());
+		textPane.setBorder(border);
 		this.setRightComponent(scrollPanel);
 		
 		this.setResizeWeight(((double) HEIGHT_IMAGE) / (HEIGHT_IMAGE + HEIGHT_TEXT));
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(SlideShowComponent::updateColors);
+	}
+
+	private static void updateColors() {
+		border = GUIUtil.getUITheme().getBorder();
 	}
 	
 	

--- a/swing/src/net/sf/openrocket/gui/main/DesignPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/DesignPanel.java
@@ -5,6 +5,7 @@ import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.gui.configdialog.ComponentConfigDialog;
 import net.sf.openrocket.gui.main.componenttree.ComponentTree;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.gui.widgets.IconButton;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.rocketcomponent.AxialStage;
@@ -24,6 +25,7 @@ import javax.swing.KeyStroke;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
+import javax.swing.border.Border;
 import javax.swing.border.TitledBorder;
 import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
@@ -50,6 +52,12 @@ import static net.sf.openrocket.gui.main.BasicFrame.SHORTCUT_KEY;
 public class DesignPanel extends JSplitPane {
     private static final Translator trans = Application.getTranslator();
     private final Component tree;
+
+    private static Border border;
+
+    static {
+        initColors();
+    }
 
     public DesignPanel(final BasicFrame parent, final OpenRocketDocument document, final ComponentTree tree) {
         super(JSplitPane.HORIZONTAL_SPLIT, true);
@@ -174,7 +182,7 @@ public class DesignPanel extends JSplitPane {
 
         // Place tree inside scroll pane
         JScrollPane scroll = new JScrollPane(tree);
-        tree.setBorder(GUIUtil.getUITheme().getBorder());
+        tree.setBorder(border);
         panel.add(scroll, "spany, wmin 140px, grow, wrap");
 
 
@@ -228,6 +236,15 @@ public class DesignPanel extends JSplitPane {
         panel.add(scroll, "grow");
 
         this.setRightComponent(panel);
+    }
+
+    private static void initColors() {
+        updateColors();
+        UITheme.Theme.addUIThemeChangeListener(DesignPanel::updateColors);
+    }
+
+    private static void updateColors() {
+        border = GUIUtil.getUITheme().getBorder();
     }
 
     /**

--- a/swing/src/net/sf/openrocket/gui/main/componenttree/ComponentTreeRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/main/componenttree/ComponentTreeRenderer.java
@@ -1,12 +1,14 @@
 package net.sf.openrocket.gui.main.componenttree;
 
 import java.awt.BorderLayout;
+import java.awt.Color;
 import java.awt.Component;
 import java.awt.FlowLayout;
 import java.awt.Font;
 import java.util.List;
 
 import javax.swing.BorderFactory;
+import javax.swing.Icon;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -18,6 +20,7 @@ import javax.swing.tree.TreePath;
 
 import net.sf.openrocket.gui.main.ComponentIcons;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.rocketcomponent.MassComponent;
 import net.sf.openrocket.rocketcomponent.MassComponent.MassComponentType;
@@ -31,6 +34,21 @@ import net.sf.openrocket.util.TextUtil;
 public class ComponentTreeRenderer extends DefaultTreeCellRenderer {
 
 	private static final Translator trans = Application.getTranslator();
+	
+	private static Color textSelectionBackgroundColor;
+	private static Color textSelectionForegroundColor;
+	private static Color componentTreeBackgroundColor;
+	private static Color componentTreeForegroundColor;
+	private static Icon massOverrideSubcomponentIcon;
+	private static Icon massOverrideIcon;
+	private static Icon CGOverrideSubcomponentIcon;
+	private static Icon CGOverrideIcon;
+	private static Icon CDOverrideSubcomponentIcon;
+	private static Icon CDOverrideIcon;
+
+	static {
+		initColors();
+	}
 
 	@Override
 	public Component getTreeCellRendererComponent(JTree tree, Object value,
@@ -81,12 +99,12 @@ public class ComponentTreeRenderer extends DefaultTreeCellRenderer {
 		// Set the background and foreground colors of the text JLabel
 		if (sel) {
 			textLabel.setOpaque(true);
-			textLabel.setBackground(GUIUtil.getUITheme().getTextSelectionBackgroundColor());
-			textLabel.setForeground(GUIUtil.getUITheme().getTextSelectionForegroundColor());
+			textLabel.setBackground(textSelectionBackgroundColor);
+			textLabel.setForeground(textSelectionForegroundColor);
 		} else {
 			textLabel.setOpaque(true); // Set this to true to allow the background color to be visible
-			textLabel.setBackground(GUIUtil.getUITheme().getComponentTreeBackgroundColor());
-			textLabel.setForeground(GUIUtil.getUITheme().getComponentTreeForegroundColor());
+			textLabel.setBackground(componentTreeBackgroundColor);
+			textLabel.setForeground(componentTreeForegroundColor);
 		}
 
 		applyToolTipText(components, c, panel);
@@ -99,23 +117,23 @@ public class ComponentTreeRenderer extends DefaultTreeCellRenderer {
 				c.isCDOverridden() || c.getCDOverriddenBy() != null) {
 			JPanel p = new JPanel();
 			p.setLayout(new FlowLayout(FlowLayout.LEFT, 1, 1));
-			p.setBackground(GUIUtil.getUITheme().getComponentTreeBackgroundColor());
-			p.setForeground(GUIUtil.getUITheme().getComponentTreeForegroundColor());
+			p.setBackground(componentTreeBackgroundColor);
+			p.setForeground(componentTreeForegroundColor);
 			p.add(comp/* , BorderLayout.WEST */);
 			if (c.getMassOverriddenBy() != null) {
-				p.add(new JLabel(GUIUtil.getUITheme().getMassOverrideSubcomponentIcon()));
+				p.add(new JLabel(massOverrideSubcomponentIcon));
 			} else if (c.isMassOverridden()) {
-				p.add(new JLabel(GUIUtil.getUITheme().getMassOverrideIcon()));
+				p.add(new JLabel(massOverrideIcon));
 			}
 			if (c.getCGOverriddenBy() != null) {
-				p.add(new JLabel(GUIUtil.getUITheme().getCGOverrideSubcomponentIcon()));
+				p.add(new JLabel(CGOverrideSubcomponentIcon));
 			} else if (c.isCGOverridden()) {
-				p.add(new JLabel(GUIUtil.getUITheme().getCGOverrideIcon()));
+				p.add(new JLabel(CGOverrideIcon));
 			}
 			if (c.getCDOverriddenBy() != null) {
-				p.add(new JLabel(GUIUtil.getUITheme().getCDOverrideSubcomponentIcon()));
+				p.add(new JLabel(CDOverrideSubcomponentIcon));
 			} else if (c.isCDOverridden()) {
-				p.add(new JLabel(GUIUtil.getUITheme().getCDOverrideIcon()));
+				p.add(new JLabel(CDOverrideIcon));
 			}
 			
 			// Make sure the tooltip also works on the override icons
@@ -129,6 +147,25 @@ public class ComponentTreeRenderer extends DefaultTreeCellRenderer {
 		applyToolTipText(components, c, this);
 
 		return comp;
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(ComponentTreeRenderer::updateColors);
+	}
+	
+	private static void updateColors() {
+		textSelectionBackgroundColor = GUIUtil.getUITheme().getTextSelectionBackgroundColor();
+		textSelectionForegroundColor = GUIUtil.getUITheme().getTextSelectionForegroundColor();
+		componentTreeBackgroundColor = GUIUtil.getUITheme().getComponentTreeBackgroundColor();
+		componentTreeForegroundColor = GUIUtil.getUITheme().getComponentTreeForegroundColor();
+
+		massOverrideSubcomponentIcon = GUIUtil.getUITheme().getMassOverrideSubcomponentIcon();
+		massOverrideIcon = GUIUtil.getUITheme().getMassOverrideIcon();
+		CGOverrideSubcomponentIcon = GUIUtil.getUITheme().getCGOverrideSubcomponentIcon();
+		CGOverrideIcon = GUIUtil.getUITheme().getCGOverrideIcon();
+		CDOverrideSubcomponentIcon = GUIUtil.getUITheme().getCDOverrideSubcomponentIcon();
+		CDOverrideIcon = GUIUtil.getUITheme().getCDOverrideIcon();
 	}
 
 	private void applyToolTipText(List<RocketComponent> components, RocketComponent c, JComponent comp) {

--- a/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/flightconfigpanel/FlightConfigurablePanel.java
@@ -25,6 +25,7 @@ import javax.swing.table.DefaultTableCellRenderer;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.gui.main.FlightConfigurationPanel;
 import net.sf.openrocket.gui.util.SwingPreferences;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.util.ArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,6 +56,13 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 	protected final OpenRocketDocument document;
 	protected final Rocket rocket;
 	protected final JTable table;
+
+	private static Color textColor;
+	private static Color dimTextColor;
+
+	static {
+		initColors();
+	}
 	
 	public FlightConfigurablePanel(final FlightConfigurationPanel flightConfigurationPanel, OpenRocketDocument document, Rocket rocket) {
 		super(new MigLayout("fill"));
@@ -65,6 +73,16 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 
 		installTableListener();
 		synchronizeConfigurationSelection();
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(FlightConfigurablePanel::updateColors);
+	}
+
+	private static void updateColors() {
+		textColor = GUIUtil.getUITheme().getTextColor();
+		dimTextColor = GUIUtil.getUITheme().getDimTextColor();
 	}
 
 	/**
@@ -400,14 +418,14 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 			c.setBorder(b);
 		}
 
-		protected final void shaded(JLabel label) {
-			GUIUtil.changeFontStyle(label, Font.ITALIC);
-			label.setForeground(GUIUtil.getUITheme().getDimTextColor());
-		}
-
 		protected final void regular(JLabel label) {
 			GUIUtil.changeFontStyle(label, Font.PLAIN);
-			label.setForeground(GUIUtil.getUITheme().getTextColor());
+			label.setForeground(textColor);
+		}
+
+		protected final void shaded(JLabel label) {
+			GUIUtil.changeFontStyle(label, Font.ITALIC);
+			label.setForeground(dimTextColor);
 		}
 
 		protected abstract JLabel format( T component, FlightConfigurationId configId, JLabel label );

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlotDialog.java
@@ -1,5 +1,6 @@
 package net.sf.openrocket.gui.plot;
 
+import java.awt.Color;
 import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -24,6 +25,7 @@ import net.sf.openrocket.gui.util.FileHelper;
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.gui.util.Icons;
 import net.sf.openrocket.gui.util.SwingPreferences;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.gui.widgets.SaveFileChooser;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.simulation.FlightDataType;
@@ -42,6 +44,12 @@ import org.jfree.chart.JFreeChart;
  */
 public class SimulationPlotDialog extends JDialog {
 	private static final Translator trans = Application.getTranslator();
+
+	private static Color darkWarningColor;
+
+	static {
+		initColors();
+	}
 
 	private SimulationPlotDialog(Window parent, Simulation simulation, PlotConfiguration config) {
 		//// Flight data plot
@@ -73,7 +81,7 @@ public class SimulationPlotDialog extends JDialog {
 		// Add warning if X axis type is not time
 		if (config.getDomainAxisType() != FlightDataType.TYPE_TIME) {
 			JLabel msg = new StyledLabel(trans.get("PlotDialog.lbl.timeSeriesWarning"), -2);
-			msg.setForeground(GUIUtil.getUITheme().getDarkWarningColor());
+			msg.setForeground(darkWarningColor);
 			panel.add(msg, "wrap");
 		}
 		
@@ -155,7 +163,7 @@ public class SimulationPlotDialog extends JDialog {
 		button.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				doPngExport(chartPanel,jChart);
+				doPNGExport(chartPanel,jChart);
 			}
 		});
 		panel.add(button, "gapleft rel");
@@ -178,7 +186,16 @@ public class SimulationPlotDialog extends JDialog {
 		GUIUtil.rememberWindowPosition(this);
 	}
 
-	private boolean doPngExport(ChartPanel chartPanel, JFreeChart chart){
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(SimulationPlotDialog::updateColors);
+	}
+
+	private static void updateColors() {
+		darkWarningColor = GUIUtil.getUITheme().getDarkWarningColor();
+	}
+
+	private boolean doPNGExport(ChartPanel chartPanel, JFreeChart chart){
 		JFileChooser chooser = new SaveFileChooser();
 		chooser.setAcceptAllFileFilterUsed(false);
 		chooser.setFileFilter(FileHelper.PNG_FILTER);

--- a/swing/src/net/sf/openrocket/gui/scalefigure/AbstractScaleFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/AbstractScaleFigure.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 import javax.swing.JPanel;
 
+import net.sf.openrocket.gui.util.UITheme;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +55,12 @@ public abstract class AbstractScaleFigure extends JPanel {
 	protected AffineTransform projection = null;
 
 	protected final List<EventListener> listeners = new LinkedList<EventListener>();
+
+	private static Color backgroundColor;
+
+	static {
+		initColors();
+	}
 	
 	
 	public AbstractScaleFigure() {
@@ -70,8 +77,17 @@ public abstract class AbstractScaleFigure extends JPanel {
 		this.setPreferredSize(new Dimension(100,100));
 		setSize(100,100);
 
-		setBackground(GUIUtil.getUITheme().getBackgroundColor());
+		setBackground(backgroundColor);
 		setOpaque(true);
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(AbstractScaleFigure::updateColors);
+	}
+
+	private static void updateColors() {
+		backgroundColor = GUIUtil.getUITheme().getBackgroundColor();
 	}
 
 	public int getBorderHeight(){ return borderThickness_px.height; }

--- a/swing/src/net/sf/openrocket/gui/scalefigure/FinPointFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/FinPointFigure.java
@@ -1,6 +1,7 @@
 package net.sf.openrocket.gui.scalefigure;
 
 import java.awt.BasicStroke;
+import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Point;
@@ -56,6 +57,12 @@ public class FinPointFigure extends AbstractScaleFigure {
 
 	private Rectangle2D.Double[] finPointHandles = null;
 	private int selectedIndex = -1;
+
+	private static Color finPointBodyLineColor;
+	private static Color finPointGridMajorLineColor;
+	private static Color finPointGridMinorLineColor;
+	private static Color finPointPointColor;
+	private static Color finPointSelectedPointColor;
 	
 	public FinPointFigure(FreeformFinSet finset) {
 		this.finset = finset;
@@ -63,7 +70,16 @@ public class FinPointFigure extends AbstractScaleFigure {
 		setBackground(GUIUtil.getUITheme().getBackgroundColor());
 		setOpaque(true);
 
+		updateColors();
 		updateFigure();
+	}
+
+	private static void updateColors() {
+		finPointBodyLineColor = GUIUtil.getUITheme().getFinPointBodyLineColor();
+		finPointGridMajorLineColor = GUIUtil.getUITheme().getFinPointGridMajorLineColor();
+		finPointGridMinorLineColor = GUIUtil.getUITheme().getFinPointGridMinorLineColor();
+		finPointPointColor = GUIUtil.getUITheme().getFinPointPointColor();
+		finPointSelectedPointColor = GUIUtil.getUITheme().getFinPointSelectedPointColor();
 	}
 
 	@Override
@@ -122,11 +138,11 @@ public class FinPointFigure extends AbstractScaleFigure {
 		Line2D.Double line = new Line2D.Double();
 		for (Tick t : verticalTicks) {
 			if (t.major) {
-				g2.setColor(GUIUtil.getUITheme().getFinPointGridMajorLineColor());
+				g2.setColor(finPointGridMajorLineColor);
 				line.setLine( t.value, y0, t.value, y1);
 				g2.draw(line);
 			}else{
-				g2.setColor(GUIUtil.getUITheme().getFinPointGridMinorLineColor());
+				g2.setColor(finPointGridMinorLineColor);
 				line.setLine( t.value, y0, t.value, y1);
 				g2.draw(line);
 			}
@@ -136,11 +152,11 @@ public class FinPointFigure extends AbstractScaleFigure {
 		Tick[] horizontalTicks = unit.getTicks(y0, y1, MINOR_TICKS / this.scale, MAJOR_TICKS / this.scale);
 		for (Tick t : horizontalTicks) {
 			if (t.major) {
-				g2.setColor(GUIUtil.getUITheme().getFinPointGridMajorLineColor());
+				g2.setColor(finPointGridMajorLineColor);
 				line.setLine( x0, t.value, x1, t.value);
 				g2.draw(line);
 			}else{
-				g2.setColor(GUIUtil.getUITheme().getFinPointGridMinorLineColor());
+				g2.setColor(finPointGridMinorLineColor);
 				line.setLine( x0, t.value, x1, t.value);
 				g2.draw(line);
 			}
@@ -163,7 +179,7 @@ public class FinPointFigure extends AbstractScaleFigure {
 		// setup lines
 		final float bodyLineWidth = (float) ( LINE_WIDTH_BODY_PIXELS / scale );
 		g2.setStroke(new BasicStroke( bodyLineWidth, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL));
-		g2.setColor(GUIUtil.getUITheme().getFinPointBodyLineColor());
+		g2.setColor(finPointBodyLineColor);
 
 		Transition body = (Transition) finset.getParent();
 		final float xResolution_m = 0.01f; // distance between draw points, in meters
@@ -213,7 +229,7 @@ public class FinPointFigure extends AbstractScaleFigure {
 
 		final float bodyLineWidth = (float) ( LINE_WIDTH_BODY_PIXELS / scale );
 		g2.setStroke(new BasicStroke( bodyLineWidth, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL));
-		g2.setColor(GUIUtil.getUITheme().getFinPointBodyLineColor());
+		g2.setColor(finPointBodyLineColor);
 		g2.draw(shape);
 	}
 
@@ -230,12 +246,12 @@ public class FinPointFigure extends AbstractScaleFigure {
 
 		final float finEdgeWidth_m = (float) (LINE_WIDTH_FIN_PIXELS / scale  );
 		g2.setStroke(new BasicStroke( finEdgeWidth_m, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL));
-		g2.setColor(GUIUtil.getUITheme().getFinPointBodyLineColor());
+		g2.setColor(finPointBodyLineColor);
 		g2.draw(shape);
 	}
 	
 	private void paintFinHandles(final Graphics2D g2) {
-		// excludes fin tab points
+		// Excludes fin tab points
 		final Coordinate[] drawPoints = finset.getFinPoints();
 
 		// Fin point boxes
@@ -244,7 +260,7 @@ public class FinPointFigure extends AbstractScaleFigure {
 
 		final float boxEdgeWidth_m = (float) ( LINE_WIDTH_BOX_PIXELS / scale );
 		g2.setStroke(new BasicStroke( boxEdgeWidth_m, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL));
-		g2.setColor(GUIUtil.getUITheme().getFinPointPointColor());
+		g2.setColor(finPointPointColor);
 
 		finPointHandles = new Rectangle2D.Double[ drawPoints.length];
 		for (int currentIndex = 0; currentIndex < drawPoints.length; currentIndex++) {
@@ -256,15 +272,15 @@ public class FinPointFigure extends AbstractScaleFigure {
 
 				final Rectangle2D.Double selectedPointHighlight = new Rectangle2D.Double(c.x - selBoxHalfWidth, c.y - selBoxHalfWidth, selBoxWidth, selBoxWidth);
 
-				// switch to the highlight color
-				g2.setColor(GUIUtil.getUITheme().getFinPointSelectedPointColor());
+				// Switch to the highlight color
+				g2.setColor(finPointSelectedPointColor);
 				g2.draw(selectedPointHighlight);
 
-				// reset to the normal color
-				g2.setColor(GUIUtil.getUITheme().getFinPointPointColor());
+				// Reset to the normal color
+				g2.setColor(finPointPointColor);
 			}
 
-			// normal boxes
+			// Normal boxes
 			finPointHandles[currentIndex] = new Rectangle2D.Double(c.x - boxHalfWidth, c.y - boxHalfWidth, boxWidth, boxWidth);
 
 			g2.draw(finPointHandles[currentIndex]);

--- a/swing/src/net/sf/openrocket/gui/scalefigure/FinPointFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/FinPointFigure.java
@@ -16,6 +16,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.rocketcomponent.FreeformFinSet;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.rocketcomponent.SymmetricComponent;
@@ -58,23 +59,33 @@ public class FinPointFigure extends AbstractScaleFigure {
 	private Rectangle2D.Double[] finPointHandles = null;
 	private int selectedIndex = -1;
 
+	private static Color backgroundColor;
 	private static Color finPointBodyLineColor;
 	private static Color finPointGridMajorLineColor;
 	private static Color finPointGridMinorLineColor;
 	private static Color finPointPointColor;
 	private static Color finPointSelectedPointColor;
+
+	static {
+		initColors();
+	}
 	
 	public FinPointFigure(FreeformFinSet finset) {
 		this.finset = finset;
 
-		setBackground(GUIUtil.getUITheme().getBackgroundColor());
+		setBackground(backgroundColor);
 		setOpaque(true);
 
-		updateColors();
 		updateFigure();
 	}
 
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(FinPointFigure::updateColors);
+	}
+
 	private static void updateColors() {
+		backgroundColor = GUIUtil.getUITheme().getBackgroundColor();
 		finPointBodyLineColor = GUIUtil.getUITheme().getFinPointBodyLineColor();
 		finPointGridMajorLineColor = GUIUtil.getUITheme().getFinPointGridMajorLineColor();
 		finPointGridMinorLineColor = GUIUtil.getUITheme().getFinPointGridMinorLineColor();

--- a/swing/src/net/sf/openrocket/gui/scalefigure/RocketFigure.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/RocketFigure.java
@@ -18,6 +18,7 @@ import java.util.*;
 import java.util.Map.Entry;
 
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.rocketcomponent.AxialStage;
 import net.sf.openrocket.rocketcomponent.ParallelStage;
 import net.sf.openrocket.rocketcomponent.PodSet;
@@ -93,6 +94,13 @@ public class RocketFigure extends AbstractScaleFigure {
 	
 	private final ArrayList<FigureElement> relativeExtra = new ArrayList<FigureElement>();
 	private final ArrayList<FigureElement> absoluteExtra = new ArrayList<FigureElement>();
+
+	private static Color motorFillColor;
+	private static Color motorBorderColor;
+
+	static {
+		initColors();
+	}
 	
 	
 	/**
@@ -106,6 +114,16 @@ public class RocketFigure extends AbstractScaleFigure {
 		this.axialRotation = Transformation.rotate_x(0.0);
 
 		updateFigure();
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(RocketFigure::updateColors);
+	}
+
+	private static void updateColors() {
+		motorFillColor = GUIUtil.getUITheme().getMotorFillColor();
+		motorBorderColor = GUIUtil.getUITheme().getMotorBorderColor();
 	}
 
 	public Point getAutoZoomPoint(){
@@ -291,8 +309,8 @@ public class RocketFigure extends AbstractScaleFigure {
 				RenderingHints.VALUE_STROKE_NORMALIZE);
 	
 		// Draw motors
-		Color fillColor = GUIUtil.getUITheme().getMotorFillColor();
-		Color borderColor = GUIUtil.getUITheme().getMotorBorderColor();
+		Color fillColor = motorFillColor;
+		Color borderColor = motorBorderColor;
 
 		FlightConfiguration config = rocket.getSelectedConfiguration();
 		for (MotorConfiguration curInstance : config.getActiveMotors()) {

--- a/swing/src/net/sf/openrocket/gui/scalefigure/ScaleScrollPane.java
+++ b/swing/src/net/sf/openrocket/gui/scalefigure/ScaleScrollPane.java
@@ -26,6 +26,7 @@ import javax.swing.event.ChangeListener;
 import net.sf.openrocket.gui.adaptors.DoubleModel;
 import net.sf.openrocket.gui.components.UnitSelector;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.unit.Tick;
 import net.sf.openrocket.unit.Unit;
 import net.sf.openrocket.unit.UnitGroup;
@@ -72,6 +73,12 @@ public class ScaleScrollPane extends JScrollPane
 
 	private Point2D.Double viewCenter_frac = new Point2D.Double(0.5f, 0.5f);
 
+	private static Color textColor;
+
+	static {
+		initColors();
+	}
+
 	/**
 	 * Create a scale scroll pane.
 	 * 
@@ -83,7 +90,7 @@ public class ScaleScrollPane extends JScrollPane
 		if (!(component instanceof AbstractScaleFigure)) {
 			throw new IllegalArgumentException("component must implement ScaleFigure");
 		}
-		
+
 		this.component = component;
 		this.figure = (AbstractScaleFigure) component;
 
@@ -126,6 +133,15 @@ public class ScaleScrollPane extends JScrollPane
 		viewport.addMouseListener(this);
 		viewport.addMouseMotionListener(this);
 		viewport.addComponentListener(this);
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(ScaleScrollPane::updateColors);
+	}
+
+	private static void updateColors() {
+		textColor = GUIUtil.getUITheme().getTextColor();
 	}
 	
 	public AbstractScaleFigure getFigure() {
@@ -399,7 +415,7 @@ public class ScaleScrollPane extends JScrollPane
             }
 			
 			// Set color & hints
-			g2.setColor(GUIUtil.getUITheme().getTextColor());
+			g2.setColor(textColor);
 			g2.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL,
 					RenderingHints.VALUE_STROKE_NORMALIZE);
 			g2.setRenderingHint(RenderingHints.KEY_RENDERING,

--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationEditDialog.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationEditDialog.java
@@ -33,6 +33,7 @@ import net.sf.openrocket.document.events.DocumentChangeEvent;
 import net.sf.openrocket.gui.components.ConfigurationComboBox;
 import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.gui.widgets.SelectColorButton;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.rocketcomponent.FlightConfiguration;
@@ -61,6 +62,12 @@ public class SimulationEditDialog extends JDialog {
 	private final boolean initialIsSaved;		// Whether the document was saved before the dialog was opened
 	private boolean isModified = false;			// Whether the simulation has been modified
 	private final boolean isNewSimulation;		// Whether you are editing a new simulation, or an existing one
+
+	private static Color multiCompEditColor;
+
+	static {
+		initColors();
+	}
 	
 	public SimulationEditDialog(Window parent, final OpenRocketDocument document, boolean isNewSimulation, Simulation... sims) {
 		//// Edit simulation
@@ -101,6 +108,15 @@ public class SimulationEditDialog extends JDialog {
 		this.addWindowListener(applyChangesToSimsListener);
 		
 		GUIUtil.setDisposableDialogOptions(this, null);
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(SimulationEditDialog::updateColors);
+	}
+
+	private static void updateColors() {
+		multiCompEditColor = GUIUtil.getUITheme().getMultiCompEditColor();
 	}
 	
 	private boolean isSingleEdit() {
@@ -247,7 +263,7 @@ public class SimulationEditDialog extends JDialog {
 		//// Multi-simulation edit
 		if (simulationList.length > 1) {
 			StyledLabel multiSimEditLabel = new StyledLabel("", -1, StyledLabel.Style.BOLD);
-			multiSimEditLabel.setFontColor(new Color(170, 0, 100));
+			multiSimEditLabel.setFontColor(multiCompEditColor);
 			multiSimEditLabel.setText(trans.get("simedtdlg.title.MultiSimEdit"));
 			StringBuilder components = new StringBuilder(trans.get("simedtdlg.title.MultiSimEdit.ttip"));
 			for (int i = 0; i < simulationList.length; i++) {

--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationOptionsPanel.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationOptionsPanel.java
@@ -22,6 +22,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JSpinner;
 import javax.swing.MenuElement;
 import javax.swing.SwingUtilities;
+import javax.swing.border.Border;
 
 import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.document.OpenRocketDocument;
@@ -36,6 +37,7 @@ import net.sf.openrocket.gui.components.StyledLabel.Style;
 import net.sf.openrocket.gui.components.UnitSelector;
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.gui.util.Icons;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.simulation.RK4SimulationStepper;
 import net.sf.openrocket.simulation.SimulationOptions;
@@ -62,12 +64,19 @@ class SimulationOptionsPanel extends JPanel {
 	private JPanel currentExtensions;
 	final JPopupMenu extensionMenu;
 	JMenu extensionMenuCopyExtension;
+
+	private static Color textColor;
+	private static Border border;
+
+	static {
+		initColors();
+	}
 	
 	SimulationOptionsPanel(OpenRocketDocument document, final Simulation simulation) {
 		super(new MigLayout("fill"));
 		this.document = document;
 		this.simulation = simulation;
-		
+
 		final SimulationOptions conditions = simulation.getOptions();
 		
 		JPanel sub, subsub;
@@ -207,13 +216,23 @@ class SimulationOptionsPanel extends JPanel {
 		
 		currentExtensions = new JPanel(new MigLayout("fillx, gap 0 0, ins 0"));
 		JScrollPane scroll = new JScrollPane(currentExtensions);
-		currentExtensions.setBorder(GUIUtil.getUITheme().getBorder());
-		scroll.setForeground(GUIUtil.getUITheme().getTextColor());
+		currentExtensions.setBorder(border);
+		scroll.setForeground(textColor);
 		//  &#$%! scroll pane will not honor "growy"...
 		sub.add(scroll, "growx, growy, h 100%");
 		
 		updateCurrentExtensions();
 		
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(SimulationOptionsPanel::updateColors);
+	}
+
+	private static void updateColors() {
+		textColor = GUIUtil.getUITheme().getTextColor();
+		border = GUIUtil.getUITheme().getBorder();
 	}
 	
 	private JPopupMenu getExtensionMenu() {

--- a/swing/src/net/sf/openrocket/gui/simulation/SimulationPlotPanel.java
+++ b/swing/src/net/sf/openrocket/gui/simulation/SimulationPlotPanel.java
@@ -12,7 +12,6 @@ import javax.swing.BorderFactory;
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
-import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -20,6 +19,7 @@ import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
+import javax.swing.border.Border;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
@@ -33,6 +33,7 @@ import net.sf.openrocket.gui.plot.SimulationPlotDialog;
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.gui.util.Icons;
 import net.sf.openrocket.gui.util.SwingPreferences;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.simulation.FlightDataBranch;
 import net.sf.openrocket.simulation.FlightDataType;
@@ -40,7 +41,6 @@ import net.sf.openrocket.simulation.FlightEvent;
 import net.sf.openrocket.startup.Application;
 import net.sf.openrocket.startup.Preferences;
 import net.sf.openrocket.unit.Unit;
-import net.sf.openrocket.util.Color;
 import net.sf.openrocket.util.Utils;
 import net.sf.openrocket.gui.widgets.SelectColorButton;
 
@@ -107,11 +107,18 @@ public class SimulationPlotPanel extends JPanel {
 	
 	private int modifying = 0;
 
-	private DescriptionArea simPlotPanelDesc;	
+	private DescriptionArea simPlotPanelDesc;
+
+	private static java.awt.Color darkWarningColor;
+	private static Border border;
+
+	static {
+		initColors();
+	}
 	
 	public SimulationPlotPanel(final Simulation simulation) {
 		super(new MigLayout("fill"));
-		
+
 		this.simulation = simulation;
 		if (simulation.getSimulatedData() == null ||
 				simulation.getSimulatedData().getBranchCount() == 0) {
@@ -205,7 +212,7 @@ public class SimulationPlotPanel extends JPanel {
 		//// The data will be plotted in time order even if the X axis type is not time.
 		simPlotPanelDesc = new DescriptionArea("", 2, -2f, false);
 		simPlotPanelDesc.setVisible(false);
-		simPlotPanelDesc.setForeground(GUIUtil.getUITheme().getDarkWarningColor());
+		simPlotPanelDesc.setForeground(darkWarningColor);
 		simPlotPanelDesc.setViewportBorder(BorderFactory.createEmptyBorder());
 		this.add(simPlotPanelDesc, "width 1px, growx 1, wrap unrel");
 		
@@ -220,7 +227,7 @@ public class SimulationPlotPanel extends JPanel {
 		
 		typeSelectorPanel = new JPanel(new MigLayout("gapy rel"));
 		JScrollPane scroll = new JScrollPane(typeSelectorPanel);
-		scroll.setBorder(GUIUtil.getUITheme().getBorder());
+		scroll.setBorder(border);
 		this.add(scroll, "spany 3, height 10px, wmin 400lp, grow 100, gapright para");
 		
 		
@@ -377,6 +384,16 @@ public class SimulationPlotPanel extends JPanel {
 		this.add(button, "right");
 		*/
 		updatePlots();
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(SimulationPlotPanel::updateColors);
+	}
+
+	private static void updateColors() {
+		darkWarningColor = GUIUtil.getUITheme().getDarkWarningColor();
+		border = GUIUtil.getUITheme().getBorder();
 	}
 
 	private void updateStyleEventWidgets(JLabel styleEventMarker, JRadioButton radioVerticalMarker, JRadioButton radioIcon) {

--- a/swing/src/net/sf/openrocket/gui/util/BetterListCellRenderer.java
+++ b/swing/src/net/sf/openrocket/gui/util/BetterListCellRenderer.java
@@ -4,6 +4,7 @@ package net.sf.openrocket.gui.util;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.JLabel;
 import javax.swing.JList;
+import java.awt.Color;
 import java.awt.Component;
 
 /**
@@ -12,6 +13,14 @@ import java.awt.Component;
  * @author Sibo Van Gool <sibo.vangool@hotmail.com>
  */
 public class BetterListCellRenderer extends DefaultListCellRenderer {
+    private static Color rowBackgroundDarkerColor;
+    private static Color rowBackgroundLighterColor;
+    private static Color textSelectionForegroundColor;
+    private static Color textColor;
+
+    static {
+        initColors();
+    }
 
     @Override
     public Component getListCellRendererComponent(JList<?> list, Object value, int index,
@@ -21,17 +30,29 @@ public class BetterListCellRenderer extends DefaultListCellRenderer {
         // Alternating row colors
         if (!isSelected) {
             if (index % 2 == 0) {
-                label.setBackground(GUIUtil.getUITheme().getRowBackgroundDarkerColor());
+                label.setBackground(rowBackgroundDarkerColor);
             } else {
-                label.setBackground(GUIUtil.getUITheme().getRowBackgroundLighterColor());
+                label.setBackground(rowBackgroundLighterColor);
             }
         }
         // Text color
         if (isSelected) {
-            label.setForeground(GUIUtil.getUITheme().getTextSelectionForegroundColor());
+            label.setForeground(textSelectionForegroundColor);
         } else {
-            label.setForeground(GUIUtil.getUITheme().getTextColor());
+            label.setForeground(textColor);
         }
         return label;
+    }
+
+    private static void initColors() {
+        updateColors();
+        UITheme.Theme.addUIThemeChangeListener(BetterListCellRenderer::updateColors);
+    }
+
+    private static void updateColors() {
+        rowBackgroundDarkerColor = GUIUtil.getUITheme().getRowBackgroundDarkerColor();
+        rowBackgroundLighterColor = GUIUtil.getUITheme().getRowBackgroundLighterColor();
+        textSelectionForegroundColor = GUIUtil.getUITheme().getTextSelectionForegroundColor();
+        textColor = GUIUtil.getUITheme().getTextColor();
     }
 }

--- a/swing/src/net/sf/openrocket/gui/util/UITheme.java
+++ b/swing/src/net/sf/openrocket/gui/util/UITheme.java
@@ -18,8 +18,10 @@ import java.awt.Color;
 import java.awt.Font;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -83,6 +85,27 @@ public class UITheme {
         Border getBorder();
 
         void formatScriptTextArea(RSyntaxTextArea textArea);
+
+        // Static list of listeners
+        static List<Runnable> themeChangeListeners = new ArrayList<>();
+
+        // Static method to add a listener
+        static void addUIThemeChangeListener(Runnable listener) {
+            // TODO: implement this once you have implemented invalidation for each listener so that we don't get memory leaks
+            //themeChangeListeners.add(listener);
+        }
+
+        // Static method to remove a listener
+        static void removeUIThemeChangeListener(Runnable listener) {
+            themeChangeListeners.remove(listener);
+        }
+
+        // Static method to notify all listeners
+        static void notifyUIThemeChangeListeners() {
+            for (Runnable listener : themeChangeListeners) {
+                listener.run();
+            }
+        }
     }
 
     public static boolean isLightTheme(Theme theme) {
@@ -115,6 +138,9 @@ public class UITheme {
 
                 GUIUtil.setBestLAF();
                 setGlobalFontSize(prefs.getUIFontSize());
+
+                // After applying the theme settings, notify listeners
+                Theme.notifyUIThemeChangeListeners();
             }
 
             @Override
@@ -338,6 +364,9 @@ public class UITheme {
 
                 LafManager.install(new DarculaTheme());
                 setGlobalFontSize(prefs.getUIFontSize());
+
+                // After applying the theme settings, notify listeners
+                Theme.notifyUIThemeChangeListeners();
             }
 
             @Override

--- a/swing/src/net/sf/openrocket/gui/util/UITheme.java
+++ b/swing/src/net/sf/openrocket/gui/util/UITheme.java
@@ -45,6 +45,7 @@ public class UITheme {
         Color getRowBackgroundDarkerColor();
         Color getFlightDataTextActiveColor();
         Color getFlightDataTextInactiveColor();
+        Color getMultiCompEditColor();
 
         // Component colors
         String getDefaultBodyComponentColor();
@@ -206,6 +207,11 @@ public class UITheme {
             @Override
             public Color getFlightDataTextInactiveColor() {
             	return new Color(0,0,127,127);
+            }
+
+            @Override
+            public Color getMultiCompEditColor() {
+                return new Color(170, 0, 100);
             }
 
             @Override
@@ -432,6 +438,11 @@ public class UITheme {
             @Override
             public Color getFlightDataTextInactiveColor() {
                 return new Color(128, 166, 230, 127);
+            }
+
+            @Override
+            public Color getMultiCompEditColor() {
+                return new Color(222, 146, 176);
             }
 
             @Override
@@ -666,6 +677,11 @@ public class UITheme {
             @Override
             public Color getFlightDataTextInactiveColor() {
                 return getCurrentTheme().getFlightDataTextInactiveColor();
+            }
+
+            @Override
+            public Color getMultiCompEditColor() {
+                return getCurrentTheme().getMultiCompEditColor();
             }
 
             @Override

--- a/swing/src/net/sf/openrocket/simulation/extension/impl/JavaCodeConfigurator.java
+++ b/swing/src/net/sf/openrocket/simulation/extension/impl/JavaCodeConfigurator.java
@@ -10,10 +10,13 @@ import javax.swing.event.DocumentListener;
 import net.sf.openrocket.document.Simulation;
 import net.sf.openrocket.gui.components.StyledLabel;
 import net.sf.openrocket.gui.util.GUIUtil;
+import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.l10n.Translator;
 import net.sf.openrocket.plugin.Plugin;
 import net.sf.openrocket.simulation.extension.AbstractSwingSimulationExtensionConfigurator;
 import net.sf.openrocket.startup.Application;
+
+import java.awt.Color;
 
 @Plugin
 public class JavaCodeConfigurator extends AbstractSwingSimulationExtensionConfigurator<JavaCode> {
@@ -23,8 +26,23 @@ public class JavaCodeConfigurator extends AbstractSwingSimulationExtensionConfig
 
 	private static final Translator trans = Application.getTranslator();
 
+	private static Color darkWarningColor;
+
+	static {
+		initColors();
+	}
+
 	public JavaCodeConfigurator() {
 		super(JavaCode.class);
+	}
+
+	private static void initColors() {
+		updateColors();
+		UITheme.Theme.addUIThemeChangeListener(JavaCodeConfigurator::updateColors);
+	}
+
+	private static void updateColors() {
+		darkWarningColor = GUIUtil.getUITheme().getDarkWarningColor();
 	}
 	
 	@Override
@@ -35,7 +53,7 @@ public class JavaCodeConfigurator extends AbstractSwingSimulationExtensionConfig
 		classNameField = new JTextField(extension.getClassName());
 		panel.add(classNameField, "growx, wrap");
 		this.errorMsg = new StyledLabel();
-		errorMsg.setFontColor(GUIUtil.getUITheme().getDarkWarningColor());
+		errorMsg.setFontColor(darkWarningColor);
 		errorMsg.setVisible(false);
 		panel.add(errorMsg, "growx, wrap");
 


### PR DESCRIPTION
This PR fixes #2344. The issue was that the UI colors were fetched dynamically, which apparently caused a lot of computation (I think because the get color methods returned a new Color instance, so new Color objects kept being generated). With this PR, colors are cached.

So, everything works smooth again:

https://github.com/openrocket/openrocket/assets/11031519/e89387d4-def1-48bb-a335-71f4b0fcc511

