### PR TITLE
Allow design view click-drag rotation to be locked + input rotation angle in spinner

### DIFF
--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -87,6 +87,9 @@ RocketPanel.ttip.Rotation = Change the rocket's roll rotation (only affects the 
 RocketPanel.check.showWarnings = Show warnings
 RocketPanel.check.showWarnings.ttip = Show/hide geometry warnings in the rocket design view.
 
+RocketPanel.ttip.RotationValue = Enter rotation angle in degrees
+RocketPanel.ttip.lockDragRotation = Lock/unlock click-drag rotation
+
 ! BasicFrame
 BasicFrame.tab.Rocketdesign = Rocket design
 BasicFrame.tab.Flightconfig = Motors & Configuration

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/ViewRotationControl.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/ViewRotationControl.java
@@ -1,0 +1,122 @@
+package info.openrocket.swing.gui.scalefigure;
+
+import info.openrocket.core.l10n.Translator;
+import info.openrocket.core.startup.Application;
+import info.openrocket.core.unit.UnitGroup;
+import info.openrocket.swing.gui.SpinnerEditor;
+import info.openrocket.swing.gui.adaptors.DoubleModel;
+import info.openrocket.swing.gui.components.BasicSlider;
+import info.openrocket.swing.gui.components.UnitSelector;
+import info.openrocket.swing.gui.util.Icons;
+import net.miginfocom.swing.MigLayout;
+
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSlider;
+import javax.swing.JSpinner;
+import javax.swing.JToggleButton;
+import javax.swing.plaf.basic.BasicSpinnerUI;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/**
+ * An enhanced version of the rotation control component for the RocketPanel.
+ * This implementation adds a text field for direct value input and a lock button
+ * for disabling/enabling the click-drag rotation.
+ */
+public class ViewRotationControl extends JPanel {
+
+	private static final Translator trans = Application.getTranslator();
+	private final DoubleModel rotationModel;
+	private final BasicSlider rotationSlider;
+	private final JToggleButton lockButton;
+	private boolean dragRotationLocked = false;
+
+	/**
+	 * Creates a new enhanced rotation control panel
+	 *
+	 * @param figure the rocket figure to control
+	 */
+	public ViewRotationControl(RocketFigure figure) {
+		super(new MigLayout("fill, insets 0, gap 0"));
+
+		// Create rotation model
+		rotationModel = new DoubleModel(figure, "Rotation", UnitGroup.UNITS_ANGLE, 0, 2 * Math.PI);
+		figure.addChangeListener(rotationModel);
+
+		// Create spinner
+		JSpinner spinner = new JSpinner(rotationModel.getSpinnerModel());
+		spinner.setEditor(new SpinnerEditor(spinner));
+		// Remove the spinner buttons
+		spinner.setUI(new BasicSpinnerUI() {
+			@Override
+			protected Component createNextButton() {
+				return null;
+			}
+
+			@Override
+			protected Component createPreviousButton() {
+				return null;
+			}
+		});
+
+		// Create unit selector
+		UnitSelector unitSelector = new UnitSelector(rotationModel);
+		unitSelector.setHorizontalAlignment(JLabel.CENTER);
+		unitSelector.setToolTipText(trans.get("RocketPanel.ttip.Rotation"));
+
+		// Create a panel for the rotation controls
+		JPanel controlsPanel = new JPanel(new MigLayout("fill, insets 0, gap 0"));
+
+		// Create lock button
+		lockButton = new JToggleButton(Icons.UNLOCKED);
+		lockButton.setSelectedIcon(Icons.LOCKED);
+		lockButton.setToolTipText(trans.get("RocketPanel.ttip.lockDragRotation"));
+		lockButton.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				dragRotationLocked = lockButton.isSelected();
+			}
+		});
+		Dimension lockSize = new Dimension(24, 24);
+		lockButton.setPreferredSize(lockSize);
+		lockButton.setMaximumSize(lockSize);
+		lockButton.setMinimumSize(lockSize);
+
+		// Add components to the control panel
+		controlsPanel.add(spinner, "width 50!");
+		controlsPanel.add(unitSelector, "growx, wrap");
+
+		rotationSlider = new BasicSlider(rotationModel.getSliderModel(0, 2 * Math.PI), JSlider.VERTICAL, true);
+		rotationSlider.setToolTipText(trans.get("RocketPanel.ttip.Rotation"));
+
+		// Add components to this panel
+		add(controlsPanel, "growx, wrap");
+		add(rotationSlider, "ax 50%, growy, pushy, wrap");
+		add(lockButton, "ax 50%");
+	}
+
+	/**
+	 * Gets the rotation slider component
+	 */
+	public BasicSlider getRotationSlider() {
+		return rotationSlider;
+	}
+
+	/**
+	 * Checks if drag rotation is currently locked
+	 */
+	public boolean isDragRotationLocked() {
+		return dragRotationLocked;
+	}
+
+	/**
+	 * Sets whether drag rotation is locked
+	 */
+	public void setDragRotationLocked(boolean locked) {
+		this.dragRotationLocked = locked;
+		this.lockButton.setSelected(locked);
+	}
+}

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/ViewRotationControl.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/ViewRotationControl.java
@@ -52,6 +52,7 @@ public class ViewRotationControl extends JPanel {
 
 		// Create spinner
 		JSpinner spinner = new JSpinner(rotationModel.getSpinnerModel());
+		spinner.setToolTipText(trans.get("RocketPanel.ttip.Rotation"));
 		spinner.setEditor(new SpinnerEditor(spinner));
 		// Remove the spinner buttons
 		spinner.setUI(new BasicSpinnerUI() {

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/ViewRotationControl.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/ViewRotationControl.java
@@ -8,6 +8,7 @@ import info.openrocket.swing.gui.adaptors.DoubleModel;
 import info.openrocket.swing.gui.components.BasicSlider;
 import info.openrocket.swing.gui.components.UnitSelector;
 import info.openrocket.swing.gui.util.Icons;
+import info.openrocket.swing.gui.util.SwingPreferences;
 import net.miginfocom.swing.MigLayout;
 
 import javax.swing.JLabel;
@@ -27,8 +28,9 @@ import java.awt.event.ActionListener;
  * for disabling/enabling the click-drag rotation.
  */
 public class ViewRotationControl extends JPanel {
-
 	private static final Translator trans = Application.getTranslator();
+	private static final SwingPreferences prefs = (SwingPreferences) Application.getPreferences();
+
 	private final DoubleModel rotationModel;
 	private final BasicSlider rotationSlider;
 	private final JToggleButton lockButton;
@@ -41,6 +43,8 @@ public class ViewRotationControl extends JPanel {
 	 */
 	public ViewRotationControl(RocketFigure figure) {
 		super(new MigLayout("fill, insets 0, gap 0"));
+
+		dragRotationLocked = prefs.isClickDragRotationLocked();
 
 		// Create rotation model
 		rotationModel = new DoubleModel(figure, "Rotation", UnitGroup.UNITS_ANGLE, 0, 2 * Math.PI);
@@ -78,12 +82,14 @@ public class ViewRotationControl extends JPanel {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				dragRotationLocked = lockButton.isSelected();
+				prefs.setClickDragRotationLocked(dragRotationLocked);
 			}
 		});
 		Dimension lockSize = new Dimension(24, 24);
 		lockButton.setPreferredSize(lockSize);
 		lockButton.setMaximumSize(lockSize);
 		lockButton.setMinimumSize(lockSize);
+		lockButton.setSelected(dragRotationLocked);
 
 		// Add components to the control panel
 		controlsPanel.add(spinner, "width 50!");

--- a/swing/src/main/java/info/openrocket/swing/gui/util/Icons.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/util/Icons.java
@@ -10,7 +10,6 @@ import org.slf4j.LoggerFactory;
 import javax.swing.GrayFilter;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
-import java.awt.Component;
 import java.awt.Graphics;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
@@ -56,7 +55,8 @@ public class Icons {
 		SIMULATION_LISTENER_OK = SIMULATION_STATUS_ICON_MAP.get(Simulation.Status.UPTODATE);
 		SIMULATION_LISTENER_ERROR = SIMULATION_STATUS_ICON_MAP.get(Simulation.Status.OUTDATED);
 	}
-	
+
+	// Note: most of these icons are from famfamicons Silk set
 	
 	public static final Icon FILE_NEW = loadImageIcon("pix/icons/document-new.png", "New document");
 	public static final Icon FILE_OPEN = loadImageIcon("pix/icons/document-open.png", "Open document");
@@ -130,6 +130,9 @@ public class Icons {
 	public static final Icon COMPONENT_HIDDEN_LIGHT = loadImageIcon("pix/icons/component-hidden_light.png", "Component Hidden");
 	public static final Icon COMPONENT_SHOWING_DARK = loadImageIcon("pix/icons/component-showing_dark.png", "Component Showing");
 	public static final Icon COMPONENT_SHOWING_LIGHT = loadImageIcon("pix/icons/component-showing_light.png", "Component Showing");
+
+	public static final Icon LOCKED = loadImageIcon("pix/icons/locked.png", "Locked");
+	public static final Icon UNLOCKED = loadImageIcon("pix/icons/unlocked.png", "Unlocked");
 
 	// MANUFACTURERS ICONS
 	public static final Icon RASAERO = loadImageIcon("pix/icons/RASAero_16.png", "RASAero Icon");

--- a/swing/src/main/java/info/openrocket/swing/gui/util/SwingPreferences.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/util/SwingPreferences.java
@@ -70,6 +70,7 @@ public class SwingPreferences extends ApplicationPreferences {
 	public static final String UI_FONT_STYLE = "UIFontStyle";
 	public static final String UI_FONT_TRACKING = "UIFontTracking";
 	public static final String UPDATE_PLATFORM = "UpdatePlatform";
+	public static final String LOCK_CLICK_DRAG_ROTATION = "LockClickDragRotation";
 	
 	private static final List<Locale> SUPPORTED_LOCALES;
 	static {
@@ -475,6 +476,22 @@ public class SwingPreferences extends ApplicationPreferences {
 	 */
 	public void setUIFontTracking(double tracking) {
 		putDouble(UI_FONT_TRACKING, tracking);
+	}
+
+	/**
+	 * Whether to lock the click-drag rotation in the rocket panel.
+	 * @return true if the rotation is locked, false otherwise (allow click-drag rotation)
+	 */
+	public boolean isClickDragRotationLocked() {
+		return getBoolean(LOCK_CLICK_DRAG_ROTATION, false);
+	}
+
+	/**
+	 * Set whether to lock the click-drag rotation in the rocket panel.
+	 * @param lock true to lock the rotation, false to allow click-drag rotation
+	 */
+	public void setClickDragRotationLocked(boolean lock) {
+		putBoolean(LOCK_CLICK_DRAG_ROTATION, lock);
 	}
 
 	public ORColor getDefaultColor(Class<? extends RocketComponent> c) {


### PR DESCRIPTION
As requested by user tollyman on Discord, this PR allows you to lock/unlock the click-drag rotation in the design view, and it allows you to input the rotation angle in a spinner.

Demo:

https://github.com/user-attachments/assets/0670ac98-bd3d-45bb-87fd-d05eec8be7ed

