### PR TITLE
Calculate whether CD is being overridden by an ancestor as needed, instead of maintaining in a boolean variable

### DIFF
--- a/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
@@ -908,7 +908,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 
 		updateChildrenMassOverriddenBy();
 
-		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE | ComponentChangeEvent.TREE_CHANGE_CHILDREN);
+		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE | ComponentChangeEvent.TREE_CHANGE_CHILDREN);
 	}
 
 	/**
@@ -946,7 +946,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 
 		updateChildrenCGOverriddenBy();
 
-		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE | ComponentChangeEvent.TREE_CHANGE_CHILDREN);
+		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE | ComponentChangeEvent.TREE_CHANGE_CHILDREN);
 	}
 
 	/**
@@ -986,7 +986,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 
 		overrideSubcomponentsCD(override);
 
-		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE | ComponentChangeEvent.TREE_CHANGE_CHILDREN);
+		fireComponentChangeEvent(ComponentChangeEvent.AERODYNAMIC_CHANGE | ComponentChangeEvent.TREE_CHANGE_CHILDREN);
 	}
 
 	/**

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
@@ -124,9 +124,6 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 	private boolean cdOverridden = false;
 	private boolean overrideSubcomponentsCD = false;
 	private RocketComponent CDOverriddenBy = null;	// The (super-)parent component that overrides the CD of this component
-
-	private boolean cdOverriddenByAncestor = false;
-	
 	
 	// User-given name of the component
     protected String name = null;
@@ -862,7 +859,9 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 	 */
 	public final boolean isCDOverriddenByAncestor() {
 		mutex.verify();
-		return cdOverriddenByAncestor;
+		return (null != parent) &&
+			(parent.isCDOverriddenByAncestor() ||
+			 (parent.isCDOverridden() && parent.isSubcomponentsOverriddenCD()));
 	}
 	
 	
@@ -1008,8 +1007,6 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 	void overrideSubcomponentsCD(boolean override) {
 		for (RocketComponent c : this.children) {
 			if (c.isCDOverriddenByAncestor() != override) {
-
-				c.cdOverriddenByAncestor = override;
 
 				if (!override && c.isCDOverridden() && c.isSubcomponentsOverriddenCD()) {
 					c.overrideSubcomponentsCD(true);
@@ -2982,7 +2979,6 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 		this.massOverridden = src.massOverridden;
 		this.overrideCGX = src.overrideCGX;
 		this.cgOverridden = src.cgOverridden;
-		this.cdOverriddenByAncestor = src.cdOverriddenByAncestor;
 		this.overrideSubcomponentsMass = src.overrideSubcomponentsMass;
 		this.overrideSubcomponentsCG = src.overrideSubcomponentsCG;
 		this.overrideSubcomponentsCD = src.overrideSubcomponentsCD;


### PR DESCRIPTION
The issue in #2745 is that when a new component is added to the component tree and its parent's CD is being overridden by an ancestor, the new component isn't getting marked as also being overridden by an ancestor. Rather than try to track down why, this PR takes the slightly more robust approach of eliminating the boolean and determining whether a component's CD is being overridden as needed.

Fixes #2745