### PR TITLE
Dynamically resize the sim table Warnings column based on its content

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/adaptors/Column.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/adaptors/Column.java
@@ -9,6 +9,8 @@ import info.openrocket.core.unit.UnitGroup;
 public abstract class Column {
 	private final String name;
 	private final String toolTip;
+	private final boolean autoSize;
+	private final boolean includeHeaderInAutoSize;
 	
 	/**
 	 * Create a new column with specified name.  Additionally, the {@link #getValueAt(int)}
@@ -17,8 +19,7 @@ public abstract class Column {
 	 * @param name	the caption of the column.
 	 */
 	public Column(String name) {
-		this.name = name;
-		this.toolTip = null;
+		this(name, name);
 	}
 	
 	/**
@@ -26,9 +27,23 @@ public abstract class Column {
 	 * 
 	 * 
 	 */
-	public Column(String name, String toolTip ) {
+	public Column(String name, String toolTip) {
+		this(name, toolTip, false);
+	}
+
+	public Column(String name, String toolTip, boolean autoSize) {
+		this(name, toolTip, autoSize, true);
+	}
+
+	public Column(String name, boolean autoSize, boolean includeHeaderInAutoSize) {
+		this(name, name, autoSize, includeHeaderInAutoSize);
+	}
+
+	public Column(String name, String toolTip, boolean autoSize, boolean includeHeaderInAutoSize) {
 		this.name = name;
 		this.toolTip = toolTip;
+		this.autoSize = autoSize;
+		this.includeHeaderInAutoSize = includeHeaderInAutoSize;
 	}
 	
 	/**
@@ -43,6 +58,8 @@ public abstract class Column {
 	 * Return the default width of the column.  This is used by the method
 	 * {@link #ColumnTableModel.setColumnWidth(TableColumnModel)}.  The default width is
 	 * 100, the method may be overridden to return other values relative to this value.
+	 *
+	 * If autoSize is true, this value is used as the minimum width.
 	 * 
 	 * @return		the relative width of the column (default 100).
 	 */
@@ -59,6 +76,14 @@ public abstract class Column {
 	 */
 	public int getExactWidth() {
 		return 0;
+	}
+
+	public boolean isAutoSize() {
+		return autoSize;
+	}
+
+	public boolean includeHeaderInAutoSize() {
+		return includeHeaderInAutoSize;
 	}
 	
 	public UnitGroup getUnits() {

--- a/swing/src/main/java/info/openrocket/swing/gui/adaptors/ColumnTable.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/adaptors/ColumnTable.java
@@ -1,9 +1,12 @@
 package info.openrocket.swing.gui.adaptors;
 
+import java.awt.Component;
 import java.awt.event.MouseEvent;
 
 import javax.swing.JTable;
 import javax.swing.table.JTableHeader;
+import javax.swing.table.TableCellRenderer;
+import javax.swing.table.TableColumn;
 
 @SuppressWarnings("serial")
 public class ColumnTable extends JTable {
@@ -27,6 +30,62 @@ public class ColumnTable extends JTable {
 				return tip;
 			}
 		};
+	}
+
+	/**
+	 * Get the maximum width needed by the column.
+	 * @param colIndex the index of the column
+	 * @return the maximum width needed by the column
+	 */
+	private int getMaxColumnWidth(int colIndex) {
+		int maxWidth = 0;
+		ColumnTableModel columnModel = (ColumnTableModel) getModel();
+		Column column = columnModel.getColumn(colIndex);
+
+		// Check header width if needed
+		if (column.includeHeaderInAutoSize()) {
+			TableColumn tableColumn = getColumnModel().getColumn(colIndex);
+			TableCellRenderer headerRenderer = tableColumn.getHeaderRenderer();
+			if (headerRenderer == null) {
+				headerRenderer = getTableHeader().getDefaultRenderer();
+			}
+			Component headerComp = headerRenderer.getTableCellRendererComponent(
+					this, tableColumn.getHeaderValue(), false, false, 0, colIndex);
+			maxWidth = headerComp.getPreferredSize().width;
+		}
+
+		// Check each row
+		for (int row = 0; row < getRowCount(); row++) {
+			TableCellRenderer renderer = getCellRenderer(row, colIndex);
+			Component comp = prepareRenderer(renderer, row, colIndex);
+			maxWidth = Math.max(maxWidth, comp.getPreferredSize().width);
+		}
+
+		return maxWidth;
+	}
+
+	/**
+	 * Set the preferred width of each column to the maximum width needed by the
+	 * column.
+	 */
+	public void setupAutoSizeColumns() {
+		ColumnTableModel columnModel = (ColumnTableModel) getModel();
+
+		for (int i = 0; i < columnModel.getColumnCount(); i++) {
+			Column col = columnModel.getColumn(i);
+			if (col.isAutoSize()) {
+				TableColumn tableColumn = getColumnModel().getColumn(i);
+
+				// Get max width needed
+				int maxWidth = getMaxColumnWidth(i);
+
+				// Add some padding
+				maxWidth += 10;
+
+				// Set the preferred width
+				tableColumn.setPreferredWidth(maxWidth);
+			}
+		}
 	}
 	
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/adaptors/ColumnTableModel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/adaptors/ColumnTableModel.java
@@ -13,18 +13,29 @@ public abstract class ColumnTableModel extends AbstractTableModel {
 	public ColumnTableModel(Column... columns) {
 		this.columns = columns;
 	}
-	
+
 	public void setColumnWidths(TableColumnModel model) {
 		for (int i = 0; i < columns.length; i++) {
+			TableColumn col = model.getColumn(i);
+
 			if (columns[i].getExactWidth() > 0) {
-				TableColumn col = model.getColumn(i);
+				// Handle exact width columns as before
 				int w = columns[i].getExactWidth();
 				col.setResizable(false);
 				col.setMinWidth(w);
 				col.setMaxWidth(w);
 				col.setPreferredWidth(w);
-			} else {
-				model.getColumn(i).setPreferredWidth(columns[i].getDefaultWidth());
+			}
+			else if (columns[i].isAutoSize()) {
+				// For auto-size columns, set minimum width but allow expansion
+				col.setResizable(true);
+				col.setMinWidth(columns[i].getDefaultWidth());
+				col.setPreferredWidth(columns[i].getDefaultWidth());
+				col.setMaxWidth(Integer.MAX_VALUE);
+			}
+			else {
+				// Handle normal columns as before
+				col.setPreferredWidth(columns[i].getDefaultWidth());
 			}
 		}
 	}

--- a/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
@@ -106,7 +106,7 @@ public class SimulationPanel extends JPanel {
 	private final OpenRocketDocument document;
 
 	private final ColumnTableModel simulationTableModel;
-	private final JTable simulationTable;
+	private final ColumnTable simulationTable;
 
 	private final JButton editButton;
 	private final JButton runButton;
@@ -207,6 +207,7 @@ public class SimulationPanel extends JPanel {
 		simulationTable.setDefaultRenderer(Object.class, new JLabelRenderer());
 		simulationTable.setDefaultRenderer(WarningsBox.class, new WarningsBoxRenderer());
 		simulationTableModel.setColumnWidths(simulationTable.getColumnModel());
+		simulationTable.setupAutoSizeColumns();
 		simulationTable.setFillsViewportHeight(true);
 
 		// Unregister the default actions that would otherwise conflict with RocketActions and their acceleration keys
@@ -1366,7 +1367,7 @@ public class SimulationPanel extends JPanel {
 					},
 
 					//// Warnings column
-					new Column(trans.get("simpanel.col.Warnings")) {
+					new Column(trans.get("simpanel.col.Warnings"), true, false) {
 						private WarningsBox box = null;
 
 						@Override
@@ -1388,7 +1389,7 @@ public class SimulationPanel extends JPanel {
 
 						@Override
 						public int getDefaultWidth() {
-							return 80;
+							return 40;
 						}
 
 						@Override


### PR DESCRIPTION
This PR dynamically resizes the Warnings column in the sim table to fit the content of the sim. Before, it was a relatively wide, statically sized column.

Examples:
<img width="1557" alt="Screenshot 2024-12-23 at 02 48 30" src="https://github.com/user-attachments/assets/9bdb885e-0734-4e9f-bd20-fad6f3b77a69" />
<img width="1558" alt="Screenshot 2024-12-23 at 02 48 43" src="https://github.com/user-attachments/assets/4a040952-0cea-4954-92de-2578d0168ac6" />
<img width="1557" alt="Screenshot 2024-12-23 at 02 48 57" src="https://github.com/user-attachments/assets/7902f19f-26e9-4a23-af17-f8173abcd224" />

The column header text is cut off, but the full name is accessible with the tooltip:
<img width="170" alt="Screenshot 2024-12-23 at 02 49 08" src="https://github.com/user-attachments/assets/4b003285-de52-4f3a-8754-4da74fb535f0" />
