### PR TITLE
Add a cleanup method to AbstractSimulationStepper to write values from final step to flight data branch

### DIFF
--- a/core/src/main/java/info/openrocket/core/simulation/AbstractEulerStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/AbstractEulerStepper.java
@@ -24,19 +24,6 @@ public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 	
 	@Override
 	public SimulationStatus initialize(SimulationStatus status) {
-		store.thrustForce = 0;
-		
-		// note most of our forces don't end up getting set, so they're all NaN.
-		AerodynamicForces forces = new AerodynamicForces();
-
-		double cd = computeCD(status);
-		forces.setCD(cd);
-		forces.setCDaxial(cd);
-		forces.setFrictionCD(0);
-		forces.setPressureCD(cd);
-		forces.setBaseCD(0);
-		
-		store.forces = forces;
 
 		return status;
 	}
@@ -165,6 +152,19 @@ public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 
 	@Override
 	void calculateAcceleration(SimulationStatus status, DataStore store) throws SimulationException {
+		store.thrustForce = 0;
+		
+		// note most of our forces don't end up getting set, so they're all NaN.
+		AerodynamicForces forces = new AerodynamicForces();
+
+		double cd = computeCD(status);
+		forces.setCD(cd);
+		forces.setCDaxial(cd);
+		forces.setFrictionCD(0);
+		forces.setPressureCD(cd);
+		forces.setBaseCD(0);
+		
+		store.forces = forces;
 		AtmosphericConditions atmosphericConditions = store.flightConditions.getAtmosphericConditions();
 		
 		//// airSpeed

--- a/core/src/main/java/info/openrocket/core/simulation/AbstractEulerStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/AbstractEulerStepper.java
@@ -48,7 +48,7 @@ public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 		
 		calculateFlightConditions(status, store);
 
-		store.accelerationData = calculateAcceleration(status, store);
+		calculateAcceleration(status, store);
 		AtmosphericConditions atmosphericConditions = store.flightConditions.getAtmosphericConditions();
 		Coordinate airSpeed = status.getRocketVelocity().add(store.windVelocity);
 		Coordinate linearAcceleration = store.accelerationData.getLinearAccelerationWC();
@@ -163,7 +163,8 @@ public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 		log.trace("time " + dataBranch.getLast(FlightDataType.TYPE_TIME) + ", altitude " + dataBranch.getLast(FlightDataType.TYPE_ALTITUDE) + ", velocity " + dataBranch.getLast(FlightDataType.TYPE_VELOCITY_Z));
 	}
 
-	AccelerationData calculateAcceleration(SimulationStatus status, DataStore store) throws SimulationException {
+	@Override
+	void calculateAcceleration(SimulationStatus status, DataStore store) throws SimulationException {
 		AtmosphericConditions atmosphericConditions = store.flightConditions.getAtmosphericConditions();
 		
 		//// airSpeed
@@ -198,7 +199,7 @@ public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 				status.getRocketWorldPosition(), status.getRocketVelocity());
 		linearAcceleration = linearAcceleration.add(store.coriolisAcceleration);
 
-		return new AccelerationData(null, null, linearAcceleration, Coordinate.NUL, status.getRocketOrientationQuaternion());
+		store.accelerationData = new AccelerationData(null, null, linearAcceleration, Coordinate.NUL, status.getRocketOrientationQuaternion());
 	}
 
 	private static class EulerValues {

--- a/core/src/main/java/info/openrocket/core/simulation/AbstractEulerStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/AbstractEulerStepper.java
@@ -95,7 +95,10 @@ public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 			// use chain rule to compute jerk
 			// dA/dT = dA/dV * dV/dT
 			final double dFdV = CdA * atmosphericConditions.getDensity() * airSpeed.length();
-			final Coordinate dAdV = airSpeed.normalize().multiply(dFdV / store.rocketMass.getMass());
+			Coordinate dAdV = Coordinate.ZERO;
+			if (airSpeed.length() > MathUtil.EPSILON) {
+				dAdV = airSpeed.normalize().multiply(dFdV / store.rocketMass.getMass());
+			}
 			final Coordinate jerk = linearAcceleration.multiply(dAdV);
 			final Coordinate newAcceleration = linearAcceleration.add(jerk.multiply(store.timeStep));
 
@@ -188,7 +191,10 @@ public abstract class AbstractEulerStepper extends AbstractSimulationStepper {
 			atmosphericConditions.getKinematicViscosity();
 
 		// Compute drag acceleration
-		Coordinate linearAcceleration = airSpeed.normalize().multiply(-store.dragForce / store.rocketMass.getMass());
+		Coordinate linearAcceleration = Coordinate.ZERO;
+		if (airSpeed.length() > MathUtil.EPSILON) {
+			linearAcceleration = airSpeed.normalize().multiply(-store.dragForce / store.rocketMass.getMass());
+		}
 		
 		// Add effect of gravity
 		store.gravity = modelGravity(status);

--- a/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
@@ -35,7 +35,7 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 	 * the FlightDataBranch
 	 */
 	public void cleanup(SimulationStatus status) throws SimulationException {
-		log.debug("called cleanup");
+		log.debug("called cleanup from stepper " + this);
 		DataStore store = new DataStore();
 		calculateFlightConditions(status, store);
 		calculateAcceleration(status, store);

--- a/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
@@ -228,6 +228,15 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 		}
 	}
 
+	/*
+	 * The DataStore holds calculated data to be used in computing a simulation step.
+	 * It is saved to the FlightDataBranch at the beginning of the time step, and one
+	 * extra time following the final simulation step so we have a full set of data for
+	 * the final step.
+
+	 * Note that it's a little shady to save this data only at the start of an RK4SimulationStepper
+	 * step, since the contents change over the course of a step.
+	 */
 	protected static class DataStore {
 	
 		public double timeStep = Double.NaN;

--- a/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
@@ -139,8 +139,8 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 		// Call post-listener
 		conditions = SimulationListenerHelper.firePostAtmosphericModel(status, conditions);
 
-		checkNaN(conditions.getPressure());
-		checkNaN(conditions.getTemperature());
+		checkNaN(conditions.getPressure(), "conditions.getPressure()");
+		checkNaN(conditions.getTemperature(), "conditions.getTemperature()");
 
 		return conditions;
 	}
@@ -168,7 +168,7 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 		// Call post-listener
 		wind = SimulationListenerHelper.firePostWindModel(status, wind);
 
-		checkNaN(wind);
+		checkNaN(wind, "wind");
 
 		return wind;
 	}
@@ -195,7 +195,7 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 		// Call post-listener
 		gravity = SimulationListenerHelper.firePostGravityModel(status, gravity);
 
-		checkNaN(gravity);
+		checkNaN(gravity, "gravity");
 
 		return gravity;
 	}
@@ -221,9 +221,9 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 		// Call post-listener
 		structureMass = SimulationListenerHelper.firePostMassCalculation(status, structureMass);
 
-		checkNaN(structureMass.getCenterOfMass());
-		checkNaN(structureMass.getLongitudinalInertia());
-		checkNaN(structureMass.getRotationalInertia());
+		checkNaN(structureMass.getCenterOfMass(), "structureMass.getCenterOfMass()");
+		checkNaN(structureMass.getLongitudinalInertia(), "structureMass.getLongitudinalInertia()");
+		checkNaN(structureMass.getRotationalInertia(), "structureMass.getRotationalInertia()");
 
 		return structureMass;
 	}
@@ -243,9 +243,9 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 		// Call post-listener
 		motorMass = SimulationListenerHelper.firePostMassCalculation(status, motorMass);
 
-		checkNaN(motorMass.getCenterOfMass());
-		checkNaN(motorMass.getLongitudinalInertia());
-		checkNaN(motorMass.getRotationalInertia());
+		checkNaN(motorMass.getCenterOfMass(), "motorMass.getCenterOfMass()");
+		checkNaN(motorMass.getLongitudinalInertia(), "motorMass.getLongitudinalInertia()");
+		checkNaN(motorMass.getRotationalInertia(), "motorMass.getRotationalInertia()");
 
 		return motorMass;
 	}
@@ -282,7 +282,7 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 		// Post-listeners
 		thrust = SimulationListenerHelper.firePostThrustCalculation(status, thrust);
 
-		checkNaN(thrust);
+		checkNaN(thrust, "thrust");
 
 		return thrust;
 	}
@@ -293,9 +293,9 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 	 * @param d					the double value to check.
 	 * @throws BugException		if the value is NaN.
 	 */
-	protected void checkNaN(double d) {
+	protected void checkNaN(double d, String var) {
 		if (Double.isNaN(d)) {
-			throw new BugException("Simulation resulted in not-a-number (NaN) value, please report a bug.");
+			throw new BugException("Simulation resulted in not-a-number (NaN) value for " + var + ", please report a bug.");
 		}
 	}
 	
@@ -305,9 +305,9 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 	 * @param c					the coordinate value to check.
 	 * @throws BugException		if the value is NaN.
 	 */
-	protected void checkNaN(Coordinate c) {
+	protected void checkNaN(Coordinate c, String var) {
 		if (c.isNaN()) {
-			throw new BugException("Simulation resulted in not-a-number (NaN) value, please report a bug, c=" + c);
+			throw new BugException("Simulation resulted in not-a-number (NaN) value for " + var + ", please report a bug, c=" + c);
 		}
 	}
 	
@@ -318,9 +318,9 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 	 * @param q					the quaternion value to check.
 	 * @throws BugException		if the value is NaN.
 	 */
-	protected void checkNaN(Quaternion q) {
+	protected void checkNaN(Quaternion q, String var) {
 		if (q.isNaN()) {
-			throw new BugException("Simulation resulted in not-a-number (NaN) value, please report a bug, q=" + q);
+			throw new BugException("Simulation resulted in not-a-number (NaN) value for " + var + ", please report a bug, q=" + q);
 		}
 	}
 

--- a/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
@@ -20,6 +20,8 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 
 	protected static final double MIN_TIME_STEP = 0.001;
 
+	abstract void calculateAcceleration(SimulationStatus status, DataStore store) throws SimulationException;
+
 	/**
 	 * Calculate the flight conditions for the current rocket status.
 	 * Listeners can override these if necessary.
@@ -434,5 +436,5 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 				}
 			}
 		}
-	}		
+	}
 }

--- a/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
@@ -19,9 +19,24 @@ import info.openrocket.core.util.Rotation2D;
 public abstract class AbstractSimulationStepper implements SimulationStepper {
 
 	protected static final double MIN_TIME_STEP = 0.001;
-
+	
+	/*
+	 * calculate acceleration at a given point in time
+	 *
+	 */
 	abstract void calculateAcceleration(SimulationStatus status, DataStore store) throws SimulationException;
 
+	/*
+	 * clean up at end of a simulation branch. Computes acceleration parameters and puts them in
+	 * the FlightDataBranch
+	 */
+	public void cleanup(SimulationStatus status) throws SimulationException {
+		DataStore store = new DataStore();
+		calculateFlightConditions(status, store);
+		calculateAcceleration(status, store);
+		store.storeData(status);
+	}
+	
 	/**
 	 * Calculate the flight conditions for the current rocket status.
 	 * Listeners can override these if necessary.
@@ -99,7 +114,6 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 			store.thetaRotation = new Rotation2D(store.flightConditions.getTheta());
 			store.lateralPitchRate = Math.hypot(store.flightConditions.getPitchRate(), store.flightConditions.getYawRate());
 		}
-		
 	}
 
 	/**

--- a/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
@@ -2,6 +2,9 @@ package info.openrocket.core.simulation;
 
 import java.util.Collection;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import info.openrocket.core.aerodynamics.AerodynamicForces;
 import info.openrocket.core.aerodynamics.FlightConditions;
 import info.openrocket.core.masscalc.MassCalculator;
@@ -17,6 +20,7 @@ import info.openrocket.core.util.Quaternion;
 import info.openrocket.core.util.Rotation2D;
 
 public abstract class AbstractSimulationStepper implements SimulationStepper {
+	private static final Logger log = LoggerFactory.getLogger(AbstractSimulationStepper.class);
 
 	protected static final double MIN_TIME_STEP = 0.001;
 	
@@ -31,6 +35,7 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 	 * the FlightDataBranch
 	 */
 	public void cleanup(SimulationStatus status) throws SimulationException {
+		log.debug("called cleanup");
 		DataStore store = new DataStore();
 		calculateFlightConditions(status, store);
 		calculateAcceleration(status, store);
@@ -135,7 +140,7 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 		// Compute conditions
 		double altitude = status.getRocketPosition().z + status.getSimulationConditions().getLaunchSite().getAltitude();
 		conditions = status.getSimulationConditions().getAtmosphericModel().getConditions(altitude);
-
+		
 		// Call post-listener
 		conditions = SimulationListenerHelper.firePostAtmosphericModel(status, conditions);
 

--- a/core/src/main/java/info/openrocket/core/simulation/BasicEventSimulationEngine.java
+++ b/core/src/main/java/info/openrocket/core/simulation/BasicEventSimulationEngine.java
@@ -632,18 +632,18 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 				// Inhibit if we've deployed a parachute or we're on the ground
 				if ((currentStatus.getDeployedRecoveryDevices().size() > 0) || currentStatus.isLanded())
 					break;
-
-				currentStepper = tumbleStepper;
-				lastStepper = currentStepper;
-				currentStatus = currentStepper.initialize(currentStatus);
 				
 				final boolean tooMuchThrust = currentStatus.getFlightDataBranch().getLast(FlightDataType.TYPE_THRUST_FORCE) > THRUST_TUMBLE_CONDITION;
 				if (tooMuchThrust) {
 					currentStatus.abortSimulation(SimulationAbort.Cause.TUMBLE_UNDER_THRUST);
-				}					
-				
-				currentStatus.setTumbling(true);
-				currentStatus.getFlightDataBranch().addEvent(event);
+				} else {
+					currentStepper = tumbleStepper;
+					lastStepper = currentStepper;
+					currentStatus = currentStepper.initialize(currentStatus);
+					
+					currentStatus.setTumbling(true);
+					currentStatus.getFlightDataBranch().addEvent(event);
+				}
 				break;
 			}
 			

--- a/core/src/main/java/info/openrocket/core/simulation/BasicEventSimulationEngine.java
+++ b/core/src/main/java/info/openrocket/core/simulation/BasicEventSimulationEngine.java
@@ -41,12 +41,14 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 	private final SimulationStepper landingStepper = new BasicLandingStepper();
 	private final SimulationStepper tumbleStepper = new BasicTumbleStepper();
 	private final SimulationStepper groundStepper = new GroundStepper();
-	
+
 	// The thrust must be below this value for the transition to tumbling.
 	// TODO HIGH: this is an arbitrary value
 	private final static double THRUST_TUMBLE_CONDITION = 0.01;
 	
 	private SimulationStepper currentStepper;
+	// used to remember last stepper in use before ground hit
+	private SimulationStepper lastStepper;
 	
 	private SimulationStatus currentStatus;
 	
@@ -121,6 +123,7 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 				log.info(">>Starting simulation of branch: " + currentStatus.getFlightDataBranch().getName());
 				
 				simulateLoop(simulationConditions);
+				
 				dataBranch.immute();
 				flightData.getWarningSet().addAll(currentStatus.getWarnings());
 				
@@ -141,6 +144,7 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 			if (!flightData.getWarningSet().isEmpty()) {
 				log.info("Warnings at the end of simulation:  " + flightData.getWarningSet());
 			}
+			
 		} catch (SimulationException e) {
 			throw e;
 		} finally {
@@ -149,13 +153,13 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 	}
 	
 	private void simulateLoop(SimulationConditions simulationConditions) throws SimulationException {
-
 		// Initialize the simulation. We'll use the flight stepper unless we're already
-		// on the ground
+		// on the ground.
 		if (currentStatus.isLanded())
 			currentStepper = groundStepper;
 		else
 			currentStepper = flightStepper;
+		lastStepper = flightStepper;
 		
 		currentStatus = currentStepper.initialize(currentStatus);
 		double previousSimulationTime = currentStatus.getSimulationTime();
@@ -291,6 +295,9 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 
 				previousSimulationTime = currentStatus.getSimulationTime();
 			}
+
+			// clean up at end of simulation
+			lastStepper.cleanup(currentStatus);
 			
 		} catch (SimulationException e) {
 			
@@ -589,6 +596,7 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 					// switch to landing stepper (unless we're already on the ground)
 					if (!currentStatus.isLanded()) {
 						currentStepper = landingStepper;
+						lastStepper = currentStepper;
 						currentStatus = currentStepper.initialize(currentStatus);
 					}
 					
@@ -599,7 +607,7 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 			
 			case GROUND_HIT:
 				currentStatus.setLanded(true);
-				
+
 				currentStepper = groundStepper;
 				currentStatus = currentStepper.initialize(currentStatus);
 				
@@ -626,8 +634,9 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 					break;
 
 				currentStepper = tumbleStepper;
+				lastStepper = currentStepper;
 				currentStatus = currentStepper.initialize(currentStatus);
-
+				
 				final boolean tooMuchThrust = currentStatus.getFlightDataBranch().getLast(FlightDataType.TYPE_THRUST_FORCE) > THRUST_TUMBLE_CONDITION;
 				if (tooMuchThrust) {
 					currentStatus.abortSimulation(SimulationAbort.Cause.TUMBLE_UNDER_THRUST);

--- a/core/src/main/java/info/openrocket/core/simulation/GroundStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/GroundStepper.java
@@ -20,4 +20,9 @@ public class GroundStepper extends AbstractSimulationStepper {
 		status.setSimulationTime(status.getSimulationTime() + timeStep);
 		status.storeData();
 	}
+
+	@Override
+	void calculateAcceleration(SimulationStatus status, DataStore store) throws SimulationException {
+		// empty
+	}
 }

--- a/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
@@ -102,7 +102,6 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 		 * Get the current atmospheric conditions
 		 */
 		calculateFlightConditions(status, store);
-		store.atmosphericConditions = store.flightConditions.getAtmosphericConditions();
 
 		/*
 		 * Perform RK4 integration.  Decide the time step length after the first step.
@@ -451,90 +450,6 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 	}
 	
 	
-
-	/**
-	 * Calculate and return the flight conditions for the current rocket status.
-	 * Listeners can override these if necessary.
-	 * <p>
-	 * Additionally the fields thetaRotation and lateralPitchRate are defined in
-	 * the data store, and can be used after calling this method.
-	 */
-	private void calculateFlightConditions(SimulationStatus status, DataStore store)
-			throws SimulationException {
-		
-		// Call pre listeners, allow complete override
-		store.flightConditions = SimulationListenerHelper.firePreFlightConditions(
-				status);
-		if (store.flightConditions != null) {
-			// Compute the store values
-			store.thetaRotation = new Rotation2D(store.flightConditions.getTheta());
-			store.lateralPitchRate = Math.hypot(store.flightConditions.getPitchRate(), store.flightConditions.getYawRate());
-			return;
-		}
-		
-
-
-		//// Atmospheric conditions
-		AtmosphericConditions atmosphere = modelAtmosphericConditions(status);
-		store.flightConditions = new FlightConditions(status.getConfiguration());
-		store.flightConditions.setAtmosphericConditions(atmosphere);
-		
-
-		//// Local wind speed and direction
-		store.windVelocity = modelWindVelocity(status);
-		Coordinate airSpeed = status.getRocketVelocity().add(store.windVelocity);
-		airSpeed = status.getRocketOrientationQuaternion().invRotate(airSpeed);
-		
-
-		// Lateral direction:
-		double len = MathUtil.hypot(airSpeed.x, airSpeed.y);
-		if (len > 0.0001) {
-			store.thetaRotation = new Rotation2D(airSpeed.y / len, airSpeed.x / len);
-			store.flightConditions.setTheta(Math.atan2(airSpeed.y, airSpeed.x));
-		} else {
-			store.thetaRotation = Rotation2D.ID;
-			store.flightConditions.setTheta(0);
-		}
-		
-		double velocity = airSpeed.length();
-		store.flightConditions.setVelocity(velocity);
-		if (velocity > 0.01) {
-			// aoa must be calculated from the monotonous cosine
-			// sine can be calculated by a simple division
-			store.flightConditions.setAOA(Math.acos(airSpeed.z / velocity), len / velocity);
-		} else {
-			store.flightConditions.setAOA(0);
-		}
-		
-
-		// Roll, pitch and yaw rate
-		Coordinate rot = status.getRocketOrientationQuaternion().invRotate(status.getRocketRotationVelocity());
-		rot = store.thetaRotation.invRotateZ(rot);
-		
-		store.flightConditions.setRollRate(rot.z);
-		if (len < 0.001) {
-			store.flightConditions.setPitchRate(0);
-			store.flightConditions.setYawRate(0);
-			store.lateralPitchRate = 0;
-		} else {
-			store.flightConditions.setPitchRate(rot.y);
-			store.flightConditions.setYawRate(rot.x);
-			// TODO: LOW: set this as power of two?
-			store.lateralPitchRate = MathUtil.hypot(rot.x, rot.y);
-		}
-		
-
-		// Call post listeners
-		FlightConditions c = SimulationListenerHelper.firePostFlightConditions(
-				status, store.flightConditions);
-		if (c != store.flightConditions) {
-			// Listeners changed the values, recalculate data store
-			store.flightConditions = c;
-			store.thetaRotation = new Rotation2D(store.flightConditions.getTheta());
-			store.lateralPitchRate = Math.hypot(store.flightConditions.getPitchRate(), store.flightConditions.getYawRate());
-		}
-		
-	}
 
 	private static class RK4Parameters {
 		/** Linear acceleration */

--- a/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
@@ -182,7 +182,7 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 			store.timeStep = minTimeStep;
 		}
 
-		checkNaN(store.timeStep);
+		checkNaN(store.timeStep, "store.timeStep");
 
 
 
@@ -274,10 +274,10 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 		params.v = status.getRocketVelocity();
 		params.rv = status.getRocketRotationVelocity();
 		
-		checkNaN(params.a);
-		checkNaN(params.ra);
-		checkNaN(params.v);
-		checkNaN(params.rv);
+		checkNaN(params.a, "params.a");
+		checkNaN(params.ra, "params.ra");
+		checkNaN(params.v, "params.v");
+		checkNaN(params.rv, "params.rv");
 		
 		return params;
 	}

--- a/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
@@ -266,17 +266,8 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 	private RK4Parameters computeParameters(SimulationStatus status, DataStore store)
 			throws SimulationException {
 		RK4Parameters params = new RK4Parameters();
-		
-		// Call pre-listeners
-		store.accelerationData = SimulationListenerHelper.firePreAccelerationCalculation(status);
 
-		// Calculate acceleration (if not overridden by pre-listeners)
-		if (store.accelerationData == null) {
-			store.accelerationData = calculateAcceleration(status, store);
-		}
-
-		// Call post-listeners
-		store.accelerationData = SimulationListenerHelper.firePostAccelerationCalculation(status, store.accelerationData);
+		calculateAcceleration(status, store);
 
 		params.a = store.accelerationData.getLinearAccelerationWC();
 		params.ra = store.accelerationData.getRotationalAccelerationWC();
@@ -292,8 +283,20 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 	}
 	
 	
+	void calculateAcceleration(SimulationStatus status, DataStore store) throws SimulationException {
+		
+		// Call pre-listeners
+		store.accelerationData = SimulationListenerHelper.firePreAccelerationCalculation(status);
 
+		// Calculate acceleration (if not overridden by pre-listeners)
+		if (store.accelerationData == null) {
+			store.accelerationData = computeAcceleration(status, store);
+		}
 
+		// Call post-listeners
+		store.accelerationData = SimulationListenerHelper.firePostAccelerationCalculation(status, store.accelerationData);
+
+	}
 
 	/**
 	 * Calculate the linear and angular acceleration at the given status.  The results
@@ -302,7 +305,7 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 	 * @param status   the status of the rocket.
 	 * @throws SimulationException 
 	 */
-	private AccelerationData calculateAcceleration(SimulationStatus status, DataStore store) throws SimulationException {
+	private AccelerationData computeAcceleration(SimulationStatus status, DataStore store) throws SimulationException {
 		Coordinate linearAcceleration;
 		Coordinate angularAcceleration;
 		

--- a/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
@@ -282,7 +282,7 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 		return params;
 	}
 	
-	
+	@Override
 	void calculateAcceleration(SimulationStatus status, DataStore store) throws SimulationException {
 		
 		// Call pre-listeners

--- a/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
@@ -263,7 +263,7 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 
 
 
-	private RK4Parameters computeParameters(SimulationStatus status, DataStore dataStore)
+	private RK4Parameters computeParameters(SimulationStatus status, DataStore store)
 			throws SimulationException {
 		RK4Parameters params = new RK4Parameters();
 		
@@ -272,14 +272,14 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 
 		// Calculate acceleration (if not overridden by pre-listeners)
 		if (store.accelerationData == null) {
-			store.accelerationData = calculateAcceleration(status, dataStore);
+			store.accelerationData = calculateAcceleration(status, store);
 		}
 
 		// Call post-listeners
 		store.accelerationData = SimulationListenerHelper.firePostAccelerationCalculation(status, store.accelerationData);
 
-		params.a = dataStore.accelerationData.getLinearAccelerationWC();
-		params.ra = dataStore.accelerationData.getRotationalAccelerationWC();
+		params.a = store.accelerationData.getLinearAccelerationWC();
+		params.ra = store.accelerationData.getRotationalAccelerationWC();
 		params.v = status.getRocketVelocity();
 		params.rv = status.getRocketRotationVelocity();
 		

--- a/core/src/main/java/info/openrocket/core/simulation/SimulationStatus.java
+++ b/core/src/main/java/info/openrocket/core/simulation/SimulationStatus.java
@@ -33,8 +33,13 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A holder class for the dynamic status during the rocket's flight.
- * 
+ *
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
+ *
+ * The initial SimulationStatus is saved to the FlightDataBranch when it is
+ * created.
+ * The updated SimulationStatus is saved to the FlightDataBranch at the very
+ * end of each step.
  */
 
 public class SimulationStatus implements Cloneable, Monitorable {

--- a/core/src/main/java/info/openrocket/core/simulation/SimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/SimulationStepper.java
@@ -23,6 +23,16 @@ public interface SimulationStepper {
 	 *                    can be used to limit a stepper
 	 *                    from stepping over upcoming flight events (motor ignition
 	 *                    etc).
+	 *
+	 * When the step() is called, a new record has been started for the simulation step, and
+	 * the SimulationStatus at the start time of the step has been saved to the FlightDataBranch.
+	 * The stepper's DataStore is saved to the FlightDataBranch as soon as it has been calculated.
+	 *
+	 * At the end of the step, the simulation time is updated, a new record is created in the FlightDataBranch,
+	 * and the updated SimulationStatus is saved to the FlightDataBranch.
+	 *
+	 * When the simulation terminates, the DataStore has to be computed one more time and saved to the
+	 * FlightDataBranch to complete the last record.
 	 */
 	public void step(SimulationStatus status, double maxTimeStep) throws SimulationException;
 

--- a/core/src/main/java/info/openrocket/core/simulation/SimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/SimulationStepper.java
@@ -36,4 +36,9 @@ public interface SimulationStepper {
 	 */
 	public void step(SimulationStatus status, double maxTimeStep) throws SimulationException;
 
+	/*
+	 * clean up at end of simulation. Calculates DataStore values one last time and
+	 * writes them to FlightDataBranch
+	 */
+	void cleanup(SimulationStatus status) throws SimulationException;
 }

--- a/core/src/main/java/info/openrocket/core/util/TestRockets.java
+++ b/core/src/main/java/info/openrocket/core/util/TestRockets.java
@@ -1884,6 +1884,8 @@ public class TestRockets {
 		Simulation simulation1 = new Simulation(rocket);
 		simulation1.getOptions().setISAAtmosphere(false); // helps cover code in saveComponent()
 		simulation1.getOptions().setTimeStep(0.05);
+		simulation1.getOptions().setLaunchPressure(100000);
+		simulation1.getOptions().setLaunchTemperature(288);
 		rocketDoc.addSimulation(simulation1);
 
 		Simulation simulation2 = new Simulation(rocket);

--- a/core/src/test/java/info/openrocket/core/simulation/FlightEventsTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/FlightEventsTest.java
@@ -1,5 +1,8 @@
 package info.openrocket.core.simulation;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -16,6 +19,7 @@ import info.openrocket.core.rocketcomponent.InnerTube;
 import info.openrocket.core.rocketcomponent.Parachute;
 import info.openrocket.core.rocketcomponent.ParallelStage;
 import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.simulation.FlightDataBranch;
 import info.openrocket.core.simulation.exception.SimulationException;
 import info.openrocket.core.util.BaseTestCase;
 import info.openrocket.core.util.TestRockets;
@@ -62,6 +66,7 @@ public class FlightEventsTest extends BaseTestCase {
 				new FlightEvent(FlightEvent.Type.SIMULATION_END, 42.97, null)
 		};
 
+		checkLastRecord(sim, 0);
 		checkEvents(expectedEvents, sim, 0);
 	}
 
@@ -119,7 +124,6 @@ public class FlightEventsTest extends BaseTestCase {
 						new FlightEvent(FlightEvent.Type.EJECTION_CHARGE, 2.11, centerBooster),
 						new FlightEvent(FlightEvent.Type.STAGE_SEPARATION, 2.11, centerBooster),
 						new FlightEvent(FlightEvent.Type.IGNITION, 2.11, sustainerBody),
-						new FlightEvent(FlightEvent.Type.TUMBLE, 2.37, null),
 						new FlightEvent(FlightEvent.Type.SIM_ABORT, RK4SimulationStepper.RECOMMENDED_MAX_TIME, null, simAbort)
 				};
 
@@ -150,10 +154,15 @@ public class FlightEventsTest extends BaseTestCase {
 				default -> throw new IllegalStateException("Invalid branch number " + b);
 			};
 
+			checkLastRecord(sim, b);
 			checkEvents(expectedEvents, sim, b);
 		}
 	}
 
+	/*
+	 * make sure expected and actual events match
+	 *
+	 */
 	private void checkEvents(FlightEvent[] expectedEvents, Simulation sim, int branchNo) {
 
 		FlightEvent[] actualEvents = sim.getSimulatedData().getBranch(branchNo).getEvents().toArray(new FlightEvent[0]);
@@ -204,7 +213,27 @@ public class FlightEventsTest extends BaseTestCase {
 			}
 		}
 
-		// Test event count
+		// Test event count.  I don't think it's possible to fail here without having failed earlier, but just in case.
 		assertEquals(expectedEvents.length, actualEvents.length, "Branch " + branchNo + " incorrect number of events ");
+	}
+
+	/*
+	 * make sure no flight data variables are present in next-to-last flight record, but not last record, except
+	 * sim step time which should be NaN on the last step
+	 */
+	private void checkLastRecord(Simulation sim, int b) {
+		FlightData data = sim.getSimulatedData();
+		FlightDataBranch branch = data.getBranch(b);
+		List<String> mismatches = new ArrayList<>();
+		int length = branch.getLength();
+		for (FlightDataType type : branch.getTypes()) {
+			if (!branch.getByIndex(type, length-2).isNaN() &&
+				Double.isNaN(branch.getLast(type)) &&
+				(type != FlightDataType.TYPE_TIME_STEP)) {
+				mismatches.add(type.getName());
+			}
+		}
+		assertTrue(mismatches.isEmpty(), "Final flight data variables " + mismatches + " are NaN");
+		assertTrue(Double.isNaN(branch.getLast(FlightDataType.TYPE_TIME_STEP)), "FlightDataType.TYPE_TIME_STEP isn't NaN");
 	}
 }

--- a/core/src/test/java/info/openrocket/core/simulation/FlightEventsTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/FlightEventsTest.java
@@ -234,6 +234,6 @@ public class FlightEventsTest extends BaseTestCase {
 			}
 		}
 		assertTrue(mismatches.isEmpty(), "Final flight data variables " + mismatches + " are NaN");
-		assertTrue(Double.isNaN(branch.getLast(FlightDataType.TYPE_TIME_STEP)), "FlightDataType.TYPE_TIME_STEP isn't NaN");
+		assertTrue(Double.isNaN(branch.getLast(FlightDataType.TYPE_TIME_STEP)), "Final FlightDataType.TYPE_TIME_STEP isn't NaN");
 	}
 }

--- a/core/src/test/java/info/openrocket/core/simulation/FlightEventsTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/FlightEventsTest.java
@@ -172,16 +172,15 @@ public class FlightEventsTest extends BaseTestCase {
 			if (actual.getType() == FlightEvent.Type.SIM_WARN) {
 				actualWarning = (Warning) actual.getData();
 			}
+			
+			assertSame(expected.getType(), actual.getType(),
+					   "Branch " + branchNo + " FlightEvent " + i);
 
 			assertTrue(((expectedWarning == null) && (actualWarning == null)) ||
 					   ((expectedWarning != null) && expectedWarning.equals(actualWarning)) ||
 					   ((actualWarning != null) && actualWarning.equals(expectedWarning)),
 					   "Branch " + branchNo + " FlightEvent " + i + ": " + expectedWarning
 					   + " not found; " + actualWarning + " found instead");
-			
-			assertSame(expected.getType(), actual.getType(),
-					   "Branch " + branchNo + " FlightEvent " + i + ": type " + expected.getType()
-					   + " not found; FlightEvent " + actual.getType() + " found instead");
 
 			if (expected.getTime() != RK4SimulationStepper.RECOMMENDED_MAX_TIME) {
 				// event times that are dependent on simulation step time shouldn't be held to


### PR DESCRIPTION
Final time step isn't calculated since there will be no next step.
Updates unit tests to check for flight data variables that are NaN in the last sample, but not previous.

Fixes #2608 