### PR TITLE
Remove duplicate "Open last design file" preference from design tab

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/DesignPreferencesPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/DesignPreferencesPanel.java
@@ -76,19 +76,6 @@ public class DesignPreferencesPanel extends PreferencesPanel {
 		spin.setEditor(new SpinnerEditor(spin));
 		this.add(spin, "wrap");
 
-		final JCheckBox autoOpenDesignFile = new JCheckBox(
-				trans.get("pref.dlg.but.openlast"));
-		autoOpenDesignFile.setSelected(preferences
-				.isAutoOpenLastDesignOnStartupEnabled());
-		autoOpenDesignFile.addActionListener(new ActionListener() {
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				preferences.setAutoOpenLastDesignOnStartup(autoOpenDesignFile
-						.isSelected());
-			}
-		});
-		this.add(autoOpenDesignFile, "wrap, growx, span 2");
-
 		// // Always open leftmost tab when opening a component edit dialog
 		final JCheckBox alwaysOpenLeftmostTab = new JCheckBox(
 				trans.get("pref.dlg.checkbox.AlwaysOpenLeftmost"));


### PR DESCRIPTION
While working on the new documentation, I noticed that the "Open last design file on startup" preference is present in both the Design tab and the General tab. This PR removes that option from the Design, so that it is only accessible in the General tab from now on.