### PR TITLE
Fix 2353

### DIFF
--- a/core/src/net/sf/openrocket/file/openrocket/OpenRocketSaver.java
+++ b/core/src/net/sf/openrocket/file/openrocket/OpenRocketSaver.java
@@ -401,6 +401,8 @@ public class OpenRocketSaver extends RocketSaver {
 				str += " launchrodvelocity=\"" + TextUtil.doubleToString(data.getLaunchRodVelocity()) + "\"";
 			if (!Double.isNaN(data.getDeploymentVelocity()))
 				str += " deploymentvelocity=\"" + TextUtil.doubleToString(data.getDeploymentVelocity()) + "\"";
+			if (!Double.isNaN(data.getOptimumDelay()))
+				str += " optimumdelay=\"" + TextUtil.doubleToString(data.getOptimumDelay()) + "\"";
 			str += ">";
 			writeln(str);
 			indent++;

--- a/core/src/net/sf/openrocket/file/openrocket/importt/FlightDataHandler.java
+++ b/core/src/net/sf/openrocket/file/openrocket/importt/FlightDataHandler.java
@@ -104,6 +104,7 @@ class FlightDataHandler extends AbstractElementHandler {
 			double groundHitVelocity = Double.NaN;
 			double launchRodVelocity = Double.NaN;
 			double deploymentVelocity = Double.NaN;
+			double optimumDelay = Double.NaN;
 			
 			try {
 				maxAltitude = DocumentConfig.stringToDouble(attributes.get("maxaltitude"));
@@ -142,9 +143,13 @@ class FlightDataHandler extends AbstractElementHandler {
 				deploymentVelocity = DocumentConfig.stringToDouble(attributes.get("deploymentvelocity"));
 			} catch (NumberFormatException ignore) {
 			}
+			try {
+				optimumDelay = DocumentConfig.stringToDouble(attributes.get("optimumdelay"));
+			} catch (NumberFormatException ignore) {
+			}
 			
 			data = new FlightData(maxAltitude, maxVelocity, maxAcceleration, maxMach,
-					timeToApogee, flightTime, groundHitVelocity, launchRodVelocity, deploymentVelocity);
+					timeToApogee, flightTime, groundHitVelocity, launchRodVelocity, deploymentVelocity, optimumDelay);
 		}
 		
 		data.getWarningSet().addAll(warningSet);

--- a/core/src/net/sf/openrocket/simulation/FlightData.java
+++ b/core/src/net/sf/openrocket/simulation/FlightData.java
@@ -51,7 +51,7 @@ public class FlightData {
 	private double groundHitVelocity = Double.NaN;
 	private double launchRodVelocity = Double.NaN;
 	private double deploymentVelocity = Double.NaN;
-	
+	private double optimumDelay = Double.NaN;
 	
 	/**
 	 * Create a FlightData object with no content.  The resulting object is mutable.
@@ -74,10 +74,11 @@ public class FlightData {
 	 * @param groundHitVelocity		ground hit velocity.
 	 * @param launchRodVelocity     velocity at launch rod clearance
 	 * @param deploymentVelocity    velocity at deployment
+	 * @param optimumDelay          optimum motor ejection delay time
 	 */
 	public FlightData(double maxAltitude, double maxVelocity, double maxAcceleration,
 			double maxMachNumber, double timeToApogee, double flightTime,
-			double groundHitVelocity, double launchRodVelocity, double deploymentVelocity) {
+					  double groundHitVelocity, double launchRodVelocity, double deploymentVelocity, double optimumDelay) {
 		this.maxAltitude = maxAltitude;
 		this.maxVelocity = maxVelocity;
 		this.maxAcceleration = maxAcceleration;
@@ -87,6 +88,8 @@ public class FlightData {
 		this.groundHitVelocity = groundHitVelocity;
 		this.launchRodVelocity = launchRodVelocity;
 		this.deploymentVelocity = deploymentVelocity;
+		this.optimumDelay = optimumDelay;
+		System.out.println("optimum delay " + optimumDelay);
 	}
 	
 	
@@ -188,6 +191,10 @@ public class FlightData {
 		return deploymentVelocity;
 	}
 
+	public double getOptimumDelay() {
+		return optimumDelay;
+	}
+
 
 	/**
 	 * Calculate the max. altitude/velocity/acceleration, time to apogee, flight time
@@ -201,7 +208,6 @@ public class FlightData {
 		maxAltitude = branch.getMaximum(FlightDataType.TYPE_ALTITUDE);
 		maxVelocity = branch.getMaximum(FlightDataType.TYPE_VELOCITY_TOTAL);
 		maxMachNumber = branch.getMaximum(FlightDataType.TYPE_MACH_NUMBER);
-		
 		flightTime = branch.getLast(FlightDataType.TYPE_TIME);
 		
 		// Time to apogee
@@ -227,6 +233,7 @@ public class FlightData {
 		else
 			timeToApogee = Double.NaN;
 		
+		optimumDelay = branch.getOptimumDelay();
 
 		// Launch rod velocity + deployment velocity + ground hit velocity
 		for (FlightEvent event : branch.getEvents()) {
@@ -260,7 +267,8 @@ public class FlightData {
 				" timeToApogee=" + timeToApogee +
 				" flightTime=" + flightTime +
 				" groundHitVelocity=" + groundHitVelocity +
-				" launchRodVelocity=" + launchRodVelocity);
+				" launchRodVelocity=" + launchRodVelocity +
+				" optimumDelay=" + optimumDelay);
 	}
 	
 	

--- a/core/test/net/sf/openrocket/simulation/TestFlightData.java
+++ b/core/test/net/sf/openrocket/simulation/TestFlightData.java
@@ -52,11 +52,12 @@ public class TestFlightData {
 		double maxAltitude = 355.1;
 		double maxMachNumber = 0.31;
 		double timeToApogee = 7.96;
+		double optimumDelay = 5.2;
 		
 		FlightData data = new FlightData(maxAltitude, maxVelocity, maxAcceleration,
 				                         maxMachNumber, timeToApogee, flightTime,
 				                         groundHitVelocity, launchRodVelocity,
-				                         deploymentVelocity);
+				                         deploymentVelocity, optimumDelay);
 		
 		WarningSet warnings = data.getWarningSet();
 		assertNotNull(warnings);
@@ -71,6 +72,7 @@ public class TestFlightData {
 		assertEquals(maxAltitude, data.getMaxAltitude(), 0.00);
 		assertEquals(maxMachNumber, data.getMaxMachNumber(), 0.00);
 		assertEquals(timeToApogee, data.getTimeToApogee(), 0.00);
+		assertEquals(optimumDelay, data.getOptimumDelay(), 0.00);
 	}
 	
 	/**

--- a/swing/src/net/sf/openrocket/gui/main/SimulationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/main/SimulationPanel.java
@@ -1306,14 +1306,10 @@ public class SimulationPanel extends JPanel {
 								return null;
 
 							FlightData data = document.getSimulation(row).getSimulatedData();
-							if (data == null || data.getBranchCount() == 0)
+							if (data == null)
 								return null;
 
-							double val = data.getBranch(0).getOptimumDelay();
-							if (Double.isNaN(val)) {
-								return null;
-							}
-							return val;
+							return data.getOptimumDelay();
 						}
 					},
 


### PR DESCRIPTION
Instead of saving optimum delay in a simulations flight summary data, it was recalculated every time it was displayed. So, only saving flight summary data didn't save the optimal delay, and with no flight data branches saved in this circumstance it couldn't be recalculated. This puts it in the flight summary data, and saves it to and loads it from a .ork file

Fixes #2353