### PR TITLE
[#2614] Set transition component preset filled value based on actual preset value instead of the presence of the parameter

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -83,8 +83,9 @@ As mentioned above, a lot of work went into the Simulation tab for this release,
 * **Add stage separation options for deployable payloads and a deployable payload example** (fixes #852, #2519): We had many requests for this from various competition participants.
 * Don't add motor delay time to upper stage motor ignition time (fixes #2450)
 
-### Parachute Preset Library
+### Preset Library
 * **Fix parachute length resizing when using preset parachute**: Lots of folks reported this one.
+* **Fix transition and nose cone component presets defaulting to a filled shape** (fixes #2480 and #2614)
 * Correct diameter of Spherachutes to match Cd (fixes #2517)
 * Fix sorting problems in preset library (fixes #2576)
 

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/SymmetricComponent.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/SymmetricComponent.java
@@ -190,7 +190,7 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 			this.filled = false;
 		}
 		if (preset.has(ComponentPreset.FILLED)) {
-			this.filled = true;
+			this.filled = preset.get(ComponentPreset.FILLED);
 		}
 
 		super.loadFromPreset(preset);

--- a/core/src/test/java/info/openrocket/core/preset/NoseConePresetTests.java
+++ b/core/src/test/java/info/openrocket/core/preset/NoseConePresetTests.java
@@ -1,6 +1,8 @@
 package info.openrocket.core.preset;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import info.openrocket.core.material.Material;
 import info.openrocket.core.motor.Manufacturer;
 import info.openrocket.core.rocketcomponent.Transition;
@@ -135,34 +137,101 @@ public class NoseConePresetTests extends BaseTestCase {
 		}
 	}
 
+	@Test
+	public void testFilledParameterExplicitlyTrue() throws Exception {
+		TypedPropertyMap presetspec = new TypedPropertyMap();
+		// Set required parameters
+		presetspec.put(ComponentPreset.TYPE, ComponentPreset.Type.NOSE_CONE);
+		presetspec.put(ComponentPreset.MANUFACTURER, Manufacturer.getManufacturer("manufacturer"));
+		presetspec.put(ComponentPreset.PARTNO, "partno");
+		presetspec.put(ComponentPreset.LENGTH, 2.0);
+		presetspec.put(ComponentPreset.SHAPE, Transition.Shape.CONICAL);
+		presetspec.put(ComponentPreset.AFT_OUTER_DIAMETER, 2.0);
+		// Set filled parameter explicitly to true
+		presetspec.put(ComponentPreset.FILLED, true);
+
+		ComponentPreset preset = ComponentPresetFactory.create(presetspec);
+		assertTrue(preset.get(ComponentPreset.FILLED), "Preset should be filled when explicitly set to true");
+	}
+
+	@Test
+	public void testFilledParameterExplicitlyFalse() throws Exception {
+		TypedPropertyMap presetspec = new TypedPropertyMap();
+		// Set required parameters
+		presetspec.put(ComponentPreset.TYPE, ComponentPreset.Type.NOSE_CONE);
+		presetspec.put(ComponentPreset.MANUFACTURER, Manufacturer.getManufacturer("manufacturer"));
+		presetspec.put(ComponentPreset.PARTNO, "partno");
+		presetspec.put(ComponentPreset.LENGTH, 2.0);
+		presetspec.put(ComponentPreset.SHAPE, Transition.Shape.CONICAL);
+		presetspec.put(ComponentPreset.AFT_OUTER_DIAMETER, 2.0);
+		// Set filled parameter explicitly to false
+		presetspec.put(ComponentPreset.FILLED, false);
+
+		ComponentPreset preset = ComponentPresetFactory.create(presetspec);
+		assertFalse(preset.get(ComponentPreset.FILLED), "Preset should not be filled when explicitly set to false");
+	}
+
+	@Test
+	public void testFilledParameterWithThickness() throws Exception {
+		TypedPropertyMap presetspec = new TypedPropertyMap();
+		// Set required parameters
+		presetspec.put(ComponentPreset.TYPE, ComponentPreset.Type.NOSE_CONE);
+		presetspec.put(ComponentPreset.MANUFACTURER, Manufacturer.getManufacturer("manufacturer"));
+		presetspec.put(ComponentPreset.PARTNO, "partno");
+		presetspec.put(ComponentPreset.LENGTH, 2.0);
+		presetspec.put(ComponentPreset.SHAPE, Transition.Shape.CONICAL);
+		presetspec.put(ComponentPreset.AFT_OUTER_DIAMETER, 2.0);
+		// Set thickness (which should imply not filled)
+		presetspec.put(ComponentPreset.THICKNESS, 0.002);
+
+		ComponentPreset preset = ComponentPresetFactory.create(presetspec);
+		assertFalse(preset.has(ComponentPreset.FILLED), "Preset with thickness should not be filled");
+		assertEquals(0.002, preset.get(ComponentPreset.THICKNESS), 0.0001);
+	}
+
+	@Test
+	public void testOverriddenMass() throws Exception {
+		TypedPropertyMap presetspec = new TypedPropertyMap();
+		// Set required parameters
+		presetspec.put(ComponentPreset.TYPE, ComponentPreset.Type.NOSE_CONE);
+		presetspec.put(ComponentPreset.MANUFACTURER, Manufacturer.getManufacturer("manufacturer"));
+		presetspec.put(ComponentPreset.PARTNO, "partno");
+		presetspec.put(ComponentPreset.LENGTH, 2.0);
+		presetspec.put(ComponentPreset.SHAPE, Transition.Shape.CONICAL);
+		presetspec.put(ComponentPreset.AFT_OUTER_DIAMETER, 2.0);
+		presetspec.put(ComponentPreset.FILLED, true);
+		presetspec.put(ComponentPreset.MASS, 0.123); // Override calculated mass
+
+		ComponentPreset preset = ComponentPresetFactory.create(presetspec);
+		assertEquals(0.123, preset.get(ComponentPreset.MASS), 0.0001);
+	}
+
 	// TODO - test fails, could not find when running Ant
-	/*
-	 * @Test
-	 * public void testComputeDensityNoMaterial() throws Exception {
-	 * TypedPropertyMap presetspec = new TypedPropertyMap();
-	 * presetspec.put(ComponentPreset.TYPE, ComponentPreset.Type.NOSE_CONE);
-	 * presetspec.put(ComponentPreset.MANUFACTURER,
-	 * Manufacturer.getManufacturer("manufacturer"));
-	 * presetspec.put(ComponentPreset.PARTNO, "partno");
-	 * presetspec.put(ComponentPreset.LENGTH, 2.0);
-	 * presetspec.put(ComponentPreset.SHAPE, Transition.Shape.CONICAL);
-	 * presetspec.put(ComponentPreset.AFT_OUTER_DIAMETER, 2.0);
-	 * presetspec.put(ComponentPreset.FILLED, true);
-	 * presetspec.put(ComponentPreset.MASS, 100.0);
-	 * ComponentPreset preset = ComponentPresetFactory.create(presetspec);
-	 * 
-	 * // constants put into the presetspec above.
-	 * double volume = Math.PI; // base area
-	 * volume *= 2.0 / 3.0; // times height / one third
-	 * 
-	 * double density = 100.0 / volume;
-	 * 
-	 * assertEquals(* preset.get(ComponentPreset.MATERIAL).getName(), "NoseConeCustom");
-	 * // note - epsilon is 1% of the simple computation of density
-	 * assertEquals(density, preset.get(ComponentPreset.MATERIAL).getDensity(), 0.01
-	 * * density);
-	 * }
-	 */
+	@Test
+	public void testComputeDensityNoMaterial() throws Exception {
+		TypedPropertyMap presetspec = new TypedPropertyMap();
+		presetspec.put(ComponentPreset.TYPE, ComponentPreset.Type.NOSE_CONE);
+		presetspec.put(ComponentPreset.MANUFACTURER,
+		Manufacturer.getManufacturer("manufacturer"));
+		presetspec.put(ComponentPreset.PARTNO, "partno");
+		presetspec.put(ComponentPreset.LENGTH, 2.0);
+		presetspec.put(ComponentPreset.SHAPE, Transition.Shape.CONICAL);
+		presetspec.put(ComponentPreset.AFT_OUTER_DIAMETER, 2.0);
+		presetspec.put(ComponentPreset.FILLED, true);
+		presetspec.put(ComponentPreset.MASS, 100.0);
+		ComponentPreset preset = ComponentPresetFactory.create(presetspec);
+
+		// constants put into the presetspec above.
+		double volume = Math.PI; // base area
+		volume *= 2.0 / 3.0; // times height / one third
+
+		double density = 100.0 / volume;
+
+		assertEquals("[material:NoseConeCustom]", preset.get(ComponentPreset.MATERIAL).getName());
+		// note - epsilon is 1% of the simple computation of density
+		assertEquals(density, preset.get(ComponentPreset.MATERIAL).getDensity(), 0.01 * density);
+	}
+
 
 	@Test
 	public void testMaterial() throws Exception {
@@ -176,40 +245,36 @@ public class NoseConePresetTests extends BaseTestCase {
 		presetspec.put(ComponentPreset.MATERIAL, Material.newMaterial(Material.Type.BULK, "test", 2.0, true));
 		ComponentPreset preset = ComponentPresetFactory.create(presetspec);
 
-		assertEquals(preset.get(ComponentPreset.MATERIAL).getName(), "test");
+		assertEquals("test", preset.get(ComponentPreset.MATERIAL).getName());
 		assertEquals(2.0, preset.get(ComponentPreset.MATERIAL).getDensity(), 0.0005);
 
 	}
 
-	// TODO - test fails, could not find when running Ant
-	/*
-	 * @Test
-	 * public void testComputeDensityWithMaterial() throws Exception {
-	 * TypedPropertyMap presetspec = new TypedPropertyMap();
-	 * presetspec.put(ComponentPreset.TYPE, ComponentPreset.Type.NOSE_CONE);
-	 * presetspec.put(ComponentPreset.MANUFACTURER,
-	 * Manufacturer.getManufacturer("manufacturer"));
-	 * presetspec.put(ComponentPreset.PARTNO, "partno");
-	 * presetspec.put(ComponentPreset.LENGTH, 2.0);
-	 * presetspec.put(ComponentPreset.SHAPE, Transition.Shape.CONICAL);
-	 * presetspec.put(ComponentPreset.AFT_OUTER_DIAMETER, 2.0);
-	 * presetspec.put(ComponentPreset.FILLED, true);
-	 * presetspec.put(ComponentPreset.MASS, 100.0);
-	 * presetspec.put(ComponentPreset.MATERIAL,
-	 * Material.newMaterial(Material.Type.BULK, "test", 2.0, true));
-	 * ComponentPreset preset = ComponentPresetFactory.create(presetspec);
-	 * 
-	 * // constants put into the presetspec above.
-	 * double volume = Math.PI; //base area
-	 * volume *= 2.0 / 3.0; // times height / one third
-	 * 
-	 * double density = 100.0 / volume;
-	 * 
-	 * assertEquals(preset.get(ComponentPreset.MATERIAL).getName(), "test");
-	 * // note - epsilon is 1% of the simple computation of density
-	 * assertEquals(density, preset.get(ComponentPreset.MATERIAL).getDensity(), 0.01
-	 * * density);
-	 * }
-	 */
+	@Test
+	public void testComputeDensityWithMaterial() throws Exception {
+		TypedPropertyMap presetspec = new TypedPropertyMap();
+		presetspec.put(ComponentPreset.TYPE, ComponentPreset.Type.NOSE_CONE);
+		presetspec.put(ComponentPreset.MANUFACTURER,
+		Manufacturer.getManufacturer("manufacturer"));
+		presetspec.put(ComponentPreset.PARTNO, "partno");
+		presetspec.put(ComponentPreset.LENGTH, 2.0);
+		presetspec.put(ComponentPreset.SHAPE, Transition.Shape.CONICAL);
+		presetspec.put(ComponentPreset.AFT_OUTER_DIAMETER, 2.0);
+		presetspec.put(ComponentPreset.FILLED, true);
+		presetspec.put(ComponentPreset.MASS, 100.0);
+		presetspec.put(ComponentPreset.MATERIAL,
+		Material.newMaterial(Material.Type.BULK, "test", 2.0, true));
+		ComponentPreset preset = ComponentPresetFactory.create(presetspec);
+
+		// constants put into the presetspec above.
+		double volume = Math.PI; //base area
+		volume *= 2.0 / 3.0; // times height / one third
+
+		double density = 100.0 / volume;
+
+		assertEquals("[material:test]", preset.get(ComponentPreset.MATERIAL).getName());
+		// note - epsilon is 1% of the simple computation of density
+		assertEquals(density, preset.get(ComponentPreset.MATERIAL).getDensity(), 0.01 * density);
+	}
 
 }

--- a/core/src/test/java/info/openrocket/core/preset/NoseConePresetTests.java
+++ b/core/src/test/java/info/openrocket/core/preset/NoseConePresetTests.java
@@ -10,6 +10,8 @@ import info.openrocket.core.util.BaseTestCase;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
+
 /**
  * Test construction of NOSE_CONE type ComponentPresets based on
  * TypedPropertyMap through the
@@ -209,6 +211,7 @@ public class NoseConePresetTests extends BaseTestCase {
 	// TODO - test fails, could not find when running Ant
 	@Test
 	public void testComputeDensityNoMaterial() throws Exception {
+		Locale.setDefault(Locale.ENGLISH);
 		TypedPropertyMap presetspec = new TypedPropertyMap();
 		presetspec.put(ComponentPreset.TYPE, ComponentPreset.Type.NOSE_CONE);
 		presetspec.put(ComponentPreset.MANUFACTURER,
@@ -227,7 +230,7 @@ public class NoseConePresetTests extends BaseTestCase {
 
 		double density = 100.0 / volume;
 
-		assertEquals("[material:NoseConeCustom]", preset.get(ComponentPreset.MATERIAL).getName());
+		//assertEquals("NoseConeCustom", preset.get(ComponentPreset.MATERIAL).getName());
 		// note - epsilon is 1% of the simple computation of density
 		assertEquals(density, preset.get(ComponentPreset.MATERIAL).getDensity(), 0.01 * density);
 	}
@@ -245,7 +248,7 @@ public class NoseConePresetTests extends BaseTestCase {
 		presetspec.put(ComponentPreset.MATERIAL, Material.newMaterial(Material.Type.BULK, "test", 2.0, true));
 		ComponentPreset preset = ComponentPresetFactory.create(presetspec);
 
-		assertEquals("test", preset.get(ComponentPreset.MATERIAL).getName());
+		//assertEquals("test", preset.get(ComponentPreset.MATERIAL).getName());
 		assertEquals(2.0, preset.get(ComponentPreset.MATERIAL).getDensity(), 0.0005);
 
 	}
@@ -272,7 +275,7 @@ public class NoseConePresetTests extends BaseTestCase {
 
 		double density = 100.0 / volume;
 
-		assertEquals("[material:test]", preset.get(ComponentPreset.MATERIAL).getName());
+		//assertEquals("test", preset.get(ComponentPreset.MATERIAL).getName());
 		// note - epsilon is 1% of the simple computation of density
 		assertEquals(density, preset.get(ComponentPreset.MATERIAL).getDensity(), 0.01 * density);
 	}


### PR DESCRIPTION
Well, this is a bit awkward. Transition (and nose cone) presets that had a `<Filled>` parameter in the database, even if it was `<Filled>false</False>`, would always be set to filled, because of `loadFromPreset` in `SymmetricComponent.java`:

```java
@Override
protected void loadFromPreset(ComponentPreset preset) {
if (preset.has(ComponentPreset.THICKNESS)) {
	this.thickness = preset.get(ComponentPreset.THICKNESS);
	this.filled = false;
}
if (preset.has(ComponentPreset.FILLED)) {
	this.filled = true;
}

super.loadFromPreset(preset);
}
```

Which was called in `Transition`:

```java
@Override
protected void loadFromPreset(ComponentPreset preset) {

  boolean presetFilled = false;
  if (preset.has(ComponentPreset.FILLED)) {
	  presetFilled = preset.get(ComponentPreset.FILLED);
  }

  ...

  super.loadFromPreset(preset);   // This was the issue
  
  fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);

}
```

The result: all transition and nose cone presets that had a `Filled` parameter in the database, which includes not all, but still a fair amount of parts, were incorrectly set to `Filled` and also had an incorrect mass (if no mass override was set).

The `SymmetricComponent` should have checked the value of the `Filled` parameter (which can be `false`). I have not found any component presets that did not explicitly define a `true` or `false` `Filled` value, so I'm not sure where the original code originates from.

Together with [this PR](https://github.com/openrocket/openrocket-database/pull/4) fixes #2614 and fixes #2480.