### PR TITLE
Updated texture select combobox

### DIFF
--- a/core/resources/l10n/messages.properties
+++ b/core/resources/l10n/messages.properties
@@ -2393,7 +2393,7 @@ PresetModel.lbl.partsLib = Parts Library
 PresetModel.lbl.partsLib.ttip = Select a preset model for this rocket component from a library of parts.
 
 DecalModel.lbl.select = <none>
-DecalModel.lbl.choose = From file\u2026
+DecalModel.lbl.choose = Select file\u2026
 
 ! Export Decal Dialog
 ExportDecalDialog.title = Export Decal

--- a/core/resources/l10n/messages_uk_UA.properties
+++ b/core/resources/l10n/messages_uk_UA.properties
@@ -1799,7 +1799,7 @@ PresetModel.lbl.custompreset = Custom
 PresetModel.lbl.partsLib = Parts Library
 
 DecalModel.lbl.select = <none>
-DecalModel.lbl.choose = From file...
+DecalModel.lbl.choose = Select file...
 
 ! Export Decal Dialog
 ExportDecalDialog.title = Export Decal

--- a/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
+++ b/swing/src/net/sf/openrocket/gui/configdialog/AppearancePanel.java
@@ -505,6 +505,7 @@ public class AppearancePanel extends JPanel {
 
 		DecalModel decalModel = new DecalModel(panel, document, builder);
 		JComboBox<DecalImage> textureDropDown = new JComboBox<DecalImage>(decalModel);
+		textureDropDown.setMaximumRowCount(20);
 
 		// We need to add this action listener that triggers a decalModel update when the same item is selected, because
 		// for multi-comp edits, the listeners' decals may not be updated otherwise


### PR DESCRIPTION
I made two changes to things that have been bugging me for a long time.

1) Show up to 20 items at once, instead of 8.
2) Change the "From file..." option to "Select file..." in both the default and UK variants.  "From file..." never made sense to me.  I would probably prefer it to be at the top of the list (or perhaps just below "<none>" but was too lazy to make all the necessary changes and try it out.  Just avoiding the scrollbar will make it much better even in its current location at the bottom.

Before:
<img width="429" alt="image" src="https://github.com/openrocket/openrocket/assets/243872/15603f7c-9ff8-4761-a287-472f3fda04ec">

After:
<img width="429" alt="image" src="https://github.com/openrocket/openrocket/assets/243872/07e63296-503f-4ef3-b549-2e6ae8d9db30">


