### PR TITLE
Filter out events from components that are no longer attached immediately after stage separation

### DIFF
--- a/core/src/main/java/info/openrocket/core/simulation/BasicEventSimulationEngine.java
+++ b/core/src/main/java/info/openrocket/core/simulation/BasicEventSimulationEngine.java
@@ -342,16 +342,6 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 				}
 			}
 			
-			// Ignore events for components that are no longer attached to the rocket
-			if (event.getSource() != null && event.getSource().getParent() != null &&
-					!currentStatus.getConfiguration().isComponentActive(event.getSource())) {
-				log.trace("Ignoring event from unattached component");
-				log.debug("    source " + event.getSource());
-				log.debug("    parent " + event.getSource().getParent());
-				log.debug("    active " + currentStatus.getConfiguration().isComponentActive(event.getSource()));
-				continue;
-			}
-			
 			// Call simulation listeners, allow aborting event handling
 			if (!SimulationListenerHelper.fireHandleFlightEvent(currentStatus, event)) {
 				continue;
@@ -526,10 +516,12 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 						// Mark the current status as having dropped the current stage and all stages
 						// below it
 						currentStatus.getConfiguration().clearStagesBelow(stageNumber);
-
+						currentStatus.removeUnattachedEvents();
+						
 						// Mark the booster status as having no active stages above
 						boosterStatus.getConfiguration().clearStagesAbove(stageNumber);
-
+						boosterStatus.removeUnattachedEvents();
+						
 						toSimulate.push(boosterStatus);
 
 					// Make sure upper stages can still be simulated

--- a/core/src/main/java/info/openrocket/core/simulation/SimulationStatus.java
+++ b/core/src/main/java/info/openrocket/core/simulation/SimulationStatus.java
@@ -3,6 +3,7 @@ package info.openrocket.core.simulation;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -459,6 +460,35 @@ public class SimulationStatus implements Cloneable, Monitorable {
 		return eventQueue;
 	}
 
+	/**
+	 * Remove all events that came from components which are no longer
+	 * attached from the event queue.
+	 */
+	public void removeUnattachedEvents() {
+		Iterator<FlightEvent> i = getEventQueue().iterator();
+		while (i.hasNext()) {
+			if (!isAttached(i.next())) {
+				i.remove();
+			}
+		}
+	}
+
+	/**
+	 * Determine whether a FlightEvent came from a RocketComponent that is
+	 * still attached to the current stage
+	 *
+	 * @param event the event to be tested
+	 * return true if attached, false if not
+	 */
+	private boolean isAttached(FlightEvent event) {
+		if ((null == event.getSource()) ||
+			(null == event.getSource().getParent()) ||
+			getConfiguration().isComponentActive(event.getSource())) {
+			return true;
+			}
+		return false;
+	}
+	
 	public void setSimulationConditions(SimulationConditions simulationConditions) {
 		if (this.simulationConditions != null)
 			this.modIDadd = new ModID();

--- a/core/src/test/java/info/openrocket/core/simulation/FlightEventsTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/FlightEventsTest.java
@@ -90,8 +90,9 @@ public class FlightEventsTest extends BaseTestCase {
 		*/
 
 		// Test branch count
-		final int branchCount = sim.getSimulatedData().getBranchCount();
-		assertEquals(3, branchCount, " Multi-stage simulation invalid branch count ");
+		final int expectedBranchCount = 3;
+		final int actualBranchCount = sim.getSimulatedData().getBranchCount();
+		assertEquals(expectedBranchCount, actualBranchCount, " Multi-stage simulation invalid branch count ");
 
 		final AxialStage sustainer = rocket.getStage(0);
 		final BodyTube sustainerBody = (BodyTube) sustainer.getChild(1);
@@ -107,7 +108,7 @@ public class FlightEventsTest extends BaseTestCase {
 		warn.setSources(new BodyTube[]{centerBoosterBody});
 		
 		// events whose time is too variable to check are given a time of 1200
-		for (int b = 0; b < branchCount; b++) {
+		for (int b = 0; b < actualBranchCount; b++) {
 			FlightEvent[] expectedEvents = switch (b) {
 				// Sustainer
 				case 0 -> new FlightEvent[]{

--- a/core/src/test/java/info/openrocket/core/simulation/FlightEventsTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/FlightEventsTest.java
@@ -107,7 +107,7 @@ public class FlightEventsTest extends BaseTestCase {
 		warn.setSources(new BodyTube[]{centerBoosterBody});
 		
 		// events whose time is too variable to check are given a time of 1200
-		for (int b = 0; b < 2; b++) {
+		for (int b = 0; b < branchCount; b++) {
 			FlightEvent[] expectedEvents = switch (b) {
 				// Sustainer
 				case 0 -> new FlightEvent[]{


### PR DESCRIPTION
It is possible for a FlightEvent, scheduled by a component of one stage of a rocket, to end up on the event queue for another stage and still be on the queue after the second stage lands. For instance, in FlightEventsTest.testMultiStage(), the center booster doesn't burn out until after the side boosters are on the ground. This results in a spurious EventAfterLanding warning.

In addition, there is a bug in the test causing events from the side booster branch to not be checked, so the bug had not been noticed until now.

This PR fixes the bug in the test, and also filters the events in the queue immediately after stage separation to eliminate the unattached events.