### PR TITLE
[#2385] Use plot colors for thrust curves

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/MotorInformationPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/MotorInformationPanel.java
@@ -48,6 +48,8 @@ class MotorInformationPanel extends JPanel {
 	private static Color WITH_COMMENT_COLOR;
 	private static Color textColor;
 	private static Color dimTextColor;
+	private static Color backgroundColor;
+	private static Color gridColor;
 	private static Border border;
 
 	// Motors in set
@@ -203,9 +205,9 @@ class MotorInformationPanel extends JPanel {
 			title.setPaint(textColor);
 			chart.setTitle(title);
 			chart.setBackgroundPaint(this.getBackground());
-			plot.setBackgroundPaint(Color.WHITE);
-			plot.setDomainGridlinePaint(Color.LIGHT_GRAY);
-			plot.setRangeGridlinePaint(Color.LIGHT_GRAY);
+			plot.setBackgroundPaint(backgroundColor);
+			plot.setDomainGridlinePaint(gridColor);
+			plot.setRangeGridlinePaint(gridColor);
 
 			chartPanel = new ChartPanel(chart,
 					false, // properties
@@ -259,6 +261,8 @@ class MotorInformationPanel extends JPanel {
 		WITH_COMMENT_COLOR = GUIUtil.getUITheme().getTextColor();
 		textColor = GUIUtil.getUITheme().getTextColor();
 		dimTextColor = GUIUtil.getUITheme().getDimTextColor();
+		backgroundColor = GUIUtil.getUITheme().getBackgroundColor();
+		gridColor = GUIUtil.getUITheme().getFinPointGridMajorLineColor();
 		border = GUIUtil.getUITheme().getBorder();
 	}
 	

--- a/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorSelectionPanel.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/motor/thrustcurve/ThrustCurveMotorSelectionPanel.java
@@ -2,7 +2,6 @@ package net.sf.openrocket.gui.dialogs.motor.thrustcurve;
 
 import java.awt.Color;
 import java.awt.Component;
-import java.awt.Font;
 import java.awt.Paint;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
@@ -45,6 +44,7 @@ import javax.swing.event.RowSorterListener;
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
 
+import net.sf.openrocket.gui.plot.Util;
 import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.util.StateChangeListener;
 import org.jfree.chart.ChartColor;
@@ -609,7 +609,7 @@ public class ThrustCurveMotorSelectionPanel extends JPanel implements MotorSelec
 
 
 	public static Color getColor(int index) {
-		Color color = (Color) CURVE_COLORS[index % CURVE_COLORS.length];
+		Color color = Util.getPlotColor(index);
 		if (UITheme.isLightTheme(GUIUtil.getUITheme())) {
 			return color;
 		} else {
@@ -752,16 +752,22 @@ public class ThrustCurveMotorSelectionPanel extends JPanel implements MotorSelec
 		public Component getListCellRendererComponent(JList<? extends MotorHolder> list, MotorHolder value, int index,
 				boolean isSelected, boolean cellHasFocus) {
 
-			Component c = renderer.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-			if (value instanceof MotorHolder) {
-				MotorHolder m = (MotorHolder) value;
-				c.setForeground(getColor(m.getIndex()));
+			JLabel label = (JLabel) renderer.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
+			if (value != null) {
+				Color color = getColor(value.getIndex());
+				if (isSelected || cellHasFocus) {
+					label.setBackground(color);
+					label.setOpaque(true);
+					Color fg = list.getBackground();
+					fg = new Color(fg.getRed(), fg.getGreen(), fg.getBlue());		// List background changes for some reason, so clone the color
+					label.setForeground(fg);
+				} else {
+					label.setBackground(list.getBackground());
+					label.setForeground(color);
+				}
 			}
 
-			return c;
+			return label;
 		}
-
 	}
-
-
 }

--- a/swing/src/net/sf/openrocket/gui/plot/SimulationPlot.java
+++ b/swing/src/net/sf/openrocket/gui/plot/SimulationPlot.java
@@ -240,13 +240,8 @@ public class SimulationPlot {
 		plot.setDomainGridlinesVisible(true);
 		plot.setDomainGridlinePaint(Color.lightGray);
 
-		Color[] colors = {new Color(0,114,189),		// Colors for data lines
-				new Color(217,83,25),
-				new Color(237,177,32),
-				new Color(126,49,142),
-				new Color(119,172,48),
-				new Color(77,190,238),
-				new Color(162,20,47)};
+		int cumulativeSeriesCount = 0;
+
 		for (int axisno = 0; axisno < 2; axisno++) {
 			// Check whether axis has any data
 			if (data[axisno].getSeriesCount() > 0) {
@@ -299,13 +294,19 @@ public class SimulationPlot {
 				plot.setRenderer(axisno, r);
 				r.setBaseShapesVisible(initialShowPoints);
 				r.setBaseShapesFilled(true);
-				r.setSeriesPaint(0, colors[axisno]);
-				r.setSeriesPaint(1, colors[axisno+2]);
-				r.setSeriesPaint(2, colors[axisno+4]);
-				for (int j = 0; j < data[axisno].getSeriesCount(); j++) {
+
+				// Set colors for all series of the current axis
+				for (int seriesIndex = 0; seriesIndex < data[axisno].getSeriesCount(); seriesIndex++) {
+					int colorIndex = cumulativeSeriesCount + seriesIndex;
+					r.setSeriesPaint(seriesIndex, Util.getPlotColor(colorIndex));
+
 					Stroke lineStroke = new BasicStroke(PLOT_STROKE_WIDTH);
-					r.setSeriesStroke(j, lineStroke);
+					r.setSeriesStroke(seriesIndex, lineStroke);
 				}
+
+				// Update the cumulative count for the next axis
+				cumulativeSeriesCount += data[axisno].getSeriesCount();
+
 				// Now we pull the colors for the legend.
 				for (int j = 0; j < data[axisno].getSeriesCount(); j += branchCount) {
 					String name = data[axisno].getSeries(j).getDescription();

--- a/swing/src/net/sf/openrocket/gui/plot/Util.java
+++ b/swing/src/net/sf/openrocket/gui/plot/Util.java
@@ -1,5 +1,6 @@
 package net.sf.openrocket.gui.plot;
 
+import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -7,6 +8,18 @@ import java.util.List;
 import net.sf.openrocket.document.Simulation;
 
 public abstract class Util {
+	private static final Color[] PLOT_COLORS = {
+			new Color(0,114,189),
+			new Color(217,83,25),
+			new Color(237,177,32),
+			new Color(126,49,142),
+			new Color(119,172,48),
+			new Color(77,190,238),
+			new Color(162,20,47),
+			new Color(197, 106, 122),
+			new Color(255, 127, 80),
+			new Color(85, 107, 47),
+	};
 
 	public static List<String> generateSeriesLabels( Simulation simulation ) {
 		int size = simulation.getSimulatedData().getBranchCount();
@@ -32,5 +45,9 @@ public abstract class Util {
 			}
 		}
 		return stages;
+	}
+
+	public static Color getPlotColor(int index) {
+		return PLOT_COLORS[index % PLOT_COLORS.length];
 	}
 }


### PR DESCRIPTION
This PR fixes #2385 by using the OpenRocket plot colors for the thrust curves as well.

Additionally, I added an improvement where hovering over an item in the thrust curve combobox now uses the thrust curve color as the selection background color:

https://github.com/openrocket/openrocket/assets/11031519/6d1b5ff6-dc11-491e-98d7-bc3809162fb4


https://github.com/openrocket/openrocket/assets/11031519/ef4ec21e-d345-4560-9518-5d185b6cb98a

