### PR TITLE
[#2576] Fix Sorting Problem With Sides and Line Count columns on Parachute Preset Library

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/preset/ComponentPresetTable.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/preset/ComponentPresetTable.java
@@ -6,11 +6,7 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import javax.swing.ButtonGroup;
 import javax.swing.JCheckBoxMenuItem;
@@ -57,7 +53,6 @@ public class ComponentPresetTable extends JTable {
 		this.presetType = presetType;
 		this.favorites = Application.getPreferences().getComponentFavorites(presetType);
 		this.columns = new ComponentPresetTableColumn[ComponentPreset.ORDERED_KEY_LIST.size() + 1];
-
 
 		this.tableModel = new AbstractTableModel() {
 			final ComponentPresetTableColumn[] myColumns = columns;
@@ -134,6 +129,13 @@ public class ComponentPresetTable extends JTable {
 							return Double.compare(o1.getValue(), o2.getValue());
 						}
 
+					});
+				} else if (key.getType() == Integer.class){
+					sorter.setComparator(index, new Comparator<Integer>() {
+						@Override
+						public int compare(Integer o1, Integer o2) {
+							return Integer.compare(o1.intValue(), o2.intValue());
+						}
 					});
 				} else if (key.getType() == Boolean.class) {
 					sorter.setComparator(index, new Comparator<Boolean>() {

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/preset/ComponentPresetTable.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/preset/ComponentPresetTable.java
@@ -6,7 +6,11 @@ import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
 
 import javax.swing.ButtonGroup;
 import javax.swing.JCheckBoxMenuItem;


### PR DESCRIPTION
This PR fixes #2576 where the "Sides" and "Line Count" column in the Parachute Component panel sort lexically instead of numerically.

The problem was in ComponentPresetTable. During column initialization, the sorter did not have a special case for Integers as it did for Doubles and Booleans. This caused it to sort Integers like Strings instead of numbers because there was no base case other than the default.

The issue was fixed by adding a simple special case, just like the Booleans or Doubles, that handles Integers separately than all other Objects.
