### PR TITLE
[Typo] Align spellings for contributing translations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Right, you've dug into the codebase, found that one nasty line that caused all y
 You can take a look at example PR [#979](https://github.com/openrocket/openrocket/pull/979).
 
 ## Translation
-Both the OpenRocket software and the end-user documentation site are multilingual. The job of a translator is to maintain the existing languages, or to make a new translation of an unlisted language. During the development sometimes new translation keys get added in the English language that are not simultaneously translated to other languages. The translator must therefor check which translation keys are still missing in his/her/they language.
+Both the OpenRocket software and the end-user documentation site are multilingual. The job of a translator is to maintain the existing languages, or to make a new translation of an unlisted language. During the development sometimes new translation keys get added in the English language that are not simultaneously translated to other languages. The translator must therefore check which translation keys are still missing in his/her/their language.
 
 How you can make/edit a translation can be found on [this site](http://openrocket.trans.free.fr/index.php?lang=en) or the [GitHub wiki](https://github.com/openrocket/openrocket/wiki/Instructions-for-translators).
 


### PR DESCRIPTION
This PR is a patch for spellings in the contribution guide. 

* his/her are possessive, so 'they' should be possessive as well
* therefor generally means 'in return for' while therefore generally means 'as a result', with the latter seeming to fit better

From a copy editing perspective, it may be more inclusive and flow more smoothly to shorten 'his/her/their' to 'their', as this would retain the meaning, but this would be a more stylistic choice for the author. 

Hope this helps! Happy to make any edits and look forward to contributing more.