### PR TITLE
[#2700] Add "Altitude above sea level" flight data type

### DIFF
--- a/core/src/main/java/info/openrocket/core/rocketcomponent/FlightConfiguration.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/FlightConfiguration.java
@@ -652,7 +652,7 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 	}
 
 	public boolean hasMotors() {
-		return (0 < motors.size());
+		return !motors.isEmpty();
 	}
 
 	public Collection<MotorConfiguration> getAllMotors() {
@@ -660,8 +660,18 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 	}
 
 	public Collection<MotorConfiguration> getActiveMotors() {
-
 		return activeMotors;
+	}
+
+	public void clearAllMotors() {
+		for (RocketComponent comp : getActiveComponents()) {
+			if ((comp instanceof MotorMount) && (((MotorMount) comp).isMotorMount())) {
+				MotorMount mount = (MotorMount) comp;
+				mount.reset(fcid);
+				motors.put(mount.getMotorConfig(fcid).getMID(), null);
+			}
+		}
+		updateMotors();
 	}
 
 	private void updateMotors() {

--- a/core/src/main/java/info/openrocket/core/simulation/FlightDataType.java
+++ b/core/src/main/java/info/openrocket/core/simulation/FlightDataType.java
@@ -54,56 +54,60 @@ public class FlightDataType implements Comparable<FlightDataType>, Groupable<Fli
 	public static final FlightDataType TYPE_ALTITUDE = newType(trans.get("FlightDataType.TYPE_ALTITUDE"), "h",
 			UnitGroup.UNITS_DISTANCE,
 			FlightDataTypeGroup.POSITION_AND_MOTION, 0);
+	//// Altitude above sea level
+	public static final FlightDataType TYPE_ALTITUDE_ABOVE_SEA = newType(trans.get("FlightDataType.TYPE_ALTITUDE_ABOVE_SEA"),
+			"ha", UnitGroup.UNITS_DISTANCE,
+			FlightDataTypeGroup.POSITION_AND_MOTION, 1);
 	//// Vertical velocity
 	public static final FlightDataType TYPE_VELOCITY_Z = newType(trans.get("FlightDataType.TYPE_VELOCITY_Z"), "Vz",
 			UnitGroup.UNITS_VELOCITY,
-			FlightDataTypeGroup.POSITION_AND_MOTION, 1);
+			FlightDataTypeGroup.POSITION_AND_MOTION, 2);
 	//// Total velocity
 	public static final FlightDataType TYPE_VELOCITY_TOTAL = newType(trans.get("FlightDataType.TYPE_VELOCITY_TOTAL"),
 			"Vt", UnitGroup.UNITS_VELOCITY,
-			FlightDataTypeGroup.POSITION_AND_MOTION, 2);
+			FlightDataTypeGroup.POSITION_AND_MOTION, 3);
 	//// Vertical acceleration
 	public static final FlightDataType TYPE_ACCELERATION_Z = newType(trans.get("FlightDataType.TYPE_ACCELERATION_Z"),
 			"Az", UnitGroup.UNITS_ACCELERATION,
-			FlightDataTypeGroup.POSITION_AND_MOTION, 3);
+			FlightDataTypeGroup.POSITION_AND_MOTION, 4);
 	//// Total acceleration
 	public static final FlightDataType TYPE_ACCELERATION_TOTAL = newType(
 			trans.get("FlightDataType.TYPE_ACCELERATION_TOTAL"), "At", UnitGroup.UNITS_ACCELERATION,
-			FlightDataTypeGroup.POSITION_AND_MOTION, 4);
+			FlightDataTypeGroup.POSITION_AND_MOTION, 5);
 
 	//// Lateral position and motion
 	//// Position East of launch
 	public static final FlightDataType TYPE_POSITION_X = newType(trans.get("FlightDataType.TYPE_POSITION_X"), "Px",
 			UnitGroup.UNITS_DISTANCE,
-			FlightDataTypeGroup.POSITION_AND_MOTION, 0);
+			FlightDataTypeGroup.POSITION_AND_MOTION, 10);
 	//// Position North of launch
 	public static final FlightDataType TYPE_POSITION_Y = newType(trans.get("FlightDataType.TYPE_POSITION_Y"), "Py",
 			UnitGroup.UNITS_DISTANCE,
-			FlightDataTypeGroup.POSITION_AND_MOTION, 1);
+			FlightDataTypeGroup.POSITION_AND_MOTION, 11);
 	//// Lateral distance
 	public static final FlightDataType TYPE_POSITION_XY = newType(trans.get("FlightDataType.TYPE_POSITION_XY"), "Pl",
 			UnitGroup.UNITS_DISTANCE,
-			FlightDataTypeGroup.POSITION_AND_MOTION, 2);
+			FlightDataTypeGroup.POSITION_AND_MOTION, 12);
 	//// Lateral direction
 	public static final FlightDataType TYPE_POSITION_DIRECTION = newType(
 			trans.get("FlightDataType.TYPE_POSITION_DIRECTION"), "\u03b8l", UnitGroup.UNITS_ANGLE,
-			FlightDataTypeGroup.POSITION_AND_MOTION, 3);
+			FlightDataTypeGroup.POSITION_AND_MOTION, 13);
 	//// Lateral velocity
 	public static final FlightDataType TYPE_VELOCITY_XY = newType(trans.get("FlightDataType.TYPE_VELOCITY_XY"), "Vl",
 			UnitGroup.UNITS_VELOCITY,
-			FlightDataTypeGroup.POSITION_AND_MOTION, 4);
+			FlightDataTypeGroup.POSITION_AND_MOTION, 14);
 	//// Lateral acceleration
 	public static final FlightDataType TYPE_ACCELERATION_XY = newType(trans.get("FlightDataType.TYPE_ACCELERATION_XY"),
 			"Al", UnitGroup.UNITS_ACCELERATION,
-			FlightDataTypeGroup.POSITION_AND_MOTION, 5);
+			FlightDataTypeGroup.POSITION_AND_MOTION, 15);
 	//// Latitude
 	public static final FlightDataType TYPE_LATITUDE = newType(trans.get("FlightDataType.TYPE_LATITUDE"), "\u03c6",
 			UnitGroup.UNITS_LATITUDE,
-			FlightDataTypeGroup.POSITION_AND_MOTION, 6);
+			FlightDataTypeGroup.POSITION_AND_MOTION, 16);
 	//// Longitude
 	public static final FlightDataType TYPE_LONGITUDE = newType(trans.get("FlightDataType.TYPE_LONGITUDE"), "\u03bb",
 			UnitGroup.UNITS_LONGITUDE,
-			FlightDataTypeGroup.POSITION_AND_MOTION, 7);
+			FlightDataTypeGroup.POSITION_AND_MOTION, 17);
 
 	// Orientation
 	//// Angle of attack
@@ -299,6 +303,7 @@ public class FlightDataType implements Comparable<FlightDataType>, Groupable<Fli
 	public static final FlightDataType[] ALL_TYPES = {
 			TYPE_TIME,
 			TYPE_ALTITUDE,
+			TYPE_ALTITUDE_ABOVE_SEA,
 			TYPE_VELOCITY_Z,
 			TYPE_ACCELERATION_Z,
 			TYPE_VELOCITY_TOTAL,

--- a/core/src/main/java/info/openrocket/core/simulation/SimulationStatus.java
+++ b/core/src/main/java/info/openrocket/core/simulation/SimulationStatus.java
@@ -277,20 +277,36 @@ public class SimulationStatus implements Cloneable, Monitorable {
 		return flightDataBranch;
 	}
 
+	/**
+	 * Set the rocket position relative to the launch site; at t = 0s, equals (0, 0, 0).
+	 * @param position the rocket position
+	 */
 	public void setRocketPosition(Coordinate position) {
 		this.position = position;
 		modID = new ModID();
 	}
 
+	/**
+	 * Get the rocket position relative to the launch site; at t = 0s, equals (0, 0, 0).
+	 * @return the rocket position
+	 */
 	public Coordinate getRocketPosition() {
 		return position;
 	}
 
+	/**
+	 * Set the rocket position in world coordinates (including the launch site altitude, longitude, and latitude).
+	 * @param wc the rocket position in world coordinates
+	 */
 	public void setRocketWorldPosition(WorldCoordinate wc) {
 		this.worldPosition = wc;
 		modID = new ModID();
 	}
 
+	/**
+	 * Get the rocket position in world coordinates (including the launch site altitude, longitude, and latitude).
+	 * @return the rocket position in world coordinates
+	 */
 	public WorldCoordinate getRocketWorldPosition() {
 		return worldPosition;
 	}

--- a/core/src/main/java/info/openrocket/core/simulation/SimulationStatus.java
+++ b/core/src/main/java/info/openrocket/core/simulation/SimulationStatus.java
@@ -586,6 +586,7 @@ public class SimulationStatus implements Cloneable, Monitorable {
 	public void storeData() {
 		flightDataBranch.setValue(FlightDataType.TYPE_TIME, getSimulationTime());
 		flightDataBranch.setValue(FlightDataType.TYPE_ALTITUDE, getRocketPosition().z);
+		flightDataBranch.setValue(FlightDataType.TYPE_ALTITUDE_ABOVE_SEA, getRocketWorldPosition().getAltitude());
 		flightDataBranch.setValue(FlightDataType.TYPE_POSITION_X, getRocketPosition().x);
 		flightDataBranch.setValue(FlightDataType.TYPE_POSITION_Y, getRocketPosition().y);
 		

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -2275,6 +2275,7 @@ FinSet.TabRelativePosition.END = Root chord trailing edge
 ! FlightDataType
 FlightDataType.TYPE_TIME = Time
 FlightDataType.TYPE_ALTITUDE = Altitude
+FlightDataType.TYPE_ALTITUDE_ABOVE_SEA = Altitude above sea level
 FlightDataType.TYPE_VELOCITY_Z = Vertical velocity
 FlightDataType.TYPE_ACCELERATION_Z = Vertical acceleration
 FlightDataType.TYPE_VELOCITY_TOTAL = Total velocity

--- a/core/src/test/java/info/openrocket/core/ServicesForTesting.java
+++ b/core/src/test/java/info/openrocket/core/ServicesForTesting.java
@@ -12,12 +12,14 @@ import info.openrocket.core.l10n.DebugTranslator;
 import info.openrocket.core.l10n.ResourceBundleTranslator;
 import info.openrocket.core.l10n.Translator;
 import info.openrocket.core.material.Material;
+import info.openrocket.core.models.atmosphere.ExtendedISAModel;
 import info.openrocket.core.preferences.ApplicationPreferences;
 import info.openrocket.core.preset.ComponentPreset;
 import info.openrocket.core.preset.ComponentPreset.Type;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provider;
+import info.openrocket.core.simulation.DefaultSimulationOptionFactory;
 
 public class ServicesForTesting extends AbstractModule {
 	
@@ -91,6 +93,12 @@ public class ServicesForTesting extends AbstractModule {
 		
 		@Override
 		public double getDouble(String key, double defaultValue) {
+			if (key.equals(ApplicationPreferences.LAUNCH_TEMPERATURE) || key.equals(DefaultSimulationOptionFactory.SIMCONDITION_ATMOS_TEMP)) {
+				return ExtendedISAModel.STANDARD_TEMPERATURE;
+			}
+			if (key.equals(ApplicationPreferences.LAUNCH_PRESSURE) || key.equals(DefaultSimulationOptionFactory.SIMCONDITION_ATMOS_PRESSURE)) {
+				return ExtendedISAModel.STANDARD_PRESSURE;
+			}
 			// TODO Auto-generated method stub
 			return 0;
 		}

--- a/core/src/test/java/info/openrocket/core/document/SimulationTest.java
+++ b/core/src/test/java/info/openrocket/core/document/SimulationTest.java
@@ -1,0 +1,132 @@
+package info.openrocket.core.document;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import info.openrocket.core.rocketcomponent.FlightConfiguration;
+import info.openrocket.core.rocketcomponent.FlightConfigurationId;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.simulation.FlightData;
+import info.openrocket.core.simulation.FlightEvent;
+import info.openrocket.core.simulation.SimulationOptions;
+import info.openrocket.core.simulation.exception.SimulationException;
+import info.openrocket.core.util.BaseTestCase;
+import info.openrocket.core.util.TestRockets;
+import info.openrocket.core.logging.SimulationAbort;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+
+public class SimulationTest extends BaseTestCase {
+	private static final double EPSILON = 0.0001;
+
+	private Rocket rocket;
+	private Simulation simulation;
+
+	@BeforeEach
+	public void setUpSim() {
+		rocket = TestRockets.makeEstesAlphaIII();
+		simulation = new Simulation(rocket);
+		simulation.setFlightConfigurationId(TestRockets.TEST_FCID_0);
+		simulation.getOptions().setISAAtmosphere(true);
+		simulation.getOptions().setTimeStep(0.05);
+	}
+
+	@Test
+	public void testBasicSimulationCreation() {
+		assertNotNull(simulation);
+		assertEquals(rocket, simulation.getRocket());
+		assertEquals(Simulation.Status.NOT_SIMULATED, simulation.getStatus());
+		assertEquals("", simulation.getName());
+	}
+
+	@Test
+	public void testSimulationName() {
+		String testName = "Test Flight #1";
+		simulation.setName(testName);
+		assertEquals(testName, simulation.getName());
+
+		simulation.setName(null);
+		assertEquals("", simulation.getName());
+	}
+
+	@Test
+	public void testSimulationCopy() {
+		simulation.setName("Original Sim");
+		simulation.getOptions().setLaunchRodLength(2.0);
+		simulation.getOptions().setLaunchRodAngle(45.0);
+
+		Simulation copy = simulation.copy();
+
+		assertNotNull(copy);
+		assertEquals(simulation.getName(), copy.getName());
+		assertEquals(simulation.getOptions().getLaunchRodLength(),
+				copy.getOptions().getLaunchRodLength(),
+				EPSILON);
+		assertEquals(simulation.getOptions().getLaunchRodAngle(),
+				copy.getOptions().getLaunchRodAngle(),
+				EPSILON);
+		assertEquals(Simulation.Status.NOT_SIMULATED, copy.getStatus());
+
+		// Verify copy is independent
+		copy.setName("Modified Copy");
+		assertNotEquals(simulation.getName(), copy.getName());
+	}
+
+	@Test
+	public void testSimulationWithNoMotors() throws SimulationException {
+		// Create configuration without motors
+		FlightConfiguration config = rocket.getFlightConfiguration(TestRockets.TEST_FCID_0);
+		config.clearAllMotors();
+
+		simulation.simulate();
+
+		// Verify simulation aborted due to no motors
+		FlightData data = simulation.getSimulatedData();
+		FlightEvent abort = data.getBranch(0).getLastEvent(FlightEvent.Type.SIM_ABORT);
+		assertNotNull(abort, "Simulation without motors should abort");
+		assertEquals(SimulationAbort.Cause.NO_MOTORS_DEFINED,
+				((SimulationAbort)abort.getData()).getCause());
+	}
+
+	@Test
+	public void testBasicSimulationExecution() throws SimulationException {
+		simulation.simulate();
+
+		FlightData data = simulation.getSimulatedData();
+		assertNotNull(data, "Simulation data should not be null");
+		assertTrue(data.getMaxAltitude() > 0, "Max altitude should be positive");
+		assertTrue(data.getMaxVelocity() > 0, "Max velocity should be positive");
+		assertTrue(data.getFlightTime() > 0, "Flight time should be positive");
+		assertEquals(Simulation.Status.UPTODATE, simulation.getStatus());
+	}
+
+	@Test
+	public void testConfigurationManagement() {
+		FlightConfigurationId newId = new FlightConfigurationId();
+		simulation.setFlightConfigurationId(newId);
+		assertEquals(newId, simulation.getFlightConfigurationId());
+
+		FlightConfiguration config = simulation.getActiveConfiguration();
+		assertNotNull(config);
+		assertEquals(newId, config.getFlightConfigurationID());
+	}
+
+	@Test
+	public void testOptionsModification() {
+		SimulationOptions options = simulation.getOptions();
+
+		// Modify some options
+		double rodLength = 2.0;
+		double rodAngle = 4 * Math.PI / 13;
+
+		options.setLaunchRodLength(rodLength);
+		options.setLaunchRodAngle(rodAngle);
+
+		// Verify changes are reflected
+		assertEquals(rodLength, options.getLaunchRodLength(), EPSILON);
+		assertEquals(rodAngle, options.getLaunchRodAngle(), EPSILON);
+
+		// Status should be outdated after options change
+		assertEquals(Simulation.Status.NOT_SIMULATED, simulation.getStatus());
+	}
+}

--- a/core/src/test/java/info/openrocket/core/simulation/FlightDataTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/FlightDataTest.java
@@ -13,7 +13,7 @@ import info.openrocket.core.logging.WarningSet;
  * 
  * @author Billy Olsen
  */
-public class TestFlightData {
+public class FlightDataTest {
 
 	/**
 	 * Test method for


### PR DESCRIPTION
This PR fixes #2700 and adds "Altitude above sea level" as a new flight data type. Example for launch site altitude set to 190 m:
<img width="1056" alt="Screenshot 2025-02-06 at 00 56 03" src="https://github.com/user-attachments/assets/5a4378bc-5df3-4052-b339-c76ea3135d6d" />
