### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@
 
 /swing/build
 /swing/tmp
+/swing/resources/datafiles/components/
 
 # IntelliJ
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm


### PR DESCRIPTION
Added /swing/resources/datafiles/components/ to .gitignore so that git doesn't track changes in the directory due to building.

I noticed this because after pulling the repo and building for the first time, when I run `git status`, I saw that the files in this directory were untracked.  It seems that the files in this directory are only used for building, since running `ant clean` removes the directory (and hence git working tree becomes clean).  I figured that there is no reason not to have git ignore the directory so that it doesn't accidentally get pulled into a commit if someone forgets to clean after building.

It is also possible I am missing something here, as I am new to developing.