### PR TITLE
Booster open airframe warning

### DIFF
--- a/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanCalculator.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanCalculator.java
@@ -340,7 +340,11 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 					SymmetricComponent sym = (SymmetricComponent) comp;
 					if (null == prevComp) {
 						if (sym.getForeRadius() - sym.getThickness() > MathUtil.EPSILON) {
-							warnings.add(Warning.OPEN_AIRFRAME_FORWARD, sym);
+							if (comp.getStageNumber() == 0) {
+								warnings.add(Warning.OPEN_AIRFRAME_FORWARD, sym);
+							} else {
+								warnings.add(Warning.OPEN_BOOSTER_FORWARD, sym);
+							}
 						}
 					} else {
 						// Check for radius discontinuity

--- a/core/src/main/java/info/openrocket/core/logging/Warning.java
+++ b/core/src/main/java/info/openrocket/core/logging/Warning.java
@@ -400,6 +400,9 @@ public abstract class Warning extends Message {
 	/** A <code>Warning</code> that a ComponentAssembly has an open forward end */	
 	public static final Warning OPEN_AIRFRAME_FORWARD = new Other(trans.get("Warning.OPEN_AIRFRAME_FORWARD"), MessagePriority.LOW);
 
+	/** A <code>Warning</code> that the lower stage of a rocket has an open forward airframe following stage separation **/
+	public static final Warning OPEN_BOOSTER_FORWARD = new Other(trans.get("Warning.OPEN_BOOSTER_FORWARD"), MessagePriority.LOW);
+	
 	/** A <code>Warning</code> that there is a gap in the airframe */
 	public static final Warning AIRFRAME_GAP = new Other(trans.get("Warning.AIRFRAME_GAP"), MessagePriority.LOW);
 

--- a/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
@@ -436,7 +436,7 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 			}
 			
 			if (!sustainer && (!stable || recoverySoon)) {
-				warnings.filterOut(Warning.OPEN_AIRFRAME_FORWARD);
+				warnings.filterOut(Warning.OPEN_BOOSTER_FORWARD);
 			}
 				
 			status.addWarnings(warnings);

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -2301,6 +2301,7 @@ Warning.LargeAOA.str1 = Large angle of attack encountered.
 Warning.LargeAOA.str2 = Large angle of attack encountered (
 Warning.DISCONTINUITY = Discontinuity in rocket body diameter
 Warning.OPEN_AIRFRAME_FORWARD = Open forward airframe (diameter > 0)
+Warning.OPEN_BOOSTER_FORWARD = Lower stage has open forward aiframe (diameter > 0) following stage separation
 Warning.AIRFRAME_GAP = Gap in rocket airframe
 Warning.AIRFRAME_OVERLAP = Overlap in airframe components
 Warning.PODSET_FORWARD = In-line podset forward of parent airframe component


### PR DESCRIPTION
This PR attempts to further clarify the infamous "open airframe warning" by distinguishing between sustainer open airframe and boosters with open airframe following stage separation.

Running the two stage high power rocket simulation, the warning that appears at stage separation is:
![booster-open](https://github.com/user-attachments/assets/f36570cf-d61a-42ec-a041-6763195f168d)
