### PR TITLE
Add JVM arguments to fix 3D issue on Windows

### DIFF
--- a/install4j/23.09/openrocket-23.09.install4j
+++ b/install4j/23.09/openrocket-23.09.install4j
@@ -29,7 +29,7 @@
           <versionLine x="489" y="143" text="version ${compiler:sys.version}" fontSize="10" fontColor="255,255,255" />
         </text>
       </splashScreen>
-      <java mainClass="net.sf.openrocket.startup.OpenRocket">
+      <java mainClass="net.sf.openrocket.startup.OpenRocket" vmParameters="--add-exports java.base/java.lang=ALL-UNNAMED --add-exports java.desktop/sun.awt=ALL-UNNAMED --add-exports java.desktop/sun.java2d=ALL-UNNAMED">
         <classPath>
           <archive location="OpenRocket.jar" failOnError="false" />
         </classPath>


### PR DESCRIPTION
This PR adds the JVM arguments `--add-exports java.base/java.lang=ALL-UNNAMED --add-exports java.desktop/sun.awt=ALL-UNNAMED --add-exports java.desktop/sun.java2d=ALL-UNNAMED` to the install4j configuration which is a Q&D fix for #2336. See also https://github.com/jzy3d/jogl/issues/4.

Created a Windows installer and tested on my Windows machine, which did not throw the exception from #2336 anymore.