### PR TITLE
[2258] Changed the static text box in the component analysis dialog to a JSpinner

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
@@ -42,6 +42,7 @@ import net.miginfocom.swing.MigLayout;
 import net.sf.openrocket.aerodynamics.AerodynamicCalculator;
 import net.sf.openrocket.aerodynamics.AerodynamicForces;
 import net.sf.openrocket.aerodynamics.FlightConditions;
+import net.sf.openrocket.gui.components.*;
 import net.sf.openrocket.gui.util.UITheme;
 import net.sf.openrocket.logging.Warning;
 import net.sf.openrocket.logging.WarningSet;
@@ -49,11 +50,6 @@ import net.sf.openrocket.gui.adaptors.Column;
 import net.sf.openrocket.gui.adaptors.ColumnTable;
 import net.sf.openrocket.gui.adaptors.ColumnTableModel;
 import net.sf.openrocket.gui.adaptors.DoubleModel;
-import net.sf.openrocket.gui.components.BasicSlider;
-import net.sf.openrocket.gui.components.ConfigurationComboBox;
-import net.sf.openrocket.gui.components.StageSelector;
-import net.sf.openrocket.gui.components.StyledLabel;
-import net.sf.openrocket.gui.components.UnitSelector;
 import net.sf.openrocket.gui.scalefigure.RocketPanel;
 import net.sf.openrocket.gui.util.GUIUtil;
 import net.sf.openrocket.gui.widgets.SelectColorToggleButton;
@@ -134,7 +130,9 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 
 		//// Wind direction:
 		panel.add(new JLabel(trans.get("componentanalysisdlg.lbl.winddir")), "width 120lp!");
-		panel.add(new UnitSelector(theta, true), "width 50lp!");
+		EditableSpinner spinner = new EditableSpinner(theta.getSpinnerModel());
+		panel.add(spinner, "growx");
+		panel.add(new UnitSelector(theta), "width 50lp!");
 		BasicSlider slider = new BasicSlider(theta.getSliderModel(0, 2 * Math.PI));
 		panel.add(slider, "growx, split 2");
 		//// Worst button
@@ -165,17 +163,20 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 
 		////Angle of attack:
 		panel.add(new JLabel(trans.get("componentanalysisdlg.lbl.angleofattack")), "width 120lp!");
-		panel.add(new UnitSelector(aoa, true), "width 50lp!");
+		panel.add(new EditableSpinner(aoa.getSpinnerModel()), "growx");
+		panel.add(new UnitSelector(aoa), "width 50lp!");
 		panel.add(new BasicSlider(aoa.getSliderModel(0, Math.PI)), "growx, wrap");
 
 		//// Mach number:
 		panel.add(new JLabel(trans.get("componentanalysisdlg.lbl.machnumber")), "width 120lp!");
+		panel.add(new EditableSpinner(mach.getSpinnerModel()), "width 120lp!");
 		panel.add(new UnitSelector(mach, true), "width 50lp!");
 		panel.add(new BasicSlider(mach.getSliderModel(0, 3)), "growx, wrap");
 
 		//// Roll rate:
 		panel.add(new JLabel(trans.get("componentanalysisdlg.lbl.rollrate")), "width 120lp!");
-		panel.add(new UnitSelector(roll, true), "width 50lp!");
+		panel.add(new EditableSpinner(roll.getSpinnerModel()), "growx");
+		panel.add(new UnitSelector(roll), "width 50lp!");
 		panel.add(new BasicSlider(roll.getSliderModel(-20 * 2 * Math.PI, 20 * 2 * Math.PI)),
 				"growx, wrap");
 


### PR DESCRIPTION
This PR fixes [issue 2258](https://github.com/openrocket/openrocket/issues/2258) where you could only edit the parameters on the component analysis by a slider.

The problem was that in the component analysis dialog the parameters could only be edited by using a slider, this made it difficult for fine-tuning and selecting a specific value. 

This has been fixed by adding a spinner so the parameters can be incremented or have the value typed. The unit selector and slider still remain. 

[jar file](https://www.dropbox.com/scl/fi/so2l90cpbawbfe0cnvgf4/OpenRocket-2258.jar?rlkey=yzgjfrug41o9cwm04z7zzvsf5&dl=0) for testing