### PR TITLE
#2510 Change UI theme to light mode when printing the design info

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/file/wavefrontobj/OBJOptionChooser.java
+++ b/swing/src/main/java/info/openrocket/swing/file/wavefrontobj/OBJOptionChooser.java
@@ -341,7 +341,7 @@ public class OBJOptionChooser extends JPanel {
         UITheme.Theme.addUIThemeChangeListener(OBJOptionChooser::updateColors);
     }
 
-    private static void updateColors() {
+    public static void updateColors() {
         darkWarningColor = GUIUtil.getUITheme().getDarkErrorColor();
     }
 

--- a/swing/src/main/java/info/openrocket/swing/gui/components/BasicTree.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/components/BasicTree.java
@@ -53,7 +53,7 @@ public class BasicTree extends JTree {
 		UITheme.Theme.addUIThemeChangeListener(BasicTree::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		backgroundColor = GUIUtil.getUITheme().getBackgroundColor();
 	}
 	

--- a/swing/src/main/java/info/openrocket/swing/gui/components/URLLabel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/components/URLLabel.java
@@ -80,7 +80,7 @@ public class URLLabel extends SelectableLabel {
 		UITheme.Theme.addUIThemeChangeListener(URLLabel::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		URLColor = GUIUtil.getUITheme().getURLColor();
 	}
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/components/UnitSelector.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/components/UnitSelector.java
@@ -116,7 +116,7 @@ public class UnitSelector extends StyledLabel implements StateChangeListener, Mo
 		UITheme.Theme.addUIThemeChangeListener(UnitSelector::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		normalBorder = GUIUtil.getUITheme().getUnitSelectorBorder();
 		withinBorder = GUIUtil.getUITheme().getUnitSelectorFocusBorder();
 	}

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/InnerTubeConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/InnerTubeConfig.java
@@ -518,7 +518,7 @@ class ClusterSelectionPanel extends JPanel {
 		UITheme.Theme.addUIThemeChangeListener(ClusterSelectionPanel::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		UNSELECTED_COLOR = GUIUtil.getUITheme().getBackgroundColor();
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/RocketComponentConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/RocketComponentConfig.java
@@ -207,7 +207,7 @@ public class RocketComponentConfig extends JPanel implements Invalidatable, Inva
 		UITheme.Theme.addUIThemeChangeListener(RocketComponentConfig::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		darkErrorColor = GUIUtil.getUITheme().getDarkErrorColor();
 		multiCompEditColor = GUIUtil.getUITheme().getMultiCompEditColor();
 		marginBorder = GUIUtil.getUITheme().getMarginBorder();

--- a/swing/src/main/java/info/openrocket/swing/gui/customexpression/CustomExpressionPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/customexpression/CustomExpressionPanel.java
@@ -182,7 +182,7 @@ public class CustomExpressionPanel extends JPanel {
 			initColors();
 		}
 
-		private static void updateColors() {
+		public static void updateColors() {
 			backgroundColor = GUIUtil.getUITheme().getBackgroundColor();
 		}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/BugReportDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/BugReportDialog.java
@@ -121,7 +121,7 @@ public class BugReportDialog extends JDialog {
 		UITheme.Theme.addUIThemeChangeListener(BugReportDialog::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		darkErrorColor = GUIUtil.getUITheme().getDarkErrorColor();
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/ErrorWarningDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/ErrorWarningDialog.java
@@ -40,7 +40,7 @@ public abstract class ErrorWarningDialog {
         UITheme.Theme.addUIThemeChangeListener(ErrorWarningDialog::updateColors);
     }
 
-    private static void updateColors() {
+    public static void updateColors() {
 		darkErrorColor = GUIUtil.getUITheme().getDarkErrorColor();
         textSelectionForegroundColor = GUIUtil.getUITheme().getTextSelectionForegroundColor();
     }

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/UpdateInfoDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/UpdateInfoDialog.java
@@ -214,7 +214,7 @@ public class UpdateInfoDialog extends JDialog {
 		UITheme.Theme.addUIThemeChangeListener(UpdateInfoDialog::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		textColor = GUIUtil.getUITheme().getTextColor();
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/ComponentAnalysisGeneralPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/ComponentAnalysisGeneralPanel.java
@@ -699,7 +699,7 @@ public class ComponentAnalysisGeneralPanel extends JPanel implements StateChange
 			UITheme.Theme.addUIThemeChangeListener(CustomCellRenderer::updateColors);
 		}
 
-		private static void updateColors() {
+		public static void updateColors() {
 			backgroundColor = GUIUtil.getUITheme().getBackgroundColor();
 			foregroundColor = GUIUtil.getUITheme().getTextColor();
 		}

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/flightconfiguration/RenameConfigDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/flightconfiguration/RenameConfigDialog.java
@@ -108,7 +108,7 @@ public class RenameConfigDialog extends JDialog {
 		UITheme.Theme.addUIThemeChangeListener(RenameConfigDialog::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		dimTextColor = GUIUtil.getUITheme().getDimTextColor();
 	}
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/motor/thrustcurve/MotorInformationPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/motor/thrustcurve/MotorInformationPanel.java
@@ -255,7 +255,7 @@ class MotorInformationPanel extends JPanel {
 		UITheme.Theme.addUIThemeChangeListener(MotorInformationPanel::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		NO_COMMENT_COLOR = GUIUtil.getUITheme().getDimTextColor();
 		WITH_COMMENT_COLOR = GUIUtil.getUITheme().getTextColor();
 		textColor = GUIUtil.getUITheme().getTextColor();

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/motor/thrustcurve/ThrustCurveMotorSelectionPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/motor/thrustcurve/ThrustCurveMotorSelectionPanel.java
@@ -413,7 +413,7 @@ public class ThrustCurveMotorSelectionPanel extends JPanel implements MotorSelec
 		UITheme.Theme.addUIThemeChangeListener(ThrustCurveMotorSelectionPanel::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		dimTextColor = GUIUtil.getUITheme().getDimTextColor();
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/optimization/SimulationModifierTree.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/optimization/SimulationModifierTree.java
@@ -75,7 +75,7 @@ public class SimulationModifierTree extends BasicTree {
 		UITheme.Theme.addUIThemeChangeListener(SimulationModifierTree::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		textColor = GUIUtil.getUITheme().getTextColor();
 		dimTextColor = GUIUtil.getUITheme().getDimTextColor();
 		disabledTextColor = GUIUtil.getUITheme().getDisabledTextColor();

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/LaunchPreferencesPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/LaunchPreferencesPanel.java
@@ -42,7 +42,7 @@ public class LaunchPreferencesPanel extends PreferencesPanel {
 		UITheme.Theme.addUIThemeChangeListener(LaunchPreferencesPanel::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		darkErrorColor = GUIUtil.getUITheme().getDarkErrorColor();
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/SimulationPreferencesPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/SimulationPreferencesPanel.java
@@ -327,7 +327,7 @@ public class SimulationPreferencesPanel extends PreferencesPanel {
 		UITheme.Theme.addUIThemeChangeListener(SimulationPreferencesPanel::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		darkErrorColor = GUIUtil.getUITheme().getDarkErrorColor();
 	}
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/figure3d/RocketFigure3d.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/figure3d/RocketFigure3d.java
@@ -129,7 +129,7 @@ public class RocketFigure3d extends JPanel implements GLEventListener {
 		UITheme.Theme.addUIThemeChangeListener(RocketFigure3d::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		backgroundColor = GUIUtil.getUITheme().getBackgroundColor();
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/figureelements/CGCaret.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/figureelements/CGCaret.java
@@ -38,7 +38,7 @@ public class CGCaret extends Caret {
 		UITheme.Theme.addUIThemeChangeListener(CGCaret::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		CGColor = GUIUtil.getUITheme().getCGColor();
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/figureelements/CPCaret.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/figureelements/CPCaret.java
@@ -37,7 +37,7 @@ public class CPCaret extends Caret {
 		UITheme.Theme.addUIThemeChangeListener(CPCaret::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		CPColor = GUIUtil.getUITheme().getCPColor();
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/figureelements/RocketInfo.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/figureelements/RocketInfo.java
@@ -93,7 +93,7 @@ public class RocketInfo implements FigureElement {
 		UITheme.Theme.addUIThemeChangeListener(RocketInfo::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		textColor = GUIUtil.getUITheme().getTextColor();
 		dimTextColor = GUIUtil.getUITheme().getDimTextColor();
 		darkErrorColor = GUIUtil.getUITheme().getErrorColor();

--- a/swing/src/main/java/info/openrocket/swing/gui/help/tours/SlideSetManager.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/help/tours/SlideSetManager.java
@@ -58,7 +58,7 @@ public class SlideSetManager {
 		UITheme.Theme.addUIThemeChangeListener(SlideSetManager::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		textColor = GUIUtil.getUITheme().getTextColor();
 	}
 	

--- a/swing/src/main/java/info/openrocket/swing/gui/main/ComponentIcons.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/ComponentIcons.java
@@ -147,7 +147,7 @@ public class ComponentIcons {
 		UITheme.Theme.addUIThemeChangeListener(ComponentIcons::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		noseCone = GUIUtil.getUITheme().getComponentIconNoseCone();
 		bodyTube = GUIUtil.getUITheme().getComponentIconBodyTube();
 		transition = GUIUtil.getUITheme().getComponentIconTransition();

--- a/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
@@ -339,7 +339,7 @@ public class SimulationPanel extends JPanel {
 		UITheme.Theme.addUIThemeChangeListener(SimulationPanel::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		dimTextColor = GUIUtil.getUITheme().getDimTextColor();
 		warningColor = GUIUtil.getUITheme().getWarningColor();
 		errorColor = GUIUtil.getUITheme().getErrorColor();

--- a/swing/src/main/java/info/openrocket/swing/gui/main/componenttree/ComponentTreeRenderer.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/componenttree/ComponentTreeRenderer.java
@@ -137,7 +137,7 @@ public class ComponentTreeRenderer extends DefaultTreeCellRenderer {
 		UITheme.Theme.addUIThemeChangeListener(ComponentTreeRenderer::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		massOverrideSubcomponentIcon = GUIUtil.getUITheme().getMassOverrideSubcomponentIcon();
 		massOverrideIcon = GUIUtil.getUITheme().getMassOverrideIcon();
 		CGOverrideSubcomponentIcon = GUIUtil.getUITheme().getCGOverrideSubcomponentIcon();

--- a/swing/src/main/java/info/openrocket/swing/gui/main/componenttree/SelectableComponentTreeRenderer.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/componenttree/SelectableComponentTreeRenderer.java
@@ -41,7 +41,7 @@ public class SelectableComponentTreeRenderer extends ComponentTreeRenderer {
 		italicFont = regularFont.deriveFont(Font.ITALIC);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		disabledTextColor = GUIUtil.getUITheme().getDisabledTextColor();
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/main/flightconfigpanel/FlightConfigurablePanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/flightconfigpanel/FlightConfigurablePanel.java
@@ -81,7 +81,7 @@ public abstract class FlightConfigurablePanel<T extends FlightConfigurableCompon
 		UITheme.Theme.addUIThemeChangeListener(FlightConfigurablePanel::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		textColor = GUIUtil.getUITheme().getTextColor();
 		dimTextColor = GUIUtil.getUITheme().getDimTextColor();
 	}

--- a/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationPlotDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationPlotDialog.java
@@ -120,7 +120,7 @@ public class SimulationPlotDialog extends PlotDialog<FlightDataType, FlightDataB
 		UITheme.Theme.addUIThemeChangeListener(SimulationPlotDialog::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		darkErrorColor = GUIUtil.getUITheme().getDarkErrorColor();
 	}
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/print/DesignReport.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/print/DesignReport.java
@@ -14,6 +14,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import com.itextpdf.awt.PdfGraphics2D;
+import info.openrocket.swing.gui.figureelements.CGCaret;
+import info.openrocket.swing.gui.figureelements.CPCaret;
 import info.openrocket.swing.gui.scalefigure.AbstractScaleFigure;
 import info.openrocket.swing.gui.scalefigure.RocketFigure;
 import info.openrocket.swing.gui.theme.UITheme;
@@ -374,6 +376,8 @@ public class DesignReport {
 	private void updateColors() {
 		AbstractScaleFigure.updateColors();
 		RocketFigure.updateColors();
+		CGCaret.updateColors();
+		CPCaret.updateColors();
 		((SwingPreferences) Application.getPreferences()).updateColors();
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/print/DesignReport.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/print/DesignReport.java
@@ -14,6 +14,11 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import com.itextpdf.awt.PdfGraphics2D;
+import info.openrocket.swing.gui.scalefigure.AbstractScaleFigure;
+import info.openrocket.swing.gui.scalefigure.RocketFigure;
+import info.openrocket.swing.gui.theme.UITheme;
+import info.openrocket.swing.gui.util.GUIUtil;
+import info.openrocket.swing.gui.util.SwingPreferences;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -131,6 +136,8 @@ public class DesignReport {
 	 * Parent window for showing simulation run dialog as necessary
 	 */
 	private Window window = null;
+
+	private final UITheme.Theme originalTheme;
 	
 	/** The displayed strings. */
 	private static final String STAGES = "Stages: ";
@@ -192,10 +199,13 @@ public class DesignReport {
 	 */
 	public DesignReport(OpenRocketDocument theRocDoc, Document theIDoc, Double figureRotation,
 	                    boolean runOutOfDateSims, boolean updateExistingSims, Window window) {
-		document = theIDoc;
-		rocketDocument = theRocDoc;
-		panel = new RocketPanel(rocketDocument);
-		rotation = figureRotation;
+		this.originalTheme = GUIUtil.getUITheme();
+		GUIUtil.setUITheme(UITheme.Themes.LIGHT);
+		updateColors();
+		this.document = theIDoc;
+		this.rocketDocument = theRocDoc;
+		this.panel = new RocketPanel(this.rocketDocument);
+		this.rotation = figureRotation;
 		this.runOutOfDateSimulations = runOutOfDateSims;
 		this.updateExistingSimulations = updateExistingSims;
 		this.window = window;
@@ -355,7 +365,18 @@ public class DesignReport {
 		g2d.dispose();
 		return scale;
 	}
-	
+
+	public void restoreUITheme() {
+		GUIUtil.setUITheme(originalTheme);
+		updateColors();
+	}
+
+	private void updateColors() {
+		AbstractScaleFigure.updateColors();
+		RocketFigure.updateColors();
+		((SwingPreferences) Application.getPreferences()).updateColors();
+	}
+
 	/**
 	 * Add the motor data for a motor configuration to the table.
 	 *

--- a/swing/src/main/java/info/openrocket/swing/gui/print/PrintController.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/print/PrintController.java
@@ -97,6 +97,7 @@ public class PrintController {
                         DesignReport dp = new DesignReport(doc, idoc, rotation, runSims, true, this.window);
                         dp.writeToDocument(writer);
                         idoc.newPage();
+						dp.restoreUITheme();
                         break;
 
                     case FIN_TEMPLATE:

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/AbstractScaleFigure.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/AbstractScaleFigure.java
@@ -86,7 +86,7 @@ public abstract class AbstractScaleFigure extends JPanel {
 		UITheme.Theme.addUIThemeChangeListener(AbstractScaleFigure::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		backgroundColor = GUIUtil.getUITheme().getBackgroundColor();
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/FinPointFigure.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/FinPointFigure.java
@@ -88,7 +88,7 @@ public class FinPointFigure extends AbstractScaleFigure {
 		UITheme.Theme.addUIThemeChangeListener(FinPointFigure::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		backgroundColor = GUIUtil.getUITheme().getBackgroundColor();
 		finPointBodyLineColor = GUIUtil.getUITheme().getFinPointBodyLineColor();
 		finPointGridMajorLineColor = GUIUtil.getUITheme().getFinPointGridMajorLineColor();

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketFigure.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketFigure.java
@@ -128,7 +128,7 @@ public class RocketFigure extends AbstractScaleFigure {
 		UITheme.Theme.addUIThemeChangeListener(RocketFigure::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		motorFillColor = GUIUtil.getUITheme().getMotorFillColor();
 		motorBorderColor = GUIUtil.getUITheme().getMotorBorderColor();
 	}

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/ScaleScrollPane.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/ScaleScrollPane.java
@@ -140,7 +140,7 @@ public class ScaleScrollPane extends JScrollPane
 		UITheme.Theme.addUIThemeChangeListener(ScaleScrollPane::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		textColor = GUIUtil.getUITheme().getTextColor();
 	}
 	

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConfigDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConfigDialog.java
@@ -219,7 +219,7 @@ public class SimulationConfigDialog extends JDialog {
 		UITheme.Theme.addUIThemeChangeListener(SimulationConfigDialog::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		multiCompEditColor = GUIUtil.getUITheme().getMultiCompEditColor();
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationOptionsPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationOptionsPanel.java
@@ -250,7 +250,7 @@ class SimulationOptionsPanel extends JPanel {
 		UITheme.Theme.addUIThemeChangeListener(SimulationOptionsPanel::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		textColor = GUIUtil.getUITheme().getTextColor();
 		dimTextColor = GUIUtil.getUITheme().getDimTextColor();
 	}

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationPlotPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationPlotPanel.java
@@ -149,7 +149,7 @@ public class SimulationPlotPanel extends PlotPanel<FlightDataType, FlightDataBra
 		UITheme.Theme.addUIThemeChangeListener(SimulationPlotPanel::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		darkErrorColor = GUIUtil.getUITheme().getDarkErrorColor();
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationWarningsPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationWarningsPanel.java
@@ -89,7 +89,7 @@ public class SimulationWarningsPanel extends JPanel {
 		UITheme.Theme.addUIThemeChangeListener(SimulationWarningsPanel::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		border = GUIUtil.getUITheme().getBorder();
 		dimTextColor = GUIUtil.getUITheme().getDimTextColor();
 		darkErrorColor = GUIUtil.getUITheme().getDarkErrorColor();

--- a/swing/src/main/java/info/openrocket/swing/gui/theme/UITheme.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/theme/UITheme.java
@@ -168,7 +168,7 @@ public class UITheme {
     }
 
     public static boolean isLightTheme(Theme theme) {
-        if (theme == Themes.DARK) {
+        if (theme == Themes.DARK || theme == Themes.DARK_CONTRAST) {
             return false;
         } else if (theme == Themes.LIGHT) {
             return true;

--- a/swing/src/main/java/info/openrocket/swing/gui/util/BetterListCellRenderer.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/util/BetterListCellRenderer.java
@@ -75,7 +75,7 @@ public class BetterListCellRenderer extends DefaultListCellRenderer {
         UITheme.Theme.addUIThemeChangeListener(BetterListCellRenderer::updateColors);
     }
 
-    private static void updateColors() {
+    public static void updateColors() {
         rowBackgroundDarkerColor = GUIUtil.getUITheme().getRowBackgroundDarkerColor();
         rowBackgroundLighterColor = GUIUtil.getUITheme().getRowBackgroundLighterColor();
         textSelectionForegroundColor = GUIUtil.getUITheme().getTextSelectionForegroundColor();

--- a/swing/src/main/java/info/openrocket/swing/gui/util/GUIUtil.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/util/GUIUtil.java
@@ -296,6 +296,13 @@ public class GUIUtil {
 		return UITheme.Themes.LIGHT;
 	}
 
+	public static void setUITheme(UITheme.Theme theme) {
+		ApplicationPreferences prefs = Application.getPreferences();
+		prefs.setUITheme(theme);
+		theme.applyTheme();
+		// TODO: use UITheme notifyUIThemeChangeListeners once properly implemented
+	}
+
 	public static void applyLAF() {
 		UITheme.Theme theme = getUITheme();
 		theme.applyTheme();

--- a/swing/src/main/java/info/openrocket/swing/gui/util/SwingPreferences.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/util/SwingPreferences.java
@@ -131,6 +131,10 @@ public class SwingPreferences extends ApplicationPreferences {
 		DEFAULT_COLORS.put(ParallelStage.class, getUIThemeAsTheme().getDefaultParallelStageColor());
 	}
 
+	public void updateColors() {
+		fillDefaultComponentColors();
+	}
+
 	public String getNodename() {
 		return NODENAME;
 	}

--- a/swing/src/main/java/info/openrocket/swing/gui/widgets/CSVExportPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/widgets/CSVExportPanel.java
@@ -142,7 +142,7 @@ public class CSVExportPanel<T extends UnitValue> extends JPanel {
 		UITheme.Theme.addUIThemeChangeListener(CSVExportPanel::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		ALTERNATE_ROW_COLOR = GUIUtil.getUITheme().getRowBackgroundLighterColor();
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/widgets/GroupableAndSearchableComboBox.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/widgets/GroupableAndSearchableComboBox.java
@@ -125,7 +125,7 @@ public class GroupableAndSearchableComboBox<G extends Group, T extends Groupable
 		UITheme.Theme.addUIThemeChangeListener(GroupableAndSearchableComboBox::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		textSelectionBackground = GUIUtil.getUITheme().getTextSelectionBackgroundColor();
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/simulation/extension/impl/JavaCodeConfigurator.java
+++ b/swing/src/main/java/info/openrocket/swing/simulation/extension/impl/JavaCodeConfigurator.java
@@ -42,7 +42,7 @@ public class JavaCodeConfigurator extends AbstractSwingSimulationExtensionConfig
 		UITheme.Theme.addUIThemeChangeListener(JavaCodeConfigurator::updateColors);
 	}
 
-	private static void updateColors() {
+	public static void updateColors() {
 		darkErrorColor = GUIUtil.getUITheme().getDarkErrorColor();
 	}
 


### PR DESCRIPTION
This PR fixes #2510 and correctly exports the rocket design view in the Design Info PDF:

<img width="1241" alt="image" src="https://github.com/user-attachments/assets/ad92c812-bcc5-49b6-a1d4-e73901091c8c" />

The solution: right before exporting, I set the UITheme to light mode, then export it, and then revert the UITheme back to the previously set theme.