### PR TITLE
 [#2725] Include assembly copies in motor count display 

### DIFF
--- a/core/src/main/java/info/openrocket/core/formatting/MotorConfigurationSubstitutor.java
+++ b/core/src/main/java/info/openrocket/core/formatting/MotorConfigurationSubstitutor.java
@@ -207,7 +207,7 @@ public class MotorConfigurationSubstitutor implements RocketSubstitutor {
 
 		for (String motorData : sortedKeys) {
 			int count = motorCounts.get(motorData);
-			String formatted = count > 1 ? "" + count + Chars.TIMES + motorData : motorData;
+			String formatted = count > 1 ? "" + count + Chars.TIMES + " " + motorData : motorData;
 			formattedMotors.add(formatted);
 		}
 

--- a/core/src/main/java/info/openrocket/core/formatting/MotorConfigurationSubstitutor.java
+++ b/core/src/main/java/info/openrocket/core/formatting/MotorConfigurationSubstitutor.java
@@ -274,7 +274,7 @@ public class MotorConfigurationSubstitutor implements RocketSubstitutor {
 					String data = getData(motor, inst);
 
 					// Add the data for each motor instance
-					for (int i = 0; i < mount.getMotorCount(); i++) {
+					for (int i = 0; i < mount.getMotorCountIncludingAssemblyCopies(); i++) {
 						dataList.add(data);
 					}
 				}

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/BodyTube.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/BodyTube.java
@@ -1,6 +1,7 @@
 package info.openrocket.core.rocketcomponent;
 
 import java.util.Iterator;
+import java.util.List;
 
 import info.openrocket.core.l10n.Translator;
 import info.openrocket.core.motor.Motor;
@@ -468,6 +469,19 @@ public class BodyTube extends SymmetricComponent implements BoxBounded, MotorMou
 	@Override
 	public int getMotorCount() {
 		return this.getClusterConfiguration().getClusterCount();
+	}
+
+	@Override
+	public int getMotorCountIncludingAssemblyCopies() {
+		// Get the parent assemblies of the motor mount, and multiply the data by the number of instances
+		int multiplier = 1;
+		List<RocketComponent> parents = getParentAssemblies();
+		for (RocketComponent parent : parents) {
+			multiplier *= parent.getInstanceCount();
+		}
+
+		int count = getMotorCount();
+		return count * multiplier;
 	}
 		
 	@Override

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/InnerTube.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/InnerTube.java
@@ -388,6 +388,19 @@ public class InnerTube extends ThicknessRingComponent
 	public int getMotorCount() {
 		return this.getClusterConfiguration().getClusterCount();
 	}
+
+	@Override
+	public int getMotorCountIncludingAssemblyCopies() {
+		// Get the parent assemblies of the motor mount, and multiply the data by the number of instances
+		int multiplier = 1;
+		List<RocketComponent> parents = getParentAssemblies();
+		for (RocketComponent parent : parents) {
+			multiplier *= parent.getInstanceCount();
+		}
+
+		int count = getMotorCount();
+		return count * multiplier;
+	}
 	
 	
 	@Override

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/MotorMount.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/MotorMount.java
@@ -119,6 +119,14 @@ public interface MotorMount extends ChangeSource, FlightConfigurableComponent {
 	public int getMotorCount();
 
 	/**
+	 * Get the number of motors available for all flight configurations, including
+	 * assembly copies (e.g. if you have 1 motor in a 2-instance booster, the total returned will be 2).
+	 *
+	 * @return the number of motors.
+	 */
+	public int getMotorCountIncludingAssemblyCopies();
+
+	/**
 	 * Return the distance that the motors hang outside this motor mount.
 	 * 
 	 * @return the overhang length.

--- a/core/src/test/java/info/openrocket/core/rocketcomponent/FlightConfigurationTest.java
+++ b/core/src/test/java/info/openrocket/core/rocketcomponent/FlightConfigurationTest.java
@@ -583,87 +583,94 @@ public class FlightConfigurationTest extends BaseTestCase {
 		Rocket rocket = TestRockets.makeFalcon9Heavy();
 		FlightConfiguration selected = rocket.getSelectedConfiguration();
 
-		// Test only motors
-		selected.setName("[{motors}]");
+		ParallelStage boosterStage = (ParallelStage) rocket.getChild(1).getChild(0).getChild(0);
 
-		selected.setAllStages();
-		assertEquals("[[Rocket.motorCount.noStageMotors]; M1350-0; 4\u00D7G77-0]", selected.getName());
+		// Parse over different instances
+		for (int i = 1; i < 3; i++) {
+			boosterStage.setInstanceCount(i);
 
-		// Test only manufacturers
-		selected.setName("[{manufacturers}]");
+			// Test only motors
+			selected.setName("[{motors}]");
 
-		selected.setAllStages();
-		assertEquals("[[Rocket.motorCount.noStageMotors]; AeroTech; 4\u00D7AeroTech]", selected.getName());
+			selected.setAllStages();
+			assertEquals("[[Rocket.motorCount.noStageMotors]; M1350-0; " + 4*i + "\u00D7 G77-0]", selected.getName());
 
-		// Test only cases
-		selected.setName("[{cases}]");
+			// Test only manufacturers
+			selected.setName("[{manufacturers}]");
 
-		selected.setAllStages();
-		assertEquals("[[Rocket.motorCount.noStageMotors]; SU 75/512; 4\u00D7SU 29/180]", selected.getName());
+			selected.setAllStages();
+			assertEquals("[[Rocket.motorCount.noStageMotors]; AeroTech; " + 4*i + "\u00D7 AeroTech]", selected.getName());
 
-		// Test only motors or only manufacturers
-		selected.setName("[{motors}] - [{manufacturers}]");
+			// Test only cases
+			selected.setName("[{cases}]");
 
-		selected.setAllStages();
-		assertEquals("[[Rocket.motorCount.noStageMotors]; M1350-0; 4\u00D7G77-0] - [[Rocket.motorCount.noStageMotors]; AeroTech; 4\u00D7AeroTech]",
-					 selected.getName());
+			selected.setAllStages();
+			assertEquals("[[Rocket.motorCount.noStageMotors]; SU 75/512; " + 4*i + "\u00D7 SU 29/180]", selected.getName());
 
-		selected.setOnlyStage(0);
-		assertEquals("[[Rocket.motorCount.Nomotor]] - [[Rocket.motorCount.Nomotor]]", selected.getName());
+			// Test only motors or only manufacturers
+			selected.setName("[{motors}] - [{manufacturers}]");
 
-		selected.setOnlyStage(1);
-		assertEquals("[; M1350-0; ] - [; AeroTech; ]", selected.getName());
+			selected.setAllStages();
+			assertEquals("[[Rocket.motorCount.noStageMotors]; M1350-0; " + 4*i + "\u00D7 G77-0] - [[Rocket.motorCount.noStageMotors]; AeroTech; " + 4*i + "\u00D7 AeroTech]",
+					selected.getName());
 
-		selected.setAllStages();
-		selected._setStageActive(0, false);
-		assertEquals("[; M1350-0; 4\u00D7G77-0] - [; AeroTech; 4\u00D7AeroTech]", selected.getName());
+			selected.setOnlyStage(0);
+			assertEquals("[[Rocket.motorCount.Nomotor]] - [[Rocket.motorCount.Nomotor]]", selected.getName());
 
-		// Test combination of motors and manufacturers
-		selected.setName("[{motors  manufacturers}] -- [{manufacturers}] - [{motors}]");
+			selected.setOnlyStage(1);
+			assertEquals("[; M1350-0; ] - [; AeroTech; ]", selected.getName());
 
-		selected.setAllStages();
-		assertEquals("[[Rocket.motorCount.noStageMotors]; M1350-0  AeroTech; 4\u00D7G77-0  AeroTech] -- [[Rocket.motorCount.noStageMotors]; AeroTech; 4\u00D7AeroTech] - [[Rocket.motorCount.noStageMotors]; M1350-0; 4\u00D7G77-0]",
-					 selected.getName());
+			selected.setAllStages();
+			selected._setStageActive(0, false);
+			assertEquals("[; M1350-0; " + 4*i + "\u00D7 G77-0] - [; AeroTech; " + 4*i + "\u00D7 AeroTech]", selected.getName());
 
-		selected.setOnlyStage(0);
-		assertEquals("[[Rocket.motorCount.Nomotor]] -- [[Rocket.motorCount.Nomotor]] - [[Rocket.motorCount.Nomotor]]", selected.getName());
+			// Test combination of motors and manufacturers
+			selected.setName("[{motors  manufacturers}] -- [{manufacturers}] - [{motors}]");
 
-		selected.setOnlyStage(1);
-		assertEquals("[; M1350-0  AeroTech; ] -- [; AeroTech; ] - [; M1350-0; ]", selected.getName());
+			selected.setAllStages();
+			assertEquals("[[Rocket.motorCount.noStageMotors]; M1350-0  AeroTech; " + 4*i + "\u00D7 G77-0  AeroTech] -- [[Rocket.motorCount.noStageMotors]; AeroTech; " + 4*i + "\u00D7 AeroTech] - [[Rocket.motorCount.noStageMotors]; M1350-0; " + 4*i + "\u00D7 G77-0]",
+					selected.getName());
 
-		selected.setAllStages();
-		selected._setStageActive(0, false);
-		assertEquals("[; M1350-0  AeroTech; 4\u00D7G77-0  AeroTech] -- [; AeroTech; 4\u00D7AeroTech] - [; M1350-0; 4\u00D7G77-0]",
-					 selected.getName());
+			selected.setOnlyStage(0);
+			assertEquals("[[Rocket.motorCount.Nomotor]] -- [[Rocket.motorCount.Nomotor]] - [[Rocket.motorCount.Nomotor]]", selected.getName());
 
-		// Test combination of manufacturers and motors
-		selected.setName("[{manufacturers | motors}]");
+			selected.setOnlyStage(1);
+			assertEquals("[; M1350-0  AeroTech; ] -- [; AeroTech; ] - [; M1350-0; ]", selected.getName());
 
-		selected.setAllStages();
-		assertEquals("[[Rocket.motorCount.noStageMotors]; AeroTech | M1350-0; 4\u00D7AeroTech | G77-0]",
-					 selected.getName());
+			selected.setAllStages();
+			selected._setStageActive(0, false);
+			assertEquals("[; M1350-0  AeroTech; " + 4*i + "\u00D7 G77-0  AeroTech] -- [; AeroTech; " + 4*i + "\u00D7 AeroTech] - [; M1350-0; " + 4*i + "\u00D7 G77-0]",
+					selected.getName());
 
-		selected.setOnlyStage(0);
-		assertEquals("[[Rocket.motorCount.Nomotor]]", selected.getName());
+			// Test combination of manufacturers and motors
+			selected.setName("[{manufacturers | motors}]");
 
-		selected.setOnlyStage(1);
-		assertEquals("[; AeroTech | M1350-0; ]", selected.getName());
+			selected.setAllStages();
+			assertEquals("[[Rocket.motorCount.noStageMotors]; AeroTech | M1350-0; " + 4*i + "\u00D7 AeroTech | G77-0]",
+					selected.getName());
 
-		selected.setAllStages();
-		selected._setStageActive(0, false);
-		assertEquals("[; AeroTech | M1350-0; 4\u00D7AeroTech | G77-0]", selected.getName());
+			selected.setOnlyStage(0);
+			assertEquals("[[Rocket.motorCount.Nomotor]]", selected.getName());
 
-		// Test combination of motors, manufacturers and cases
-		selected.setName("[{motors manufacturers | cases}]");
+			selected.setOnlyStage(1);
+			assertEquals("[; AeroTech | M1350-0; ]", selected.getName());
 
-		selected.setAllStages();
-		assertEquals("[[Rocket.motorCount.noStageMotors]; M1350-0 AeroTech | SU 75/512; 4\u00D7G77-0 AeroTech | SU 29/180]", selected.getName());
+			selected.setAllStages();
+			selected._setStageActive(0, false);
+			assertEquals("[; AeroTech | M1350-0; " + 4*i + "\u00D7 AeroTech | G77-0]", selected.getName());
 
-		// Test combination of motors, manufacturers and cases
-		selected.setName("[{motors manufacturers | cases}]");
+			// Test combination of motors, manufacturers and cases
+			selected.setName("[{motors manufacturers | cases}]");
 
-		selected.setAllStages();
-		assertEquals("[[Rocket.motorCount.noStageMotors]; M1350-0 AeroTech | SU 75/512; 4\u00D7G77-0 AeroTech | SU 29/180]", selected.getName());
+			selected.setAllStages();
+			assertEquals("[[Rocket.motorCount.noStageMotors]; M1350-0 AeroTech | SU 75/512; " + 4*i + "\u00D7 G77-0 AeroTech | SU 29/180]", selected.getName());
+
+			// Test combination of motors, manufacturers and cases
+			selected.setName("[{motors manufacturers | cases}]");
+
+			selected.setAllStages();
+			assertEquals("[[Rocket.motorCount.noStageMotors]; M1350-0 AeroTech | SU 75/512; " + 4*i + "\u00D7 G77-0 AeroTech | SU 29/180]", selected.getName());
+		}
 
 		// Test empty tags
 		selected.setName("{}");

--- a/swing/src/main/java/info/openrocket/swing/gui/main/flightconfigpanel/MotorConfigurationPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/flightconfigpanel/MotorConfigurationPanel.java
@@ -526,7 +526,7 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 			}
 
 			String str = motor.getMotorName(curMotorInstance.getEjectionDelay());
-			int count = mount.getInstanceCount();
+			int count = mount.getMotorCountIncludingAssemblyCopies();
 			if (count > 1) {
 				str = "" + count + Chars.TIMES + " " + str;
 			}

--- a/swing/src/main/java/info/openrocket/swing/gui/print/DesignReport.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/print/DesignReport.java
@@ -448,7 +448,7 @@ public class DesignReport {
 					continue;
 				}
 				
-				int motorCount = mount.getMotorCount();
+				int motorCount = mount.getMotorCountIncludingAssemblyCopies();
 				
 				int border = Rectangle.NO_BORDER;
 				if (topBorder) {


### PR DESCRIPTION
This PR fixes #2725.

Parallel booster staging example design:
<img width="1634" alt="image" src="https://github.com/user-attachments/assets/a3a23049-8226-42cb-8065-bb143a1e8014" />

Changed booster inner tube to 3-motor cluster:
<img width="1634" alt="image" src="https://github.com/user-attachments/assets/7db41120-c921-4f1f-9db9-01e690ee091d" />

No cluster and only one instance:
<img width="1634" alt="image" src="https://github.com/user-attachments/assets/c47f3872-bfef-45be-b21a-ef1a9795687e" />

---

Note that there I discovered a bug while working on this (which was already present in 23.09). When opening the "Pods--powered with recovery deployment" example design, for the last flight config, the"A10-3" motor displayed as "217A10-3". The booster stage in that config has 2 A10-3 motors, which should display "2× A10-3". However, the '×' symbol is coded using `Chars.TIMES` (`u00D7`). In the motor config display code, there was this: `count + Chars.TIMES + " " + motorData`. But, since `count` is an integer, `Chars.TIMES` was also interpreted as an int (=215), instead of the '×' char. So you just did an integer sum... The solution was to force String summation: `"" + count + Chars.TIMES + " " + motorData`.