### PR TITLE
[#2699] Extrapolate sea level atmospheric conditions if launch site altitude is above 0 &  [#2677] Limit launch site altitude to Troposphere 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
     id 'java'
     id 'checkstyle'
-    id 'org.javamodularity.moduleplugin' version '1.8.14'
+    id 'org.javamodularity.moduleplugin' version '1.8.15'
     id 'application'
 }
 
@@ -27,8 +27,8 @@ version = buildProperties['build.version']
 allprojects {
     repositories {
         mavenCentral()
-        maven { url "https://jitpack.io" }
-        maven { url "https://jogamp.org/deployment/maven/" }
+        maven { url = "https://jitpack.io" }
+        maven { url = "https://jogamp.org/deployment/maven/" }
     }
 }
 
@@ -93,8 +93,8 @@ jar {
 
 // Project dependencies
 dependencies {
-    implementation(project(":core"))
-    implementation(project(":swing"))
+    implementation(project(path: ":core", configuration: "default"))
+    implementation(project(path: ":swing", configuration: "default"))
 }
 
 shadowJar {

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ subprojects {
         testImplementation group: 'org.junit.platform', name: 'junit-platform-launcher', version: '1.10.2'
         testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.10.0'
         testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.10.0'
+        testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: '5.10.0'
         testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.10.0'
         testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.10.0'
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id 'com.github.johnrengelman.shadow'
     id 'java'
-    id 'com.adarshr.test-logger' version '3.2.0'
     id 'checkstyle'
+    id 'com.adarshr.test-logger' version '3.2.0'
     id 'org.gradlex.extra-java-module-info' version '1.8'
 }
 
@@ -18,7 +18,7 @@ version = buildProperties['build.version']
 
 repositories {
     mavenCentral()
-    maven { url "https://repository.mulesoft.org/nexus/content/repositories/public/" }
+    maven { url = "https://repository.mulesoft.org/nexus/content/repositories/public/" }
 }
 
 checkstyle {
@@ -26,10 +26,18 @@ checkstyle {
     maxWarnings = 0
 }
 
+configurations {
+    testArtifactsClasspath {
+        canBeConsumed = false
+        canBeResolved = true
+        visible = false  // Add this line
+    }
+}
+
 // Some older libraries are not modularized, so we need to add module-info.java files for them.
 extraJavaModuleInfo {
     failOnMissingModuleInfo.set(false)
-    module('obj-0.4.0.jar', 'de.javagl.obj', '0.4.0')
+    automaticModule('obj-0.4.0.jar', 'de.javagl.obj')
 }
 
 dependencies {

--- a/core/gradle/wrapper/gradle-wrapper.properties
+++ b/core/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/core/src/main/java/info/openrocket/core/models/atmosphere/AtmosphericConditions.java
+++ b/core/src/main/java/info/openrocket/core/models/atmosphere/AtmosphericConditions.java
@@ -5,18 +5,23 @@ import info.openrocket.core.util.MathUtil;
 import info.openrocket.core.util.Monitorable;
 import info.openrocket.core.util.ModID;
 
+/**
+ * Represents atmospheric conditions at a specific point, containing fundamental
+ * properties (temperature and pressure) and methods to calculate derived properties.
+ * This class serves as the basic unit of atmospheric data in the simulation.
+ */
 public class AtmosphericConditions implements Cloneable, Monitorable {
 
-	/** Specific gas constant of dry air. */
+	/** Specific gas constant of dry air (J/(kg*K)). */
 	public static final double R = 287.053;
 
-	/** Specific heat ratio of air. */
+	/** Specific heat ratio of air (dimensionless). */
 	public static final double GAMMA = 1.4;
 
-	/** The standard air pressure (1.01325 bar). */
+	/** The standard air pressure (Pa). */
 	public static final double STANDARD_PRESSURE = 101325.0;
 
-	/** The standard air temperature (20 degrees Celsius). */
+	/** The standard air temperature (K). */
 	public static final double STANDARD_TEMPERATURE = 293.15;
 
 	/** Air pressure, in Pascals. */
@@ -71,9 +76,14 @@ public class AtmosphericConditions implements Cloneable, Monitorable {
 	}
 
 	/**
-	 * Return the current density of air for dry air.
-	 * 
-	 * @return the current density of air.
+	 * Calculate the current density of air using the ideal gas law for dry air.
+	 * The formula used is rho = P/(R*T) where:
+	 * - rho is the density in kg/m3
+	 * - P is the pressure in Pa
+	 * - R is the specific gas constant for dry air
+	 * - T is the temperature in Kelvin
+	 *
+	 * @return The current air density in kg/m3
 	 */
 	public double getDensity() {
 		return getPressure() / (R * getTemperature());

--- a/core/src/main/java/info/openrocket/core/models/atmosphere/AtmosphericConditions.java
+++ b/core/src/main/java/info/openrocket/core/models/atmosphere/AtmosphericConditions.java
@@ -51,6 +51,9 @@ public class AtmosphericConditions implements Cloneable, Monitorable {
 	}
 
 	public void setPressure(double pressure) {
+		if (pressure <= 0) {
+			throw new IllegalArgumentException("Pressure must be positive (Pascals)");
+		}
 		this.pressure = pressure;
 		this.modID = new ModID();
 	}
@@ -60,6 +63,9 @@ public class AtmosphericConditions implements Cloneable, Monitorable {
 	}
 
 	public void setTemperature(double temperature) {
+		if (temperature <= 0) {
+			throw new IllegalArgumentException("Temperature must be positive (Kelvin)");
+		}
 		this.temperature = temperature;
 		this.modID = new ModID();
 	}

--- a/core/src/main/java/info/openrocket/core/models/atmosphere/AtmosphericModel.java
+++ b/core/src/main/java/info/openrocket/core/models/atmosphere/AtmosphericModel.java
@@ -2,8 +2,19 @@ package info.openrocket.core.models.atmosphere;
 
 import info.openrocket.core.util.Monitorable;
 
+/**
+ * Defines the base interface for atmospheric models in OpenRocket.
+ * An atmospheric model is responsible for providing atmospheric conditions
+ * (temperature, pressure, and derived properties) at any given altitude.
+ */
 public interface AtmosphericModel extends Monitorable {
 
-	public AtmosphericConditions getConditions(double altitude);
+	/**
+	 * Returns the atmospheric conditions at the specified altitude.
+	 *
+	 * @param altitude The altitude in meters above sea level (or launch site)
+	 * @return AtmosphericConditions object containing the conditions at that altitude
+	 */
+	AtmosphericConditions getConditions(double altitude);
 
 }

--- a/core/src/main/java/info/openrocket/core/models/atmosphere/ExtendedISAModel.java
+++ b/core/src/main/java/info/openrocket/core/models/atmosphere/ExtendedISAModel.java
@@ -5,31 +5,65 @@ import info.openrocket.core.util.MathUtil;
 import info.openrocket.core.util.ModID;
 
 /**
- * An atmospheric temperature/pressure model based on the International Standard
- * Atmosphere
- * (ISA). The no-argument constructor creates an {@link AtmosphericModel} that
- * corresponds
- * to the ISA model. It is extended by the other constructors to allow defining
- * a custom
- * first layer. The base temperature and pressure are as given, and all other
- * values
- * are calculated based on these.
- * <p>
+ * An atmospheric model based on the International Standard Atmosphere (ISA)
+ * with extensions for custom launch site conditions. This model divides the
+ * atmosphere into distinct layers based on the ISA standard, each with its
+ * own temperature and pressure characteristics.
+ *
+ * Key Features:
+ * 1. Implements standard ISA model by default
+ * 2. Supports custom launch site conditions
+ * 3. Maintains ISA behavior above launch site
+ * 4. Uses interpolation for efficient computation
+ *
+ * Layer Structure:
+ * - 0-11km (Troposphere): Temperature decreases linearly (288.15K -> 216.65K, -6.5 degC/km)
+ * - 11-20km (Tropopause): Temperature constant (216.65K)
+ * - 20-32km (Stratosphere 1): Temperature increases linearly (216.65K -> 228.65K, +1.0 degC/km)
+ * - 32-47km (Stratosphere 2): Temperature increases linearly (228.65K -> 270.65K, +2.8 degC/km)
+ * - 47-51km (Stratopause): Temperature constant (270.65K)
+ * - 51-71km (Mesosphere 1): Temperature decreases linearly (270.65K -> 214.65K, -2.8 degC/km)
+ * - 71-84.852km (Mesosphere 2): Temperature decreases linearly (214.65K -> 186.95K, -2.0 degC/km)
+ * - > 84.852km (Mesopause): Temperature constant (186.95K)
+ *
+ * Usage:
+ * 1. Standard ISA: new ExtendedISAModel()
+ * 2. Custom sea level: new ExtendedISAModel(temperature, pressure)
+ * 3. Custom altitude: new ExtendedISAModel(altitude, temperature, pressure)
+ *
+ *
  * TODO: LOW: Values at altitudes over 32km differ from standard results by ~5%.
- * 
+ *
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
 public class ExtendedISAModel extends InterpolatingAtmosphericModel {
-
+	/** Standard sea level temperature in Kelvin */
 	public static final double STANDARD_TEMPERATURE = 288.15;
+
+	/** Standard sea level pressure in Pascal */
 	public static final double STANDARD_PRESSURE = 101325;
 
+	/** Gravitational acceleration in m/s² */
 	private static final double G = 9.80665;
 
+	/**
+	 * ISA atmospheric layers.
+	 * Each element represents the altitude in meters where a new layer begins.
+	 */
 	private final double[] layer = { 0, 11000, 20000, 32000, 47000, 51000, 71000, 84852 };
+
+	/**
+	 * Base temperatures for each ISA layer in Kelvin.
+	 * These define the temperature profile of the standard atmosphere.
+	 */
 	private final double[] baseTemperature = {
 			288.15, 216.65, 216.65, 228.65, 270.65, 270.65, 214.65, 186.95
 	};
+
+	/**
+	 * Base pressures for each layer, computed based on the temperature profile
+	 * and the hydrostatic equation.
+	 */
 	private final double[] basePressure = new double[layer.length];
 
 	/**
@@ -59,9 +93,7 @@ public class ExtendedISAModel extends InterpolatingAtmosphericModel {
 	 * @param altitude    the altitude of the measurements.
 	 * @param temperature the temperature.
 	 * @param pressure    the pressure.
-	 * @throws IllegalArgumentException if the altitude exceeds the second layer
-	 *                                  boundary
-	 *                                  of the ISA model (over 11km).
+	 * @throws IllegalArgumentException if the altitude exceeds the second layer boundary of the ISA model (over 11km).
 	 */
 	public ExtendedISAModel(double altitude, double temperature, double pressure) {
 		if (altitude >= layer[1]) {
@@ -83,6 +115,12 @@ public class ExtendedISAModel extends InterpolatingAtmosphericModel {
 		}
 	}
 
+	/**
+	 * Calculates exact atmospheric conditions at the specified altitude by interpolating between ISA layers.
+	 * The pressure is calculated using the barometric formula, and the temperature is interpolated linearly.
+	 * @param altitude The altitude in meters
+	 * @return Atmospheric conditions at the specified altitude
+	 */
 	@Override
 	protected AtmosphericConditions getExactConditions(double altitude) {
 		altitude = MathUtil.clamp(altitude, layer[0], layer[layer.length - 1]);

--- a/core/src/main/java/info/openrocket/core/models/atmosphere/ExtendedISAModel.java
+++ b/core/src/main/java/info/openrocket/core/models/atmosphere/ExtendedISAModel.java
@@ -204,6 +204,14 @@ public class ExtendedISAModel extends InterpolatingAtmosphericModel {
 		return layer[layer.length - 1];
 	}
 
+	/**
+	 * Get the maximum allowed launch site altitude where the model is valid.
+	 * @return The maximum altitude in meters
+	 */
+	public static double getMaximumAllowedAltitude() {
+		return STANDARD_LAYERS[1] - 1;
+	}
+
 	public static void main(String[] foo) {
 		ExtendedISAModel model1 = new ExtendedISAModel();
 		ExtendedISAModel model2 = new ExtendedISAModel(278.15, 100000);

--- a/core/src/main/java/info/openrocket/core/models/atmosphere/ExtendedISAModel.java
+++ b/core/src/main/java/info/openrocket/core/models/atmosphere/ExtendedISAModel.java
@@ -67,6 +67,12 @@ public class ExtendedISAModel extends InterpolatingAtmosphericModel {
 		if (altitude >= layer[1]) {
 			throw new IllegalArgumentException("Too high first altitude: " + altitude);
 		}
+		if (temperature <= 0) {
+			throw new IllegalArgumentException("Temperature must be positive (Kelvin)");
+		}
+		if (pressure <= 0) {
+			throw new IllegalArgumentException("Pressure must be positive (Pascals)");
+		}
 
 		layer[0] = altitude;
 		baseTemperature[0] = temperature;

--- a/core/src/main/java/info/openrocket/core/models/atmosphere/InterpolatingAtmosphericModel.java
+++ b/core/src/main/java/info/openrocket/core/models/atmosphere/InterpolatingAtmosphericModel.java
@@ -1,18 +1,39 @@
 package info.openrocket.core.models.atmosphere;
 
 /**
- * An abstract atmospheric model that pre-computes the conditions on a number of
- * layers
- * and later linearly interpolates the values from between these layers.
- * 
+ * An abstract implementation of AtmosphericModel that uses pre-computed layers
+ * for efficient altitude lookups. This class implements a performance optimization
+ * strategy where atmospheric conditions are pre-calculated at fixed intervals
+ * (layers) and then interpolated between these layers when needed.
+ *
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
 public abstract class InterpolatingAtmosphericModel implements AtmosphericModel {
-	/** Layer thickness of interpolated altitude. */
+	/**
+	 * Layer thickness for interpolation in meters.
+	 * Set to 500m as a balance between accuracy and performance.
+	 * - Small enough to maintain good accuracy for typical rocket flights
+	 * - Large enough to keep memory usage and computation time reasonable
+	 */
 	private static final double DELTA = 500;
 
+	/** Cache of pre-computed atmospheric conditions at each layer. */
 	private AtmosphericConditions[] levels = null;
 
+	/**
+	 * Returns atmospheric conditions at the specified altitude using linear interpolation
+	 * between pre-computed layers. The first time this method is called, it triggers
+	 * the computation of all layers up to the maximum altitude.
+	 *
+	 * Process:
+	 * 1. If layers haven't been computed, compute them
+	 * 2. For altitudes below 0, return conditions at lowest layer
+	 * 3. For altitudes above max, return conditions at highest layer
+	 * 4. Otherwise, interpolate between nearest layers
+	 *
+	 * @param altitude The altitude in meters
+	 * @return Interpolated atmospheric conditions at the specified altitude
+	 */
 	@Override
 	public AtmosphericConditions getConditions(double altitude) {
 		if (levels == null)
@@ -49,7 +70,11 @@ public abstract class InterpolatingAtmosphericModel implements AtmosphericModel 
 		return c;
 	}
 
-	private void computeLayers() {
+	/**
+	 * Compute atmospheric conditions at fixed intervals from 0 m up to the maximum altitude.
+	 * @return Array of atmospheric conditions at each layer in DELTA intervals
+	 */
+	private AtmosphericConditions[] computeLayers() {
 		double max = getMaxAltitude();
 		int n = (int) (max / DELTA) + 1;
 		levels = new AtmosphericConditions[n];

--- a/core/src/main/java/info/openrocket/core/models/atmosphere/InterpolatingAtmosphericModel.java
+++ b/core/src/main/java/info/openrocket/core/models/atmosphere/InterpolatingAtmosphericModel.java
@@ -1,5 +1,7 @@
 package info.openrocket.core.models.atmosphere;
 
+import static info.openrocket.core.util.MathUtil.interpolate;
+
 /**
  * An abstract implementation of AtmosphericModel that uses pre-computed layers
  * for efficient altitude lookups. This class implements a performance optimization
@@ -19,6 +21,7 @@ public abstract class InterpolatingAtmosphericModel implements AtmosphericModel 
 
 	/** Cache of pre-computed atmospheric conditions at each layer. */
 	private AtmosphericConditions[] levels = null;
+	private final Object lock = new Object();
 
 	/**
 	 * Returns atmospheric conditions at the specified altitude using linear interpolation
@@ -36,38 +39,31 @@ public abstract class InterpolatingAtmosphericModel implements AtmosphericModel 
 	 */
 	@Override
 	public AtmosphericConditions getConditions(double altitude) {
-		if (levels == null)
-			computeLayers();
+		if (levels == null) {
+			synchronized (lock) {
+				levels = computeLayers();
+			}
+		}
 
 		if (altitude <= 0) {
-			// TODO: LOW: levels[0] returned null in some cases, see GitHub issue #952 for
-			// more information
-			if (levels[0] == null) {
-				computeLayers();
-			}
 			return levels[0];
 		}
-		if (altitude >= DELTA * (levels.length - 1)) {
-			// TODO: LOW: levels[levels.length - 1] returned null in some cases, see GitHub
-			// issue #952 for more information
-			if (levels[levels.length - 1] == null) {
-				computeLayers();
-			}
-			return levels[levels.length - 1];
+
+		int maxIndex = levels.length - 1;
+		if (altitude >= DELTA * maxIndex) {
+			return levels[maxIndex];
 		}
 
-		int n = (int) (altitude / DELTA);
-		double d = (altitude - n * DELTA) / DELTA;
-		AtmosphericConditions c = new AtmosphericConditions();
-		// TODO: LOW: levels[n] returned null in some cases, see GitHub issue #2180 for
-		// more information
-		if (levels[n] == null) {
-			computeLayers();
-		}
-		c.setTemperature(levels[n].getTemperature() * (1 - d) + levels[n + 1].getTemperature() * d);
-		c.setPressure(levels[n].getPressure() * (1 - d) + levels[n + 1].getPressure() * d);
+		int lowerIndex = (int) Math.floor(altitude / DELTA);
+		double fraction = (altitude - lowerIndex * DELTA) / DELTA;
 
-		return c;
+		AtmosphericConditions lower = levels[lowerIndex];
+		AtmosphericConditions upper = levels[lowerIndex + 1];
+
+		return new AtmosphericConditions(
+				interpolate(lower.getTemperature(), upper.getTemperature(), fraction),
+				interpolate(lower.getPressure(), upper.getPressure(), fraction)
+		);
 	}
 
 	/**
@@ -76,11 +72,13 @@ public abstract class InterpolatingAtmosphericModel implements AtmosphericModel 
 	 */
 	private AtmosphericConditions[] computeLayers() {
 		double max = getMaxAltitude();
-		int n = (int) (max / DELTA) + 1;
-		levels = new AtmosphericConditions[n];
-		for (int i = 0; i < n; i++) {
-			levels[i] = getExactConditions(i * DELTA);
+		int size = (int) Math.ceil(max / DELTA);
+		AtmosphericConditions[] newLevels = new AtmosphericConditions[size];
+
+		for (int i = 0; i < size; i++) {
+			newLevels[i] = getExactConditions(i * DELTA);
 		}
+		return newLevels;
 	}
 
 	protected abstract double getMaxAltitude();

--- a/core/src/main/java/info/openrocket/core/simulation/SimulationOptions.java
+++ b/core/src/main/java/info/openrocket/core/simulation/SimulationOptions.java
@@ -183,7 +183,7 @@ public class SimulationOptions implements ChangeSource, Cloneable, SimulationOpt
 	public void setLaunchAltitude(double altitude) {
 		if (MathUtil.equals(this.launchAltitude, altitude))
 			return;
-		this.launchAltitude = altitude;
+		this.launchAltitude = MathUtil.min(altitude, ExtendedISAModel.getMaximumAllowedAltitude());
 
 		// Update the launch temperature and pressure if using ISA
 		if (useISA) {

--- a/core/src/main/java/info/openrocket/core/simulation/SimulationOptionsInterface.java
+++ b/core/src/main/java/info/openrocket/core/simulation/SimulationOptionsInterface.java
@@ -43,12 +43,28 @@ public interface SimulationOptionsInterface extends ChangeSource {
 
 	void setISAAtmosphere(boolean isa);
 
+	/**
+	 * Get the launch temperature in Kelvin at the launch site.
+	 * @return the launch temperature in Kelvin
+	 */
 	double getLaunchTemperature();
 
+	/**
+	 * Set the launch temperature in Kelvin at the launch site.
+	 * @param launchTemperature the launch temperature in Kelvin
+	 */
 	void setLaunchTemperature(double launchTemperature);
 
+	/**
+	 * Get the launch pressure in Pascals at the launch site.
+	 * @return the launch pressure in Pascals
+	 */
 	double getLaunchPressure();
 
+	/**
+	 * Set the launch pressure in Pascals at the launch site.
+	 * @param launchPressure the launch pressure in Pascals
+	 */
 	void setLaunchPressure(double launchPressure);
 
 }

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -14,7 +14,7 @@ open module info.openrocket.core {
 	requires org.graalvm.sdk;
 	requires org.graalvm.js;
 	requires org.graalvm.truffle;
-	requires transitive de.javagl.obj;
+	requires de.javagl.obj;
 	requires com.sun.istack.runtime;
 	requires jakarta.activation;
 	requires jakarta.inject;

--- a/core/src/test/java/info/openrocket/core/models/atmosphere/AtmosphericConditionsTest.java
+++ b/core/src/test/java/info/openrocket/core/models/atmosphere/AtmosphericConditionsTest.java
@@ -26,7 +26,7 @@ public class AtmosphericConditionsTest {
 	@Test
 	@DisplayName("Density calculation should be correct for standard conditions")
 	void testDensityCalculation() {
-		// ρ = P/(R*T) where R = 287.053
+		// rho = P/(R*T) where R = 287.053
 		double expectedDensity = 101325.0 / (287.053 * 293.15);
 		assertEquals(expectedDensity, conditions.getDensity(), 0.001);
 	}
@@ -41,9 +41,9 @@ public class AtmosphericConditionsTest {
 
 	@ParameterizedTest
 	@CsvSource({
-			"273.15, 331.3",  // 0°C
-			"293.15, 343.2",  // 20°C (standard)
-			"313.15, 355.1"   // 40°C
+			"273.15, 331.3",  // 0 degC
+			"293.15, 343.2",  // 20 degC (standard)
+			"313.15, 355.1"   // 40 degC
 	})
 	@DisplayName("Mach speed calculation should be accurate")
 	void testMachSpeed(double tempK, double expectedSpeed) {

--- a/core/src/test/java/info/openrocket/core/models/atmosphere/AtmosphericConditionsTest.java
+++ b/core/src/test/java/info/openrocket/core/models/atmosphere/AtmosphericConditionsTest.java
@@ -1,0 +1,53 @@
+package info.openrocket.core.models.atmosphere;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+public class AtmosphericConditionsTest {
+	private AtmosphericConditions conditions;
+
+	@BeforeEach
+	void setUp() {
+		conditions = new AtmosphericConditions();  // Creates with standard conditions
+	}
+
+	@Test
+	@DisplayName("Constructor should set standard conditions correctly")
+	void testStandardConditions() {
+		assertEquals(293.15, conditions.getTemperature(), 0.001);
+		assertEquals(101325.0, conditions.getPressure(), 0.001);
+	}
+
+	@Test
+	@DisplayName("Density calculation should be correct for standard conditions")
+	void testDensityCalculation() {
+		// ρ = P/(R*T) where R = 287.053
+		double expectedDensity = 101325.0 / (287.053 * 293.15);
+		assertEquals(expectedDensity, conditions.getDensity(), 0.001);
+	}
+
+	@Test
+	@DisplayName("Should not allow negative temperature")
+	void testNegativeTemperature() {
+		assertThrows(IllegalArgumentException.class, () ->
+				conditions.setTemperature(-1.0)
+		);
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"273.15, 331.3",  // 0°C
+			"293.15, 343.2",  // 20°C (standard)
+			"313.15, 355.1"   // 40°C
+	})
+	@DisplayName("Mach speed calculation should be accurate")
+	void testMachSpeed(double tempK, double expectedSpeed) {
+		conditions.setTemperature(tempK);
+		assertEquals(expectedSpeed, conditions.getMachSpeed(), 1.0);
+	}
+}

--- a/core/src/test/java/info/openrocket/core/models/atmosphere/ExtendedISAModelTest.java
+++ b/core/src/test/java/info/openrocket/core/models/atmosphere/ExtendedISAModelTest.java
@@ -91,16 +91,16 @@ public class ExtendedISAModelTest {
 	}
 
 	@Test
-	@DisplayName("Should return launch site conditions for altitudes below launch site")
+	@DisplayName("Should return extrapolated launch site conditions for altitudes below launch site")
 	void testBelowLaunchSiteAltitude() {
 		AtmosphericConditions conditions500 = altitudeModel.getConditions(500.0);
 		AtmosphericConditions conditions0 = altitudeModel.getConditions(0.0);
 
 		// Should return launch site conditions for any altitude below launch site
-		assertEquals(281.15, conditions500.getTemperature(), 0.01);
-		assertEquals(89876.0, conditions500.getPressure(), 0.01);
-		assertEquals(281.15, conditions0.getTemperature(), 0.01);
-		assertEquals(89876.0, conditions0.getPressure(), 0.01);
+		assertEquals(284.375, conditions500.getTemperature(), 0.01);
+		assertEquals(95472.8, conditions500.getPressure(), 0.01);
+		assertEquals(287.6, conditions0.getTemperature(), 0.01);
+		assertEquals(101349.04, conditions0.getPressure(), 0.01);
 	}
 
 	@Test
@@ -159,7 +159,7 @@ public class ExtendedISAModelTest {
 		// Test conditions at launch site (2750m)
 		AtmosphericConditions conditions = interpolatedAltitudeModel.getConditions(2750.0);
 		assertEquals(271.15, conditions.getTemperature(), 0.01);
-		assertEquals(72500.0, conditions.getPressure(), 0.01);
+		assertEquals(72500.0, conditions.getPressure(), 50);
 
 		// Test conditions at interpolation layer boundaries
 		AtmosphericConditions lowerConditions = interpolatedAltitudeModel.getConditions(2600.0);

--- a/core/src/test/java/info/openrocket/core/models/atmosphere/ExtendedISAModelTest.java
+++ b/core/src/test/java/info/openrocket/core/models/atmosphere/ExtendedISAModelTest.java
@@ -1,0 +1,247 @@
+package info.openrocket.core.models.atmosphere;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.CsvSource;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+public class ExtendedISAModelTest {
+	private ExtendedISAModel standardModel;
+	private ExtendedISAModel customModel;
+	private ExtendedISAModel altitudeModel;
+	private ExtendedISAModel interpolatedAltitudeModel;
+
+	@BeforeEach
+	void setUp() {
+		standardModel = new ExtendedISAModel();
+		customModel = new ExtendedISAModel(278.15, 100000.0); // Custom conditions
+		// Create model for a launch site at 1000m with specific conditions
+		altitudeModel = new ExtendedISAModel(1000.0, 281.15, 89876.0);
+		// Create model for a launch site at 2750m (between 2500m and 3000m layers)
+		interpolatedAltitudeModel = new ExtendedISAModel(2750.0, 271.15, 72500.0);
+	}
+
+	@Test
+	@DisplayName("Standard ISA model should return correct sea level conditions")
+	void testStandardSeaLevel() {
+		AtmosphericConditions conditions = standardModel.getConditions(0);
+		assertEquals(288.15, conditions.getTemperature(), 0.01);
+		assertEquals(101325.0, conditions.getPressure(), 0.01);
+	}
+
+	@ParameterizedTest
+	@ValueSource(doubles = {-100.0, -1.0, 0.0}) // Test negative and zero altitudes
+	@DisplayName("Model should handle zero and negative altitudes gracefully")
+	void testNegativeAltitudes(double altitude) {
+		AtmosphericConditions conditions = standardModel.getConditions(altitude);
+		// Should return sea level conditions
+		assertEquals(288.15, conditions.getTemperature(), 0.01);
+		assertEquals(101325.0, conditions.getPressure(), 0.01);
+	}
+
+	@Test
+	@DisplayName("Custom model should return specified conditions at sea level")
+	void testCustomModelSeaLevel() {
+		AtmosphericConditions conditions = customModel.getConditions(0);
+		assertEquals(278.15, conditions.getTemperature(), 0.01);
+		assertEquals(100000.0, conditions.getPressure(), 0.01);
+	}
+
+	@Test
+	@DisplayName("Temperature should decrease with altitude in troposphere")
+	void testTemperatureGradientInTroposphere() {
+		AtmosphericConditions cond1 = standardModel.getConditions(0);
+		AtmosphericConditions cond2 = standardModel.getConditions(5000);
+		AtmosphericConditions cond3 = standardModel.getConditions(10000);
+
+		assertTrue(cond1.getTemperature() > cond2.getTemperature());
+		assertTrue(cond2.getTemperature() > cond3.getTemperature());
+	}
+
+	@Test
+	@DisplayName("Pressure should decrease with altitude")
+	void testPressureGradient() {
+		AtmosphericConditions cond1 = standardModel.getConditions(0);
+		AtmosphericConditions cond2 = standardModel.getConditions(5000);
+		AtmosphericConditions cond3 = standardModel.getConditions(10000);
+
+		assertTrue(cond1.getPressure() > cond2.getPressure());
+		assertTrue(cond2.getPressure() > cond3.getPressure());
+	}
+
+	@Test
+	@DisplayName("Model should handle very high altitudes")
+	void testHighAltitude() {
+		AtmosphericConditions conditions = standardModel.getConditions(80000);
+		// Mainly checking that it doesn't throw exceptions
+		assertTrue(conditions.getTemperature() > 0);
+		assertTrue(conditions.getPressure() > 0);
+	}
+
+	@Test
+	@DisplayName("Should respect launch site conditions at specified altitude")
+	void testLaunchSiteConditions() {
+		AtmosphericConditions conditions = altitudeModel.getConditions(1000.0);
+		assertEquals(281.15, conditions.getTemperature(), 0.01);
+		assertEquals(89876.0, conditions.getPressure(), 0.01);
+	}
+
+	@Test
+	@DisplayName("Should return launch site conditions for altitudes below launch site")
+	void testBelowLaunchSiteAltitude() {
+		AtmosphericConditions conditions500 = altitudeModel.getConditions(500.0);
+		AtmosphericConditions conditions0 = altitudeModel.getConditions(0.0);
+
+		// Should return launch site conditions for any altitude below launch site
+		assertEquals(281.15, conditions500.getTemperature(), 0.01);
+		assertEquals(89876.0, conditions500.getPressure(), 0.01);
+		assertEquals(281.15, conditions0.getTemperature(), 0.01);
+		assertEquals(89876.0, conditions0.getPressure(), 0.01);
+	}
+
+	@Test
+	@DisplayName("Should calculate correct conditions above launch site")
+	void testAboveLaunchSiteAltitude() {
+		AtmosphericConditions conditions2000 = altitudeModel.getConditions(2000.0);
+		AtmosphericConditions conditions3000 = altitudeModel.getConditions(3000.0);
+
+		// Temperature and pressure should decrease with altitude
+		assertTrue(conditions2000.getTemperature() < 281.15);
+		assertTrue(conditions2000.getPressure() < 89876.0);
+		assertTrue(conditions3000.getTemperature() < conditions2000.getTemperature());
+		assertTrue(conditions3000.getPressure() < conditions2000.getPressure());
+	}
+
+	@Test
+	@DisplayName("Should handle edge cases in launch site parameters")
+	void testEdgeCases() {
+		// Test negative altitude
+		assertDoesNotThrow(() ->
+				new ExtendedISAModel(-100.0, 288.15, 101325.0)
+		);
+
+		// Test zero pressure
+		assertThrows(IllegalArgumentException.class, () ->
+				new ExtendedISAModel(1000.0, 288.15, 0.0)
+		);
+
+		// Test zero temperature
+		assertThrows(IllegalArgumentException.class, () ->
+				new ExtendedISAModel(1000.0, 0.0, 101325.0)
+		);
+
+		// Test negative pressure
+		assertThrows(IllegalArgumentException.class, () ->
+				new ExtendedISAModel(1000.0, 288.15, -1000.0)
+		);
+
+		// Test negative temperature
+		assertThrows(IllegalArgumentException.class, () ->
+				new ExtendedISAModel(1000.0, -273.15, 101325.0)
+		);
+	}
+
+	@Test
+	@DisplayName("Should throw exception for launch sites above 11km")
+	void testTooHighLaunchSite() {
+		assertThrows(IllegalArgumentException.class, () ->
+				new ExtendedISAModel(12000.0, 220.0, 25000.0)
+		);
+	}
+
+	@Test
+	@DisplayName("Should handle launch site between interpolation layers")
+	void testInterpolatedLaunchSite() {
+		// Test conditions at launch site (2750m)
+		AtmosphericConditions conditions = interpolatedAltitudeModel.getConditions(2750.0);
+		assertEquals(271.15, conditions.getTemperature(), 0.01);
+		assertEquals(72500.0, conditions.getPressure(), 0.01);
+
+		// Test conditions at interpolation layer boundaries
+		AtmosphericConditions lowerConditions = interpolatedAltitudeModel.getConditions(2600.0);
+		AtmosphericConditions upperConditions = interpolatedAltitudeModel.getConditions(2900.0);
+
+		// Verify conditions at launch site are between layer boundary conditions
+		assertTrue(lowerConditions.getTemperature() >= conditions.getTemperature());
+		assertTrue(upperConditions.getTemperature() <= conditions.getTemperature());
+		assertTrue(lowerConditions.getPressure() >= conditions.getPressure());
+		assertTrue(upperConditions.getPressure() <= conditions.getPressure());
+	}
+
+	@Test
+	@DisplayName("Should properly interpolate around non-standard launch altitude")
+	void testInterpolationAroundLaunchSite() {
+		// Test points around the 2750m launch site (temperature should decrease with altitude in the troposphere)
+		double[] testAltitudes = {2600.0, 2700.0, 2750.0, 2800.0, 2900.0};
+		AtmosphericConditions[] conditions = new AtmosphericConditions[testAltitudes.length];
+
+		// Get conditions at each test altitude
+		for (int i = 0; i < testAltitudes.length; i++) {
+			conditions[i] = interpolatedAltitudeModel.getConditions(testAltitudes[i]);
+		}
+
+		// Verify monotonic decrease in temperature and pressure
+		for (int i = 1; i < conditions.length; i++) {
+			assertTrue(conditions[i].getTemperature() <= conditions[i-1].getTemperature(),
+					"Temperature should decrease or remain constant with altitude");
+			assertTrue(conditions[i].getPressure() <= conditions[i-1].getPressure(),
+					"Pressure should decrease or remain constant with altitude");
+		}
+
+		// Check for smooth transitions (no sudden jumps)
+		for (int i = 1; i < conditions.length - 1; i++) {
+			double currTemp = conditions[i].getTemperature();
+			double prevTemp = conditions[i-1].getTemperature();
+			double nextTemp = conditions[i+1].getTemperature();
+
+			// Differences between consecutive points should be similar (within 20%)
+			assertTrue(currTemp < prevTemp, "Temperature should decrease with altitude in the troposphere");
+			assertTrue(nextTemp < currTemp, "Temperature should decrease with altitude in the troposphere");
+		}
+	}
+
+	@ParameterizedTest
+	@CsvSource({
+			"1000.0, 281.15, 89876.0",   // Mountain launch site
+			"500.0, 285.15, 95461.0",    // Hill launch site
+			"2000.0, 275.15, 79501.0"    // High altitude launch site
+	})
+	@DisplayName("Should handle various launch site conditions correctly")
+	void testVariousLaunchSites(double altitude, double temperature, double pressure) {
+		ExtendedISAModel model = new ExtendedISAModel(altitude, temperature, pressure);
+		AtmosphericConditions conditions = model.getConditions(altitude);
+
+		assertEquals(temperature, conditions.getTemperature(), 0.01);
+		assertEquals(pressure, conditions.getPressure(), 0.01);
+
+		// Test that conditions change appropriately above launch site
+		AtmosphericConditions higherConditions = model.getConditions(altitude + 1000);
+		assertTrue(higherConditions.getTemperature() < temperature);
+		assertTrue(higherConditions.getPressure() < pressure);
+	}
+
+	@Test
+	@DisplayName("Should maintain realistic atmosphere model above launch site")
+	void testAtmosphericModelContinuity() {
+		// Create two measurement points above launch site
+		AtmosphericConditions conditions2000 = altitudeModel.getConditions(2000.0);
+		AtmosphericConditions conditions2500 = altitudeModel.getConditions(2500.0);
+
+		// Calculate approximate lapse rate (temperature change with altitude)
+		double lapseRate = (conditions2500.getTemperature() - conditions2000.getTemperature()) / 500.0;
+
+		// Standard tropospheric lapse rate is approximately -0.0065 K/m
+		// Check if our model produces reasonable results
+		assertTrue(lapseRate < 0, "Temperature should decrease with altitude");
+		assertTrue(lapseRate > -0.01, "Temperature shouldn't decrease too rapidly");
+
+		// Check pressure ratio is reasonable
+		double pressureRatio = conditions2500.getPressure() / conditions2000.getPressure();
+		assertTrue(pressureRatio < 1.0, "Pressure should decrease with altitude");
+		assertTrue(pressureRatio > 0.9, "Pressure shouldn't decrease too rapidly over 500m");
+	}
+}

--- a/core/src/test/java/info/openrocket/core/models/atmosphere/InterpolatingAtmosphericModelTest.java
+++ b/core/src/test/java/info/openrocket/core/models/atmosphere/InterpolatingAtmosphericModelTest.java
@@ -1,0 +1,33 @@
+package info.openrocket.core.models.atmosphere;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class InterpolatingAtmosphericModelTest {
+	private ExtendedISAModel model; // Using ExtendedISAModel to test interpolation
+
+	@BeforeEach
+	void setUp() {
+		model = new ExtendedISAModel();
+	}
+
+	@Test
+	@DisplayName("Interpolation should be smooth between layers")
+	void testSmoothInterpolation() {
+		// Test points between 500m layers
+		AtmosphericConditions cond1 = model.getConditions(250);
+		AtmosphericConditions cond2 = model.getConditions(500);
+		AtmosphericConditions cond3 = model.getConditions(750);
+
+		// Check that values are monotonic
+		assertTrue(cond1.getPressure() >= cond2.getPressure());
+		assertTrue(cond2.getPressure() >= cond3.getPressure());
+
+		// Check for no sudden jumps (testing smoothness)
+		double pressureDiff1 = Math.abs(cond1.getPressure() - cond2.getPressure());
+		double pressureDiff2 = Math.abs(cond2.getPressure() - cond3.getPressure());
+		assertTrue(Math.abs(pressureDiff1 - pressureDiff2) < pressureDiff1 * 0.1); // Within 10%
+	}
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     plugins {
-        id("com.github.johnrengelman.shadow") version "7.1.2"
+        id("com.github.johnrengelman.shadow") version "8.1.1"
     }
 }
 rootProject.name = 'info.openrocket'

--- a/swing/build.gradle
+++ b/swing/build.gradle
@@ -18,8 +18,8 @@ version = buildProperties['build.version']
 
 repositories {
     mavenCentral()
-    maven { url "https://jitpack.io" }
-    maven { url "https://jogamp.org/deployment/maven/" }
+    maven { url = "https://jitpack.io" }
+    maven { url = "https://jogamp.org/deployment/maven/" }
 }
 
 checkstyle {
@@ -31,15 +31,16 @@ configurations {
     testArtifactsClasspath {
         canBeConsumed = false
         canBeResolved = true
+        visible = false
     }
 }
 
 // Some older libraries are not modularized, so we need to add module-info.java files for them.
 extraJavaModuleInfo {
     failOnMissingModuleInfo.set(false)
-    module('slf4j-api-1.7.25.jar', 'org.slf4j.api', '1.7.25')
-    module('slf4j-api-1.7.32.jar', 'org.slf4j.api', '1.7.32')
-    module('versioncompare-1.5.0.jar', 'versioncompare', '1.5.0')
+    automaticModule('slf4j-api-1.7.25.jar', 'org.slf4j.api')
+    automaticModule('slf4j-api-1.7.32.jar', 'org.slf4j.api')
+    automaticModule('versioncompare-1.5.0.jar', 'versioncompare')
     module('gluegen-rt-2.5.0.jar', 'org.jogamp.gluegen.rt', '2.5.0') {
         requires('java.desktop')
         exportAllPackages()
@@ -53,16 +54,16 @@ extraJavaModuleInfo {
         requires('java.desktop')
         exportAllPackages()
     }
-    module('itextpdf-5.5.13.3.jar', 'itextpdf', '5.5.13.3') {
+    module('itextpdf-5.5.13.3.jar', 'itextpdf') {
         requires('java.desktop')
         exportAllPackages()
     }
 
-    module('obj-0.4.0.jar', 'de.javagl.obj', '0.4.0')
+    automaticModule('obj-0.4.0.jar', 'de.javagl.obj')
 }
 
 dependencies {
-    implementation project(':core')
+    implementation(project(path: ':core', configuration: 'default'))
 
     implementation 'de.javagl:obj:0.4.0'
 

--- a/swing/gradle/wrapper/gradle-wrapper.properties
+++ b/swing/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConditionsPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConditionsPanel.java
@@ -276,7 +276,7 @@ public class SimulationConditionsPanel extends JPanel {
 		label.setToolTipText(tip);
 		sub.add(label);
 
-		m = new DoubleModel(target, "LaunchAltitude", UnitGroup.UNITS_DISTANCE, 0);
+		m = new DoubleModel(target, "LaunchAltitude", UnitGroup.UNITS_DISTANCE, 0, ExtendedISAModel.getMaximumAllowedAltitude());
 
 		spin = new JSpinner(m.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));


### PR DESCRIPTION
This PR fixes 2 issues:

Fixes #2699, where air temperature and pressure interpolation failed if the launch site altitude was above 0. The issue was caused by `ExtendedISAModel` setting `layer[0]` to the launch site conditions, affecting interpolation in `InterpolatingAtmosphericModel`. When `InterpolatingAtmosphericModel` runs the `computeLayers` method, it does so by calculating the atmospheric conditions at 500 m incrementing air layers, starting at sea level (altitude = 0 m), and ending at the maximum altitude for the model.

If you set the launch site altitude to 250 m, so in the middle of an air layer (between level 0 m and level 500 m), `InterpolatingAtmosphericModel.getConditions` will calculate the temperature and pressure at that altitude using interpolation of the level below it (0 m) and above it (500 m). However, for 0 m, `ExtendedISAModel.getExactConditions` would return the temperature and pressure of the launch site (250 m) because the lowest layer of the model, `layer[0]` was set to the launch site conditions and  in`getExactConditions`, the altitude would get clamped `altitude = MathUtil.clamp(altitude, layer[0], layer[layer.length - 1]);`.

The result is a 50% interpolation between the 250 m (should be 0 m) and 500 m conditions, whereas you want the 250 m conditions.

To fix this, if the launch site altitude is > 0, I do not replace `layer[0]` with the launch site conditions. Instead, I add the launch site conditions as a new layer between `layer[0]` and `layer[1]`, and extrapolate the conditions at sea level (altitude 0) to `layer[0]`. Now, `InterpolatingAtmosphericModel.getConditions` will still interpolate between level 0 m and 500 m, but the resulting interpolation at 250 m is the same as the original launch site conditions (well, almost, there is a very slight difference for the pressure because of rounding errors or something).

Added unit tests for the atmospheric models. I also prepared our Gradle build setting somewhat for Gradle version 9.0, as I kept getting warnings.

Before (pressure at the launch site is much lower than the set 990.66 mbar):
<img width="1028" alt="Screenshot 2025-02-08 at 01 49 56" src="https://github.com/user-attachments/assets/aa04cbde-ce6e-4e7a-a539-12458638682c" />

After (correct starting pressure):
<img width="1056" alt="Screenshot 2025-02-08 at 01 50 05" src="https://github.com/user-attachments/assets/c455ecf1-d37a-4b4a-9030-aeef4570c85f" />


---

Fixes #2677, where the user could enter a launch site altitude greater than what `ExtendedISAModel` could interpolate, i.e. if the launch site altitude is > 11 km (entering the Tropopause; `layer[1]`). The altitude is now limited both in the UI and in the `SimulationOptions`.