### PR TITLE
[#1579] Add command-line argument to bypass preset and motor loading at startup

### DIFF
--- a/core/src/main/java/info/openrocket/core/database/AsynchronousDatabaseLoader.java
+++ b/core/src/main/java/info/openrocket/core/database/AsynchronousDatabaseLoader.java
@@ -43,6 +43,18 @@ public abstract class AsynchronousDatabaseLoader {
 	}
 
 	/**
+	 * Mark the database as loaded. This method is called by the loading thread when it has finished loading the database.
+	 * You can also use this to bypass the database loading, but still mark it as loaded.
+	 */
+	public void markAsLoaded() {
+		synchronized (this) {
+			startedLoading = true;
+			endedLoading = true;
+			this.notifyAll();
+		}
+	}
+
+	/**
 	 * @return whether loading the database has ended.
 	 */
 	public boolean isLoaded() {
@@ -95,10 +107,7 @@ public abstract class AsynchronousDatabaseLoader {
 
 		loadDatabase();
 
-		synchronized (this) {
-			endedLoading = true;
-			this.notifyAll();
-		}
+		markAsLoaded();
 	}
 
 	/**

--- a/swing/src/main/java/info/openrocket/swing/startup/GuiModule.java
+++ b/swing/src/main/java/info/openrocket/swing/startup/GuiModule.java
@@ -58,7 +58,10 @@ public class GuiModule extends AbstractModule {
 		BlockingMotorDatabaseProvider motorDatabaseProvider = new BlockingMotorDatabaseProvider(motorLoader);
 		bind(ThrustCurveMotorSetDatabase.class).toProvider(motorDatabaseProvider).in(Scopes.SINGLETON);
 		bind(MotorDatabase.class).toProvider(motorDatabaseProvider).in(Scopes.SINGLETON);
-		
+
+		if (System.getProperty("openrocket.debug") != null) {
+
+		}
 	}
 	
 	/**
@@ -67,8 +70,19 @@ public class GuiModule extends AbstractModule {
 	 * object's locator methods to return the correct objects.
 	 */
 	public void startLoader() {
-		presetLoader.startLoading();
-		motorLoader.startLoading();
+		boolean bypassPresets = System.getProperty("openrocket.bypass.presets") != null;
+		boolean bypassMotors = System.getProperty("openrocket.bypass.motors") != null;
+
+		if (!bypassPresets) {
+			presetLoader.startLoading();
+		} else {
+			presetLoader.markAsLoaded();
+		}
+		if (!bypassMotors) {
+			motorLoader.startLoading();
+		} else {
+			motorLoader.markAsLoaded();
+		}
 	}
 	
 }


### PR DESCRIPTION
This PR fixes #1579. You can now bypass the component preset and motor database loading respectively with the command line arguments `-Dopenrocket.bypass.presets` and `-Dopenrocket.bypass.motors`. It has been documented on the GitHub Wiki: https://github.com/openrocket/openrocket/wiki/Command-line-arguments.