### PR TITLE
[#2462] Provide air density as plottable variable

### DIFF
--- a/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
@@ -323,6 +323,8 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 									flightConditions.getAtmosphericConditions().getTemperature());
 				dataBranch.setValue(FlightDataType.TYPE_AIR_PRESSURE,
 									flightConditions.getAtmosphericConditions().getPressure());
+				dataBranch.setValue(FlightDataType.TYPE_AIR_DENSITY,
+						flightConditions.getAtmosphericConditions().getDensity());
 				dataBranch.setValue(FlightDataType.TYPE_SPEED_OF_SOUND,
 									flightConditions.getAtmosphericConditions().getMachSpeed());
 			}

--- a/core/src/main/java/info/openrocket/core/simulation/FlightDataType.java
+++ b/core/src/main/java/info/openrocket/core/simulation/FlightDataType.java
@@ -275,10 +275,14 @@ public class FlightDataType implements Comparable<FlightDataType> {
 	public static final FlightDataType TYPE_AIR_PRESSURE = newType(trans.get("FlightDataType.TYPE_AIR_PRESSURE"), "P",
 			UnitGroup.UNITS_PRESSURE,
 			FlightDataTypeGroup.ATMOSPHERIC_CONDITIONS, 2);
+	//// Air density
+	public static final FlightDataType TYPE_AIR_DENSITY = newType(trans.get("FlightDataType.TYPE_AIR_DENSITY"), "\u03C1",
+			UnitGroup.UNITS_DENSITY_BULK,
+			FlightDataTypeGroup.ATMOSPHERIC_CONDITIONS, 3);
 	//// Speed of sound
 	public static final FlightDataType TYPE_SPEED_OF_SOUND = newType(trans.get("FlightDataType.TYPE_SPEED_OF_SOUND"),
 			"Vs", UnitGroup.UNITS_VELOCITY,
-			FlightDataTypeGroup.ATMOSPHERIC_CONDITIONS, 3);
+			FlightDataTypeGroup.ATMOSPHERIC_CONDITIONS, 4);
 
 	// Simulation information
 	//// Simulation time step
@@ -345,6 +349,7 @@ public class FlightDataType implements Comparable<FlightDataType> {
 			TYPE_WIND_VELOCITY,
 			TYPE_AIR_TEMPERATURE,
 			TYPE_AIR_PRESSURE,
+			TYPE_AIR_DENSITY,
 			TYPE_SPEED_OF_SOUND,
 			TYPE_TIME_STEP,
 			TYPE_COMPUTATION_TIME

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -2119,6 +2119,7 @@ FlightDataType.TYPE_ORIENTATION_PHI = Lateral orientation (azimuth)
 FlightDataType.TYPE_WIND_VELOCITY = Wind velocity
 FlightDataType.TYPE_AIR_TEMPERATURE = Air temperature
 FlightDataType.TYPE_AIR_PRESSURE = Air pressure
+FlightDataType.TYPE_AIR_DENSITY = Air density
 FlightDataType.TYPE_SPEED_OF_SOUND = Speed of sound
 FlightDataType.TYPE_TIME_STEP = Simulation time step
 FlightDataType.TYPE_COMPUTATION_TIME = Computation time


### PR DESCRIPTION
This PR fixes #2462 by providing the air density as a plottable/exportable variable:
<img width="1056" alt="image" src="https://github.com/user-attachments/assets/659c2b99-c969-45c0-89dc-29a258bfa7dd">
