### PR TITLE
[#2679] Don't use exclusive if for component changes

### DIFF
--- a/core/src/main/java/info/openrocket/core/rocketcomponent/Rocket.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/Rocket.java
@@ -697,7 +697,8 @@ public class Rocket extends ComponentAssembly {
 
 			if (l instanceof ComponentChangeListener) {
 				((ComponentChangeListener) l).componentChanged(cce);
-			} else if (l instanceof StateChangeListener) {
+			}
+			if (l instanceof StateChangeListener) {
 				((StateChangeListener) l).stateChanged(cce);
 			}
 		}


### PR DESCRIPTION
This PR fixes #2679. The issue was in the `Rocket` `notifyAllListeners` code:

```java
private void notifyAllListeners(final ComponentChangeEvent cce) {
		// Copy the list before iterating to prevent concurrent modification exceptions.
		EventListener[] list = listenerList.toArray(new EventListener[0]);
		for (EventListener l : list) {
            { // vvvv DEVEL vvvv
                //System.err.println("notifying listener.  (type= "+l.getClass().getSimpleName()+")");
                //System.err.println("                     (type= "+l.getClass().getName()+")");
            } // ^^^^ DEVEL ^^^^

			if (l instanceof ComponentChangeListener) {
				((ComponentChangeListener) l).componentChanged(cce);
			}
			else if (l instanceof StateChangeListener) {
				((StateChangeListener) l).stateChanged(cce);
			}
		}
	}
```


The `OpenRocketDocument` is both a ComponentChangeListener and StateChangeListener, so when it arrives at the first if, only the `componentChanged` method is called, not the `stateChanged` method. This PR replaces that `else if` with a normal `if`.

----

I couldn't track down why this bug suddenly appeared, but IMO the above change is a logical one.