### PR TITLE
[#2609] Ensure non-negative inner fore/aft radius

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/TransitionExporter.java
+++ b/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/TransitionExporter.java
@@ -87,9 +87,9 @@ public class TransitionExporter extends RocketComponentExporter<Transition> {
                 (component.getShapeType() == Transition.Shape.PARABOLIC && component.getShapeParameter() == 0)) {
 
             float outerAft = (float) component.getAftRadius();
-            float innerAft = isFilled ? 0 : (float) (component.getAftRadius() - component.getThickness());
+            float innerAft = isFilled ? 0 : (float) (Math.max(0, component.getAftRadius() - component.getThickness()));
             float outerFore = (float) component.getForeRadius();
-            float innerFore = isFilled ? 0 : (float) (component.getForeRadius() - component.getThickness());
+            float innerFore = isFilled ? 0 : (float) (Math.max(0, component.getForeRadius() - component.getThickness()));
 
             TubeExporter.addTubeMesh(obj, transformer, null, outerFore, outerAft, innerFore, innerAft,
                     (float) component.getLength(), this.nrOfSides,


### PR DESCRIPTION
This PR fixes #2609. The issue in the original example was that in the nose cone, the fore radius could become negative (`innerFore = component.getForeRadius() - component.getThickness()` where the thickness was larger than the fore radius). This PR clamps the radius to positive numbers. Note that this issue only occurred for conical-shaped nose cones/transitions.