### PR TITLE
Fix 2651

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/motor/thrustcurve/MotorFilterPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/motor/thrustcurve/MotorFilterPanel.java
@@ -339,6 +339,7 @@ public abstract class MotorFilterPanel extends JPanel {
 				@Override
 				public void stateChanged(ChangeEvent e) {
 					lengthSlider.setValueAt(1, (int) (1000* maxLengthModel.getValue()));
+					onSelectionChanged();
 				}
 			});
 			sub.add(maxLengthSpinner, "growx");
@@ -351,12 +352,24 @@ public abstract class MotorFilterPanel extends JPanel {
 			lengthSlider.addChangeListener( new ChangeListener() {
 				@Override
 				public void stateChanged(ChangeEvent e) {
-					
 					int minLength = lengthSlider.getValueAt(0);
 					minLengthModel.setValue(minLength/1000.0);
-					int maxLength = lengthSlider.getValueAt(1);
-					maxLengthModel.setValue(maxLength/1000.0);
+
+					double maxLengthValue;
+					if (limitByLength) {
+						maxLengthValue = mountLength;
+					} else {
+						int maxLength = lengthSlider.getValueAt(1);
+						if (maxLength < 1000) {
+							maxLengthValue = maxLength/1000.0;
+						} else {
+							maxLengthValue = Double.POSITIVE_INFINITY;
+						}
+					}
+
+					maxLengthModel.setValue(maxLengthValue);
 					onSelectionChanged();
+					
 				}
 			});
 
@@ -393,6 +406,7 @@ public abstract class MotorFilterPanel extends JPanel {
 		((SwingPreferences) Application.getPreferences()).putBoolean("motorFilterLimitLength", limitByLength);
 		if ( mountLength != null  & limitByLength ) {
 			lengthSlider.setValueAt(1, (int) Math.min(1000,Math.round(1000*mountLength)));
+			maxLengthModel.setValue(mountLength);
 		}
 	}
 	

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/motor/thrustcurve/MotorFilterPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/motor/thrustcurve/MotorFilterPanel.java
@@ -316,7 +316,6 @@ public abstract class MotorFilterPanel extends JPanel {
 
 			sub.add( limitByLengthCheckBox, "gapleft para, spanx, growx, wrap" );
 			
-			
 			minLengthModel = new DoubleModel(filter, "MinimumLength", UnitGroup.UNITS_MOTOR_DIMENSIONS, 0);
 			maxLengthModel = new DoubleModel(filter, "MaximumLength", UnitGroup.UNITS_MOTOR_DIMENSIONS, 0);
 
@@ -325,7 +324,20 @@ public abstract class MotorFilterPanel extends JPanel {
 			minLengthModel.addChangeListener( new ChangeListener() {
 				@Override
 				public void stateChanged(ChangeEvent e) {
-					lengthSlider.setValueAt(0, (int)(1000* minLengthModel.getValue()));
+					double minValue = minLengthModel.getValue();
+
+					if (minValue > maxLengthModel.getValue()) {
+						maxLengthModel.setValue(minValue);
+					}
+
+					lengthSlider.setValueAt(0, (int)(1000 * minValue));
+					// If our value is greater than 1000 mm, moving the slider sets it down to 1000
+					// Patch it if so
+					if (minLengthModel.getValue() != minValue) {
+						minLengthModel.setValue(minValue);
+					}
+
+					onSelectionChanged();
 				}
 			});
 			sub.add(minLengthSpinner, "split 5, growx");
@@ -338,7 +350,19 @@ public abstract class MotorFilterPanel extends JPanel {
 			maxLengthModel.addChangeListener( new ChangeListener() {
 				@Override
 				public void stateChanged(ChangeEvent e) {
-					lengthSlider.setValueAt(1, (int) (1000* maxLengthModel.getValue()));
+					double maxValue = maxLengthModel.getValue();
+					
+					if (maxValue < minLengthModel.getValue()) {
+						minLengthModel.setValue(maxValue);
+					}
+					
+					lengthSlider.setValueAt(1, (int) (1000 * maxValue));
+					// If our value is greater than 1000 mm, moving the slider sets it to infinite
+					// Patch it if so
+					if (maxLengthModel.getValue() != maxValue) {
+						maxLengthModel.setValue(maxValue);
+					}
+					
 					onSelectionChanged();
 				}
 			});
@@ -366,10 +390,9 @@ public abstract class MotorFilterPanel extends JPanel {
 							maxLengthValue = Double.POSITIVE_INFINITY;
 						}
 					}
-
 					maxLengthModel.setValue(maxLengthValue);
-					onSelectionChanged();
 					
+					onSelectionChanged();
 				}
 			});
 

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/motor/thrustcurve/MotorFilterPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/motor/thrustcurve/MotorFilterPanel.java
@@ -66,7 +66,7 @@ public abstract class MotorFilterPanel extends JPanel {
 		new MotorDiameter(0.038, 0.0381),
 		new MotorDiameter(0.054, 0.054),
 		new MotorDiameter(0.075, 0.0763),
-		new MotorDiameter(0.098, 0.983),
+		new MotorDiameter(0.098, 0.0983),
 		new MotorDiameter(1.000, 1.000)
 	};
 


### PR DESCRIPTION
Enhancements and fixes to motor length and diamter filters

Diameter: Fixes typo in 98mm motor actual diameter that broke filter on minimum diameter of 98mm

Length: using the slider, can select maximum diameter from 0 to 999, or infinity.
When typing values, you can enter arbitrarily large lengths (so greater than the 999 limit in the slider).
Prevents having max length < min length when typing values

fixes #2561 