### PR TITLE
[#2531] Don't close edit sim dialog after plotting or exporting

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConfigDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConfigDialog.java
@@ -373,12 +373,13 @@ public class SimulationConfigDialog extends JDialog {
 					if (plot != null) {
 						plot.setVisible(true);
 					}
-					closeDialog();
 					return;
 				} else if (tabIdx == EXPORT_IDX) {
-					if (exportTab == null || exportTab.doExport()) {
+					if (exportTab == null) {
 						closeDialog();
+						return;
 					}
+					exportTab.doExport();
 					return;
 				}
 


### PR DESCRIPTION
This PR fixes #2531. The sim edit dialog will now remain open after plotting/exporting a sim.