### PR TITLE
Don't pass extra value (cd) to String.format

### DIFF
--- a/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
+++ b/swing/src/net/sf/openrocket/gui/dialogs/ComponentAnalysisDialog.java
@@ -770,7 +770,7 @@ public class ComponentAnalysisDialog extends JDialog implements StateChangeListe
 
 			DecimalFormat df = new DecimalFormat("0." + "#".repeat(Math.max(0, decimalPlaces)));
 			String cdFormatted = df.format(cd);
-			return String.format(cdFormatted + "  (%.0f%%)", cd, 100 * cd / totalCD);
+			return String.format(cdFormatted + "  (%.0f%%)", 100 * cd / totalCD);
 		}
 	}
 


### PR DESCRIPTION
In the component analysis drag table, an extra parameter (the Cd) was being passed to String.format().  This wound up putting the actual Cd of the component in the percentage display instead of the percentage.

I have to admit to some surprise -- this would be expected behavior from C; I would have thought Java would compare the number of parameters against the number of format conversion strings...