### PR TITLE
Reclassify polystyrene to plastics instead of foams

### DIFF
--- a/core/src/main/java/info/openrocket/core/database/Databases.java
+++ b/core/src/main/java/info/openrocket/core/database/Databases.java
@@ -60,7 +60,7 @@ public class Databases {
 		BULK_MATERIAL.add(newMaterial(Material.Type.BULK, "Pine", 530, MaterialGroup.WOODS));
 		BULK_MATERIAL.add(newMaterial(Material.Type.BULK, "Plywood (birch)", 630, MaterialGroup.WOODS));
 		BULK_MATERIAL.add(newMaterial(Material.Type.BULK, "Polycarbonate (Lexan)", 1200, MaterialGroup.PLASTICS));
-		BULK_MATERIAL.add(newMaterial(Material.Type.BULK, "Polystyrene", 1050, MaterialGroup.FOAMS));
+		BULK_MATERIAL.add(newMaterial(Material.Type.BULK, "Polystyrene", 1050, MaterialGroup.PLASTICS));
 		BULK_MATERIAL.add(newMaterial(Material.Type.BULK, "PVC", 1390, MaterialGroup.PLASTICS));
 		BULK_MATERIAL.add(newMaterial(Material.Type.BULK, "Spruce", 450, MaterialGroup.WOODS));
 		BULK_MATERIAL.add(newMaterial(Material.Type.BULK, "Steel", 7850, MaterialGroup.METALS));


### PR DESCRIPTION
The density (1.05 g/cm^3) corresponds to polystyrene plastics instead of foams (typically 0.01 to 0.05 g/cm³).