### PR TITLE
[#2345] Reintroduce motor ignition delay optimization

### DIFF
--- a/core/src/net/sf/openrocket/optimization/services/DefaultSimulationModifierService.java
+++ b/core/src/net/sf/openrocket/optimization/services/DefaultSimulationModifierService.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import net.sf.openrocket.document.OpenRocketDocument;
 import net.sf.openrocket.document.Simulation;
 import net.sf.openrocket.l10n.Translator;
+import net.sf.openrocket.motor.MotorConfiguration;
 import net.sf.openrocket.optimization.general.OptimizationException;
 import net.sf.openrocket.optimization.rocketoptimization.SimulationModifier;
 import net.sf.openrocket.optimization.rocketoptimization.modifiers.FlightConfigurationModifier;
@@ -180,7 +181,8 @@ public class DefaultSimulationModifierService implements SimulationModifierServi
 			if (c instanceof MotorMount) {
 				MotorMount mount = (MotorMount) c;
 				if (mount.isMotorMount()) {
-					
+
+					// Motor overhang
 					SimulationModifier mod = new GenericComponentModifier(
 							trans.get("optimization.modifier.motormount.overhang"),
 							trans.get("optimization.modifier.motormount.overhang.desc"),
@@ -188,22 +190,18 @@ public class DefaultSimulationModifierService implements SimulationModifierServi
 							1.0, c.getClass(), c.getID(), "MotorOverhang");
 					setDefaultMinMax(mod, simulation);
 					modifiers.add(mod);
-					
-//	TODO: reimplement motor ignition optimization				
-//					mod = new FlightConfigurationModifier<MotorInstance>(
-//							trans.get("optimization.modifier.motormount.delay"),
-//							trans.get("optimization.modifier.motormount.delay.desc"),
-//							c, UnitGroup.UNITS_SHORT_TIME,
-//							1.0,
-//							c.getClass(),
-//							c.getID(),
-//							"IgnitionConfiguration",
-//							IgnitionConfiguration.class,
-//							"IgnitionDelay");
-//					
-//					mod.setMinValue(0);
-//					mod.setMaxValue(5);
-//					modifiers.add(mod);
+
+					// Motor ignition delay
+					mod = new FlightConfigurationModifier<MotorConfiguration>(
+							trans.get("optimization.modifier.motormount.delay"),
+							trans.get("optimization.modifier.motormount.delay.desc"),
+							c, UnitGroup.UNITS_SHORT_TIME,
+							1.0, c.getClass(), c.getID(), "MotorConfigurationSet",
+							MotorConfiguration.class,
+							"IgnitionDelay");
+					mod.setMinValue(0);
+					mod.setMaxValue(5);
+					modifiers.add(mod);
 				}
 			}
 			

--- a/swing/src/net/sf/openrocket/gui/dialogs/optimization/SimulationModifierTree.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/optimization/SimulationModifierTree.java
@@ -42,6 +42,7 @@ public class SimulationModifierTree extends BasicTree {
 
 	private static Color textColor;
 	private static Color dimTextColor;
+	private static Color disabledTextColor;
 	private static Color textSelectionForegroundColor;
 	private static Color textSelectionBackgroundColor;
 
@@ -77,6 +78,7 @@ public class SimulationModifierTree extends BasicTree {
 	private static void updateColors() {
 		textColor = GUIUtil.getUITheme().getTextColor();
 		dimTextColor = GUIUtil.getUITheme().getDimTextColor();
+		disabledTextColor = GUIUtil.getUITheme().getDisabledTextColor();
 		textSelectionForegroundColor = GUIUtil.getUITheme().getTextSelectionForegroundColor();
 		textSelectionBackgroundColor = GUIUtil.getUITheme().getTextSelectionBackgroundColor();
 	}
@@ -197,16 +199,18 @@ public class SimulationModifierTree extends BasicTree {
 				setForeground(dimTextColor);
 				setFont(stringFont);
 			} else if (object instanceof SimulationModifier) {
+				boolean isSelected = tree.getSelectionRows() != null && IntStream.of(tree.getSelectionRows()).anyMatch(r -> r == row);
+				if (isSelected) {
+					setBackground(textSelectionBackgroundColor);
+					setOpaque(true);
+				}
 				
 				if (selectedModifiers.contains(object)) {
-					setForeground(dimTextColor);
+					setForeground(disabledTextColor);
 					setFont(stringFont);
 				} else {
-					if (tree.getSelectionRows() != null &&
-							IntStream.of(tree.getSelectionRows()).anyMatch(r -> r == row)) {
+					if (isSelected) {
 						setForeground(textSelectionForegroundColor);
-						setBackground(textSelectionBackgroundColor);
-						setOpaque(true);
 					} else {
 						setForeground(textColor);
 					}

--- a/swing/src/net/sf/openrocket/gui/util/UITheme.java
+++ b/swing/src/net/sf/openrocket/gui/util/UITheme.java
@@ -38,6 +38,7 @@ public class UITheme {
         Color getBorderColor();
         Color getTextColor();
         Color getDimTextColor();
+        Color getDisabledTextColor();
         Color getTextSelectionForegroundColor();
         Color getTextSelectionBackgroundColor();
         Color getWarningColor();
@@ -203,6 +204,11 @@ public class UITheme {
             @Override
             public Color getDimTextColor() {
                 return Color.GRAY;
+            }
+
+            @Override
+            public Color getDisabledTextColor() {
+                return getDimTextColor();
             }
 
             @Override
@@ -568,6 +574,11 @@ public class UITheme {
             }
 
             @Override
+            public Color getDisabledTextColor() {
+                return new Color(161, 161, 161);
+            }
+
+            @Override
             public Color getTextSelectionForegroundColor() {
                 return Color.WHITE;
             }
@@ -924,6 +935,12 @@ public class UITheme {
             public Color getDimTextColor() {
                 return new Color(165, 171, 184);
             }
+
+            @Override
+            public Color getDisabledTextColor() {
+                return new Color(128, 128, 128);
+            }
+
 
             @Override
             public Color getTextSelectionForegroundColor() {
@@ -1294,6 +1311,11 @@ public class UITheme {
             @Override
             public Color getDimTextColor() {
                 return getCurrentTheme().getDimTextColor();
+            }
+
+            @Override
+            public Color getDisabledTextColor() {
+                return getCurrentTheme().getDisabledTextColor();
             }
 
             @Override


### PR DESCRIPTION
This PR fixes #2345. The motor ignition delay is now back for motor mounts.

There was also a rendering issue in the dark theme UI with already added optimization parameters; the contrast compared to normal text wasn't high. This PR fixes that as well.

Demo:

https://github.com/openrocket/openrocket/assets/11031519/762dcf4b-ae47-4b56-8181-505a4faec8e9

