### PR TITLE
format time in sim abort window to two decimal places

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationPlot.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationPlot.java
@@ -421,7 +421,7 @@ public class SimulationPlot extends Plot<FlightDataType, FlightDataBranch, Simul
 					}
 					abortString.append("\n")
 							.append(trans.get("simulationplot.abort.stage")).append(": ").append(branch.getName()).append("; ")
-							.append(trans.get("simulationplot.abort.time")).append(": ").append(abortEvent.getTime()).append(" s; ")
+						.append(trans.get("simulationplot.abort.time")).append(": ").append(String.format("%.2f", abortEvent.getTime())).append(" s; ")
 							.append(trans.get("simulationplot.abort.cause")).append(": ").append(((SimulationAbort) abortEvent.getData()).getMessageDescription());
 				}
 			}


### PR DESCRIPTION
 currently it uses the default formatting, which means you can get a dozen or so decimal places