### PR TITLE
Fix parachute length resizing when loading preset parachute

### DIFF
--- a/core/src/net/sf/openrocket/file/openrocket/importt/ComponentParameterHandler.java
+++ b/core/src/net/sf/openrocket/file/openrocket/importt/ComponentParameterHandler.java
@@ -14,6 +14,7 @@ import net.sf.openrocket.rocketcomponent.RecoveryDevice;
 import net.sf.openrocket.rocketcomponent.Rocket;
 import net.sf.openrocket.rocketcomponent.RocketComponent;
 import net.sf.openrocket.rocketcomponent.AxialStage;
+import org.xml.sax.SAXException;
 
 /**
  * A handler that populates the parameters of a previously constructed rocket component.
@@ -27,6 +28,10 @@ class ComponentParameterHandler extends AbstractElementHandler {
 	public ComponentParameterHandler(RocketComponent c, DocumentLoadingContext context) {
 		this.component = c;
 		this.context = context;
+
+		// Sometimes setting certain component parameters will clear the preset. We don't want that to happen, so
+		// ignore preset clearing.
+		this.component.setIgnorePresetClearing(true);
 	}
 	
 	@Override
@@ -123,5 +128,13 @@ class ComponentParameterHandler extends AbstractElementHandler {
 			warnings.add(Warning.fromString("Unknown parameter type '" + element + "' for "
 					+ component.getComponentName() + ", ignoring."));
 		}
+	}
+
+	@Override
+	public void endHandler(String element, HashMap<String, String> attributes, String content, WarningSet warnings) throws SAXException {
+		super.endHandler(element, attributes, content, warnings);
+
+		// Restore the preset clearing behavior
+		this.component.setIgnorePresetClearing(false);
 	}
 }

--- a/core/src/net/sf/openrocket/file/openrocket/importt/ComponentPresetSetter.java
+++ b/core/src/net/sf/openrocket/file/openrocket/importt/ComponentPresetSetter.java
@@ -13,9 +13,15 @@ import net.sf.openrocket.util.Reflection;
 ////ComponentPresetSetter  -  sets a ComponentPreset value
 class ComponentPresetSetter implements Setter {
 	private final Reflection.Method setMethod;
+	private Object[] extraParameters = null;
 	
 	public ComponentPresetSetter(Reflection.Method set) {
 		this.setMethod = set;
+	}
+
+	public ComponentPresetSetter(Reflection.Method set, Object... parameters) {
+		this.setMethod = set;
+		this.extraParameters = parameters;
 	}
 	
 	@Override
@@ -71,7 +77,11 @@ class ComponentPresetSetter implements Setter {
 
 		// The preset loader can override the component name, so first store it and then apply it again
 		String componentName = c.getName();
-		setMethod.invoke(c, matchingPreset);
+		if (extraParameters != null) {
+			setMethod.invoke(c, matchingPreset, extraParameters);
+		} else {
+			setMethod.invoke(c, matchingPreset);
+		}
 		c.setName(componentName);
 	}
 }

--- a/core/src/net/sf/openrocket/file/openrocket/importt/DocumentConfig.java
+++ b/core/src/net/sf/openrocket/file/openrocket/importt/DocumentConfig.java
@@ -452,6 +452,9 @@ class DocumentConfig {
 		setters.put("Parachute:linematerial", new MaterialSetter(
 				Reflection.findMethod(Parachute.class, "setLineMaterial", Material.class),
 				Material.Type.LINE));
+		setters.put("Parachute:preset", new ComponentPresetSetter(
+				Reflection.findMethod(Parachute.class, "loadPreset", ComponentPreset.class, Object[].class),
+				false));
 		
 		// PodSet
 		setters.put("PodSet:instancecount", new IntSetter(

--- a/core/src/net/sf/openrocket/file/rocksim/importt/ParachuteHandler.java
+++ b/core/src/net/sf/openrocket/file/rocksim/importt/ParachuteHandler.java
@@ -81,6 +81,7 @@ class ParachuteHandler extends RecoveryDeviceHandler<Parachute> {
 					packed = chute.getDiameter() * 0.025;
 				}
 				chute.setRadius(packed);
+				chute.setLength(packed);
 			}
 			if (RockSimCommonConstants.SHROUD_LINE_COUNT.equals(element)) {
 				chute.setLineCount(Math.max(0, Integer.parseInt(content)));

--- a/core/src/net/sf/openrocket/rocketcomponent/Parachute.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/Parachute.java
@@ -153,8 +153,18 @@ public class Parachute extends RecoveryDevice {
 		return false;
 	}
 
+	/**
+	 * Load the component from a preset.
+	 * @param preset	the preset to load from
+	 * @param params    extra parameters to be used in the preset loading
+	 *                  	params[0] = boolean allowAutoRadius: true = allow auto radius to be set during preset loading, false = do not allow auto radius
+	 */
 	@Override
-	protected void loadFromPreset(ComponentPreset preset) {
+	protected void loadFromPreset(ComponentPreset preset, Object...params) {
+		boolean allowAutoRadius = true;
+		if (params != null && params.length > 0) {
+			allowAutoRadius = (boolean) params[0];
+		}
 
 		// SUBSTITUTE preset parachute values for existing component values
 		//	//	Set preset parachute description
@@ -176,13 +186,13 @@ public class Parachute extends RecoveryDevice {
 			this.diameter = DEFAULT_DIAMETER;
 		}
 		//	//	Set preset parachute drag coefficient
-		 if ((preset.has(ComponentPreset.CD)) && preset.get(ComponentPreset.CD) > 0){
-		 		cdAutomatic = false;
-		 		cd = preset.get(ComponentPreset.CD);
-		 } else {
-			 cdAutomatic = true;
-			 cd = Parachute.DEFAULT_CD;
-		 }
+		if ((preset.has(ComponentPreset.CD)) && preset.get(ComponentPreset.CD) > 0){
+			cdAutomatic = false;
+			cd = preset.get(ComponentPreset.CD);
+		} else {
+			cdAutomatic = true;
+			cd = Parachute.DEFAULT_CD;
+		}
 		//	//	Set preset parachute line count
 		if ((preset.has(ComponentPreset.LINE_COUNT)) && preset.get(ComponentPreset.LINE_COUNT) > 0) {
 			this.lineCount = preset.get(ComponentPreset.LINE_COUNT);
@@ -196,7 +206,7 @@ public class Parachute extends RecoveryDevice {
 			this.lineLength = DEFAULT_LINE_LENGTH;
 		}
 		//	//	Set preset parachute line material
-			//	NEED a better way to set preset if field is empty ----
+		//	NEED a better way to set preset if field is empty ----
 		if ((preset.has(ComponentPreset.LINE_MATERIAL))) {
 			String lineMaterialEmpty = preset.get(ComponentPreset.LINE_MATERIAL).toString();
 			int count = lineMaterialEmpty.length();
@@ -219,7 +229,8 @@ public class Parachute extends RecoveryDevice {
 		}
 		//	// Size parachute packed diameter within parent inner diameter
 		if (preset.has(ComponentPreset.PACKED_LENGTH) && (getLength() > 0) &&
-			preset.has(ComponentPreset.PACKED_DIAMETER) && (getRadius() > 0)) {
+				preset.has(ComponentPreset.PACKED_DIAMETER) && (getRadius() > 0) &&
+				allowAutoRadius) {
 			setRadiusAutomatic(true);
 		}
 
@@ -232,7 +243,12 @@ public class Parachute extends RecoveryDevice {
 			massOverridden = false;
 		}
 
-		super.loadFromPreset(preset);
+		super.loadFromPreset(preset, params);
+	}
+
+	@Override
+	protected void loadFromPreset(ComponentPreset preset) {
+		loadFromPreset(preset, true);
 	}
 
 	@Override


### PR DESCRIPTION
Some users on [TRF](https://www.rocketryforum.com/threads/openrocket-parachutes-resize-themselves.183828/) noticed a bug where the parachute size would change when loading designs that use preset parachutes.

The issue was that loading a parachute preset could set the packed radius to auto mode, which would in turn calculate a new packed length. This PR fixes that. Hope this is the last parachute length bug 🙂.

Problematic design file:
[lengthening_parachute_example.ork.zip](https://github.com/openrocket/openrocket/files/13781994/lengthening_parachute_example.ork.zip)

Resulted in this bug:
<img width="1445" alt="image" src="https://github.com/openrocket/openrocket/assets/11031519/4c10179e-ab2c-4757-a674-37dabdfe4b81">

Which is now fixed:
<img width="1445" alt="image" src="https://github.com/openrocket/openrocket/assets/11031519/270a649d-27cb-414f-ad13-98da67a85770">
