### PR TITLE
[#2626] Initialize CG in SymmetricComponent

### DIFF
--- a/core/src/main/java/info/openrocket/core/rocketcomponent/SymmetricComponent.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/SymmetricComponent.java
@@ -9,6 +9,8 @@ import info.openrocket.core.rocketcomponent.position.AxialMethod;
 import info.openrocket.core.util.BoundingBox;
 import info.openrocket.core.util.Coordinate;
 import info.openrocket.core.util.MathUtil;
+import org.checkerframework.checker.units.qual.C;
+
 import static info.openrocket.core.util.MathUtil.pow2;
 
 /**
@@ -440,6 +442,7 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 		volume = 0;
 		longitudinalUnitInertia = 0;
 		rotationalUnitInertia = 0;
+		cg = new Coordinate();
 
 		double cgx = 0;
 

--- a/core/src/test/java/info/openrocket/core/rocketcomponent/TransitionTest.java
+++ b/core/src/test/java/info/openrocket/core/rocketcomponent/TransitionTest.java
@@ -159,4 +159,20 @@ public class TransitionTest extends BaseTestCase {
 		assertEquals(0.011, nose.getAftShoulderRadius(), EPSILON, "Alpha3 nose cone aft shoulder radius is wrong ");
 	}
 
+	/**
+	 * Test the calculation of the properties of a zero-length transition.
+	 * This is to ensure no regressions with GitHub issue #2626.
+	 */
+	@Test
+	public void testZeroLengthTransitionCalculations() {
+		Transition transition = new Transition() {
+			@Override
+			public double getLength() {
+				return 0.0;
+			}
+		};
+		transition.setAftShoulderLength(0.1);
+		transition.calculateProperties();
+	}
+
 }


### PR DESCRIPTION
This PR fixes #2626. There was an issue for 0-length transitions that got loaded from the .ork file. The `Transition` was loaded, which initializes the CG to `null`. Then `calculateProperties()` was called on the `Transition`, which first goes to `calculateProperties()` of `SymmetricComponent`, but because the length was 0, the method immediately returned, leaving the CG to `null`, and causing the `NullPointerException`. This PR just initializes the CG in `calculateProperties()` of `SymmetricComponent` so it cannot be `null`.