### PR TITLE
[#2624] Don't check for material group in database search

### DIFF
--- a/core/src/main/java/info/openrocket/core/database/Databases.java
+++ b/core/src/main/java/info/openrocket/core/database/Databases.java
@@ -197,6 +197,7 @@ public class Databases {
 		String name = trans.get("material", baseName);
 
 		for (Material m : db) {
+			// Material group comparison is omitted to keep compatibility with files pre OR 24.12
 			if (m.getName().equalsIgnoreCase(name) && MathUtil.equals(m.getDensity(), density)) {
 				return m;
 			}

--- a/core/src/main/java/info/openrocket/core/database/Databases.java
+++ b/core/src/main/java/info/openrocket/core/database/Databases.java
@@ -197,7 +197,7 @@ public class Databases {
 		String name = trans.get("material", baseName);
 
 		for (Material m : db) {
-			if (m.getName().equalsIgnoreCase(name) && MathUtil.equals(m.getDensity(), density) && m.getGroup() == group) {
+			if (m.getName().equalsIgnoreCase(name) && MathUtil.equals(m.getDensity(), density)) {
 				return m;
 			}
 		}


### PR DESCRIPTION
This PR fixes #2624 by ignoring material groups in the material database search. I don't think this will ever be a problem. The only problem could be that if you have e.g. "MAT A, 1 g/m3" in the Metals group and "MAT A, 1 g/m3" in the Woods group, that there is no distinction between both, since they have the same material name and density. But again, not really an issue since functionality they are the same materials.