### PR TITLE
[#2409] Don't use fixed precision for shape parameter

### DIFF
--- a/core/src/net/sf/openrocket/unit/GeneralUnit.java
+++ b/core/src/net/sf/openrocket/unit/GeneralUnit.java
@@ -7,6 +7,7 @@ public class GeneralUnit extends Unit {
 	@SuppressWarnings("unused")
 	private final int significantNumbers;
 	private final int decimalRounding;
+	private final double stepValue;
 	
 	// Values smaller that this are rounded using decimal rounding
 	// [pre-calculated as 10^(significantNumbers-1)]
@@ -23,14 +24,19 @@ public class GeneralUnit extends Unit {
 	public GeneralUnit(double multiplier, String unit, int significantNumbers) {
 		this(multiplier, unit, significantNumbers, 10);
 	}
-	
+
 	public GeneralUnit(double multiplier, String unit, int significantNumbers, int decimalRounding) {
+		this(multiplier, unit, significantNumbers, decimalRounding, 1.0);
+	}
+	
+	public GeneralUnit(double multiplier, String unit, int significantNumbers, int decimalRounding, double stepValue) {
 		super(multiplier, unit);
 		assert(significantNumbers>0);
 		assert(decimalRounding>0);
 		
 		this.significantNumbers = significantNumbers;
 		this.decimalRounding = decimalRounding;
+		this.stepValue = stepValue;
 		
 		double d=1;
 		double e=10;
@@ -188,13 +194,13 @@ public class GeneralUnit extends Unit {
 	@Override
 	public double getNextValue(double value) {
 		// TODO: HIGH: Auto-generated method stub
-		return value+1;
+		return value + stepValue;
 	}
 
 	@Override
 	public double getPreviousValue(double value) {
 		// TODO: HIGH: Auto-generated method stub
-		return value-1;
+		return value - stepValue;
 	}
 	
 	

--- a/core/src/net/sf/openrocket/unit/UnitGroup.java
+++ b/core/src/net/sf/openrocket/unit/UnitGroup.java
@@ -166,7 +166,7 @@ public class UnitGroup {
 		UNITS_AREA.addUnit(new GeneralUnit(pow2(0.3048), "ft" + SQUARED));
 
 		UNITS_SHAPE_PARAMETER = new UnitGroup();
-		UNITS_SHAPE_PARAMETER.addUnit(new FixedPrecisionUnit("" + ZWSP, 0.1)); // zero-width space
+		UNITS_SHAPE_PARAMETER.addUnit(new GeneralUnit(1, "" + ZWSP, 1, 10, 0.1));
 		
 		
 		UNITS_STABILITY = new UnitGroup();


### PR DESCRIPTION
This PR fixes #2409. You can now enter values up to 3 decimals, while the spinner's up- and down arrows increment/decrement in 0.1 steps.


https://github.com/openrocket/openrocket/assets/11031519/417ae0dc-2672-40e7-81b9-7a50ce54d20c

