### PR TITLE
[#2625] Update welcome info path

### DIFF
--- a/core/src/main/java/info/openrocket/core/communication/WelcomeInfoRetriever.java
+++ b/core/src/main/java/info/openrocket/core/communication/WelcomeInfoRetriever.java
@@ -28,7 +28,7 @@ public abstract class WelcomeInfoRetriever {
         if (in == null) {
             // Try to load the file from the file system (only really useful when running
             // the unit tests directly from your IDE)
-            File f = new File("../ReleaseNotes.md");
+            File f = new File("ReleaseNotes.md");
             in = f.toURI().toURL().openStream();
             if (in == null) {
                 throw new FileNotFoundException("ReleaseNotes.md not found");


### PR DESCRIPTION
Description: This PR fixes #2625, where the retrieveWelcomeInfo method used outdated file paths after the Gradle migration, preventing the welcome dialogue from displaying correctly.

Solution: Updated the file path for ReleaseNotes.md to the correct location to ensure the release notes are loaded properly.
