### PR TITLE
[#2146] Focus Rocket Config Dialog when opening a file.

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/RocketConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/RocketConfig.java
@@ -144,8 +144,6 @@ public class RocketConfig extends RocketComponentConfig {
 
 		addButtons();
 		addEasterEgg();
-
-		SwingUtilities.invokeLater(componentNameField::requestFocus);
 	}
 
 	/**

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/RocketConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/RocketConfig.java
@@ -144,6 +144,8 @@ public class RocketConfig extends RocketComponentConfig {
 
 		addButtons();
 		addEasterEgg();
+
+		SwingUtilities.invokeLater(componentNameField::requestFocus);
 	}
 
 	/**

--- a/swing/src/main/java/info/openrocket/swing/gui/main/BasicFrame.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/BasicFrame.java
@@ -1357,7 +1357,7 @@ public class BasicFrame extends JFrame {
 		}
 
 		////	Handle the document
-		OpenRocketDocument doc = null;
+		final OpenRocketDocument doc;
 		try {
 			doc = worker.get();
 		} catch (ExecutionException e) {
@@ -1407,11 +1407,11 @@ public class BasicFrame extends JFrame {
 		BasicFrame frame = new BasicFrame(doc);
 		frame.setVisible(true);
 
-		if (parent != null && parent instanceof BasicFrame) {
+		if (parent instanceof BasicFrame) {
 			((BasicFrame) parent).closeIfReplaceable();
 		}
 		if (openRocketConfigDialog) {
-			ComponentConfigDialog.showDialog(frame, doc, doc.getRocket());
+			SwingUtilities.invokeLater(() -> ComponentConfigDialog.showDialog(frame, doc, doc.getRocket()));
 		}
 
 		return frame;


### PR DESCRIPTION
This change fixes the issue #2146 where the Rocket Config Dialog that opens up when opening an example is not focused.

The same was happening when opening it in full screen mode, so now it is focused when it opens and it can be closed with the 'esc' key or modified.

The change is just requesting focus from the Design Name text field component.