### PR TITLE
 [#2019] Highlight selected component in CA dialog in rocket panel  & Add per-instance CD column to component analysis dialog

### DIFF
--- a/core/src/main/java/info/openrocket/core/aerodynamics/AerodynamicForces.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/AerodynamicForces.java
@@ -234,6 +234,10 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 		modID = new ModID();
 	}
 
+	/**
+	 * Get the drag coefficient <b>per instance</b>.
+	 * @return The drag coefficient.
+	 */
 	public double getCD() {
 		if (component == null)
 			return CD;
@@ -243,6 +247,10 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 			return component.getOverrideCD();
 		}
 		return CD;
+	}
+
+	public double getCDTotal() {
+		return getCD() * component.getInstanceCount();
 	}
 
 	public void setPressureCD(double pressureCD) {

--- a/core/src/main/java/info/openrocket/core/componentanalysis/CADataType.java
+++ b/core/src/main/java/info/openrocket/core/componentanalysis/CADataType.java
@@ -39,8 +39,10 @@ public class CADataType implements Comparable<CADataType>, Groupable<CADataTypeG
 			"CD,base", UnitGroup.UNITS_NONE, CADataTypeGroup.DRAG, 21);
 	public static final CADataType FRICTION_CD = new CADataType(trans.get("ComponentAnalysisGeneralTab.dragTableModel.Col.friction"),
 			"CD,friction", UnitGroup.UNITS_NONE, CADataTypeGroup.DRAG, 22);
+	public static final CADataType PER_INSTANCE_CD = new CADataType(trans.get("ComponentAnalysisGeneralTab.dragTableModel.Col.perInstance"),
+			"CD,instance", UnitGroup.UNITS_NONE, CADataTypeGroup.DRAG, 23);
 	public static final CADataType TOTAL_CD = new CADataType(trans.get("ComponentAnalysisGeneralTab.dragTableModel.Col.total"),
-			"CD,total", UnitGroup.UNITS_NONE, CADataTypeGroup.DRAG, 23);
+			"CD,total", UnitGroup.UNITS_NONE, CADataTypeGroup.DRAG, 24);
 
 	//// Roll
 	public static final CADataType ROLL_FORCING_COEFFICIENT = new CADataType(trans.get("ComponentAnalysisGeneralTab.rollTableModel.Col.rollforc"),
@@ -53,7 +55,7 @@ public class CADataType implements Comparable<CADataType>, Groupable<CADataTypeG
 
 	public static final CADataType[] ALL_TYPES = {
 			CP_X, CNa,
-			PRESSURE_CD, BASE_CD, FRICTION_CD, TOTAL_CD,
+			PRESSURE_CD, BASE_CD, FRICTION_CD, PER_INSTANCE_CD, TOTAL_CD,
 			ROLL_FORCING_COEFFICIENT, ROLL_DAMPING_COEFFICIENT, TOTAL_ROLL_COEFFICIENT
 	};
 
@@ -124,9 +126,14 @@ public class CADataType implements Comparable<CADataType>, Groupable<CADataTypeG
 			return false;
 		}
 
+		// Doesn't make sense to calculate per-instance drag for rockets
+		if (component instanceof Rocket && type.equals(CADataType.PER_INSTANCE_CD)) {
+			return false;
+		}
+
 		if (type.equals(CADataType.CP_X) || type.equals(CADataType.CNa) ||
 				type.equals(CADataType.PRESSURE_CD) || type.equals(CADataType.BASE_CD) ||
-				type.equals(CADataType.FRICTION_CD) || type.equals(CADataType.TOTAL_CD)) {
+				type.equals(CADataType.FRICTION_CD) || type.equals(CADataType.PER_INSTANCE_CD) || type.equals(CADataType.TOTAL_CD)) {
 			return true;
 		} else if (type.equals(CADataType.ROLL_FORCING_COEFFICIENT) || type.equals(CADataType.ROLL_DAMPING_COEFFICIENT) ||
 				type.equals(CADataType.TOTAL_ROLL_COEFFICIENT)) {

--- a/core/src/main/java/info/openrocket/core/componentanalysis/CAParameterSweep.java
+++ b/core/src/main/java/info/openrocket/core/componentanalysis/CAParameterSweep.java
@@ -129,7 +129,8 @@ public class CAParameterSweep {
 				dataBranch.setValue(CADataType.PRESSURE_CD, component, forces.getPressureCD());
 				dataBranch.setValue(CADataType.BASE_CD, component, forces.getBaseCD());
 				dataBranch.setValue(CADataType.FRICTION_CD, component, forces.getFrictionCD());
-				dataBranch.setValue(CADataType.TOTAL_CD, component, forces.getCD());
+				dataBranch.setValue(CADataType.PER_INSTANCE_CD, component, forces.getCD());
+				dataBranch.setValue(CADataType.TOTAL_CD, component, forces.getCDTotal());
 			}
 
 			if (component instanceof FinSet) {
@@ -154,7 +155,8 @@ public class CAParameterSweep {
 			dataBranch.setValue(CADataType.PRESSURE_CD, rocket, totalForces.getPressureCD());
 			dataBranch.setValue(CADataType.BASE_CD, rocket, totalForces.getBaseCD());
 			dataBranch.setValue(CADataType.FRICTION_CD, rocket, totalForces.getFrictionCD());
-			dataBranch.setValue(CADataType.TOTAL_CD, rocket, totalForces.getCD());
+			dataBranch.setValue(CADataType.PER_INSTANCE_CD, rocket, totalForces.getCD());
+			dataBranch.setValue(CADataType.TOTAL_CD, rocket, totalForces.getCDTotal());
 		}
 	}
 

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -937,6 +937,7 @@ ComponentAnalysisGeneralTab.dragTableModel.Col.Component = Component
 ComponentAnalysisGeneralTab.dragTableModel.Col.Pressure = <html>Pressure C<sub>D</sub>
 ComponentAnalysisGeneralTab.dragTableModel.Col.Base = <html>Base C<sub>D</sub>
 ComponentAnalysisGeneralTab.dragTableModel.Col.friction = <html>Friction C<sub>D</sub>
+ComponentAnalysisGeneralTab.dragTableModel.Col.perInstance = <html>Per instance C<sub>D</sub>
 ComponentAnalysisGeneralTab.dragTableModel.Col.total = <html>Total C<sub>D</sub>
 ComponentAnalysisGeneralTab.dragTabchar = Drag characteristics
 ComponentAnalysisGeneralTab.dragTabchar.ttip = Drag characteristics

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/CAPlotTypeSelector.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/CAPlotTypeSelector.java
@@ -33,7 +33,7 @@ public class CAPlotTypeSelector extends PlotTypeSelector<CADataType, CADataTypeG
 		componentSelector = new JComboBox<>(componentsForType.toArray(new RocketComponent[0]));
 		componentSelector.setSelectedItem(selectedComponent);
 		configuration.setPlotDataComponent(plotIndex, selectedComponent);
-		this.add(componentSelector, "gapright para");
+		this.add(componentSelector, "growx, gapright para");
 
 		addRemoveButton();
 

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/ComponentAnalysisGeneralPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/ComponentAnalysisGeneralPanel.java
@@ -764,11 +764,12 @@ public class ComponentAnalysisGeneralPanel extends JPanel implements StateChange
 	private class DragCellRenderer extends CustomCellRenderer {
 		private static final long serialVersionUID = 1L;
 		private final StripedLabelUI stripedUI;
-		private final LabelUI defaultUI = new BasicLabelUI();
+		private final LabelUI defaultUI;
 
 		public DragCellRenderer() {
 			super(dragData, 3);
 			this.stripedUI = new StripedLabelUI(1, 12);
+			this.defaultUI = new BasicLabelUI();
 		}
 
 		@Override
@@ -779,36 +780,48 @@ public class ComponentAnalysisGeneralPanel extends JPanel implements StateChange
 			// Reset to default UI
 			label.setUI(defaultUI);
 
-			if (!isSelected && (value instanceof Double)) {
-				double cd = (Double) value;
-				float r = (float) (cd / 1.5);
+			// Handle selection coloring
+			if (isSelected) {
+				label.setBackground(table.getSelectionBackground());
+				label.setForeground(table.getSelectionForeground());
+				label.setOpaque(true);
+			} else {
+				// Non-selected styling
+				if (value instanceof Double) {
+					double cd = (Double) value;
+					float r = (float) (cd / 1.5);
 
-				float hue = MathUtil.clamp(0.3333f * (1 - 2.0f * r), 0, 0.3333f);
-				float sat = MathUtil.clamp(0.8f * r + 0.1f * (1 - r), 0, 1);
-				float val = 1.0f;
+					float hue = MathUtil.clamp(0.3333f * (1 - 2.0f * r), 0, 0.3333f);
+					float sat = MathUtil.clamp(0.8f * r + 0.1f * (1 - r), 0, 1);
+					float val = 1.0f;
 
-				label.setBackground(Color.getHSBColor(hue, sat, val));
-				label.setForeground(Color.BLACK);
+					label.setBackground(Color.getHSBColor(hue, sat, val));
+					label.setForeground(Color.BLACK);
+				} else {
+					label.setBackground(table.getBackground());
+					label.setForeground(table.getForeground());
+				}
+				label.setOpaque(true);
 			}
 
-			// For the per instance CD, we want to use a different formatting, because the relative percentages
-			// don't matter, and the total instance CD for the rocket makes no sense.
+			// Special handling for column 4
 			if (column == 4) {
 				if (row == 0) {
 					label.setText("");
-					label.setOpaque(true);
-					label.setBackground(backgroundColor);
-					label.setForeground(foregroundColor);
-					label.setBorder(BorderFactory.createEmptyBorder(1, 1, 1, 1));
 					label.setUI(stripedUI);
+					if (!isSelected) {
+						label.setBackground(table.getBackground());
+						label.setForeground(table.getForeground());
+					}
 				} else {
 					label.setText(decimalFormat(dragData.get(row).getCD()));
 				}
-				return label;
 			}
 
-			if ((row < 0) || (row >= dragData.size()))
+			// Set font
+			if ((row < 0) || (row >= dragData.size())) {
 				return label;
+			}
 
 			if ((dragData.get(row).getComponent() instanceof Rocket) || (column == 5)) {
 				label.setFont(boldFont);

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
@@ -541,6 +541,15 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		valueChanged((TreeSelectionEvent) null); // updates FigureParameters
 	}
 
+	public void setSelectedComponent(RocketComponent component) {
+		if (component == null) {
+			selectionModel.setSelectionPath(null);
+			return;
+		}
+		TreePath path = ComponentTreeModel.makeTreePath(component);
+		selectionModel.setSelectionPath(path);
+	}
+
 	/**
 	 * Return the angle of attack used in CP calculation.  NaN signifies the default value
 	 * of zero.
@@ -672,8 +681,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 			if (newClick) {
 				for (RocketComponent rocketComponent : clicked) {
 					if (!selectedComponents.contains(rocketComponent)) {
-						TreePath path = ComponentTreeModel.makeTreePath(rocketComponent);
-						selectionModel.setSelectionPath(path);
+						setSelectedComponent(rocketComponent);
 					}
 				}
 			}

--- a/swing/src/main/java/info/openrocket/swing/gui/widgets/GroupableAndSearchableComboBox.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/widgets/GroupableAndSearchableComboBox.java
@@ -130,18 +130,32 @@ public class GroupableAndSearchableComboBox<G extends Group, T extends Groupable
 	}
 
 	private Map<G, List<T>> constructItemGroupMapFromList(List<T> items) {
-		Map<G, List<T>> itemGroupMap = new TreeMap<>(new Comparator<G>() {
-			@Override
-			public int compare(G g1, G g2) {
-				return Integer.compare(g1.getPriority(), g2.getPriority());
-			}
-		});
+		Map<G, List<T>> itemGroupMap = new TreeMap<>(Comparator.comparing(Group::getPriority));
 
 		for (T item : items) {
 			G group = item.getGroup();
 			itemGroupMap.computeIfAbsent(group, k -> new ArrayList<>()).add(item);
 		}
+
+		// Sort items within each group
+		for (List<T> groupItems : itemGroupMap.values()) {
+			groupItems.sort(new ItemComparator());
+		}
+
 		return itemGroupMap;
+	}
+
+	private class ItemComparator implements Comparator<T> {
+		@Override
+		@SuppressWarnings("unchecked")
+		public int compare(T item1, T item2) {
+			if (item1 instanceof Comparable && item2 instanceof Comparable) {
+				return ((Comparable<T>) item1).compareTo(item2);
+			} else {
+				// Fall back to alphabetical sorting using the display string
+				return getDisplayString(item1).compareToIgnoreCase(getDisplayString(item2));
+			}
+		}
 	}
 
 	public void setupMainRenderer() {


### PR DESCRIPTION
This PR fixes #2019. When selecting a row in the component analysis tables, the corresponding component is highlighted in the rocket panel. There is now also a column for per instance CD and total CD. In the per instance CD, the cell of the rocket is left blank and there are no relative contributions (the percentages).


https://github.com/user-attachments/assets/9ec575d8-c3af-4e11-a068-68a06bd0f70f

