### PR TITLE
Don't let vertical acceleration be negative before liftoff.

### DIFF
--- a/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
@@ -347,10 +347,17 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 		store.coriolisAcceleration = status.getSimulationConditions().getGeodeticComputation()
 				.getCoriolisAcceleration(status.getRocketWorldPosition(), status.getRocketVelocity());
 		linearAcceleration = linearAcceleration.add(store.coriolisAcceleration);
-		
-		// If still on the launch rod, project acceleration onto launch rod direction and
-		// set angular acceleration to zero.
-		if (!status.isLaunchRodCleared()) {
+
+		// If we haven't taken off yet, don't sink into the ground
+		if (!status.isLiftoff()) {
+			angularAcceleration = Coordinate.NUL;
+			if (linearAcceleration.z < 0) {
+				linearAcceleration = Coordinate.ZERO;
+			}
+		} else if (!status.isLaunchRodCleared()) {
+
+			// If still on the launch rod, project acceleration onto launch rod direction and
+			// set angular acceleration to zero.
 			
 			linearAcceleration = store.launchRodDirection.multiply(linearAcceleration.dot(store.launchRodDirection));
 			angularAcceleration = Coordinate.NUL;


### PR DESCRIPTION
This addresses a minor annoyance that nonetheless has caused some users confusion: before launch, a rocket's altitude is clamped so it can't be negative (the rocket can't sink into the ground), but the acceleration and velocity are not. This results in plots that appear as if the rocket is in free fall but simultaneously not moving, as shown in this screen shot of the beginning of a simulation of the simple model rocket example:
![dont-clamp-acceleration](https://github.com/user-attachments/assets/31bda049-7448-44c5-b6ba-c69d4cafd76d)

This PR clamps acceleration, so it is also not allowed to be negative (or be non-zero in any direction) until after launch:
![clamp-acceleration](https://github.com/user-attachments/assets/6f1bc9be-341b-4bc9-8ebf-72bb9758c737)
