### PR TITLE
Reduce redundant acceleration data storage

### DIFF
--- a/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
@@ -257,9 +257,6 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 		public double dragForce = Double.NaN;
 		public double lateralPitchRate = Double.NaN;
 		
-		public double rollAcceleration = Double.NaN;
-		public double lateralPitchAcceleration = Double.NaN;
-		
 		public Rotation2D thetaRotation;
 
 		void storeData(SimulationStatus status) {

--- a/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
@@ -163,14 +163,12 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 	 *  
 	 * @param status					the current simulation status.
 	 * @param timestep					the time step of the current iteration.
-	 * @param acceleration				the current (approximate) acceleration
-	 * @param atmosphericConditions		the current atmospheric conditions
+	 * @param store                     the simulation calculation DataStore (contains acceleration, atmosphere)
 	 * @param stepMotors				whether to step the motors forward or work on a clone object
 	 * @return							the average thrust during the time step.
 	 */
-	protected double calculateThrust(SimulationStatus status,
-			double acceleration, AtmosphericConditions atmosphericConditions,
-			boolean stepMotors) throws SimulationException {
+	protected double calculateThrust(SimulationStatus status, DataStore store,
+									 boolean stepMotors) throws SimulationException {
 		double thrust;
 
 		// Pre-listeners
@@ -239,8 +237,6 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 		public AtmosphericConditions atmosphericConditions;
 		
 		public FlightConditions flightConditions;
-		
-		public double longitudinalAcceleration = Double.NaN;
 		
 		public RigidBody rocketMass;
 		

--- a/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
@@ -243,9 +243,6 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 		public RigidBody motorMass;
 		
 		public Coordinate coriolisAcceleration;
-		
-		public Coordinate linearAcceleration;
-		public Coordinate angularAcceleration;
 
 		public Coordinate launchRodDirection = null;
 		
@@ -282,12 +279,12 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 				dataBranch.setValue(FlightDataType.TYPE_CORIOLIS_ACCELERATION, coriolisAcceleration.length());
 			}
 			
-			if (null != linearAcceleration) {
+			if (null != accelerationData) {
 				dataBranch.setValue(FlightDataType.TYPE_ACCELERATION_XY,
-									MathUtil.hypot(linearAcceleration.x, linearAcceleration.y));
+									MathUtil.hypot(accelerationData.getLinearAccelerationWC().x, accelerationData.getLinearAccelerationWC().y));
 				
-				dataBranch.setValue(FlightDataType.TYPE_ACCELERATION_TOTAL, linearAcceleration.length());
-				dataBranch.setValue(FlightDataType.TYPE_ACCELERATION_Z, linearAcceleration.z);
+				dataBranch.setValue(FlightDataType.TYPE_ACCELERATION_TOTAL, accelerationData.getLinearAccelerationWC().length());
+				dataBranch.setValue(FlightDataType.TYPE_ACCELERATION_Z, accelerationData.getLinearAccelerationWC().z);
 			}
 			
 			if (null != rocketMass) {

--- a/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
@@ -273,8 +273,8 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 		// Call post-listeners
 		store.accelerationData = SimulationListenerHelper.firePostAccelerationCalculation(status, store.accelerationData);
 
-		params.a = dataStore.linearAcceleration;
-		params.ra = dataStore.angularAcceleration;
+		params.a = dataStore.accelerationData.getLinearAccelerationWC();
+		params.ra = dataStore.accelerationData.getRotationalAccelerationWC();
 		params.v = status.getRocketVelocity();
 		params.rv = status.getRocketRotationVelocity();
 		
@@ -298,7 +298,9 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 	 * @throws SimulationException 
 	 */
 	private AccelerationData calculateAcceleration(SimulationStatus status, DataStore store) throws SimulationException {
-		
+		Coordinate linearAcceleration;
+		Coordinate angularAcceleration;
+			
 		// Compute the forces affecting the rocket
 		calculateForces(status, store);
 		
@@ -328,30 +330,30 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 		store.thrustForce = calculateThrust(status, store, false);
 		double forceZ =  store.thrustForce - store.dragForce;
 		
-		store.linearAcceleration = new Coordinate(-fN / store.rocketMass.getMass(),
+		linearAcceleration = new Coordinate(-fN / store.rocketMass.getMass(),
 					-fSide / store.rocketMass.getMass(),
 					forceZ / store.rocketMass.getMass());
 		
-		store.linearAcceleration = store.thetaRotation.rotateZ(store.linearAcceleration);
+		linearAcceleration = store.thetaRotation.rotateZ(linearAcceleration);
 		
 		// Convert into rocket world coordinates
-		store.linearAcceleration = status.getRocketOrientationQuaternion().rotate(store.linearAcceleration);
+		linearAcceleration = status.getRocketOrientationQuaternion().rotate(linearAcceleration);
 		
 		// add effect of gravity
 		store.gravity = modelGravity(status);
-		store.linearAcceleration = store.linearAcceleration.sub(0, 0, store.gravity);
+		linearAcceleration = linearAcceleration.sub(0, 0, store.gravity);
 		
 		// add effect of Coriolis acceleration
 		store.coriolisAcceleration = status.getSimulationConditions().getGeodeticComputation()
 				.getCoriolisAcceleration(status.getRocketWorldPosition(), status.getRocketVelocity());
-		store.linearAcceleration = store.linearAcceleration.add(store.coriolisAcceleration);
+		linearAcceleration = linearAcceleration.add(store.coriolisAcceleration);
 		
 		// If still on the launch rod, project acceleration onto launch rod direction and
 		// set angular acceleration to zero.
 		if (!status.isLaunchRodCleared()) {
 			
-			store.linearAcceleration = store.launchRodDirection.multiply(store.linearAcceleration.dot(store.launchRodDirection));
-			store.angularAcceleration = Coordinate.NUL;
+			linearAcceleration = store.launchRodDirection.multiply(linearAcceleration.dot(store.launchRodDirection));
+			angularAcceleration = Coordinate.NUL;
 			store.rollAcceleration = 0;
 			store.lateralPitchAcceleration = 0;
 			
@@ -367,23 +369,23 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 			double momZ = store.forces.getCroll() * dynP * refArea * refLength;
 			
 			// Compute acceleration in rocket coordinates
-			store.angularAcceleration = new Coordinate(momX / store.rocketMass.getLongitudinalInertia(),
+			angularAcceleration = new Coordinate(momX / store.rocketMass.getLongitudinalInertia(),
 						momY / store.rocketMass.getLongitudinalInertia(),
 						momZ / store.rocketMass.getRotationalInertia());
 			
-			store.rollAcceleration = store.angularAcceleration.z;
+			store.rollAcceleration = angularAcceleration.z;
 			// TODO: LOW: This should be hypot, but does it matter?
-			store.lateralPitchAcceleration = MathUtil.max(Math.abs(store.angularAcceleration.x),
-						Math.abs(store.angularAcceleration.y));
+			store.lateralPitchAcceleration = MathUtil.max(Math.abs(angularAcceleration.x),
+						Math.abs(angularAcceleration.y));
 			
-			store.angularAcceleration = store.thetaRotation.rotateZ(store.angularAcceleration);
+			angularAcceleration = store.thetaRotation.rotateZ(angularAcceleration);
 			
 			// Convert to world coordinates
-			store.angularAcceleration = status.getRocketOrientationQuaternion().rotate(store.angularAcceleration);
+			angularAcceleration = status.getRocketOrientationQuaternion().rotate(angularAcceleration);
 			
 		}
 
-		return new AccelerationData(null, null, store.linearAcceleration, store.angularAcceleration, status.getRocketOrientationQuaternion());
+		return new AccelerationData(null, null, linearAcceleration, angularAcceleration, status.getRocketOrientationQuaternion());
 	}
 	
 	

--- a/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
@@ -325,7 +325,7 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 		double fN = store.forces.getCN() * dynP * refArea;
 		double fSide = store.forces.getCside() * dynP * refArea;
 
-		store.thrustForce = calculateThrust(status, store.longitudinalAcceleration, store.flightConditions.getAtmosphericConditions(), false);
+		store.thrustForce = calculateThrust(status, store, false);
 		double forceZ =  store.thrustForce - store.dragForce;
 		
 		store.linearAcceleration = new Coordinate(-fN / store.rocketMass.getMass(),


### PR DESCRIPTION
The DataStore, AccelerationData, and SimulationStatus had redundant storage of identical acceleration data. This made the code more difficult to read and has a potential for errors in the future if the data gets out of sync. This PR removes this redundancy. Issue #2443 was originally filed because some of this data was only in the SimulationStatus when in an Euler stepper, not the RK4 Stepper.  It is now never in SimulationStatus (it is in DataStore.accelerationData at all times).

Fixes #2443