### PR TITLE
Add snapshot version to OpenRocket versioning system

### DIFF
--- a/core/resources/build.properties
+++ b/core/resources/build.properties
@@ -1,6 +1,6 @@
 
 # The OpenRocket build version
-build.version=23.09
+build.version=23.09.SNAPSHOT
 
 # The copyright year for the build. Displayed in the about dialog.
 # Will show as Copyright 2013-${build.copyright}

--- a/core/test/net/sf/openrocket/communication/UpdateInfoTest.java
+++ b/core/test/net/sf/openrocket/communication/UpdateInfoTest.java
@@ -215,6 +215,30 @@ public class UpdateInfoTest extends BaseTestCase {
 		assertEquals(UpdateInfoRetriever.ReleaseStatus.OLDER,
 				UpdateInfoRetriever.UpdateInfoFetcher.compareLatest("22.02.RC.01", "22.02.02"));
 
+		// Test snapshots
+		assertEquals(UpdateInfoRetriever.ReleaseStatus.OLDER,
+				UpdateInfoRetriever.UpdateInfoFetcher.compareLatest("23.09", "23.09.SNAPSHOT"));
+		assertEquals(UpdateInfoRetriever.ReleaseStatus.LATEST,
+				UpdateInfoRetriever.UpdateInfoFetcher.compareLatest("23.09.SNAPSHOT", "23.09.SNAPSHOT"));
+		assertEquals(UpdateInfoRetriever.ReleaseStatus.NEWER,
+				UpdateInfoRetriever.UpdateInfoFetcher.compareLatest("23.09.SNAPSHOT", "23.09"));
+		assertEquals(UpdateInfoRetriever.ReleaseStatus.NEWER,
+				UpdateInfoRetriever.UpdateInfoFetcher.compareLatest("24.01", "23.09.SNAPSHOT"));
+		assertEquals(UpdateInfoRetriever.ReleaseStatus.OLDER,
+				UpdateInfoRetriever.UpdateInfoFetcher.compareLatest("23.09.SNAPSHOT", "24.01"));
+		assertEquals(UpdateInfoRetriever.ReleaseStatus.NEWER,
+				UpdateInfoRetriever.UpdateInfoFetcher.compareLatest("24.01.SNAPSHOT", "23.09"));
+		assertEquals(UpdateInfoRetriever.ReleaseStatus.OLDER,
+				UpdateInfoRetriever.UpdateInfoFetcher.compareLatest("23.09.SNAPSHOT.01", "23.09.SNAPSHOT.02"));
+		assertEquals(UpdateInfoRetriever.ReleaseStatus.LATEST,
+				UpdateInfoRetriever.UpdateInfoFetcher.compareLatest("23.09.SNAPSHOT.02", "23.09.SNAPSHOT.02"));
+		assertEquals(UpdateInfoRetriever.ReleaseStatus.NEWER,
+				UpdateInfoRetriever.UpdateInfoFetcher.compareLatest("23.09.SNAPSHOT.02", "23.09.SNAPSHOT.01"));
+		assertEquals(UpdateInfoRetriever.ReleaseStatus.NEWER,
+				UpdateInfoRetriever.UpdateInfoFetcher.compareLatest("23.09.01", "23.09.SNAPSHOT"));
+		assertEquals(UpdateInfoRetriever.ReleaseStatus.OLDER,
+				UpdateInfoRetriever.UpdateInfoFetcher.compareLatest("23.09.SNAPSHOT", "23.09.01"));
+
 
 		// Test bogus releases
 		assertExceptionCompareLatest("22.02.gamma.01", "22.02");

--- a/core/test/net/sf/openrocket/communication/WelcomeInfoTest.java
+++ b/core/test/net/sf/openrocket/communication/WelcomeInfoTest.java
@@ -1,8 +1,10 @@
 package net.sf.openrocket.communication;
 
 import net.sf.openrocket.util.BaseTestCase.BaseTestCase;
+import net.sf.openrocket.util.BuildProperties;
 import org.junit.Test;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -12,12 +14,15 @@ public class WelcomeInfoTest extends BaseTestCase {
     @Test
     public void testWelcomeInfo() throws Exception {
         // Test the welcome info for the current build version
-        String welcomeInfo = WelcomeInfoRetriever.retrieveWelcomeInfo();
-        assertNotNull("Current release version not present in release notes", welcomeInfo);
-        assertTrue("Body of release notes is empty", welcomeInfo.length() > 0);
+        String version = BuildProperties.getVersion();
+        if (!version.contains(UpdateInfoRetriever.snapshotTag)) {      // Ignore snapshot releases; they don't need release notes
+            String welcomeInfo = WelcomeInfoRetriever.retrieveWelcomeInfo();
+            assertNotNull("Current release version not present in release notes", welcomeInfo);
+            assertFalse("Body of release notes is empty", welcomeInfo.isEmpty());
+        }
 
         // Test the release info for a bogus release version
-        welcomeInfo = WelcomeInfoRetriever.retrieveWelcomeInfo("bogus release");
+        String welcomeInfo = WelcomeInfoRetriever.retrieveWelcomeInfo("bogus release");
         assertNull(welcomeInfo);
     }
 }


### PR DESCRIPTION
Currently, we always leave OpenRocket's build version to the latest released version (e.g. "23.09"). This is not really ideal. This PR adds a new version string for snapshot versions. So, the build version is now changed to "**23.09.SNAPSHOT**".

The idea is to change the build version of the unstable branch to "xx.xx.SNAPSHOT" after each release. That way, we can easily keep track of official releases vs dev versions. Ideally, we would also append the date or git commit ID of the latest commit to the version, but that's not too important right now.