### PR TITLE
[#2537] Allow for reconfiguration of the default flight config name

### DIFF
--- a/core/src/main/java/info/openrocket/core/preferences/ApplicationPreferences.java
+++ b/core/src/main/java/info/openrocket/core/preferences/ApplicationPreferences.java
@@ -20,6 +20,7 @@ import info.openrocket.core.material.Material;
 import info.openrocket.core.models.atmosphere.AtmosphericModel;
 import info.openrocket.core.models.atmosphere.ExtendedISAModel;
 import info.openrocket.core.preset.ComponentPreset;
+import info.openrocket.core.rocketcomponent.FlightConfiguration;
 import info.openrocket.core.rocketcomponent.MassObject;
 import info.openrocket.core.rocketcomponent.Rocket;
 import info.openrocket.core.rocketcomponent.RocketComponent;
@@ -101,8 +102,10 @@ public abstract class ApplicationPreferences implements ChangeSource, ORPreferen
 
 	public static final String ROCKET_INFO_FONT_SIZE = "RocketInfoFontSize";
 
-	// Preferences Related to Simulations
+	// Preferences related to flight configurations
+	public static final String DEFAULT_FLIGHT_CONFIG_NAME = "DefaultFlightConfigName";
 
+	// Preferences Related to Simulations
 	public static final String CONFIRM_DELETE_SIMULATION = "ConfirmDeleteSimulation";
 	public static final String AUTO_RUN_SIMULATIONS = "AutoRunSimulations";
 	public static final String LAUNCH_ROD_LENGTH = "LaunchRodLength";
@@ -257,6 +260,18 @@ public abstract class ApplicationPreferences implements ChangeSource, ORPreferen
 		this.putBoolean(DISPLAY_SECONDARY_STABILITY, check);
 	}
 
+
+	/*
+	 * ******************************************************************************************
+	 */
+
+	public String getDefaultFlightConfigName() {
+		return getString(DEFAULT_FLIGHT_CONFIG_NAME, FlightConfiguration.DEFAULT_CONFIG_NAME);
+	}
+
+	public void setDefaultFlightConfigName(String name) {
+		putString(DEFAULT_FLIGHT_CONFIG_NAME, name);
+	}
 
 	/*
 	 * ******************************************************************************************

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/FlightConfiguration.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/FlightConfiguration.java
@@ -107,7 +107,7 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 			this.fcid = _fcid;
 		}
 		this.rocket = rocket;
-		this.configurationName = prefs.getDefaultFlightConfigName();
+		this.configurationName = getDefaultName();
 		this.configurationInstanceId = configurationInstanceCount++;
 
 		updateStages();
@@ -580,7 +580,15 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 	}
 
 	public boolean isNameOverridden() {
-		return (!prefs.getDefaultFlightConfigName().equals(this.configurationName));
+		return (!getDefaultName().equals(this.configurationName));
+	}
+	
+	private String getDefaultName() {
+		String name = prefs.getDefaultFlightConfigName();
+		if (name == null) {
+			name = DEFAULT_CONFIG_NAME;
+		}
+		return name;
 	}
 
 	/**
@@ -592,7 +600,7 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 	 */
 	public String getName() {
 		if (configurationName == null) {
-			configurationName = prefs.getDefaultFlightConfigName();
+			configurationName = getDefaultName();
 		}
 		return descriptor.format(configurationName, rocket, fcid);
 	}
@@ -605,7 +613,7 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 	 */
 	public String getNameRaw() {
 		if (configurationName == null) {
-			return prefs.getDefaultFlightConfigName();
+			return getDefaultName();
 		}
 		return configurationName;
 	}
@@ -922,7 +930,7 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 
 	public void setName(final String newName) {
 		if ((newName == null) || (newName.isEmpty())) {
-			this.configurationName = prefs.getDefaultFlightConfigName();
+			this.configurationName = getDefaultName();
 			return;
 		} else if (!this.getId().isValid()) {
 			return;

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/FlightConfiguration.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/FlightConfiguration.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import info.openrocket.core.formatting.RocketDescriptor;
+import info.openrocket.core.preferences.ApplicationPreferences;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +34,7 @@ import info.openrocket.core.util.Transformation;
  */
 public class FlightConfiguration implements FlightConfigurableParameter<FlightConfiguration>, Monitorable {
 	private static final Logger log = LoggerFactory.getLogger(FlightConfiguration.class);
+	private static final ApplicationPreferences prefs = Application.getPreferences();
 
 	private String configurationName;
 	public static String DEFAULT_CONFIG_NAME = "[{motors}]";
@@ -105,7 +107,7 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 			this.fcid = _fcid;
 		}
 		this.rocket = rocket;
-		this.configurationName = DEFAULT_CONFIG_NAME;
+		this.configurationName = prefs.getDefaultFlightConfigName();
 		this.configurationInstanceId = configurationInstanceCount++;
 
 		updateStages();
@@ -578,11 +580,11 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 	}
 
 	public boolean isNameOverridden() {
-		return (!DEFAULT_CONFIG_NAME.equals(this.configurationName));
+		return (!prefs.getDefaultFlightConfigName().equals(this.configurationName));
 	}
 
 	/**
-	 * Return the name of this configuration, with DEFAULT_CONFIG_NAME replaced by a
+	 * Return the name of this configuration, with the default flight config name replaced by a
 	 * one line motor description.
 	 * If configurationName is null, the one line motor description is returned.
 	 * 
@@ -590,20 +592,20 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 	 */
 	public String getName() {
 		if (configurationName == null) {
-			configurationName = DEFAULT_CONFIG_NAME;
+			configurationName = prefs.getDefaultFlightConfigName();
 		}
 		return descriptor.format(configurationName, rocket, fcid);
 	}
 
 	/**
-	 * Return the raw configuration name, without replacing DEFAULT_CONFIG_NAME.
-	 * If the configurationName is null, DEFAULT_CONFIG_NAME is returned.
+	 * Return the raw configuration name, without replacing the default flight config name.
+	 * If the configurationName is null, the default flight config name is returned.
 	 * 
 	 * @return raw flight configuration name
 	 */
 	public String getNameRaw() {
 		if (configurationName == null) {
-			return DEFAULT_CONFIG_NAME;
+			return prefs.getDefaultFlightConfigName();
 		}
 		return configurationName;
 	}
@@ -920,7 +922,7 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 
 	public void setName(final String newName) {
 		if ((newName == null) || (newName.isEmpty())) {
-			this.configurationName = DEFAULT_CONFIG_NAME;
+			this.configurationName = prefs.getDefaultFlightConfigName();
 			return;
 		} else if (!this.getId().isValid()) {
 			return;

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -251,6 +251,9 @@ edtmotorconfdlg.tbl.Separationheader = Separation
 ! Rename FlightConfiguration Dialog
 RenameConfigDialog.title = Rename Configuration
 RenameConfigDialog.lbl.name = Name for flight configuration:
+RenameConfigDialog.but.saveDefault = Save as default
+RenameConfigDialog.dlg.saveDefault.msg = This change will only affect new flight configurations.
+RenameConfigDialog.dlg.saveDefault.title = Save as default
 RenameConfigDialog.but.reset = Reset to default
 RenameConfigDialog.lbl.infoMotors = The text '<b>{motors}</b>' will be replaced with the <b>motor designation(s).</b><br><pre>\te.g. '{motors} \u2192 'M1350-0'</pre>
 RenameConfigDialog.lbl.infoManufacturers = The text '<b>{manufacturers}</b>' will be replaced with the <b>motor manufacturer(s).</b><br><pre>\te.g. '{manufacturers}' \u2192 'AeroTech'</pre>

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/flightconfiguration/RenameConfigDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/flightconfiguration/RenameConfigDialog.java
@@ -9,10 +9,12 @@ import java.awt.event.ActionListener;
 import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 
 import info.openrocket.core.l10n.Translator;
+import info.openrocket.core.preferences.ApplicationPreferences;
 import info.openrocket.core.rocketcomponent.FlightConfigurationId;
 import info.openrocket.core.rocketcomponent.Rocket;
 import info.openrocket.core.startup.Application;
@@ -26,6 +28,7 @@ import info.openrocket.swing.gui.theme.UITheme;
 public class RenameConfigDialog extends JDialog {
 	private static final long serialVersionUID = -5423008694485357248L;
 	private static final Translator trans = Application.getTranslator();
+	private static final ApplicationPreferences prefs = Application.getPreferences();
 
 	private static Color dimTextColor;
 
@@ -55,6 +58,17 @@ public class RenameConfigDialog extends JDialog {
 			}
 		});
 		panel.add(okButton);
+
+		JButton saveAsDefaultButton = new JButton(trans.get("RenameConfigDialog.but.saveDefault"));
+		saveAsDefaultButton.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				JOptionPane.showMessageDialog(RenameConfigDialog.this, trans.get("RenameConfigDialog.dlg.saveDefault.msg"),
+						trans.get("RenameConfigDialog.dlg.saveDefault.title"), JOptionPane.INFORMATION_MESSAGE);
+				prefs.setDefaultFlightConfigName(textbox.getText());
+			}
+		});
+		panel.add(saveAsDefaultButton);
 		
 		JButton resetToDefaultButton = new JButton(trans.get("RenameConfigDialog.but.reset"));
 		resetToDefaultButton.addActionListener(new ActionListener() {


### PR DESCRIPTION
This PR fixes #2537.


https://github.com/user-attachments/assets/8baef65a-8dd0-4a63-a1f7-fce7606bb7b4

