### PR TITLE
 [#2676] Migrate old net.sf.openrocket plugins at startup 

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 
     implementation 'de.javagl:obj:0.4.0'
 
+    implementation group: 'org.ow2.asm', name: 'asm', version: '9.7.1'
+    implementation group: 'org.ow2.asm', name: 'asm-commons', version: '9.7.1'
+
     implementation group: 'jakarta.activation', name: 'jakarta.activation-api', version: '2.1.2'
     implementation group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '4.0.5'
     implementation group: 'org.glassfish', name: 'jakarta.json', version: '2.0.1'

--- a/core/src/main/java/info/openrocket/core/plugin/JarMigrationHelper.java
+++ b/core/src/main/java/info/openrocket/core/plugin/JarMigrationHelper.java
@@ -1,0 +1,228 @@
+package info.openrocket.core.plugin;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.commons.ClassRemapper;
+import org.objectweb.asm.commons.Remapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarInputStream;
+import java.util.jar.JarOutputStream;
+
+/**
+ * Helper class for migrating JAR files from the old OpenRocket package structure (net.sf.openrocket) to the new
+ * structure (info.openrocket.core and info.openrocket.swing).
+ * <p>
+ * The migration process involves remapping the package names in the JAR file using ASM.
+ *
+ * @author Sibo Van Gool <sibo.vangool@hotmail.com>
+ */
+public class JarMigrationHelper {
+	private static final Logger log = LoggerFactory.getLogger(JarMigrationHelper.class);
+
+	private static final String OLD_PACKAGE_PREFIX = "net.sf.openrocket";
+	public static final String MIGRATION_SUFFIX = "-migrated";
+	public static final String NEW_MIGRATION_SUFFIX = "-new";
+
+	/**
+	 * Exception thrown when an error occurs while migrating a JAR file.
+	 */
+	public static class JarMigrationException extends Exception {
+		public JarMigrationException(String message) {
+			super(message);
+		}
+	}
+
+	/**
+	 * Check if the JAR file is still using the old OpenRocket package structure (net.sf.openrocket), and that it has
+	 * not been migrated before.
+	 * @param jarFile The JAR file to check.
+	 * @param allJars All JAR files in the plugin directory.
+	 * @return True if the JAR file should be migrated.
+	 * @throws JarMigrationException If an error occurs while checking the JAR file.
+	 */
+	public static boolean shouldMigrate(File jarFile, List<File> allJars) throws JarMigrationException {
+		return containsOldPackage(jarFile) && !isMigrated(jarFile, allJars);
+	}
+
+	/**
+	 * Check if the JAR file has already been migrated.
+	 * @param jarFile The JAR file to check.
+	 * @param allJars All JAR files in the plugin directory.
+	 * @return True if the JAR file has already been migrated.
+	 */
+	private static boolean isMigrated(File jarFile, List<File> allJars) {
+		if (jarFile.getName().contains(MIGRATION_SUFFIX)) {
+			return true;
+		}
+
+		// Check if another JAR in the list is the migrated version of this JAR
+		String migratedName = getMigratedName(jarFile);
+
+		for (File f : allJars) {
+			if (f.getName().equals(migratedName)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the name of the migrated JAR file.
+	 * @param jarFile The original JAR file.
+	 * @return The name of the migrated JAR file.
+	 */
+	private static String getMigratedName(File jarFile) {
+		return jarFile.getName().replaceFirst("\\.jar$", MIGRATION_SUFFIX + NEW_MIGRATION_SUFFIX + ".jar");
+	}
+
+	/**
+	 * Check if the JAR file still contains classes in the old OpenRocket package structure (net.sf.openrocket).
+	 * @param jarFile The JAR file to check.
+	 * @return True if the JAR file contains classes in the old package structure.
+	 * @throws JarMigrationException If an error occurs while checking the JAR file.
+	 */
+	private static boolean containsOldPackage(File jarFile) throws JarMigrationException {
+		try (JarInputStream jin = new JarInputStream(new FileInputStream(jarFile))) {
+			JarEntry entry;
+			while ((entry = jin.getNextJarEntry()) != null) {
+				String name = entry.getName();
+				if (name.replace('/', '.').startsWith(OLD_PACKAGE_PREFIX)) {
+					return true;
+				}
+			}
+		} catch (IOException e) {
+			String msg = String.format("Error checking JAR file %s: %s", jarFile.getName(), e.getMessage());
+			log.error(msg);
+			throw new JarMigrationException(msg);
+		}
+		return false;
+	}
+
+	/**
+	 * Migrate the JAR file to the new OpenRocket package structure (info.openrocket.core and info.openrocket.swing).
+	 * @param inputJar The JAR file to migrate.
+	 * @return The migrated JAR file.
+	 * @throws JarMigrationException If an error occurs while migrating the JAR file.
+	 */
+	public static File migrateJarFile(File inputJar) throws JarMigrationException {
+		final String migratedName = getMigratedName(inputJar);
+		final File migratedJar = new File(inputJar.getParent(), migratedName);
+
+		CustomRemapper remapper = new CustomRemapper();
+
+		try (JarFile jar = new JarFile(inputJar);
+			 JarOutputStream jos = new JarOutputStream(new FileOutputStream(migratedJar))) {
+
+			jar.stream().forEach(entry -> {
+				try (InputStream is = jar.getInputStream(entry)) {
+					String name = entry.getName();
+					String newName = name;
+					// Only remap entries in net/sf/openrocket
+					if (name.startsWith("net/sf/openrocket/")) {
+						newName = remapper.map(name);
+					}
+					// Skip leftover net/sf entries.
+					if (newName.startsWith("net/sf/") || newName.startsWith("net")) {
+						return;
+					}
+					JarEntry newEntry = new JarEntry(newName);
+					jos.putNextEntry(newEntry);
+					if (!entry.isDirectory()) {
+						byte[] data;
+						if (name.endsWith(".class")) {
+							// Remap class files using ASM.
+							ClassReader reader = new ClassReader(is);
+							ClassWriter writer = new ClassWriter(reader, 0);
+							ClassRemapper classRemapper = new ClassRemapper(writer, remapper);
+							reader.accept(classRemapper, 0);
+							data = writer.toByteArray();
+						} else {
+							// Copy other resources as is.
+							data = is.readAllBytes();
+						}
+						jos.write(data);
+					}
+					jos.closeEntry();
+				} catch (IOException e) {
+					throw new RuntimeException(e.getMessage());
+				}
+			});
+		} catch (IOException | RuntimeException e) {
+			if (migratedJar.exists()) {
+				migratedJar.delete();
+			}
+			String msg = String.format("Error migrating JAR file %s: %s", migratedJar.getName(), e.getMessage());
+			log.error(msg);
+			throw new JarMigrationException(e.getMessage());
+		}
+
+		log.info("Migrated JAR file: {}", migratedJar.getName());
+		return migratedJar;
+	}
+
+	/**
+	 * Custom remapper that remaps classes in net/sf/openrocket to info/openrocket/core or info/openrocket/swing.
+	 * If the class belongs to a common package, it checks if the class exists in core. If it does, it remaps to core,
+	 * otherwise it remaps to swing.
+	 * If the class belongs to a swing exclusive package, it remaps to swing.
+	 * All other classes default to core.
+	 */
+	public static class CustomRemapper extends Remapper {
+		private static final Set<String> commonPackages;
+		private static final Set<String> swingExclusivePackages;
+
+		static {
+			commonPackages = Set.of("communication", "file", "logging", "simulation/extension", "startup", "utils");
+			swingExclusivePackages = Set.of("gui");
+		}
+
+		@Override
+		public String map(String internalName) {
+			// Only remap classes in net/sf/openrocket
+			if (internalName.startsWith("net/sf/openrocket/")) {
+				String rest = internalName.substring("net/sf/openrocket/".length());
+
+				// 1. If it belongs to a swing exclusive package, map to swing.
+				for (String swingPkg : swingExclusivePackages) {
+					if (rest.startsWith(swingPkg + "/")) {
+						return "info/openrocket/swing/" + rest;
+					}
+				}
+
+				// 2. If it belongs to a common package, check if it exists in core.
+				for (String commonPkg : commonPackages) {
+					if (rest.startsWith(commonPkg + "/")) {
+						String coreCandidate = "info/openrocket/core/" + rest;
+						if (resourceExists(coreCandidate)) {
+							return coreCandidate;
+						} else {
+							return "info/openrocket/swing/" + rest;
+						}
+					}
+				}
+
+				// 3. All other classes default to core.
+				return "info/openrocket/core/" + rest;
+			}
+			return internalName;
+		}
+
+		private boolean resourceExists(String internalName) {
+			// Look for the .class resource in the classpath
+			String resourcePath = internalName + ".class";
+			return getClass().getClassLoader().getResource(resourcePath) != null;
+		}
+	}
+}

--- a/core/src/main/java/info/openrocket/core/simulation/SimulationOptions.java
+++ b/core/src/main/java/info/openrocket/core/simulation/SimulationOptions.java
@@ -176,6 +176,55 @@ public class SimulationOptions implements ChangeSource, Cloneable, SimulationOpt
 		return multiLevelPinkNoiseWindModel;
 	}
 
+	// Deprecated wind methods to keep compatibility with old plugins (e.g. the original multi-level wind code)
+	@Deprecated
+	public double getWindSpeedAverage() {
+		setWindModelType(WindModelType.AVERAGE);
+		return averageWindModel.getAverage();
+	}
+
+	@Deprecated
+	public void setWindSpeedAverage(double windAverage) {
+		setWindModelType(WindModelType.AVERAGE);
+		averageWindModel.setAverage(windAverage);
+	}
+
+	@Deprecated
+	public double getWindSpeedDeviation() {
+		setWindModelType(WindModelType.AVERAGE);
+		return averageWindModel.getStandardDeviation();
+	}
+
+	@Deprecated
+	public void setWindSpeedDeviation(double windDeviation) {
+		setWindModelType(WindModelType.AVERAGE);
+		averageWindModel.setStandardDeviation(windDeviation);
+	}
+
+	@Deprecated
+	public double getWindTurbulenceIntensity() {
+		setWindModelType(WindModelType.AVERAGE);
+		return averageWindModel.getTurbulenceIntensity();
+	}
+
+	@Deprecated
+	public void setWindTurbulenceIntensity(double intensity) {
+		setWindModelType(WindModelType.AVERAGE);
+		averageWindModel.setTurbulenceIntensity(intensity);
+	}
+
+	@Deprecated
+	public double getWindDirection() {
+		setWindModelType(WindModelType.AVERAGE);
+		return averageWindModel.getDirection();
+	}
+
+	@Deprecated
+	public void setWindDirection(double direction) {
+		setWindModelType(WindModelType.AVERAGE);
+		averageWindModel.setDirection(direction);
+	}
+
 	public double getLaunchAltitude() {
 		return launchAltitude;
 	}

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -26,6 +26,7 @@ open module info.openrocket.core {
 	requires com.opencsv;
 	requires org.commonmark;
 	requires org.locationtech.jts;
+	requires org.objectweb.asm.commons;
 
 	// TODO: I'm a JPMS noob, so I just exported each package. Should really check which ones are actually needed.
 	exports info.openrocket.core.aerodynamics;

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -15,6 +15,9 @@
 ! Set to the name of the current translation file (used for debugging purposes)
 debug.currentFile = messages.properties
 
+! SwingStartup
+SwingStartup.pluginMigrated = The plugin '%s' has been migrated to '%s' to be compatible with the current version of OpenRocket.
+
 ! RocketActions
 RocketActions.DelCompAct.Delete = Delete
 RocketActions.DelCompAct.ttip.Delete = Delete the selected components.

--- a/swing/src/main/java/info/openrocket/swing/startup/jij/PluginClasspathProvider.java
+++ b/swing/src/main/java/info/openrocket/swing/startup/jij/PluginClasspathProvider.java
@@ -6,8 +6,10 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
+import info.openrocket.core.plugin.JarMigrationHelper;
 import info.openrocket.core.plugin.PluginHelper;
 import info.openrocket.core.util.BugException;
+
 
 public class PluginClasspathProvider implements ClasspathProvider {
 	
@@ -25,7 +27,11 @@ public class PluginClasspathProvider implements ClasspathProvider {
 	
 	private void findPluginDirectoryUrls(List<URL> urls) {
 		List<File> files = PluginHelper.getPluginJars();
-		for (File f : files) {
+
+		// Migrate files that still use the old package structure (net.sf.openrocket instead of info.openrocket.core/swing)
+		List<File> migratedFiles = getCompatibleFiles(files);
+
+		for (File f : migratedFiles) {
 			try {
 				urls.add(f.toURI().toURL());
 			} catch (MalformedURLException e) {
@@ -33,7 +39,31 @@ public class PluginClasspathProvider implements ClasspathProvider {
 			}
 		}
 	}
-	
+
+	/**
+	 * Return a list of both JAR files that are already compatible with the new package structure and JAR files that
+	 * have been migrated to the new package structure.
+	 * @param files List of JAR files to check.
+	 * @return List of JAR files that are compatible with the new package structure.
+	 */
+	private static List<File> getCompatibleFiles(List<File> files) {
+		List<File> migratedFiles = new ArrayList<>();
+		for (File f : files) {
+			try {
+				if (JarMigrationHelper.shouldMigrate(f, files)) {
+					File migratedJar = JarMigrationHelper.migrateJarFile(f);
+					migratedFiles.add(migratedJar);
+				} else {
+					migratedFiles.add(f);
+				}
+			} catch (JarMigrationHelper.JarMigrationException e) {
+				// Ignore the exception, the JAR file is not migrated
+				System.err.println(e.getMessage());
+			}
+		}
+		return migratedFiles;
+	}
+
 	private void findCustomPlugins(List<URL> urls) {
 		String prop = System.getProperty(CUSTOM_PLUGIN_PROPERTY);
 		if (prop == null) {
@@ -43,7 +73,7 @@ public class PluginClasspathProvider implements ClasspathProvider {
 		String[] array = prop.split(File.pathSeparator);
 		for (String s : array) {
 			s = s.trim();
-			if (s.length() > 0) {
+			if (!s.isEmpty()) {
 				try {
 					urls.add(new File(s).toURI().toURL());
 				} catch (MalformedURLException e) {


### PR DESCRIPTION
This PR fixes #2676. When OR scans the Plugins directory at startup, it checks if the JAR uses the old package structure (`net.sf.openrocket`). If it does, and it does not find a migrated version of that JAR, it starts the migration process. The migration process involves creating a copy of the JAR file with suffix `-migrated-new`. E.g. for the `CDOverride.jar` plugin, a new file is created `CDOverride-migrate-new.jar`. The ASM library is then used to modify the byte-code if the `XX-migrate-new.jar` to migrate references from `net.sf.openrocket` to `info.openrocket.core/swing`. Finally, when the UI loaded in `SwingStartup`, it checks if there are any `XX-migrated-new.jar` files present in the Plugins directory. If so, it notifies the user and renames the JAR file from `XX-migrated-new.jar` to `XX-migrated.jar`. I had to use this workaround because I can not yet use Swing components while loading the Plugins at startup because for some reason this messes with the Guice injections.

<img width="832" alt="image" src="https://github.com/user-attachments/assets/3a4b80ac-f45a-41cb-9543-eb71d098c0ea" />


In the end, you are left with both the original JAR (so it works with older installed versions of OR) and the migrated JAR (compatible with OR 24.12).
<img width="412" alt="image" src="https://github.com/user-attachments/assets/cc5e5ddd-3e39-4d8d-8432-6dbabd6f173d" />

I also added some backward compatibility code for the popular MultiLevelWind plugin (which is now built-in in OpenRocket, but users will still have the plugin loaded in their old designs).
