### PR TITLE
 [#2590] Make input fields for longitude and latitude larger + add more decimal precision

### DIFF
--- a/core/src/main/java/info/openrocket/core/unit/FixedPrecisionUnit.java
+++ b/core/src/main/java/info/openrocket/core/unit/FixedPrecisionUnit.java
@@ -62,7 +62,8 @@ public class FixedPrecisionUnit extends Unit {
 
 	@Override
 	public double round(double value) {
-		return Math.rint(value / precision) * precision;
+		double scale = 1.0 / precision;
+		return Math.round(value * scale) / scale;
 	}
 
 	@Override

--- a/core/src/main/java/info/openrocket/core/unit/FixedPrecisionUnit.java
+++ b/core/src/main/java/info/openrocket/core/unit/FixedPrecisionUnit.java
@@ -1,28 +1,53 @@
 package info.openrocket.core.unit;
 
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
 
 public class FixedPrecisionUnit extends Unit {
 
 	private final double precision;
 	private final String formatString;
+	private final boolean displayTrailingZeros;
+	private final DecimalFormat formatter;
 
 	public FixedPrecisionUnit(String unit, double precision) {
 		this(unit, precision, 1.0);
 	}
 
 	public FixedPrecisionUnit(String unit, double precision, double multiplier) {
+		this(unit, precision, multiplier, true);
+	}
+
+	public FixedPrecisionUnit(String unit, double precision, double multiplier, boolean displayTrailingZeros) {
 		super(multiplier, unit);
 
 		this.precision = precision;
+		this.displayTrailingZeros = displayTrailingZeros;
 
+		// Calculate number of decimal places needed
 		int decimals = 0;
 		double p = precision;
 		while ((p - Math.floor(p)) > 0.0000001) {
 			p *= 10;
 			decimals++;
 		}
-		formatString = "%." + decimals + "f";
+
+		// Create format string based on whether we want trailing zeros
+		this.formatString = "%." + decimals + "f";
+
+		// Initialize DecimalFormat for handling trailing zeros
+		DecimalFormatSymbols symbols = new DecimalFormatSymbols();
+		StringBuilder pattern = new StringBuilder("0");
+		if (decimals > 0) {
+			pattern.append(".");
+			if (displayTrailingZeros) {
+				pattern.append("0".repeat(decimals));
+			} else {
+				pattern.append("#".repeat(decimals));
+			}
+		}
+		this.formatter = new DecimalFormat(pattern.toString(), symbols);
 	}
 
 	@Override
@@ -42,7 +67,12 @@ public class FixedPrecisionUnit extends Unit {
 
 	@Override
 	public String toString(double value) {
-		return String.format(formatString, this.toUnit(value));
+		double unitValue = this.toUnit(value);
+		if (displayTrailingZeros) {
+			return String.format(formatString, unitValue);
+		} else {
+			return formatter.format(unitValue);
+		}
 	}
 
 	// TODO: LOW: This is copied from GeneralUnit, perhaps combine

--- a/core/src/main/java/info/openrocket/core/unit/UnitGroup.java
+++ b/core/src/main/java/info/openrocket/core/unit/UnitGroup.java
@@ -197,12 +197,12 @@ public class UnitGroup {
 		UNITS_WINDSPEED.addUnit(new GeneralUnit(0.51444445, "kt"));
 
 		UNITS_LATITUDE = new UnitGroup();
-		UNITS_LATITUDE.addUnit(new GeneralUnit(1, DEGREE + " " + trans.get("CompassRose.lbl.north")));
-		UNITS_LATITUDE.addUnit(new GeneralUnit(-1, DEGREE + " " + trans.get("CompassRose.lbl.south")));
+		UNITS_LATITUDE.addUnit(new FixedPrecisionUnit(DEGREE + " " + trans.get("CompassRose.lbl.north"), 10E-6, 1, false));
+		UNITS_LATITUDE.addUnit(new FixedPrecisionUnit(DEGREE + " " + trans.get("CompassRose.lbl.south"), 10E-6, -1, false));
 
 		UNITS_LONGITUDE = new UnitGroup();
-		UNITS_LONGITUDE.addUnit(new GeneralUnit(1, DEGREE + " " + trans.get("CompassRose.lbl.east")));
-		UNITS_LONGITUDE.addUnit(new GeneralUnit(-1, DEGREE + " " + trans.get("CompassRose.lbl.west")));
+		UNITS_LONGITUDE.addUnit(new FixedPrecisionUnit(DEGREE + " " + trans.get("CompassRose.lbl.east"), 10E-6, 1, false));
+		UNITS_LONGITUDE.addUnit(new FixedPrecisionUnit(DEGREE + " " + trans.get("CompassRose.lbl.west"), 10E-6, -1, false));
 
 		UNITS_ACCELERATION = new UnitGroup();
 		UNITS_ACCELERATION.addUnit(new GeneralUnit(1, "m/s" + SQUARED));

--- a/core/src/test/java/info/openrocket/core/unit/FixedPrecisionUnitTest.java
+++ b/core/src/test/java/info/openrocket/core/unit/FixedPrecisionUnitTest.java
@@ -1,0 +1,131 @@
+package info.openrocket.core.unit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class FixedPrecisionUnitTest {
+	private static final double EPSILON = 1e-8;
+
+	private final Unit unitPoint1 = new FixedPrecisionUnit("unit", 0.1);
+	private final Unit unitPoint25 = new FixedPrecisionUnit("unit", 0.25);
+	private final Unit unitPoint5 = new FixedPrecisionUnit("unit", 0.5);
+	private final Unit unitNoTrailing = new FixedPrecisionUnit("unit", 0.1, 1.0, false);
+	private final Unit unitWithMultiplier = new FixedPrecisionUnit("unit", 0.1, 2.0);
+
+	@BeforeAll
+	public static void setUp() {
+		// Set locale to ensure consistent formatting
+		Locale.setDefault(Locale.US);
+	}
+
+	@Test
+	public void testRounding() {
+		// Test rounding with 0.1 precision
+		assertEquals(1.0, unitPoint1.round(1.04), EPSILON);
+		assertEquals(1.1, unitPoint1.round(1.05), EPSILON);
+		assertEquals(1.1, unitPoint1.round(1.14), EPSILON);
+		assertEquals(1.2, unitPoint1.round(1.15), EPSILON);
+
+		// Test rounding with 0.25 precision
+		assertEquals(1.0, unitPoint25.round(1.12), EPSILON);
+		assertEquals(1.25, unitPoint25.round(1.13), EPSILON);
+		assertEquals(1.25, unitPoint25.round(1.37), EPSILON);
+		assertEquals(1.5, unitPoint25.round(1.38), EPSILON);
+
+		// Test rounding with 0.5 precision
+		assertEquals(1.0, unitPoint5.round(1.24), EPSILON);
+		assertEquals(1.5, unitPoint5.round(1.25), EPSILON);
+		assertEquals(1.5, unitPoint5.round(1.74), EPSILON);
+		assertEquals(2.0, unitPoint5.round(1.75), EPSILON);
+	}
+
+	@Test
+	public void testNextValue() {
+		// Test with 0.1 precision
+		assertEquals(1.1, unitPoint1.getNextValue(1.0), EPSILON);
+		assertEquals(1.2, unitPoint1.getNextValue(1.1), EPSILON);
+		assertEquals(0.1, unitPoint1.getNextValue(0.0), EPSILON);
+		assertEquals(-0.9, unitPoint1.getNextValue(-1.0), EPSILON);
+
+		// Test with 0.25 precision
+		assertEquals(1.25, unitPoint25.getNextValue(1.0), EPSILON);
+		assertEquals(1.5, unitPoint25.getNextValue(1.25), EPSILON);
+		assertEquals(0.25, unitPoint25.getNextValue(0.0), EPSILON);
+
+		// Test with 0.5 precision
+		assertEquals(1.5, unitPoint5.getNextValue(1.0), EPSILON);
+		assertEquals(2.0, unitPoint5.getNextValue(1.5), EPSILON);
+		assertEquals(0.5, unitPoint5.getNextValue(0.0), EPSILON);
+	}
+
+	@Test
+	public void testPreviousValue() {
+		// Test with 0.1 precision
+		assertEquals(0.9, unitPoint1.getPreviousValue(1.0), EPSILON);
+		assertEquals(0.8, unitPoint1.getPreviousValue(0.9), EPSILON);
+		assertEquals(-0.1, unitPoint1.getPreviousValue(0.0), EPSILON);
+		assertEquals(-1.1, unitPoint1.getPreviousValue(-1.0), EPSILON);
+
+		// Test with 0.25 precision
+		assertEquals(0.75, unitPoint25.getPreviousValue(1.0), EPSILON);
+		assertEquals(0.5, unitPoint25.getPreviousValue(0.75), EPSILON);
+		assertEquals(-0.25, unitPoint25.getPreviousValue(0.0), EPSILON);
+
+		// Test with 0.5 precision
+		assertEquals(0.5, unitPoint5.getPreviousValue(1.0), EPSILON);
+		assertEquals(0.0, unitPoint5.getPreviousValue(0.5), EPSILON);
+		assertEquals(-0.5, unitPoint5.getPreviousValue(0.0), EPSILON);
+	}
+
+	@Test
+	public void testToString() {
+		// Test with trailing zeros (default)
+		assertEquals("1.0", unitPoint1.toString(1.0));
+		assertEquals("1.1", unitPoint1.toString(1.1));
+		assertEquals("-1.0", unitPoint1.toString(-1.0));
+		assertEquals("0.0", unitPoint1.toString(0.0));
+
+		// Test without trailing zeros
+		assertEquals("1", unitNoTrailing.toString(1.0));
+		assertEquals("1.1", unitNoTrailing.toString(1.1));
+		assertEquals("-1", unitNoTrailing.toString(-1.0));
+		assertEquals("0", unitNoTrailing.toString(0.0));
+
+		// Test with multiplier
+		assertEquals("0.5", unitWithMultiplier.toString(1.0));
+		assertEquals("0.6", unitWithMultiplier.toString(1.1));
+		assertEquals("-0.5", unitWithMultiplier.toString(-1.0));
+		assertEquals("0.0", unitWithMultiplier.toString(0.0));
+	}
+
+	@Test
+	public void testGetTicks() {
+		Unit unit = new FixedPrecisionUnit("unit", 0.5);
+		Tick[] ticks = unit.getTicks(0.0, 5.0, 0.5, 1.0);
+
+		// Verify we have the expected number of ticks
+		assertTrue(ticks.length > 0);
+
+		// Test specific tick values
+		for (int i = 0; i < ticks.length - 1; i++) {
+			// Verify ticks are in ascending order
+			assertTrue(ticks[i].value < ticks[i + 1].value);
+
+			// Verify tick spacing matches precision
+			assertEquals(0.5, ticks[i + 1].value - ticks[i].value, 0.001);
+		}
+
+		// Test major/minor tick marking
+		for (Tick tick : ticks) {
+			if (Math.abs(tick.value % 1.0) < 0.001) {
+				// Whole numbers should be major ticks
+				assertTrue(tick.major);
+			}
+		}
+	}
+}

--- a/core/src/test/java/info/openrocket/core/unit/UnitToStringTest.java
+++ b/core/src/test/java/info/openrocket/core/unit/UnitToStringTest.java
@@ -20,141 +20,141 @@ public class UnitToStringTest {
 		}
 
 		// very small positive numbers ( < 0.0005) are returned as "0"
-		assertEquals(Unit.NOUNIT.toString(0.00040), "0");
-		assertEquals(Unit.NOUNIT.toString(0.00050), "0"); // check boundary of change in format
+		assertEquals("0", Unit.NOUNIT.toString(0.00040));
+		assertEquals("0", Unit.NOUNIT.toString(0.00050)); // check boundary of change in format
 
 		// positive numbers <= 1E6
-		assertEquals(Unit.NOUNIT.toString(123.20), "123");
-		assertEquals(Unit.NOUNIT.toString(123.50), "124"); // round to even
-		assertEquals(Unit.NOUNIT.toString(123.55), "124");
-		assertEquals(Unit.NOUNIT.toString(124.20), "124");
-		assertEquals(Unit.NOUNIT.toString(124.50), "124"); // round to even
-		assertEquals(Unit.NOUNIT.toString(124.55), "125");
+		assertEquals("123", Unit.NOUNIT.toString(123.20));
+		assertEquals("124", Unit.NOUNIT.toString(123.50)); // round to even
+		assertEquals("124", Unit.NOUNIT.toString(123.55));
+		assertEquals("124", Unit.NOUNIT.toString(124.20));
+		assertEquals("124", Unit.NOUNIT.toString(124.50)); // round to even
+		assertEquals("125", Unit.NOUNIT.toString(124.55));
 
-		assertEquals(Unit.NOUNIT.toString(1234.2), "1234");
-		assertEquals(Unit.NOUNIT.toString(1234.5), "1234"); // round to even
-		assertEquals(Unit.NOUNIT.toString(1234.6), "1235");
-		assertEquals(Unit.NOUNIT.toString(1235.2), "1235");
-		assertEquals(Unit.NOUNIT.toString(1235.5), "1236"); // round to even
-		assertEquals(Unit.NOUNIT.toString(1235.6), "1236");
+		assertEquals("1234", Unit.NOUNIT.toString(1234.2));
+		assertEquals("1234", Unit.NOUNIT.toString(1234.5)); // round to even
+		assertEquals("1235", Unit.NOUNIT.toString(1234.6));
+		assertEquals("1235", Unit.NOUNIT.toString(1235.2));
+		assertEquals("1236", Unit.NOUNIT.toString(1235.5)); // round to even
+		assertEquals("1236", Unit.NOUNIT.toString(1235.6));
 
-		assertEquals(Unit.NOUNIT.toString(123456.789), "123457");
+		assertEquals("123457", Unit.NOUNIT.toString(123456.789));
 
-		assertEquals(Unit.NOUNIT.toString(1000000), "1000000"); // boundary check
+		assertEquals("1000000", Unit.NOUNIT.toString(1000000)); // boundary check
 
 	}
 
 	private void testPositiveWithPoint() {
 
 		// positive number < 0.095 use 3 digit decimal format
-		assertEquals(Unit.NOUNIT.toString(0.00051), "0.001"); // check boundary of change in format
-		assertEquals(Unit.NOUNIT.toString(0.00060), "0.001");
+		assertEquals("0.001", Unit.NOUNIT.toString(0.00051)); // check boundary of change in format
+		assertEquals("0.001", Unit.NOUNIT.toString(0.00060));
 
 		// rounding at third digit.
-		assertEquals(Unit.NOUNIT.toString(0.0014), "0.001");
-		assertEquals(Unit.NOUNIT.toString(0.0015), "0.002"); // round to even
-		assertEquals(Unit.NOUNIT.toString(0.0016), "0.002");
-		assertEquals(Unit.NOUNIT.toString(0.0024), "0.002");
-		assertEquals(Unit.NOUNIT.toString(0.0025), "0.002"); // round to even
-		assertEquals(Unit.NOUNIT.toString(0.0026), "0.003");
-		assertEquals(Unit.NOUNIT.toString(0.0094), "0.009");
+		assertEquals("0.001", Unit.NOUNIT.toString(0.0014));
+		assertEquals("0.002", Unit.NOUNIT.toString(0.0015)); // round to even
+		assertEquals("0.002", Unit.NOUNIT.toString(0.0016));
+		assertEquals("0.002", Unit.NOUNIT.toString(0.0024));
+		assertEquals("0.002", Unit.NOUNIT.toString(0.0025)); // round to even
+		assertEquals("0.003", Unit.NOUNIT.toString(0.0026));
+		assertEquals("0.009", Unit.NOUNIT.toString(0.0094));
 
-		assertEquals(Unit.NOUNIT.toString(0.0095), "0.01"); // no trailing zeros after rounding
+		assertEquals("0.01", Unit.NOUNIT.toString(0.0095)); // no trailing zeros after rounding
 
-		assertEquals(Unit.NOUNIT.toString(0.0114), "0.011");
-		assertEquals(Unit.NOUNIT.toString(0.0115), "0.012"); // round to even
-		assertEquals(Unit.NOUNIT.toString(0.0119), "0.012");
-		assertEquals(Unit.NOUNIT.toString(0.0124), "0.012");
-		assertEquals(Unit.NOUNIT.toString(0.0125), "0.012"); // round to even
-		assertEquals(Unit.NOUNIT.toString(0.0129), "0.013");
+		assertEquals("0.011", Unit.NOUNIT.toString(0.0114));
+		assertEquals("0.012", Unit.NOUNIT.toString(0.0115)); // round to even
+		assertEquals("0.012", Unit.NOUNIT.toString(0.0119));
+		assertEquals("0.012", Unit.NOUNIT.toString(0.0124));
+		assertEquals("0.012", Unit.NOUNIT.toString(0.0125)); // round to even
+		assertEquals("0.013", Unit.NOUNIT.toString(0.0129));
 
-		assertEquals(Unit.NOUNIT.toString(0.0949), "0.095"); // boundary check
+		assertEquals("0.095", Unit.NOUNIT.toString(0.0949)); // boundary check
 
 		// positive numbers < 100
-		assertEquals(Unit.NOUNIT.toString(0.0095), "0.01"); // boundary check
+		assertEquals("0.01", Unit.NOUNIT.toString(0.0095)); // boundary check
 
-		assertEquals(Unit.NOUNIT.toString(0.1111), "0.111");
-		assertEquals(Unit.NOUNIT.toString(0.1115), "0.112"); // round to even
-		assertEquals(Unit.NOUNIT.toString(0.1117), "0.112");
-		assertEquals(Unit.NOUNIT.toString(0.1121), "0.112");
-		assertEquals(Unit.NOUNIT.toString(0.1125), "0.112"); // round to even
-		assertEquals(Unit.NOUNIT.toString(0.1127), "0.113");
+		assertEquals("0.111", Unit.NOUNIT.toString(0.1111));
+		assertEquals("0.112", Unit.NOUNIT.toString(0.1115)); // round to even
+		assertEquals("0.112", Unit.NOUNIT.toString(0.1117));
+		assertEquals("0.112", Unit.NOUNIT.toString(0.1121));
+		assertEquals("0.112", Unit.NOUNIT.toString(0.1125)); // round to even
+		assertEquals("0.113", Unit.NOUNIT.toString(0.1127));
 
-		assertEquals(Unit.NOUNIT.toString(1.113), "1.11");
-		assertEquals(Unit.NOUNIT.toString(1.115), "1.12"); // round to even
-		assertEquals(Unit.NOUNIT.toString(1.117), "1.12");
-		assertEquals(Unit.NOUNIT.toString(1.123), "1.12");
-		assertEquals(Unit.NOUNIT.toString(1.125), "1.12"); // round to even
-		assertEquals(Unit.NOUNIT.toString(1.127), "1.13");
+		assertEquals("1.11", Unit.NOUNIT.toString(1.113));
+		assertEquals("1.12", Unit.NOUNIT.toString(1.115)); // round to even
+		assertEquals("1.12", Unit.NOUNIT.toString(1.117));
+		assertEquals("1.12", Unit.NOUNIT.toString(1.123));
+		assertEquals("1.12", Unit.NOUNIT.toString(1.125)); // round to even
+		assertEquals("1.13", Unit.NOUNIT.toString(1.127));
 
-		assertEquals(Unit.NOUNIT.toString(12.320), "12.3");
-		assertEquals(Unit.NOUNIT.toString(12.350), "12.4"); // round to even
-		assertEquals(Unit.NOUNIT.toString(12.355), "12.4");
-		assertEquals(Unit.NOUNIT.toString(12.420), "12.4");
-		assertEquals(Unit.NOUNIT.toString(12.450), "12.4"); // round to even
-		assertEquals(Unit.NOUNIT.toString(12.455), "12.5");
+		assertEquals("12.3", Unit.NOUNIT.toString(12.320));
+		assertEquals("12.4", Unit.NOUNIT.toString(12.350)); // round to even
+		assertEquals("12.4", Unit.NOUNIT.toString(12.355));
+		assertEquals("12.4", Unit.NOUNIT.toString(12.420));
+		assertEquals("12.4", Unit.NOUNIT.toString(12.450)); // round to even
+		assertEquals("12.5", Unit.NOUNIT.toString(12.455));
 		// positive numbers > 1E6
-		assertEquals(Unit.NOUNIT.toString(1234567.89), "1.23E6");
-		assertEquals(Unit.NOUNIT.toString(12345678.9), "1.23E7");
+		assertEquals("1.23E6", Unit.NOUNIT.toString(1234567.89));
+		assertEquals("1.23E7", Unit.NOUNIT.toString(12345678.9));
 
 		// Inch precision
-		assertEquals(UnitGroup.UNITS_LENGTH.findApproximate("in").toString(25.125 * 25.4 / 1000), "25.125");
+		assertEquals("25.125", UnitGroup.UNITS_LENGTH.findApproximate("in").toString(25.125 * 25.4 / 1000));
 	}
 
 	private void testPositiveWithComma() {
 		// positive number < 0.095 use 3 digit decimal format
-		assertEquals(Unit.NOUNIT.toString(0.00051), "0,001"); // check boundary of change in format
-		assertEquals(Unit.NOUNIT.toString(0.00060), "0,001");
+		assertEquals("0,001", Unit.NOUNIT.toString(0.00051)); // check boundary of change in format
+		assertEquals("0,001", Unit.NOUNIT.toString(0.00060));
 
 		// rounding at third digit.
-		assertEquals(Unit.NOUNIT.toString(0.0014), "0,001");
-		assertEquals(Unit.NOUNIT.toString(0.0015), "0,002"); // round to even
-		assertEquals(Unit.NOUNIT.toString(0.0016), "0,002");
-		assertEquals(Unit.NOUNIT.toString(0.0024), "0,002");
-		assertEquals(Unit.NOUNIT.toString(0.0025), "0,002"); // round to even
-		assertEquals(Unit.NOUNIT.toString(0.0026), "0,003");
-		assertEquals(Unit.NOUNIT.toString(0.0094), "0,009");
+		assertEquals("0,001", Unit.NOUNIT.toString(0.0014));
+		assertEquals("0,002", Unit.NOUNIT.toString(0.0015)); // round to even
+		assertEquals("0,002", Unit.NOUNIT.toString(0.0016));
+		assertEquals("0,002", Unit.NOUNIT.toString(0.0024));
+		assertEquals("0,002", Unit.NOUNIT.toString(0.0025)); // round to even
+		assertEquals("0,003", Unit.NOUNIT.toString(0.0026));
+		assertEquals("0,009", Unit.NOUNIT.toString(0.0094));
 
-		assertEquals(Unit.NOUNIT.toString(0.0095), "0,01"); // no trailing zeros after rounding
+		assertEquals("0,01", Unit.NOUNIT.toString(0.0095)); // no trailing zeros after rounding
 
-		assertEquals(Unit.NOUNIT.toString(0.0114), "0,011");
-		assertEquals(Unit.NOUNIT.toString(0.0115), "0,012"); // round to even
-		assertEquals(Unit.NOUNIT.toString(0.0119), "0,012");
-		assertEquals(Unit.NOUNIT.toString(0.0124), "0,012");
-		assertEquals(Unit.NOUNIT.toString(0.0125), "0,012"); // round to even
-		assertEquals(Unit.NOUNIT.toString(0.0129), "0,013");
+		assertEquals("0,011", Unit.NOUNIT.toString(0.0114));
+		assertEquals("0,012", Unit.NOUNIT.toString(0.0115)); // round to even
+		assertEquals("0,012", Unit.NOUNIT.toString(0.0119));
+		assertEquals("0,012", Unit.NOUNIT.toString(0.0124));
+		assertEquals("0,012", Unit.NOUNIT.toString(0.0125)); // round to even
+		assertEquals("0,013", Unit.NOUNIT.toString(0.0129));
 
-		assertEquals(Unit.NOUNIT.toString(0.0949), "0,095"); // boundary check
+		assertEquals("0,095", Unit.NOUNIT.toString(0.0949)); // boundary check
 
 		// positive numbers < 100
-		assertEquals(Unit.NOUNIT.toString(0.0095), "0,01"); // boundary check
+		assertEquals("0,01", Unit.NOUNIT.toString(0.0095)); // boundary check
 
-		assertEquals(Unit.NOUNIT.toString(0.1111), "0,111");
-		assertEquals(Unit.NOUNIT.toString(0.1115), "0,112"); // round to even
-		assertEquals(Unit.NOUNIT.toString(0.1117), "0,112");
-		assertEquals(Unit.NOUNIT.toString(0.1121), "0,112");
-		assertEquals(Unit.NOUNIT.toString(0.1125), "0,112"); // round to even
-		assertEquals(Unit.NOUNIT.toString(0.1127), "0,113");
+		assertEquals("0,111", Unit.NOUNIT.toString(0.1111));
+		assertEquals("0,112", Unit.NOUNIT.toString(0.1115)); // round to even
+		assertEquals("0,112", Unit.NOUNIT.toString(0.1117));
+		assertEquals("0,112", Unit.NOUNIT.toString(0.1121));
+		assertEquals("0,112", Unit.NOUNIT.toString(0.1125)); // round to even
+		assertEquals("0,113", Unit.NOUNIT.toString(0.1127));
 
-		assertEquals(Unit.NOUNIT.toString(1.113), "1,11");
-		assertEquals(Unit.NOUNIT.toString(1.115), "1,12"); // round to even
-		assertEquals(Unit.NOUNIT.toString(1.117), "1,12");
-		assertEquals(Unit.NOUNIT.toString(1.123), "1,12");
-		assertEquals(Unit.NOUNIT.toString(1.125), "1,12"); // round to even
-		assertEquals(Unit.NOUNIT.toString(1.127), "1,13");
+		assertEquals("1,11", Unit.NOUNIT.toString(1.113));
+		assertEquals("1,12", Unit.NOUNIT.toString(1.115)); // round to even
+		assertEquals("1,12", Unit.NOUNIT.toString(1.117));
+		assertEquals("1,12", Unit.NOUNIT.toString(1.123));
+		assertEquals("1,12", Unit.NOUNIT.toString(1.125)); // round to even
+		assertEquals("1,13", Unit.NOUNIT.toString(1.127));
 
-		assertEquals(Unit.NOUNIT.toString(12.320), "12,3");
-		assertEquals(Unit.NOUNIT.toString(12.350), "12,4"); // round to even
-		assertEquals(Unit.NOUNIT.toString(12.355), "12,4");
-		assertEquals(Unit.NOUNIT.toString(12.420), "12,4");
-		assertEquals(Unit.NOUNIT.toString(12.450), "12,4"); // round to even
-		assertEquals(Unit.NOUNIT.toString(12.455), "12,5");
+		assertEquals("12,3", Unit.NOUNIT.toString(12.320));
+		assertEquals("12,4", Unit.NOUNIT.toString(12.350)); // round to even
+		assertEquals("12,4", Unit.NOUNIT.toString(12.355));
+		assertEquals("12,4", Unit.NOUNIT.toString(12.420));
+		assertEquals("12,4", Unit.NOUNIT.toString(12.450)); // round to even
+		assertEquals("12,5", Unit.NOUNIT.toString(12.455));
 		// positive numbers > 1E6
-		assertEquals(Unit.NOUNIT.toString(1234567.89), "1,23E6");
-		assertEquals(Unit.NOUNIT.toString(12345678.9), "1,23E7");
+		assertEquals("1,23E6", Unit.NOUNIT.toString(1234567.89));
+		assertEquals("1,23E7", Unit.NOUNIT.toString(12345678.9));
 
 		// Inch precision
-		assertEquals(UnitGroup.UNITS_LENGTH.findApproximate("in").toString(25.125 * 25.4 / 1000), "25,125");
+		assertEquals("25,125", UnitGroup.UNITS_LENGTH.findApproximate("in").toString(25.125 * 25.4 / 1000));
 	}
 
 	@Test
@@ -166,133 +166,133 @@ public class UnitToStringTest {
 		}
 
 		// very small negative numbers ( < 0.0005) are returned as "0");
-		assertEquals(Unit.NOUNIT.toString(-0.00050), "0"); // check boundary of change in format
+		assertEquals("0", Unit.NOUNIT.toString(-0.00050)); // check boundary of change in format
 
 		// negative numbers <= 1E6
-		assertEquals(Unit.NOUNIT.toString(-123.20), "-123");
-		assertEquals(Unit.NOUNIT.toString(-123.50), "-124"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-123.55), "-124");
-		assertEquals(Unit.NOUNIT.toString(-124.20), "-124");
-		assertEquals(Unit.NOUNIT.toString(-124.50), "-124"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-124.55), "-125");
+		assertEquals("-123", Unit.NOUNIT.toString(-123.20));
+		assertEquals("-124", Unit.NOUNIT.toString(-123.50)); // round to even
+		assertEquals("-124", Unit.NOUNIT.toString(-123.55));
+		assertEquals("-124", Unit.NOUNIT.toString(-124.20));
+		assertEquals("-124", Unit.NOUNIT.toString(-124.50)); // round to even
+		assertEquals("-125", Unit.NOUNIT.toString(-124.55));
 
-		assertEquals(Unit.NOUNIT.toString(-1234.2), "-1234");
-		assertEquals(Unit.NOUNIT.toString(-1234.5), "-1234"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-1234.6), "-1235");
-		assertEquals(Unit.NOUNIT.toString(-1235.2), "-1235");
-		assertEquals(Unit.NOUNIT.toString(-1235.5), "-1236"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-1235.6), "-1236");
+		assertEquals("-1234", Unit.NOUNIT.toString(-1234.2));
+		assertEquals("-1234", Unit.NOUNIT.toString(-1234.5)); // round to even
+		assertEquals("-1235", Unit.NOUNIT.toString(-1234.6));
+		assertEquals("-1235", Unit.NOUNIT.toString(-1235.2));
+		assertEquals("-1236", Unit.NOUNIT.toString(-1235.5)); // round to even
+		assertEquals("-1236", Unit.NOUNIT.toString(-1235.6));
 
-		assertEquals(Unit.NOUNIT.toString(-123456.789), "-123457");
+		assertEquals("-123457", Unit.NOUNIT.toString(-123456.789));
 
-		assertEquals(Unit.NOUNIT.toString(-1000000), "-1000000"); // boundary check
+		assertEquals("-1000000", Unit.NOUNIT.toString(-1000000)); // boundary check
 	}
 
 	private void testNegativeWithComma() {
 		// negative number < 0.095 use 3 digit decimal format
-		assertEquals(Unit.NOUNIT.toString(-0.00051), "-0,001"); // check boundary of change in format
-		assertEquals(Unit.NOUNIT.toString(-0.00060), "-0,001");
+		assertEquals("-0,001", Unit.NOUNIT.toString(-0.00051)); // check boundary of change in format
+		assertEquals("-0,001", Unit.NOUNIT.toString(-0.00060));
 
 		// rounding at third digit.
-		assertEquals(Unit.NOUNIT.toString(-0.0014), "-0,001");
-		assertEquals(Unit.NOUNIT.toString(-0.0015), "-0,002"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-0.0016), "-0,002");
-		assertEquals(Unit.NOUNIT.toString(-0.0024), "-0,002");
-		assertEquals(Unit.NOUNIT.toString(-0.0025), "-0,002"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-0.0026), "-0,003");
-		assertEquals(Unit.NOUNIT.toString(-0.0094), "-0,009");
+		assertEquals("-0,001", Unit.NOUNIT.toString(-0.0014));
+		assertEquals("-0,002", Unit.NOUNIT.toString(-0.0015)); // round to even
+		assertEquals("-0,002", Unit.NOUNIT.toString(-0.0016));
+		assertEquals("-0,002", Unit.NOUNIT.toString(-0.0024));
+		assertEquals("-0,002", Unit.NOUNIT.toString(-0.0025)); // round to even
+		assertEquals("-0,003", Unit.NOUNIT.toString(-0.0026));
+		assertEquals("-0,009", Unit.NOUNIT.toString(-0.0094));
 
-		assertEquals(Unit.NOUNIT.toString(-0.0095), "-0,01"); // no trailing zeros after rounding
+		assertEquals("-0,01", Unit.NOUNIT.toString(-0.0095)); // no trailing zeros after rounding
 
-		assertEquals(Unit.NOUNIT.toString(-0.0114), "-0,011");
-		assertEquals(Unit.NOUNIT.toString(-0.0115), "-0,012"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-0.0119), "-0,012");
-		assertEquals(Unit.NOUNIT.toString(-0.0124), "-0,012");
-		assertEquals(Unit.NOUNIT.toString(-0.0125), "-0,012"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-0.0129), "-0,013");
+		assertEquals("-0,011", Unit.NOUNIT.toString(-0.0114));
+		assertEquals("-0,012", Unit.NOUNIT.toString(-0.0115)); // round to even
+		assertEquals("-0,012", Unit.NOUNIT.toString(-0.0119));
+		assertEquals("-0,012", Unit.NOUNIT.toString(-0.0124));
+		assertEquals("-0,012", Unit.NOUNIT.toString(-0.0125)); // round to even
+		assertEquals("-0,013", Unit.NOUNIT.toString(-0.0129));
 
-		assertEquals(Unit.NOUNIT.toString(-0.0949), "-0,095"); // boundary check
+		assertEquals("-0,095", Unit.NOUNIT.toString(-0.0949)); // boundary check
 
 		// negative numbers < 100
-		assertEquals(Unit.NOUNIT.toString(-0.0095), "-0,01"); // boundary check
+		assertEquals("-0,01", Unit.NOUNIT.toString(-0.0095)); // boundary check
 
-		assertEquals(Unit.NOUNIT.toString(-0.1111), "-0,111");
-		assertEquals(Unit.NOUNIT.toString(-0.1115), "-0,112"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-0.1117), "-0,112");
-		assertEquals(Unit.NOUNIT.toString(-0.1121), "-0,112");
-		assertEquals(Unit.NOUNIT.toString(-0.1125), "-0,112"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-0.1127), "-0,113");
+		assertEquals("-0,111", Unit.NOUNIT.toString(-0.1111));
+		assertEquals("-0,112", Unit.NOUNIT.toString(-0.1115)); // round to even
+		assertEquals("-0,112", Unit.NOUNIT.toString(-0.1117));
+		assertEquals("-0,112", Unit.NOUNIT.toString(-0.1121));
+		assertEquals("-0,112", Unit.NOUNIT.toString(-0.1125)); // round to even
+		assertEquals("-0,113", Unit.NOUNIT.toString(-0.1127));
 
-		assertEquals(Unit.NOUNIT.toString(-1.113), "-1,11");
-		assertEquals(Unit.NOUNIT.toString(-1.115), "-1,12"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-1.117), "-1,12");
-		assertEquals(Unit.NOUNIT.toString(-1.123), "-1,12");
-		assertEquals(Unit.NOUNIT.toString(-1.125), "-1,12"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-1.127), "-1,13");
+		assertEquals("-1,11", Unit.NOUNIT.toString(-1.113));
+		assertEquals("-1,12", Unit.NOUNIT.toString(-1.115)); // round to even
+		assertEquals("-1,12", Unit.NOUNIT.toString(-1.117));
+		assertEquals("-1,12", Unit.NOUNIT.toString(-1.123));
+		assertEquals("-1,12", Unit.NOUNIT.toString(-1.125)); // round to even
+		assertEquals("-1,13", Unit.NOUNIT.toString(-1.127));
 
-		assertEquals(Unit.NOUNIT.toString(-12.320), "-12,3");
-		assertEquals(Unit.NOUNIT.toString(-12.350), "-12,4"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-12.355), "-12,4");
-		assertEquals(Unit.NOUNIT.toString(-12.420), "-12,4");
-		assertEquals(Unit.NOUNIT.toString(-12.450), "-12,4"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-12.455), "-12,5");
+		assertEquals("-12,3", Unit.NOUNIT.toString(-12.320));
+		assertEquals("-12,4", Unit.NOUNIT.toString(-12.350)); // round to even
+		assertEquals("-12,4", Unit.NOUNIT.toString(-12.355));
+		assertEquals("-12,4", Unit.NOUNIT.toString(-12.420));
+		assertEquals("-12,4", Unit.NOUNIT.toString(-12.450)); // round to even
+		assertEquals("-12,5", Unit.NOUNIT.toString(-12.455));
 		// negative numbers > 1E6
-		assertEquals(Unit.NOUNIT.toString(-1234567.89), "-1,23E6");
-		assertEquals(Unit.NOUNIT.toString(-12345678.9), "-1,23E7");
+		assertEquals("-1,23E6", Unit.NOUNIT.toString(-1234567.89));
+		assertEquals("-1,23E7", Unit.NOUNIT.toString(-12345678.9));
 
 	}
 
 	private void testNegativeWithPoint() {
 		// negative number < 0.095 use 3 digit decimal format
-		assertEquals(Unit.NOUNIT.toString(-0.00051), "-0.001"); // check boundary of change in format
-		assertEquals(Unit.NOUNIT.toString(-0.00060), "-0.001");
+		assertEquals("-0.001", Unit.NOUNIT.toString(-0.00051)); // check boundary of change in format
+		assertEquals("-0.001", Unit.NOUNIT.toString(-0.00060));
 
 		// rounding at third digit.
-		assertEquals(Unit.NOUNIT.toString(-0.0014), "-0.001");
-		assertEquals(Unit.NOUNIT.toString(-0.0015), "-0.002"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-0.0016), "-0.002");
-		assertEquals(Unit.NOUNIT.toString(-0.0024), "-0.002");
-		assertEquals(Unit.NOUNIT.toString(-0.0025), "-0.002"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-0.0026), "-0.003");
-		assertEquals(Unit.NOUNIT.toString(-0.0094), "-0.009");
+		assertEquals("-0.001", Unit.NOUNIT.toString(-0.0014));
+		assertEquals("-0.002", Unit.NOUNIT.toString(-0.0015)); // round to even
+		assertEquals("-0.002", Unit.NOUNIT.toString(-0.0016));
+		assertEquals("-0.002", Unit.NOUNIT.toString(-0.0024));
+		assertEquals("-0.002", Unit.NOUNIT.toString(-0.0025)); // round to even
+		assertEquals("-0.003", Unit.NOUNIT.toString(-0.0026));
+		assertEquals("-0.009", Unit.NOUNIT.toString(-0.0094));
 
-		assertEquals(Unit.NOUNIT.toString(-0.0095), "-0.01"); // no trailing zeros after rounding
+		assertEquals("-0.01", Unit.NOUNIT.toString(-0.0095)); // no trailing zeros after rounding
 
-		assertEquals(Unit.NOUNIT.toString(-0.0114), "-0.011");
-		assertEquals(Unit.NOUNIT.toString(-0.0115), "-0.012"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-0.0119), "-0.012");
-		assertEquals(Unit.NOUNIT.toString(-0.0124), "-0.012");
-		assertEquals(Unit.NOUNIT.toString(-0.0125), "-0.012"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-0.0129), "-0.013");
+		assertEquals("-0.011", Unit.NOUNIT.toString(-0.0114));
+		assertEquals("-0.012", Unit.NOUNIT.toString(-0.0115)); // round to even
+		assertEquals("-0.012", Unit.NOUNIT.toString(-0.0119));
+		assertEquals("-0.012", Unit.NOUNIT.toString(-0.0124));
+		assertEquals("-0.012", Unit.NOUNIT.toString(-0.0125)); // round to even
+		assertEquals("-0.013", Unit.NOUNIT.toString(-0.0129));
 
-		assertEquals(Unit.NOUNIT.toString(-0.0949), "-0.095"); // boundary check
+		assertEquals("-0.095", Unit.NOUNIT.toString(-0.0949)); // boundary check
 
 		// negative numbers < 100
-		assertEquals(Unit.NOUNIT.toString(-0.0095), "-0.01"); // boundary check
+		assertEquals("-0.01", Unit.NOUNIT.toString(-0.0095)); // boundary check
 
-		assertEquals(Unit.NOUNIT.toString(-0.1111), "-0.111");
-		assertEquals(Unit.NOUNIT.toString(-0.1115), "-0.112"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-0.1117), "-0.112");
-		assertEquals(Unit.NOUNIT.toString(-0.1121), "-0.112");
-		assertEquals(Unit.NOUNIT.toString(-0.1125), "-0.112"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-0.1127), "-0.113");
+		assertEquals("-0.111", Unit.NOUNIT.toString(-0.1111));
+		assertEquals("-0.112", Unit.NOUNIT.toString(-0.1115)); // round to even
+		assertEquals("-0.112", Unit.NOUNIT.toString(-0.1117));
+		assertEquals("-0.112", Unit.NOUNIT.toString(-0.1121));
+		assertEquals("-0.112", Unit.NOUNIT.toString(-0.1125)); // round to even
+		assertEquals("-0.113", Unit.NOUNIT.toString(-0.1127));
 
-		assertEquals(Unit.NOUNIT.toString(-1.113), "-1.11");
-		assertEquals(Unit.NOUNIT.toString(-1.115), "-1.12"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-1.117), "-1.12");
-		assertEquals(Unit.NOUNIT.toString(-1.123), "-1.12");
-		assertEquals(Unit.NOUNIT.toString(-1.125), "-1.12"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-1.127), "-1.13");
+		assertEquals("-1.11", Unit.NOUNIT.toString(-1.113));
+		assertEquals("-1.12", Unit.NOUNIT.toString(-1.115)); // round to even
+		assertEquals("-1.12", Unit.NOUNIT.toString(-1.117));
+		assertEquals("-1.12", Unit.NOUNIT.toString(-1.123));
+		assertEquals("-1.12", Unit.NOUNIT.toString(-1.125)); // round to even
+		assertEquals("-1.13", Unit.NOUNIT.toString(-1.127));
 
-		assertEquals(Unit.NOUNIT.toString(-12.320), "-12.3");
-		assertEquals(Unit.NOUNIT.toString(-12.350), "-12.4"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-12.355), "-12.4");
-		assertEquals(Unit.NOUNIT.toString(-12.420), "-12.4");
-		assertEquals(Unit.NOUNIT.toString(-12.450), "-12.4"); // round to even
-		assertEquals(Unit.NOUNIT.toString(-12.455), "-12.5");
+		assertEquals("-12.3", Unit.NOUNIT.toString(-12.320));
+		assertEquals("-12.4", Unit.NOUNIT.toString(-12.350)); // round to even
+		assertEquals("-12.4", Unit.NOUNIT.toString(-12.355));
+		assertEquals("-12.4", Unit.NOUNIT.toString(-12.420));
+		assertEquals("-12.4", Unit.NOUNIT.toString(-12.450)); // round to even
+		assertEquals("-12.5", Unit.NOUNIT.toString(-12.455));
 		// negative numbers > 1E6
-		assertEquals(Unit.NOUNIT.toString(-1234567.89), "-1.23E6");
-		assertEquals(Unit.NOUNIT.toString(-12345678.9), "-1.23E7");
+		assertEquals("-1.23E6", Unit.NOUNIT.toString(-1234567.89));
+		assertEquals("-1.23E7", Unit.NOUNIT.toString(-12345678.9));
 	}
 
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConditionsPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConditionsPanel.java
@@ -209,7 +209,7 @@ public class SimulationConditionsPanel extends JPanel {
 
 		//// Launch site conditions
 		sub = new JPanel(new MigLayout("fill, gap rel unrel",
-				"[grow][65lp!][30lp!][75lp!]", ""));
+				"[grow][90lp!][30lp!][75lp!]", ""));
 		//// Launch site
 		sub.setBorder(BorderFactory.createTitledBorder(trans.get("simedtdlg.lbl.Launchsite")));
 		parent.add(sub, "growx, split 2, aligny 0, flowy");
@@ -228,7 +228,7 @@ public class SimulationConditionsPanel extends JPanel {
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		spin.setToolTipText(tip);
-		sub.add(spin, "w 65lp!");
+		sub.add(spin, "growx");
 
 		unit = new UnitSelector(m);
 		unit.setToolTipText(tip);
@@ -249,7 +249,7 @@ public class SimulationConditionsPanel extends JPanel {
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		spin.setToolTipText(tip);
-		sub.add(spin, "w 65lp!");
+		sub.add(spin, "growx");
 
 		unit = new UnitSelector(m);
 		unit.setToolTipText(tip);
@@ -272,7 +272,7 @@ public class SimulationConditionsPanel extends JPanel {
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));
 		spin.setToolTipText(tip);
-		sub.add(spin, "w 65lp!");
+		sub.add(spin, "growx");
 
 		unit = new UnitSelector(m);
 		unit.setToolTipText(tip);


### PR DESCRIPTION
This PR fixes #2590. The input fields for the longitude and latitude are now wider and support up to 5-decimal precision. The field is made wide enough to support the precision.

<img width="904" alt="image" src="https://github.com/user-attachments/assets/1422bca7-3d71-4651-a7c3-79befc1e7198" />

<img width="904" alt="image" src="https://github.com/user-attachments/assets/727a3926-1800-4877-82a5-2c8b423eac4d" />
