### PR TITLE
Remove Prandtl-Glauert correction factor

### DIFF
--- a/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/TubeCalc.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/TubeCalc.java
@@ -63,11 +63,6 @@ public abstract class TubeCalc extends RocketComponentCalc {
 			// friction coefficient using Swamee-Jain equation
 			double f = 0.25 / MathUtil.pow2(Math.log10((epsilon / (3.7 * diameter) + 5.74 / Math.pow(Re, 0.9))));
 
-			// If we're supersonic, apply a correction
-			if (conditions.getMach() > 1) {
-				f = f / conditions.getBeta();
-			}
-
 			// pressure drop using Darcy-Weissbach equation
 			deltap = f * (length * rho * MathUtil.pow2(v)) / (2 * diameter);
 


### PR DESCRIPTION
I can't find any notes giving any clue what I was thinking when I applied the Prandtl-Glauert transformation to the friction coefficient of the tube, and the papers I went from in developing the code also give me no hints. It's obviously completely invalid here. Mea culpa.

Removing it makes no difference to the accuracy of the sim results for the subsonic (B and C motor) test rocket, only slightly reduces it for the supersonic (K motor) tests, and actually improves it slightly (but still not significantly) for the low transonic peak velocity (J) rocket.
| Motor | Actual | Current Unstable | Error | This PR | Error
|-- | -- | -- | --|--|--|
|B6 | 352 |361| 2.56%|360|2.27%|
|C6 | 693 |729 | 5.19%|729|5.19%|
|J360 | 4065| 3982 | -2.04%|3986|-1.94%|
|K1103 | 5009| 5084 | 1.5%|5149|2.79%|
|K2050 | 4263| 4290 | 0.6%|4330|1.57%|

Fixes #2543 
