### PR TITLE
Make all (most?) warnings take a standard syntax

### DIFF
--- a/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanCalculator.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanCalculator.java
@@ -360,7 +360,7 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 						// Check for phantom tube
 						if ((sym.getLength() < MathUtil.EPSILON) ||
 							(sym.getAftRadius() < MathUtil.EPSILON && sym.getForeRadius() < MathUtil.EPSILON)) {
-							warnings.add(Warning.ZERO_VOLUME_BODY, sym.getName());
+							warnings.add(Warning.ZERO_VOLUME_BODY, sym);
 						}
 
 						// check for gap or overlap in airframe. We'll use a textual comparison to see

--- a/core/src/main/java/info/openrocket/core/logging/Message.java
+++ b/core/src/main/java/info/openrocket/core/logging/Message.java
@@ -44,9 +44,9 @@ public abstract class Message implements Cloneable {
 		if (sources != null && sources.length > 0) {
 			String[] sourceNames = new String[sources.length];
 			for (int i = 0; i < sources.length; i++) {
-				sourceNames[i] = sources[i].getName();
+				sourceNames[i] = "\"" + sources[i].getName() + "\"";
 			}
-			return String.join(", ", sourceNames) + ": " + text;
+			return text + ":  " + String.join(", ", sourceNames);
 		}
 		return text;
 	}

--- a/core/src/main/java/info/openrocket/core/logging/Warning.java
+++ b/core/src/main/java/info/openrocket/core/logging/Warning.java
@@ -2,6 +2,7 @@ package info.openrocket.core.logging;
 
 import info.openrocket.core.l10n.Translator;
 import info.openrocket.core.motor.Motor;
+import info.openrocket.core.rocketcomponent.RocketComponent;
 import info.openrocket.core.startup.Application;
 import info.openrocket.core.simulation.FlightEvent;
 import info.openrocket.core.unit.UnitGroup;
@@ -58,7 +59,7 @@ public abstract class Warning extends Message {
 			//// Large angle of attack encountered (
 			return (trans.get("Warning.LargeAOA.str2") +
 					//					UnitGroup.UNITS_ANGLE.getDefaultUnit().toString(aoa) + ").");
-					UnitGroup.UNITS_ANGLE.toStringUnit(aoa) + ").");
+					UnitGroup.UNITS_ANGLE.toStringUnit(aoa) + ")");
 		}
 
 		@Override
@@ -95,19 +96,22 @@ public abstract class Warning extends Message {
 		private double recoverySpeed;
 		
 		/**
-		 * Sole constructor.  The argument is the speed that caused this warning.
+		 * Sole constructor.  The arguments are the speed that caused this warning,
+		 * and the parachute that is opening
 		 * 
 		 * @param speed  the speed that caused this warning
+		 * @param chute  the chute(s) that were opening
 		 */
-		public HighSpeedDeployment(double speed) {
+		public HighSpeedDeployment(double speed, RocketComponent... chute) {
 			this.recoverySpeed = speed;
+			this.setSources(chute);
 			setPriority(MessagePriority.NORMAL);
 		}
 		
 		@Override
 		public String getMessageDescription() {
 			if (Double.isNaN(recoverySpeed)) {
-				return trans.get("Warning.RECOVERY_HIGH_SPEED");
+				 return trans.get("Warning.RECOVERY_HIGH_SPEED");
 			}
 			return trans.get("Warning.RECOVERY_HIGH_SPEED") + " (" + UnitGroup.UNITS_VELOCITY.toStringUnit(recoverySpeed) + ")";
 		}

--- a/core/src/main/java/info/openrocket/core/simulation/BasicEventSimulationEngine.java
+++ b/core/src/main/java/info/openrocket/core/simulation/BasicEventSimulationEngine.java
@@ -577,7 +577,7 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 
 					// Check current velocity
 					if (currentStatus.getRocketVelocity().length() > 20) {
-						currentStatus.addWarning(new Warning.HighSpeedDeployment(currentStatus.getRocketVelocity().length()));
+						currentStatus.addWarning(new Warning.HighSpeedDeployment(currentStatus.getRocketVelocity().length(), c));
 					}
 
 					currentStatus.setLiftoff(true);

--- a/core/src/test/java/info/openrocket/core/simulation/FlightEventsTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/FlightEventsTest.java
@@ -59,6 +59,7 @@ public class FlightEventsTest extends BaseTestCase {
 		final InnerTube motorMountTube = (InnerTube) stage.getChild(1).getChild(2);
 		final Parachute parachute = (Parachute) stage.getChild(1).getChild(3);
 
+		Warning warn = new Warning.HighSpeedDeployment(80.6, parachute);
 		final Simulation sim = new Simulation(rocket);
 		sim.getOptions().setISAAtmosphere(true);
 		sim.getOptions().setTimeStep(0.05);
@@ -77,7 +78,7 @@ public class FlightEventsTest extends BaseTestCase {
 				new FlightEvent(FlightEvent.Type.LAUNCHROD, 0.13, null),
 				new FlightEvent(FlightEvent.Type.BURNOUT, 2.0, motorMountTube),
 				new FlightEvent(FlightEvent.Type.EJECTION_CHARGE, 2.0, stage),
-				new FlightEvent(FlightEvent.Type.SIM_WARN, 2.0, null, new Warning.HighSpeedDeployment(80.6)),
+				new FlightEvent(FlightEvent.Type.SIM_WARN, 2.0, null, warn),
 				new FlightEvent(FlightEvent.Type.RECOVERY_DEVICE_DEPLOYMENT, 2.001, parachute),
 				new FlightEvent(FlightEvent.Type.APOGEE, 2.48, rocket),
 				new FlightEvent(FlightEvent.Type.GROUND_HIT, 42.97, null),
@@ -133,11 +134,10 @@ public class FlightEventsTest extends BaseTestCase {
 		motorConfig.setIgnitionEvent(IgnitionEvent.NEVER);
 		sustainerMount.setMotorConfig(motorConfig, fcid);
 
+		Warning warn = new Warning.HighSpeedDeployment(53.2, chute);
+
 		sim.simulate();
 
-		Warning warn = new Warning.HighSpeedDeployment(94.9);
-		warn.setSources(null);
-		
 		// Test branch count
 		final int expectedBranchCount = 2;
 		final int actualBranchCount = sim.getSimulatedData().getBranchCount();
@@ -216,8 +216,7 @@ public class FlightEventsTest extends BaseTestCase {
 
 		SimulationAbort simAbort = new SimulationAbort(SimulationAbort.Cause.TUMBLE_UNDER_THRUST);
 		
-		Warning warn = new Warning.HighSpeedDeployment(53.2);
-		warn.setSources(null);
+		Warning warn = new Warning.HighSpeedDeployment(53.2, sideChutes);
 		
 		// events whose time is too variable to check are given a time of the max sim time
 		for (int b = 0; b < actualBranchCount; b++) {


### PR DESCRIPTION
This PR makes all warnings look like
Problem: "component", "component"
both for uniformity and for clarity. Also properly sets zero-volume body tube priority.

Fixes #2669