### PR TITLE
Fix data field in thrustcurve events

### DIFF
--- a/core/src/net/sf/openrocket/rocketcomponent/DeploymentConfiguration.java
+++ b/core/src/net/sf/openrocket/rocketcomponent/DeploymentConfiguration.java
@@ -41,7 +41,7 @@ public class DeploymentConfiguration implements FlightConfigurableParameter<Depl
 			@SuppressWarnings("unchecked")
 			@Override
 			public boolean isActivationEvent(DeploymentConfiguration config, FlightEvent e, RocketComponent source) {
-				if (e.getType() != FlightEvent.Type.ALTITUDE)
+				if ((e.getType() != FlightEvent.Type.ALTITUDE) || (e.getData() == null))
 					return false;
 				
 				double alt = config.deployAltitude;

--- a/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
+++ b/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
@@ -418,7 +418,7 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 				ThrustCurveMotor motor = (ThrustCurveMotor) motorState.getMotor();
 				double[] timePoints = motor.getTimePoints();
 				for (double point : timePoints) {
-					addEvent(new FlightEvent(FlightEvent.Type.ALTITUDE, point, event.getSource(), motorState));
+					addEvent(new FlightEvent(FlightEvent.Type.ALTITUDE, point, event.getSource(), null));
 				}
 
 				// and queue up the burnout for this motor, as well. 


### PR DESCRIPTION
Small bug in #2432: I put the current MotorClusterConfiguration in the general purpose data field of ALTITUDE events. Most (all?) other ALTITUDE events use this to store the previous and current altitude, and altitude-based recovery deployment looks at that to decide whether to fire. So, dual-deploy configurations got an exception there.

This PR puts a null in that field, and has the deployment configuration check for null.