### PR TITLE
Improvements to the software updater

### DIFF
--- a/core/src/main/java/info/openrocket/core/communication/ReleaseInfo.java
+++ b/core/src/main/java/info/openrocket/core/communication/ReleaseInfo.java
@@ -91,6 +91,14 @@ public class ReleaseInfo {
         return assetURLs;
     }
 
+    /**
+     * Check if the release is an official release. An official release is a release that is not a pre-release.
+     * @return true if the release is an official release (e.g. 24.12), false otherwise (e.g. 24.12.beta.01)
+     */
+    public boolean isOfficialRelease() {
+        return UpdateInfoRetriever.UpdateInfoFetcher.isOfficialRelease(getReleaseName());
+    }
+
     @Override
     public String toString() {
         return String.format("releaseTag = %s ; releaseNotes = %s ; releaseURL = %s", getReleaseName(),

--- a/core/src/main/java/info/openrocket/core/communication/UpdateInfoRetriever.java
+++ b/core/src/main/java/info/openrocket/core/communication/UpdateInfoRetriever.java
@@ -292,6 +292,16 @@ public class UpdateInfoRetriever {
 		}
 
 		/**
+		 * Check if the release name is an official release, i.e. a release without a devTag (e.g. 'beta').
+		 * @param name release name to check
+		 * @return true if the release name is an official release, false otherwise
+		 */
+		public static boolean isOfficialRelease(String name) {
+			return Arrays.stream(devTags.keySet().toArray(new String[0])
+					).noneMatch(name::contains) && !name.contains(snapshotTag);
+		}
+
+		/**
 		 * Return the latest JSON GitHub release object from a JSON array of release objects.
 		 * E.g. from a JSON array where JSON objects have release tags {"14.01", "15.03", "11.01"} return the JSON object
 		 * with release tag "15.03"?

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -456,6 +456,7 @@ update.dlg.newerVersion.title = Newer version detected
 update.dlg.newerVersion = You are either running a test/unofficial release of OpenRocket, or you have a time machine and are running an official release from the future.\n\nYour version: %s\nLatest official release: %s
 update.dlg.updateAvailable.title = Update available
 update.dlg.updateAvailable.lbl.title = A new version of OpenRocket is available!
+update.dlg.lbl.preReleaseWarning = This is a pre-release version. It may contain bugs and other issues.
 update.dlg.btn.remindMeLater = Remind Me Later
 update.dlg.checkbox.skipThisVersion = Skip This Version
 update.dlg.updateAvailable.lbl.yourVersion = OpenRocket %s is available! \u2015 you have %s. Would you like to download it now?

--- a/swing/src/main/java/info/openrocket/swing/communication/AssetHandler.java
+++ b/swing/src/main/java/info/openrocket/swing/communication/AssetHandler.java
@@ -1,5 +1,6 @@
 package info.openrocket.swing.communication;
 
+import info.openrocket.core.communication.UpdateInfoRetriever;
 import info.openrocket.swing.gui.util.SwingPreferences;
 import info.openrocket.core.startup.Application;
 
@@ -73,6 +74,28 @@ public class AssetHandler {
      * @return URL to download the installer for the given platform
      */
     public static String getInstallerURLForPlatform(UpdatePlatform platform, String version) {
+        // If it is not an official release, use the GitHub download link
+        if (UpdateInfoRetriever.UpdateInfoFetcher.isOfficialRelease(version)) {
+            return getWebsiteDownloadURL(platform, version);
+        } else {
+            return getGitHubDownloadURL(version);
+        }
+
+
+    }
+
+    /**
+     * Returns the URL to download the installer for the given version from the OpenRocket website.
+     * @param platform platform to get the installer URL for; or null to get to the general download page
+     * @param version version of the installer to download
+     * @return URL to download the installer for the given version
+     */
+    private static String getWebsiteDownloadURL(UpdatePlatform platform, String version) {
+        // If the platform is null, return the general download URL
+        if (platform == null) {
+            return String.format("https://openrocket.info/downloads.html?vers=%s", version);
+        }
+
         for (Map.Entry<UpdatePlatform[], String> entry : mapPlatformToURL.entrySet()) {
             for (UpdatePlatform p : entry.getKey()) {
                 if (p == platform) {
@@ -81,6 +104,15 @@ public class AssetHandler {
             }
         }
         return null;
+    }
+
+    /**
+     * Returns the URL to download the installer for the given version from the GitHub releases page.
+     * @param version version of the installer to download
+     * @return URL to download the installer for the given version
+     */
+    private static String getGitHubDownloadURL(String version) {
+        return String.format("https://github.com/openrocket/openrocket/releases/tag/release-%s", version);
     }
 
     /**

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/UpdateInfoDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/UpdateInfoDialog.java
@@ -160,8 +160,8 @@ public class UpdateInfoDialog extends JDialog {
 		//// Install operating system combo box
 		List<String> assetURLs = release.getAssetURLs();
 		Map<UpdatePlatform, String> mappedAssets = AssetHandler.mapURLToPlatform(assetURLs);
-		JComboBox<Object> comboBox;
-		if (mappedAssets == null || mappedAssets.size() == 0) {
+		JComboBox<Object> comboBox = null;
+		/*if (mappedAssets == null || mappedAssets.size() == 0) {
 			comboBox = new JComboBox<>(new String[]{
 					String.format("- %s -", trans.get("update.dlg.updateAvailable.combo.noDownloads"))});
 		}
@@ -177,7 +177,7 @@ public class UpdateInfoDialog extends JDialog {
 				}
 			});
 		}
-		panel.add(comboBox, "pushx, right");
+		panel.add(comboBox, "pushx, right");*/
 
 		//// Install update button
 		JButton btnInstall = new JButton(trans.get("update.dlg.updateAvailable.but.install"));
@@ -185,8 +185,8 @@ public class UpdateInfoDialog extends JDialog {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				if (mappedAssets == null) return;
-				String url = AssetHandler.getInstallerURLForPlatform((UpdatePlatform) comboBox.getSelectedItem(),
-						release.getReleaseName());
+				UpdatePlatform platform = comboBox != null ? (UpdatePlatform) comboBox.getSelectedItem() : null;
+				String url = AssetHandler.getInstallerURLForPlatform(platform, release.getReleaseName());
 				if (url == null) return;
 				try {
 					URLUtil.openWebpage(url);

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/UpdateInfoDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/UpdateInfoDialog.java
@@ -54,6 +54,7 @@ public class UpdateInfoDialog extends JDialog {
 	private final SwingPreferences preferences = (SwingPreferences) Application.getPreferences();
 
 	private static Color textColor;
+	private static Color warningTextColor;
 
 	static {
 		initColors();
@@ -72,8 +73,15 @@ public class UpdateInfoDialog extends JDialog {
 		//	OpenRocket version available!
 		panel.add(new StyledLabel(trans.get("update.dlg.updateAvailable.lbl.title"), 8, StyledLabel.Style.BOLD), "spanx, wrap");
 
-		// Your version
+		//	Pre-release warning
 		ReleaseInfo release = info.getLatestRelease();
+		if (!release.isOfficialRelease()) {
+			StyledLabel label = new StyledLabel(trans.get("update.dlg.lbl.preReleaseWarning"), 5, StyledLabel.Style.BOLD);
+			label.setFontColor(warningTextColor);
+			panel.add(label, "spanx, wrap");
+		}
+
+		// Your version
 		panel.add(new StyledLabel(String.format(trans.get("update.dlg.updateAvailable.lbl.yourVersion"),
 				release.getReleaseName(), BuildProperties.getVersion()), -1, StyledLabel.Style.PLAIN), "skip 1, spanx, wrap para");
 
@@ -82,10 +90,12 @@ public class UpdateInfoDialog extends JDialog {
 
 		// Release information box
 		final JTextPane textPane = new JTextPane();
-		textPane.setBorder(BorderFactory.createLineBorder(textColor));
+		textPane.setBorder(BorderFactory.createCompoundBorder(
+				BorderFactory.createLineBorder(textColor),
+				BorderFactory.createEmptyBorder(0, 10, 10, 10)
+		));
 		textPane.setEditable(false);
 		textPane.setContentType("text/html");
-		textPane.setMargin(new Insets(10, 10, 40, 10));
 		textPane.putClientProperty(JTextPane.HONOR_DISPLAY_PROPERTIES, true);
 
 		StringBuilder sb = new StringBuilder();
@@ -216,6 +226,7 @@ public class UpdateInfoDialog extends JDialog {
 
 	public static void updateColors() {
 		textColor = GUIUtil.getUITheme().getTextColor();
+		warningTextColor = GUIUtil.getUITheme().getWarningColor();
 	}
 
 	/**

--- a/swing/src/main/java/info/openrocket/swing/startup/SwingStartup.java
+++ b/swing/src/main/java/info/openrocket/swing/startup/SwingStartup.java
@@ -290,8 +290,9 @@ public class SwingStartup {
 					UpdateInfo info = updateRetriever.getUpdateInfo();
 
 					// Only display something when an update is found
+					boolean checkAllUpdates = System.getProperty("openrocket.debug.checkAllVersionUpdates") != null;
 					if (info != null && info.getException() == null && info.getReleaseStatus() == ReleaseStatus.OLDER &&
-						!preferences.getIgnoreUpdateVersions().contains(info.getLatestRelease().getReleaseName())) {
+							(checkAllUpdates || !preferences.getIgnoreUpdateVersions().contains(info.getLatestRelease().getReleaseName()))) {
 						UpdateInfoDialog infoDialog = new UpdateInfoDialog(info);
 						infoDialog.setVisible(true);
 					}


### PR DESCRIPTION
This PR adds some improvements to the software updater:
1. Remove the OS selection combobox from the update dialog, it's not really serving a purpose. Users should just select the right installer on the website.
2. Only when the update is an official release, link to the openrocket.info website when you click "Install Update". For pre-releases, link to the GitHub release page. This is because normally, we do not upload pre-releases to the website.
3. When the update is a pre-release, add a warning text below the title, stating that it is a pre-releases and issues may be present.