### PR TITLE
[#2701] Make remove file extension method robust against periods in the file path

### DIFF
--- a/core/src/main/java/info/openrocket/core/util/FileUtils.java
+++ b/core/src/main/java/info/openrocket/core/util/FileUtils.java
@@ -44,36 +44,10 @@ public abstract class FileUtils {
 	 * @return the file name without extension
 	 */
 	public static String removeExtension(String fileName) {
-		if (fileName == null || fileName.isEmpty()) {
-			return fileName;
-		}
-
-		// First get just the filename portion if this is a path
-		String name = Paths.get(fileName).getFileName().toString();
-
-		// Handle special case of files starting with a dot
-		if (name.startsWith(".")) {
-			if (name.length() == 1) { // Just a dot
-				return name;
-			}
-			// Check if there's another dot in the name after the first character
-			int secondDot = name.indexOf('.', 1);
-			if (secondDot == -1) { // No other dots, it's a dotfile like .gitignore
-				return "";
-			}
-			// Has another extension after the dot prefix
-			return name.substring(0, secondDot);
-		}
-
-		// Find last occurrence of dot in the filename
-		int lastDot = name.lastIndexOf('.');
-
-		if (lastDot == -1) { // No extension found
-			return name;
-		}
-
-		return name.substring(0, lastDot);
+		return fileName == null || fileName.isEmpty() ? fileName :
+				fileName.replaceFirst("[.][^.]+$", "");
 	}
+
 
 	/**
 	 * Get the file name from a path.

--- a/core/src/main/java/info/openrocket/core/util/FileUtils.java
+++ b/core/src/main/java/info/openrocket/core/util/FileUtils.java
@@ -38,17 +38,41 @@ public abstract class FileUtils {
 	}
 
 	/**
-	 * Remove the extension from a file name.
-	 * 
-	 * @param fileName the file name
+	 * Remove the extension from a file name, properly handling paths and edge cases.
+	 *
+	 * @param fileName the file name or path
 	 * @return the file name without extension
 	 */
 	public static String removeExtension(String fileName) {
-		String[] splitResults = fileName.split("\\.");
-		if (splitResults.length > 0) {
-			return splitResults[0];
+		if (fileName == null || fileName.isEmpty()) {
+			return fileName;
 		}
-		return fileName;
+
+		// First get just the filename portion if this is a path
+		String name = Paths.get(fileName).getFileName().toString();
+
+		// Handle special case of files starting with a dot
+		if (name.startsWith(".")) {
+			if (name.length() == 1) { // Just a dot
+				return name;
+			}
+			// Check if there's another dot in the name after the first character
+			int secondDot = name.indexOf('.', 1);
+			if (secondDot == -1) { // No other dots, it's a dotfile like .gitignore
+				return "";
+			}
+			// Has another extension after the dot prefix
+			return name.substring(0, secondDot);
+		}
+
+		// Find last occurrence of dot in the filename
+		int lastDot = name.lastIndexOf('.');
+
+		if (lastDot == -1) { // No extension found
+			return name;
+		}
+
+		return name.substring(0, lastDot);
 	}
 
 	/**

--- a/core/src/test/java/info/openrocket/core/util/FileUtilsTest.java
+++ b/core/src/test/java/info/openrocket/core/util/FileUtilsTest.java
@@ -107,6 +107,7 @@ public class FileUtilsTest {
 		// Test periods in path
 		assertEquals("test", FileUtils.removeExtension("/path/with.dots/test.txt"));
 		assertEquals("test", FileUtils.removeExtension("C:/my.folder/sub.folder/test.txt"));
+		assertEquals("test.1.2", FileUtils.removeExtension("C:/my.folder/sub.folder/test.1.2.txt"));
 		assertEquals("test", FileUtils.removeExtension("folder.name/test.txt"));
 	}
 

--- a/core/src/test/java/info/openrocket/core/util/FileUtilsTest.java
+++ b/core/src/test/java/info/openrocket/core/util/FileUtilsTest.java
@@ -1,0 +1,183 @@
+package info.openrocket.core.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FileUtilsTest {
+	@TempDir
+	Path tempDir;
+
+	private File testFile;
+	private static final String TEST_CONTENT = "Hello, World!";
+
+	@BeforeEach
+	void setUp() throws IOException {
+		testFile = tempDir.resolve("test.txt").toFile();
+		try (FileWriter writer = new FileWriter(testFile)) {
+			writer.write(TEST_CONTENT);
+		}
+	}
+
+	@Test
+	void testCopy_WithBufferedStreams() throws IOException {
+		try (InputStream is = new BufferedInputStream(new FileInputStream(testFile));
+			 ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+
+			FileUtils.copy(is, os);
+
+			assertEquals(TEST_CONTENT, os.toString());
+		}
+	}
+
+	@Test
+	void testCopy_WithUnbufferedStreams() throws IOException {
+		try (InputStream is = new FileInputStream(testFile);
+			 ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+
+			FileUtils.copy(is, os);
+
+			assertEquals(TEST_CONTENT, os.toString());
+		}
+	}
+
+	@Test
+	void testCopy_WithEmptyFile() throws IOException {
+		File emptyFile = tempDir.resolve("empty.txt").toFile();
+		// Create the empty file
+		assertTrue(emptyFile.createNewFile());
+
+		try (InputStream is = new FileInputStream(emptyFile);
+			 ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+
+			FileUtils.copy(is, os);
+
+			assertEquals(0, os.size());
+		}
+	}
+
+	@Test
+	void testReadBytes() throws IOException {
+		try (InputStream is = new FileInputStream(testFile)) {
+			byte[] bytes = FileUtils.readBytes(is);
+
+			assertEquals(TEST_CONTENT, new String(bytes));
+		}
+	}
+
+	@Test
+	void testReadBytes_EmptyFile() throws IOException {
+		File emptyFile = tempDir.resolve("empty.txt").toFile();
+		// Create the empty file
+		assertTrue(emptyFile.createNewFile());
+
+		try (InputStream is = new FileInputStream(emptyFile)) {
+			byte[] bytes = FileUtils.readBytes(is);
+
+			assertEquals(0, bytes.length);
+		}
+	}
+
+	@Test
+	void testRemoveExtension_NormalFile() {
+		assertEquals("filename", FileUtils.removeExtension("filename.txt"));
+	}
+
+	@Test
+	void testRemoveExtension_NoExtension() {
+		assertEquals("filename", FileUtils.removeExtension("filename"));
+	}
+
+	@Test
+	void testRemoveExtension_DotFile() {
+		assertEquals("", FileUtils.removeExtension(".gitignore"));
+		// Test periods in path
+		assertEquals("test", FileUtils.removeExtension("/path/with.dots/test.txt"));
+		assertEquals("test", FileUtils.removeExtension("C:/my.folder/sub.folder/test.txt"));
+		assertEquals("test", FileUtils.removeExtension("folder.name/test.txt"));
+	}
+
+	@Test
+	void testGetFileNameFromPath() {
+		// Test absolute paths
+		assertEquals("file.txt", FileUtils.getFileNameFromPath("/path/to/file.txt"));
+		assertEquals("document.pdf", FileUtils.getFileNameFromPath("C:/Documents/document.pdf"));
+
+		// Test relative paths
+		assertEquals("image.jpg", FileUtils.getFileNameFromPath("../folder/image.jpg"));
+		assertEquals("script.sh", FileUtils.getFileNameFromPath("./script.sh"));
+
+		// Test just filename
+		assertEquals("simple.txt", FileUtils.getFileNameFromPath("simple.txt"));
+
+		// Test paths with spaces and special characters
+		assertEquals("my file.txt", FileUtils.getFileNameFromPath("/path/to/my file.txt"));
+		assertEquals("file with spaces.doc", FileUtils.getFileNameFromPath("folder/file with spaces.doc"));
+	}
+
+	@Test
+	void testGetIllegalFilenameChar_ValidFilename() {
+		assertNull(FileUtils.getIllegalFilenameChar("valid-filename.txt"));
+	}
+
+	@Test
+	void testGetIllegalFilenameChar_IllegalChars() {
+		assertEquals('/', FileUtils.getIllegalFilenameChar("illegal/filename"));
+		assertEquals('\\', FileUtils.getIllegalFilenameChar("illegal\\filename"));
+		assertEquals(':', FileUtils.getIllegalFilenameChar("illegal:filename"));
+		assertEquals('*', FileUtils.getIllegalFilenameChar("illegal*filename"));
+		assertEquals('?', FileUtils.getIllegalFilenameChar("illegal?filename"));
+		assertEquals('"', FileUtils.getIllegalFilenameChar("illegal\"filename"));
+		assertEquals('<', FileUtils.getIllegalFilenameChar("illegal<filename"));
+		assertEquals('>', FileUtils.getIllegalFilenameChar("illegal>filename"));
+		assertEquals('|', FileUtils.getIllegalFilenameChar("illegal|filename"));
+	}
+
+	@Test
+	void testGetIllegalFilenameChar_EmptyString() {
+		assertNull(FileUtils.getIllegalFilenameChar(""));
+	}
+
+	@Test
+	void testGetIllegalFilenameChar_NullInput() {
+		assertNull(FileUtils.getIllegalFilenameChar(null));
+	}
+
+	@Test
+	void testCopy_WithClosedInputStream() {
+		assertThrows(IOException.class, () -> {
+			InputStream is = new FileInputStream(testFile);
+			is.close();
+
+			try (ByteArrayOutputStream os = new ByteArrayOutputStream()) {
+				FileUtils.copy(is, os);
+			}
+		});
+	}
+
+	@Test
+	void testCopy_WithClosedOutputStream() {
+		File outputFile = tempDir.resolve("output.txt").toFile();
+		assertThrows(IOException.class, () -> {
+			try (InputStream is = new FileInputStream(testFile)) {
+				FileOutputStream os = new FileOutputStream(outputFile);
+				os.close();
+
+				FileUtils.copy(is, os);
+			}
+		});
+	}
+}

--- a/core/src/test/java/info/openrocket/core/util/FileUtilsTest.java
+++ b/core/src/test/java/info/openrocket/core/util/FileUtilsTest.java
@@ -105,10 +105,10 @@ public class FileUtilsTest {
 	void testRemoveExtension_DotFile() {
 		assertEquals("", FileUtils.removeExtension(".gitignore"));
 		// Test periods in path
-		assertEquals("test", FileUtils.removeExtension("/path/with.dots/test.txt"));
-		assertEquals("test", FileUtils.removeExtension("C:/my.folder/sub.folder/test.txt"));
-		assertEquals("test.1.2", FileUtils.removeExtension("C:/my.folder/sub.folder/test.1.2.txt"));
-		assertEquals("test", FileUtils.removeExtension("folder.name/test.txt"));
+		assertEquals("/path/with.dots/test", FileUtils.removeExtension("/path/with.dots/test.txt"));
+		assertEquals("C:/my.folder/sub.folder/test", FileUtils.removeExtension("C:/my.folder/sub.folder/test.txt"));
+		assertEquals("C:/my.folder/sub.folder/test.1.2", FileUtils.removeExtension("C:/my.folder/sub.folder/test.1.2.txt"));
+		assertEquals("folder.name/test", FileUtils.removeExtension("folder.name/test.txt"));
 	}
 
 	@Test


### PR DESCRIPTION
This PR fixes #2701. The issue was with the `removeExtension` method in `FileUtils` which was not robust against file paths with a period in it.