### PR TITLE
Refine time step in AbstractEulerStepper

### DIFF
--- a/core/src/net/sf/openrocket/simulation/AbstractEulerStepper.java
+++ b/core/src/net/sf/openrocket/simulation/AbstractEulerStepper.java
@@ -127,7 +127,9 @@ public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 		// Store data
 		final FlightDataBranch data = status.getFlightData();
 
-		// Values looked up at start of time step
+		// Values looked up or calculated at start of time step
+		data.setValue(FlightDataType.TYPE_REFERENCE_LENGTH, status.getConfiguration().getReferenceLength());
+		data.setValue(FlightDataType.TYPE_REFERENCE_AREA, status.getConfiguration().getReferenceArea());
 		data.setValue(FlightDataType.TYPE_WIND_VELOCITY, windSpeed.length());
 		data.setValue(FlightDataType.TYPE_AIR_TEMPERATURE, atmosphere.getTemperature());
 		data.setValue(FlightDataType.TYPE_AIR_PRESSURE, atmosphere.getPressure());
@@ -139,12 +141,18 @@ public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 		}
 		data.setValue(FlightDataType.TYPE_GRAVITY, gravity);
 		
+		data.setValue(FlightDataType.TYPE_DRAG_COEFF, getCD());
+		data.setValue(FlightDataType.TYPE_PRESSURE_DRAG_COEFF, getCD());
+		data.setValue(FlightDataType.TYPE_FRICTION_DRAG_COEFF, 0);
+		data.setValue(FlightDataType.TYPE_BASE_DRAG_COEFF, 0);
+		data.setValue(FlightDataType.TYPE_AXIAL_DRAG_COEFF, getCD());
 		data.setValue(FlightDataType.TYPE_THRUST_FORCE, 0);
 		data.setValue(FlightDataType.TYPE_DRAG_FORCE, dragForce);
 		
 		data.setValue(FlightDataType.TYPE_MASS, mass);
 		data.setValue(FlightDataType.TYPE_MOTOR_MASS, motorMass);
-		
+		data.setValue(FlightDataType.TYPE_THRUST_WEIGHT_RATIO, 0);
+
 		data.setValue(FlightDataType.TYPE_ACCELERATION_XY,
 					  MathUtil.hypot(linearAcceleration.x, linearAcceleration.y));
 		data.setValue(FlightDataType.TYPE_ACCELERATION_Z, linearAcceleration.z);

--- a/core/src/net/sf/openrocket/simulation/AbstractEulerStepper.java
+++ b/core/src/net/sf/openrocket/simulation/AbstractEulerStepper.java
@@ -80,8 +80,15 @@ public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 			timeStep = Math.min(timeStep, 1.0/absAccel);
 		}
 
-		// Honor max step size passed in
-		timeStep = Math.min(timeStep, maxTimeStep);
+		// Honor max step size passed in.  If the time to next time step is greater than our minimum
+		// we'll set our next step to just before it in order to better capture discontinuities in things like chute opening
+		if (maxTimeStep < timeStep) {
+			if (maxTimeStep > MIN_TIME_STEP) {
+				timeStep = maxTimeStep - MIN_TIME_STEP;
+			} else {
+				timeStep = maxTimeStep;
+			}
+		}
 
 		// but don't let it get *too* small
 		timeStep = Math.max(timeStep, MIN_TIME_STEP);

--- a/core/src/net/sf/openrocket/simulation/AbstractEulerStepper.java
+++ b/core/src/net/sf/openrocket/simulation/AbstractEulerStepper.java
@@ -38,21 +38,21 @@ public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 	public void step(SimulationStatus status, double maxTimeStep) throws SimulationException {
 		
 		// Get the atmospheric conditions
-		AtmosphericConditions atmosphere = modelAtmosphericConditions(status);
+		final AtmosphericConditions atmosphere = modelAtmosphericConditions(status);
 		
 		//// Local wind speed and direction
-		Coordinate windSpeed = modelWindVelocity(status);
+		final Coordinate windSpeed = modelWindVelocity(status);
 		Coordinate airSpeed = status.getRocketVelocity().add(windSpeed);
 		
 		// Compute drag force
-		double mach = airSpeed.length() / atmosphere.getMachSpeed();
-		double dynP = (0.5 * atmosphere.getDensity() * airSpeed.length2());
-		double dragForce = getCD() * dynP * status.getConfiguration().getReferenceArea();
+		final double mach = airSpeed.length() / atmosphere.getMachSpeed();
+		final double dynP = (0.5 * atmosphere.getDensity() * airSpeed.length2());
+		final double dragForce = getCD() * dynP * status.getConfiguration().getReferenceArea();
 
-		double rocketMass = calculateStructureMass(status).getMass();
-		double motorMass = calculateMotorMass(status).getMass();
+		final double rocketMass = calculateStructureMass(status).getMass();
+		final double motorMass = calculateMotorMass(status).getMass();
 		
-		double mass = rocketMass + motorMass;
+		final double mass = rocketMass + motorMass;
 
 		if (mass < MathUtil.EPSILON) {
 			throw new SimulationException(trans.get("SimulationStepper.error.totalMassZero"));
@@ -67,12 +67,12 @@ public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 		}
 		
 		// Add effect of gravity
-		double gravity = modelGravity(status);
+		final double gravity = modelGravity(status);
 		linearAcceleration = linearAcceleration.sub(0, 0, gravity);
 		
 
 		// Add coriolis acceleration
-		Coordinate coriolisAcceleration = status.getSimulationConditions().getGeodeticComputation().getCoriolisAcceleration(
+		final Coordinate coriolisAcceleration = status.getSimulationConditions().getGeodeticComputation().getCoriolisAcceleration(
 				status.getRocketWorldPosition(), status.getRocketVelocity());
 		linearAcceleration = linearAcceleration.add(coriolisAcceleration);
 
@@ -125,7 +125,7 @@ public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 		status.setRocketWorldPosition(w);
 
 		// Store data
-		FlightDataBranch data = status.getFlightData();
+		final FlightDataBranch data = status.getFlightData();
 		data.addPoint();
 		
 		data.setValue(FlightDataType.TYPE_TIME, status.getSimulationTime());

--- a/core/src/net/sf/openrocket/simulation/AbstractEulerStepper.java
+++ b/core/src/net/sf/openrocket/simulation/AbstractEulerStepper.java
@@ -126,60 +126,57 @@ public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 
 		// Store data
 		final FlightDataBranch data = status.getFlightData();
-		data.addPoint();
+
+		// Values looked up at start of time step
+		data.setValue(FlightDataType.TYPE_WIND_VELOCITY, windSpeed.length());
+		data.setValue(FlightDataType.TYPE_AIR_TEMPERATURE, atmosphere.getTemperature());
+		data.setValue(FlightDataType.TYPE_AIR_PRESSURE, atmosphere.getPressure());
+		data.setValue(FlightDataType.TYPE_SPEED_OF_SOUND, atmosphere.getMachSpeed());
+		data.setValue(FlightDataType.TYPE_MACH_NUMBER, mach);
 		
+		if (status.getSimulationConditions().getGeodeticComputation() != GeodeticComputationStrategy.FLAT) {
+			data.setValue(FlightDataType.TYPE_CORIOLIS_ACCELERATION, coriolisAcceleration.length());
+		}
+		data.setValue(FlightDataType.TYPE_GRAVITY, gravity);
+		
+		data.setValue(FlightDataType.TYPE_THRUST_FORCE, 0);
+		data.setValue(FlightDataType.TYPE_DRAG_FORCE, dragForce);
+		
+		data.setValue(FlightDataType.TYPE_MASS, mass);
+		data.setValue(FlightDataType.TYPE_MOTOR_MASS, motorMass);
+		
+		data.setValue(FlightDataType.TYPE_ACCELERATION_XY,
+					  MathUtil.hypot(linearAcceleration.x, linearAcceleration.y));
+		data.setValue(FlightDataType.TYPE_ACCELERATION_Z, linearAcceleration.z);
+		data.setValue(FlightDataType.TYPE_ACCELERATION_TOTAL, linearAcceleration.length());
+
+		data.setValue(FlightDataType.TYPE_TIME_STEP, timeStep);
+
+		// Values calculated on this step
+		data.addPoint();
 		data.setValue(FlightDataType.TYPE_TIME, status.getSimulationTime());
 		data.setValue(FlightDataType.TYPE_ALTITUDE, status.getRocketPosition().z);
 		data.setValue(FlightDataType.TYPE_POSITION_X, status.getRocketPosition().x);
 		data.setValue(FlightDataType.TYPE_POSITION_Y, status.getRocketPosition().y);
 
-		airSpeed = status.getRocketVelocity().add(windSpeed);
-
 		data.setValue(FlightDataType.TYPE_POSITION_XY,
 					  MathUtil.hypot(status.getRocketPosition().x, status.getRocketPosition().y));
 		data.setValue(FlightDataType.TYPE_POSITION_DIRECTION,
 					  Math.atan2(status.getRocketPosition().y, status.getRocketPosition().x));
+		data.setValue(FlightDataType.TYPE_LATITUDE, status.getRocketWorldPosition().getLatitudeRad());
+		data.setValue(FlightDataType.TYPE_LONGITUDE, status.getRocketWorldPosition().getLongitudeRad());
 		
 		data.setValue(FlightDataType.TYPE_VELOCITY_XY,
 					  MathUtil.hypot(status.getRocketVelocity().x, status.getRocketVelocity().y));
-		data.setValue(FlightDataType.TYPE_ACCELERATION_XY,
-					  MathUtil.hypot(linearAcceleration.x, linearAcceleration.y));
+		data.setValue(FlightDataType.TYPE_VELOCITY_Z, status.getRocketVelocity().z);
+		data.setValue(FlightDataType.TYPE_VELOCITY_TOTAL, airSpeed.length());
 		
-		data.setValue(FlightDataType.TYPE_ACCELERATION_TOTAL, linearAcceleration.length());
-		
-		double Re = airSpeed.length() *
+		airSpeed = status.getRocketVelocity().add(windSpeed);
+		final double Re = airSpeed.length() *
 			status.getConfiguration().getLengthAerodynamic() /
 			atmosphere.getKinematicViscosity();
 		data.setValue(FlightDataType.TYPE_REYNOLDS_NUMBER, Re);
 		
-
-		data.setValue(FlightDataType.TYPE_LATITUDE, status.getRocketWorldPosition().getLatitudeRad());
-		data.setValue(FlightDataType.TYPE_LONGITUDE, status.getRocketWorldPosition().getLongitudeRad());
-		data.setValue(FlightDataType.TYPE_GRAVITY, gravity);
-		
-		if (status.getSimulationConditions().getGeodeticComputation() != GeodeticComputationStrategy.FLAT) {
-			data.setValue(FlightDataType.TYPE_CORIOLIS_ACCELERATION, coriolisAcceleration.length());
-		}
-		
-
-		data.setValue(FlightDataType.TYPE_VELOCITY_Z, status.getRocketVelocity().z);
-		data.setValue(FlightDataType.TYPE_ACCELERATION_Z, linearAcceleration.z);
-		
-		data.setValue(FlightDataType.TYPE_VELOCITY_TOTAL, airSpeed.length());
-		data.setValue(FlightDataType.TYPE_MACH_NUMBER, mach);
-		
-		data.setValue(FlightDataType.TYPE_MASS, mass);
-		data.setValue(FlightDataType.TYPE_MOTOR_MASS, motorMass);
-		
-		data.setValue(FlightDataType.TYPE_THRUST_FORCE, 0);
-		data.setValue(FlightDataType.TYPE_DRAG_FORCE, dragForce);
-		
-		data.setValue(FlightDataType.TYPE_WIND_VELOCITY, windSpeed.length());
-		data.setValue(FlightDataType.TYPE_AIR_TEMPERATURE, atmosphere.getTemperature());
-		data.setValue(FlightDataType.TYPE_AIR_PRESSURE, atmosphere.getPressure());
-		data.setValue(FlightDataType.TYPE_SPEED_OF_SOUND, atmosphere.getMachSpeed());
-		
-		data.setValue(FlightDataType.TYPE_TIME_STEP, timeStep);
 		data.setValue(FlightDataType.TYPE_COMPUTATION_TIME,
 				(System.nanoTime() - status.getSimulationStartWallTime()) / 1000000000.0);
 		log.trace("time " + data.getLast(FlightDataType.TYPE_TIME) + ", altitude " + data.getLast(FlightDataType.TYPE_ALTITUDE) + ", velocity " + data.getLast(FlightDataType.TYPE_VELOCITY_Z));

--- a/core/src/net/sf/openrocket/simulation/AbstractEulerStepper.java
+++ b/core/src/net/sf/openrocket/simulation/AbstractEulerStepper.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import net.sf.openrocket.l10n.Translator;
+import net.sf.openrocket.logging.SimulationAbort;
 import net.sf.openrocket.models.atmosphere.AtmosphericConditions;
 import net.sf.openrocket.rocketcomponent.InstanceMap;
 import net.sf.openrocket.rocketcomponent.RecoveryDevice;
@@ -55,7 +56,7 @@ public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 		final double mass = rocketMass + motorMass;
 
 		if (mass < MathUtil.EPSILON) {
-			throw new SimulationException(trans.get("SimulationStepper.error.totalMassZero"));
+			status.abortSimulation(SimulationAbort.Cause.ACTIVE_MASS_ZERO);
 		}
 		
 		// Compute drag acceleration

--- a/core/src/net/sf/openrocket/simulation/AbstractEulerStepper.java
+++ b/core/src/net/sf/openrocket/simulation/AbstractEulerStepper.java
@@ -127,7 +127,7 @@ public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 				// If acceleration oscillation is building up, the new timestep is the solution of
 				// a + j*t = 0
 				t = Math.abs(a / jerk.z);
-				log.trace("oscillation prevention changes timeStep to " + t);
+				log.trace("oscillation avoidance changes timeStep to " + t);
 			}
 		}
 		
@@ -151,7 +151,6 @@ public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 		}
 
 		status.setSimulationTime(status.getSimulationTime() + timeStep);
-		status.setPreviousTimeStep(timeStep);
 
 		status.setRocketPosition(newVals.pos);
 		status.setRocketVelocity(newVals.vel);

--- a/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
+++ b/core/src/net/sf/openrocket/simulation/BasicEventSimulationEngine.java
@@ -706,7 +706,6 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 		double d = 0;
 		boolean b = false;
 		d += currentStatus.getSimulationTime();
-		d += currentStatus.getPreviousTimeStep();
 		b |= currentStatus.getRocketPosition().isNaN();
 		b |= currentStatus.getRocketVelocity().isNaN();
 		b |= currentStatus.getRocketOrientationQuaternion().isNaN();
@@ -716,7 +715,6 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 		if (Double.isNaN(d) || b) {
 			log.error("Simulation resulted in NaN value:" +
 					" simulationTime=" + currentStatus.getSimulationTime() +
-					" previousTimeStep=" + currentStatus.getPreviousTimeStep() +
 					" rocketPosition=" + currentStatus.getRocketPosition() +
 					" rocketVelocity=" + currentStatus.getRocketVelocity() +
 					" rocketOrientationQuaternion=" + currentStatus.getRocketOrientationQuaternion() +

--- a/core/src/net/sf/openrocket/simulation/SimulationStatus.java
+++ b/core/src/net/sf/openrocket/simulation/SimulationStatus.java
@@ -44,8 +44,6 @@ public class SimulationStatus implements Monitorable {
 	
 	private double time;
 	
-	private double previousTimeStep;
-	
 	private Coordinate position;
 	private WorldCoordinate worldPosition;
 	private Coordinate velocity;
@@ -105,7 +103,6 @@ public class SimulationStatus implements Monitorable {
 		this.configuration = configuration;
 		
 		this.time = 0;
-		this.previousTimeStep = this.simulationConditions.getTimeStep();
 		this.position = this.simulationConditions.getLaunchPosition();
 		this.velocity = this.simulationConditions.getLaunchVelocity();
 		this.worldPosition = this.simulationConditions.getLaunchSite();
@@ -178,7 +175,6 @@ public class SimulationStatus implements Monitorable {
 		// FlightData is not cloned.
 		this.flightData = orig.flightData;
 		this.time = orig.time;
-		this.previousTimeStep = orig.previousTimeStep;
 		this.position = orig.position;
 		this.acceleration = orig.acceleration;
 		this.worldPosition = orig.worldPosition;
@@ -266,17 +262,6 @@ public class SimulationStatus implements Monitorable {
 	public FlightDataBranch getFlightData() {
 		return flightData;
 	}
-	
-	public double getPreviousTimeStep() {
-		return previousTimeStep;
-	}
-	
-	
-	public void setPreviousTimeStep(double previousTimeStep) {
-		this.previousTimeStep = previousTimeStep;
-		this.modID++;
-	}
-	
 	
 	public void setRocketPosition(Coordinate position) {
 		this.position = position;

--- a/core/src/net/sf/openrocket/util/Coordinate.java
+++ b/core/src/net/sf/openrocket/util/Coordinate.java
@@ -191,6 +191,16 @@ public final class Coordinate implements Cloneable, Serializable {
 	}
 	
 	/**
+	 * Multiply the <code>Coordinate</code> with another <Coordinate> component-by-component
+	 *
+	 * @param other the other Coordinate
+	 * @return   The product. 
+	 */
+	public Coordinate multiply(Coordinate other) {
+		return new Coordinate(this.x * other.x, this.y * other.y, this.z * other.z, this.weight * other.weight);
+	}
+	
+	/**
 	 * Dot product of two Coordinates, taken as vectors.  Equal to
 	 * x1*x2+y1*y2+z1*z2
 	 * @param other  Coordinate to take product with.

--- a/core/test/net/sf/openrocket/simulation/FlightEventsTest.java
+++ b/core/test/net/sf/openrocket/simulation/FlightEventsTest.java
@@ -55,9 +55,9 @@ public class FlightEventsTest extends BaseTestCase {
 			new FlightEvent(FlightEvent.Type.BURNOUT, 2.0, motorMountTube),
 			new FlightEvent(FlightEvent.Type.EJECTION_CHARGE, 2.0, stage),
 			new FlightEvent(FlightEvent.Type.RECOVERY_DEVICE_DEPLOYMENT, 2.001, parachute),
-			new FlightEvent(FlightEvent.Type.APOGEE, 2.48338, rocket),
-			new FlightEvent(FlightEvent.Type.GROUND_HIT, 43.076, null),
-			new FlightEvent(FlightEvent.Type.SIMULATION_END, 43.076, null)
+			new FlightEvent(FlightEvent.Type.APOGEE, 2.48, rocket),
+			new FlightEvent(FlightEvent.Type.GROUND_HIT, 42.97, null),
+			new FlightEvent(FlightEvent.Type.SIMULATION_END, 42.97, null)
 		};
 	
 		checkEvents(expectedEvents, sim, 0);
@@ -138,9 +138,9 @@ public class FlightEventsTest extends BaseTestCase {
 						new FlightEvent(FlightEvent.Type.EJECTION_CHARGE, 2.01, centerBooster),
 						new FlightEvent(FlightEvent.Type.STAGE_SEPARATION, 2.01, centerBooster),
 						new FlightEvent(FlightEvent.Type.TUMBLE, 2.85, null),
-						new FlightEvent(FlightEvent.Type.APOGEE, 1200, rocket),
-						new FlightEvent(FlightEvent.Type.GROUND_HIT, 1200, null),
-						new FlightEvent(FlightEvent.Type.SIMULATION_END, 1200, null)
+						new FlightEvent(FlightEvent.Type.APOGEE, 3.78, rocket),
+						new FlightEvent(FlightEvent.Type.GROUND_HIT, 9.0, null),
+						new FlightEvent(FlightEvent.Type.SIMULATION_END, 9.0, null)
 					};
                     break;
 


### PR DESCRIPTION
This PR addresses several minor annoyances:

1. Previously, AbstractEulerTimeStep didn't honor the max time step that was passed in from BasicEventSimulationEngine. Here's an example from our "Pods--powered with recovery deployment" example:
![time-step-overruns-chute-open](https://github.com/openrocket/openrocket/assets/3065196/ac00d5bf-fc3c-4e0b-9e2e-527be679178e)
The time step runs from about 5.30 seconds to 5.80 seconds, while the parachute opens at 5.35 seconds.  The parachute's effect on the flight isn't apparent until the next step; in addition to being annoying (it's really not significant) it could also mislead a user into thinking we're simulating chute opening times or something.
This PR changes the behavior to this:
![time-step-limited-to-chute-open](https://github.com/openrocket/openrocket/assets/3065196/0fef6793-5070-4d87-9fd8-91f2e416b625)
The time step that would have included the chute opening is ended a time MIN_TIME_STEP (currently .001) seconds before the chute opening, and then a step from there to the chute opening is added. The instantaneous opening of the parachute is much more apparent.
2. As a rocket descended, the time steps weren't synchronized to the vertical acceleration.  The result was that a slight oscillation builds up around the true descent speed, like this (also from the same example rocket):
![recovery-oscillation](https://github.com/openrocket/openrocket/assets/3065196/5089fe99-cf6d-4231-94b7-71dfc88a5599)
This PR uses jerk to estimate when acceleration will cross 0, and limits the time step to that time:
![no-recovery-oscillation](https://github.com/openrocket/openrocket/assets/3065196/b587c2a7-cde8-4eba-ab6f-df845240f6c8)

The oscillation is substantially reduced. Also, instead of estimating jerk based on the previous and current time step's acceleration, it calculates it directly. Finally, now that the oscillation is more effectively clamped, the advantage of using jerk instead of acceleration to compute the time step is eliminated (this will become significant in a moment).
3. Similarly, the actual time of apogee is calculated and the time step covering it is truncated to that time. This one doesn't have the same visual improvement as the first two. Note that we now limit time steps to times when altitude, velocity, or acceleration have a 0 crossing.
4. As a result of 3 above, using jerk is no longer a good choice of time step, since jerk is 0 at apogee so we end up with a RECOVERY_TIME_STEP (currently .5 seconds) step immediately after apogee. Since a result of 2 above is that the advantage of using jerk is eliminated, we revert to using acceleration to set time step.
5. OR is very careless about tying calculations to the correct time step. Before this PR, all calculations for a time step were recorded to the flight data at the end of the step. This PR changes this so things that are calculated at the beginning of a time step (like acceleration) are recorded at the start of the step, and things that are updated in the course of the step (like velocity) are recorded at the end. This PR is only making this improvement to AbstractEulerStepper; similar work needs to be done in RK4SimulationStepper (along with some additional time step refinements there as well).
6. One last thing: if the rocket's mass was 0, it caused a SimulationException crash. It now inserts a SIM_ABORT event.



