### PR TITLE
Select between all the possible steppers when starting a new simulation branch

### DIFF
--- a/core/src/main/java/info/openrocket/core/simulation/BasicEventSimulationEngine.java
+++ b/core/src/main/java/info/openrocket/core/simulation/BasicEventSimulationEngine.java
@@ -146,13 +146,22 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 	
 	private void simulateLoop(SimulationConditions simulationConditions) throws SimulationException {
 		// Initialize the simulation.
-		
-		// Initialize the simulation. We'll use the flight stepper unless we're already
-		// on the ground.
-		if (currentStatus.isLanded())
+
+		// Select the appropriate stepper:
+		//     On the ground: ground stepper
+		//     Tumbling: tumble stepper
+		//     At least one recovery device deployed: landing stepper
+		//     Otherwise: flight stepper
+
+		if (currentStatus.isLanded()) {
 			currentStepper = groundStepper;
-		else
+		} else if (currentStatus.isTumbling()) {
+			currentStepper = tumbleStepper;
+		} else if (!currentStatus.getDeployedRecoveryDevices().isEmpty()) {
+			currentStepper = landingStepper;
+		} else {
 			currentStepper = flightStepper;
+		}
 
 		currentStatus = currentStepper.initialize(currentStatus);
 		double previousSimulationTime = currentStatus.getSimulationTime();


### PR DESCRIPTION
The cause of issue #2675 was that when a new simulation branch was started, the stepper to be used for the new branch was only selected based on whether the rocket was in the air (the flight stepper) or on the ground (the ground stepper). Consequently, even though the booster in the example rocket was under chute it was simulated by the flight stepper and came in ballistic.

This PR also checks if the rocket is under chute or tumbling, and selects the correct stepper for these cases. Here's the booster from the same sim as in the bug report:
![booster--late-separation](https://github.com/user-attachments/assets/b9780fe6-3ea7-48a0-be8d-0b504600d17f)
This time, the booster can be seen to be descending under chute.