### PR TITLE
Sim warnings updates

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
@@ -1263,9 +1263,7 @@ public class SimulationPanel extends JPanel {
 			int nrOfInfoWarnings = warnings.getNrOfInformationalWarnings();
 
 			if (nrOfCriticalWarnings > 0) {
-				if (nrOfCriticalWarnings > 1) {
-					add(new JLabel(nrOfCriticalWarnings + " "));
-				}
+				add(new JLabel(nrOfCriticalWarnings + " "));
 				add(new JLabel(Icons.WARNING_HIGH));
 			}
 
@@ -1274,9 +1272,7 @@ public class SimulationPanel extends JPanel {
 			}
 
 			if (nrOfNormalWarnings > 0) {
-				if (nrOfNormalWarnings > 1) {
-					add(new JLabel(nrOfNormalWarnings + " "));
-				}
+				add(new JLabel(nrOfNormalWarnings + " "));
 				add(new JLabel(Icons.WARNING_NORMAL));
 			}
 
@@ -1285,9 +1281,7 @@ public class SimulationPanel extends JPanel {
 			}
 
 			if (nrOfInfoWarnings > 0) {
-				if (nrOfInfoWarnings > 1) {
-					add(new JLabel(nrOfInfoWarnings + " "));
-				}
+				add(new JLabel(nrOfInfoWarnings + " "));
 				add(new JLabel(Icons.WARNING_LOW));
 			}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
@@ -1263,7 +1263,9 @@ public class SimulationPanel extends JPanel {
 			int nrOfInfoWarnings = warnings.getNrOfInformationalWarnings();
 
 			if (nrOfCriticalWarnings > 0) {
-				add(new JLabel(nrOfCriticalWarnings + " "));
+				if (nrOfCriticalWarnings > 1) {
+					add(new JLabel(nrOfCriticalWarnings + " "));
+				}
 				add(new JLabel(Icons.WARNING_HIGH));
 			}
 
@@ -1272,7 +1274,9 @@ public class SimulationPanel extends JPanel {
 			}
 
 			if (nrOfNormalWarnings > 0) {
-				add(new JLabel(nrOfNormalWarnings + " "));
+				if (nrOfNormalWarnings > 1) {
+					add(new JLabel(nrOfNormalWarnings + " "));
+				}
 				add(new JLabel(Icons.WARNING_NORMAL));
 			}
 
@@ -1281,7 +1285,9 @@ public class SimulationPanel extends JPanel {
 			}
 
 			if (nrOfInfoWarnings > 0) {
-				add(new JLabel(nrOfInfoWarnings + " "));
+				if (nrOfInfoWarnings > 1) {
+					add(new JLabel(nrOfInfoWarnings + " "));
+				}
 				add(new JLabel(Icons.WARNING_LOW));
 			}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationWarningsPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationWarningsPanel.java
@@ -104,7 +104,7 @@ public class SimulationWarningsPanel extends JPanel {
 		// Title
 		float size = 2f;
 		int nrOfWarnings = warnings == null ? 0 : warnings.size();
-		StyledLabel title = new StyledLabel(nrOfWarnings + " " + titleText, size, StyledLabel.Style.BOLD);
+		StyledLabel title = new StyledLabel(titleText, size, StyledLabel.Style.BOLD);
 		title.setFontColor(textColor);
 		panel.add(title);
 


### PR DESCRIPTION
A couple of small tweaks:

1) In the simulation warnings panel, don't show the number of warnings on each header.  You can see the warnings right in front of you, don't need to see the number

2) In the sim results table warnings column, only show the number if its greater than 1.  I am not sure about this change.

I am confident about (1), less so about (2).

<img width="1186" alt="image" src="https://github.com/user-attachments/assets/8edd080c-f482-4b89-9959-9439c74b3dda" />
