### PR TITLE
[#2660] Fix importing of invalid Double values & MassObject auto radius if the parent radius is 0

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/openrocket/importt/DoubleSetter.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/importt/DoubleSetter.java
@@ -20,6 +20,7 @@ class DoubleSetter implements Setter {
 	private final double multiplier;
 	private String separator;
 	private Object[] extraParameters = null;
+	private final boolean checkForValidDouble = true;
 
 	/**
 	 * Set only the double value.
@@ -129,6 +130,12 @@ class DoubleSetter implements Setter {
 		if (!special.equalsIgnoreCase(specialString) || (args != null && args.length > 1)) {
 			try {
 				double d = Double.parseDouble(data);
+
+				// Check for valid double
+				if (checkForValidDouble && (Double.isInfinite(d) || Double.isNaN(d))) {
+					warnings.add(Warning.FILE_INVALID_PARAMETER + " data: '" + data + "' - " + c.getName());
+					return;
+				}
 
 				Object obj = c;
 				if (configGetter != null) {

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/MassObject.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/MassObject.java
@@ -91,6 +91,9 @@ public abstract class MassObject extends InternalComponent {
 		// transform that back
 		// to the non auto radius situation to set this.length (the volume in both
 		// situations is the same).
+		if (MathUtil.equals(radius, 0)) {
+			return length;
+		}
 		return volume / Math.pow(radius, 2);
 	}
 

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/MassObject.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/MassObject.java
@@ -111,6 +111,12 @@ public abstract class MassObject extends InternalComponent {
 		if (parent == null) {
 			return radius;
 		}
+		double autoRadius = getMaxParentRadius();
+
+		return MathUtil.equals(autoRadius, 0) ? radius : autoRadius;
+	}
+
+	public double getMaxParentRadius() {
 		if (parent instanceof NoseCone) {
 			return ((NoseCone) parent).getBaseRadius();
 		} else if (parent instanceof Transition) {
@@ -122,8 +128,7 @@ public abstract class MassObject extends InternalComponent {
 		} else if (parent instanceof RingComponent) {
 			return ((RingComponent) parent).getInnerRadius();
 		}
-
-		return radius;
+		return 0;
 	}
 
 	public void setRadius(double radius) {

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/MassComponentConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/MassComponentConfig.java
@@ -11,6 +11,9 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
 
+import info.openrocket.core.rocketcomponent.ComponentChangeEvent;
+import info.openrocket.core.rocketcomponent.ComponentChangeListener;
+import info.openrocket.core.rocketcomponent.MassObject;
 import net.miginfocom.swing.MigLayout;
 
 import info.openrocket.core.document.OpenRocketDocument;
@@ -123,10 +126,17 @@ public class MassComponentConfig extends RocketComponentConfig {
 		panel.add(new BasicSlider(od.getSliderModel(0, 0.04, 0.2)), "w 100lp, wrap");
 
 		////// Automatic
-		JCheckBox checkAutoPackedRadius = new JCheckBox(od.getAutomaticAction());
+		final JCheckBox checkAutoPackedRadius = new JCheckBox(od.getAutomaticAction());
 		checkAutoPackedRadius.setText(trans.get("ParachuteCfg.checkbox.AutomaticPacked"));
 		checkAutoPackedRadius.setToolTipText(trans.get("ParachuteCfg.checkbox.AutomaticPacked.ttip"));
+		checkAutoPackedRadius.setEnabled(((MassObject) component).getMaxParentRadius() > 0);
 		panel.add(checkAutoPackedRadius, "skip, span 2, wrap");
+		component.getParent().addComponentChangeListener(new ComponentChangeListener() {
+			@Override
+			public void componentChanged(ComponentChangeEvent e) {
+				checkAutoPackedRadius.setEnabled(((MassObject) component).getMaxParentRadius() > 0);
+			}
+		});
 		order.add(checkAutoPackedRadius);
 
 

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/ParachuteConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/ParachuteConfig.java
@@ -16,6 +16,9 @@ import javax.swing.JPanel;
 import javax.swing.JSpinner;
 
 import info.openrocket.core.material.MaterialGroup;
+import info.openrocket.core.rocketcomponent.ComponentChangeEvent;
+import info.openrocket.core.rocketcomponent.ComponentChangeListener;
+import info.openrocket.core.rocketcomponent.MassObject;
 import info.openrocket.swing.gui.widgets.GroupableAndSearchableComboBox;
 import info.openrocket.swing.gui.widgets.MaterialComboBox;
 import info.openrocket.swing.gui.adaptors.CustomFocusTraversalPolicy;
@@ -209,11 +212,17 @@ public class ParachuteConfig extends RecoveryDeviceConfig {
 			placementPanel.add(new BasicSlider(od.getSliderModel(0, 0.04, 0.2)), "w 100lp, wrap");
 
 			////// Automatic
-			JCheckBox checkAutoPackedRadius = new JCheckBox(od.getAutomaticAction());
+			final JCheckBox checkAutoPackedRadius = new JCheckBox(od.getAutomaticAction());
 			checkAutoPackedRadius.setText(trans.get("ParachuteCfg.checkbox.AutomaticPacked"));
 			checkAutoPackedRadius.setToolTipText(trans.get("ParachuteCfg.checkbox.AutomaticPacked.ttip"));
+			checkAutoPackedRadius.setEnabled(((MassObject) component).getMaxParentRadius() > 0);
 			placementPanel.add(checkAutoPackedRadius, "skip, spanx 2");
-			order.add(checkAutoPackedRadius);
+			component.getParent().addComponentChangeListener(new ComponentChangeListener() {
+				@Override
+				public void componentChanged(ComponentChangeEvent e) {
+					checkAutoPackedRadius.setEnabled(((MassObject) component).getMaxParentRadius() > 0);
+				}
+			});
 		}
 
 		{// ---------------------------- Deployment ----------------------------

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/ShockCordConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/ShockCordConfig.java
@@ -1,5 +1,8 @@
 package info.openrocket.swing.gui.configdialog;
 
+import info.openrocket.core.rocketcomponent.ComponentChangeEvent;
+import info.openrocket.core.rocketcomponent.ComponentChangeListener;
+import info.openrocket.core.rocketcomponent.MassObject;
 import net.miginfocom.swing.MigLayout;
 
 import info.openrocket.core.document.OpenRocketDocument;
@@ -105,10 +108,17 @@ public class ShockCordConfig extends RocketComponentConfig {
 				placementPanel.add(new BasicSlider(od.getSliderModel(0, 0.04, 0.2)), "w 100lp, wrap");
 
 				////// Automatic
-				JCheckBox checkAutoPackedRadius = new JCheckBox(od.getAutomaticAction());
+				final JCheckBox checkAutoPackedRadius = new JCheckBox(od.getAutomaticAction());
 				checkAutoPackedRadius.setText(trans.get("ParachuteCfg.checkbox.AutomaticPacked"));
 				checkAutoPackedRadius.setToolTipText(trans.get("ParachuteCfg.checkbox.AutomaticPacked.ttip"));
+				checkAutoPackedRadius.setEnabled(((MassObject) component).getMaxParentRadius() > 0);
 				placementPanel.add(checkAutoPackedRadius, "skip, spanx 2, wrap");
+				component.getParent().addComponentChangeListener(new ComponentChangeListener() {
+					@Override
+					public void componentChanged(ComponentChangeEvent e) {
+						checkAutoPackedRadius.setEnabled(((MassObject) component).getMaxParentRadius() > 0);
+					}
+				});
 				order.add(checkAutoPackedRadius);
 			}
 		}

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/StreamerConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/StreamerConfig.java
@@ -16,6 +16,9 @@ import javax.swing.JPanel;
 import javax.swing.JSpinner;
 
 import info.openrocket.core.material.MaterialGroup;
+import info.openrocket.core.rocketcomponent.ComponentChangeEvent;
+import info.openrocket.core.rocketcomponent.ComponentChangeListener;
+import info.openrocket.core.rocketcomponent.MassObject;
 import info.openrocket.swing.gui.widgets.GroupableAndSearchableComboBox;
 import info.openrocket.swing.gui.widgets.MaterialComboBox;
 import net.miginfocom.swing.MigLayout;
@@ -187,10 +190,17 @@ public class StreamerConfig extends RecoveryDeviceConfig {
 			placementPanel.add(new BasicSlider(od.getSliderModel(0, 0.04, 0.2)), "w 100lp, wrap");
 
 			////// Automatic
-			JCheckBox checkAutoPackedRadius = new JCheckBox(od.getAutomaticAction());
+			final JCheckBox checkAutoPackedRadius = new JCheckBox(od.getAutomaticAction());
 			checkAutoPackedRadius.setText(trans.get("ParachuteCfg.checkbox.AutomaticPacked"));
 			checkAutoPackedRadius.setToolTipText(trans.get("ParachuteCfg.checkbox.AutomaticPacked.ttip"));
+			checkAutoPackedRadius.setEnabled(((MassObject) component).getMaxParentRadius() > 0);
 			placementPanel.add(checkAutoPackedRadius, "skip, spanx 2");
+			component.getParent().addComponentChangeListener(new ComponentChangeListener() {
+				@Override
+				public void componentChanged(ComponentChangeEvent e) {
+					checkAutoPackedRadius.setEnabled(((MassObject) component).getMaxParentRadius() > 0);
+				}
+			});
 			order.add(checkAutoPackedRadius);
 
 			panel.add(placementPanel, "growx, wrap");


### PR DESCRIPTION
This PR fixes #2660. When the parent of a MassObject (parachute, streamer, shock cord, mass component) has a max inner radius of 0 (e.g. when a body tube is filled), the autoRadius feature is bypassed. Additionally, there is a general sanity check in `DoubleSetter` to verify that the double value is valid (not infinite or NaN). If it is invalid, it is ignored and a warning is shown when opening the .ork file. Finally, when the auto radius is 0, the auto length value is not based on the auto radius.