### PR TITLE
Fix 2498

### DIFF
--- a/core/src/main/java/info/openrocket/core/document/Simulation.java
+++ b/core/src/main/java/info/openrocket/core/document/Simulation.java
@@ -419,12 +419,13 @@ public class Simulation implements ChangeSource, Cloneable {
 
 			SimulationConditions simulationConditions = options.toSimulationConditions();
 			simulationConditions.setSimulation(this);
-			for (SimulationListener l : additionalListeners) {
-				simulationConditions.getSimulationListenerList().add(l);
-			}
 			
 			for (SimulationExtension extension : simulationExtensions) {
 				extension.initialize(simulationConditions);
+			}
+			
+			for (SimulationListener l : additionalListeners) {
+				simulationConditions.getSimulationListenerList().add(l);
 			}
 			
 			long t1, t2;

--- a/core/src/main/java/info/openrocket/core/simulation/extension/example/DampingMoment.java
+++ b/core/src/main/java/info/openrocket/core/simulation/extension/example/DampingMoment.java
@@ -25,6 +25,9 @@ import info.openrocket.core.unit.UnitGroup;
 public class DampingMoment extends AbstractSimulationExtension {
 	private static final Logger log = LoggerFactory.getLogger(DampingMoment.class);
 
+	// Keep it internal until time to publish in the FlightDataBranch
+	private double Cdm = Double.NaN;
+	
 	// Save it as a FlightDataType
 	private static final FlightDataType cdm = FlightDataType.getType("Damping moment coefficient", "Cdm",
 			UnitGroup.UNITS_COEFFICIENT);
@@ -62,9 +65,14 @@ public class DampingMoment extends AbstractSimulationExtension {
 				throws SimulationException {
 
 			// status.getFlightDataBranch().setValue(cdm, aerodynamicPart + propulsivePart);
-			status.getFlightDataBranch().setValue(cdm, calculate(status, flightConditions));
+			Cdm = calculate(status, flightConditions);
 
 			return flightConditions;
+		}
+
+		@Override
+		public void postStep(SimulationStatus status) {
+			status.getFlightDataBranch().setValue(cdm, Cdm);
 		}
 
 		private double calculate(SimulationStatus status, FlightConditions flightConditions) {


### PR DESCRIPTION
This addresses two problems with custom expressions in general and calculation of damping ratio in particular.

1. Run postStep listeners before calculating custom expressions. They were being run after, so their results weren't available to custom expressions on the same step. There is never an actual need to run custom expressions before listeners since the listener can calculate anything it wants internally; there can be a need to run listeners first (as in this case).
2.  The damping moment coefficient listener example was saving its result to the FlightDataBranch before a new point was added to the branch at the end of the simulation step; again, this makes it unavailable to custom expressions. The listener now saves its result internally until postStep() is called (which occurs after the addition of the new data point), and puts it out at that time.

Fixes #2498