### PR TITLE
 [#2715] Allow more configurable multi-level wind import settings 

### DIFF
--- a/core/src/main/java/info/openrocket/core/models/wind/MultiLevelPinkNoiseWindModel.java
+++ b/core/src/main/java/info/openrocket/core/models/wind/MultiLevelPinkNoiseWindModel.java
@@ -16,9 +16,9 @@ import java.util.Objects;
 import info.openrocket.core.l10n.Translator;
 import info.openrocket.core.preferences.ApplicationPreferences;
 import info.openrocket.core.startup.Application;
+import info.openrocket.core.unit.Unit;
 import info.openrocket.core.util.ChangeSource;
 import info.openrocket.core.util.Coordinate;
-import info.openrocket.core.util.MathUtil;
 import info.openrocket.core.util.ModID;
 import info.openrocket.core.util.StateChangeListener;
 
@@ -30,10 +30,6 @@ public class MultiLevelPinkNoiseWindModel implements WindModel {
 	private final List<StateChangeListener> listeners = new ArrayList<>();
 
 	private static final int REQUIRED_NR_OF_CSV_COLUMNS = 3;		// alt, speed, dir
-	private static final String COLUMN_ALTITUDE = "alt";
-	private static final String COLUMN_SPEED = "speed";
-	private static final String COLUMN_DIRECTION = "dir";
-	private static final String COLUMN_STDDEV = "stddev";
 
 	private AltitudeReference altitudeReference;
 
@@ -189,53 +185,111 @@ public class MultiLevelPinkNoiseWindModel implements WindModel {
 	}
 
 	/**
-	 * Import the wind levels from a CSV file
-	 * @param file The file to import
+	 * Import wind levels from a CSV file with the specified settings.
+	 *
+	 * @param file The CSV file to import
 	 * @param fieldSeparator The field separator used in the CSV file
+	 * @param altitudeColumn The name or index of the altitude column
+	 * @param speedColumn The name or index of the speed column
+	 * @param directionColumn The name or index of the direction column
+	 * @param stdDeviationColumn The name or index of the standard deviation column (can be empty)
+	 * @param altitudeUnit The unit used for altitude values in the CSV
+	 * @param speedUnit The unit used for speed values in the CSV
+	 * @param directionUnit The unit used for direction values in the CSV
+	 * @param stdDeviationUnit The unit used for standard deviation values in the CSV
+	 * @param hasHeaders Whether the CSV file has headers
 	 * @throws IllegalArgumentException If the file could not be loaded or the format is incorrect
 	 */
-	public void importLevelsFromCSV(File file, String fieldSeparator) throws IllegalArgumentException {
+	public void importLevelsFromCSV(File file, String fieldSeparator,
+									String altitudeColumn, String speedColumn,
+									String directionColumn, String stdDeviationColumn,
+									Unit altitudeUnit, Unit speedUnit,
+									Unit directionUnit, Unit stdDeviationUnit,
+									boolean hasHeaders) throws IllegalArgumentException {
 		String line;
 
 		// Clear the current levels
 		clearLevels();
 
 		try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
-			// Read the first line as a header
-			line = reader.readLine();
-			String[] headers = line.split(fieldSeparator);
-			sanityCheckColumnSize(fieldSeparator, headers, line);
+			// Map column indices
+			int altIndex = -1, speedIndex = -1, dirIndex = -1, stddevIndex = -1;
 
-			List<String> headersList = Arrays.asList(headers);
-			int altIndex = getHeaderIndex(headersList, COLUMN_ALTITUDE);
-			int speedIndex = getHeaderIndex(headersList, COLUMN_SPEED);
-			int dirIndex = getHeaderIndex(headersList, COLUMN_DIRECTION);
-			int stddevIndex = getHeaderIndex(headersList, COLUMN_STDDEV, false);
+			if (hasHeaders) {
+				// Read the first line as a header
+				line = reader.readLine();
+				if (line == null) {
+					throw new IllegalArgumentException(trans.get("MultiLevelPinkNoiseWindModel.msg.importLevelsError.EmptyFile"));
+				}
 
+				String[] headers = line.split(fieldSeparator, -1);  // -1 to keep empty trailing fields
+
+				// Find column indices by name
+				List<String> headersList = Arrays.asList(headers);
+				altIndex = findColumnIndex(headersList, altitudeColumn, "altitude", true);
+				speedIndex = findColumnIndex(headersList, speedColumn, "speed", true);
+				dirIndex = findColumnIndex(headersList, directionColumn, "direction", true);
+
+				// Standard deviation is optional
+				if (!stdDeviationColumn.isEmpty()) {
+					stddevIndex = findColumnIndex(headersList, stdDeviationColumn, "standard deviation", false);
+				}
+			} else {
+				// No headers, parse column indices directly
+				try {
+					altIndex = Integer.parseInt(altitudeColumn);
+					speedIndex = Integer.parseInt(speedColumn);
+					dirIndex = Integer.parseInt(directionColumn);
+					stddevIndex = stdDeviationColumn.isEmpty() ? -1 : Integer.parseInt(stdDeviationColumn);
+				} catch (NumberFormatException e) {
+					throw new IllegalArgumentException(trans.get("MultiLevelPinkNoiseWindModel.msg.importLevelsError.InvalidColumnIndex"));
+				}
+			}
+
+			// Read data rows
+			int lineNumber = hasHeaders ? 1 : 0;
 			while ((line = reader.readLine()) != null) {
-				// Ignore empty lines
-				if (line.isEmpty()) {
+				lineNumber++;
+
+				// Skip empty lines
+				if (line.trim().isEmpty()) {
 					continue;
 				}
-				String[] values = line.split(fieldSeparator);
-				sanityCheckColumnSize(fieldSeparator, values, line);
-				double altitude = extractDouble(values, altIndex, COLUMN_ALTITUDE);
-				double speed = extractDouble(values, speedIndex, COLUMN_SPEED);
-				double direction = MathUtil.deg2rad(extractDouble(values, dirIndex, COLUMN_DIRECTION));
-				Double stddev;
-				if (stddevIndex != -1) {
-					stddev = extractDouble(values, stddevIndex, COLUMN_STDDEV);
-				} else {
-					stddev = null;
+
+				String[] values = line.split(fieldSeparator, -1);  // -1 to keep empty trailing fields
+
+				// Check if we have enough columns
+				int maxColumnIndex = Math.max(Math.max(altIndex, speedIndex),
+						Math.max(dirIndex, Math.max(stddevIndex, 0)));
+				if (maxColumnIndex >= values.length) {
+					throw new IllegalArgumentException(String.format(
+							trans.get("MultiLevelPinkNoiseWindModel.msg.importLevelsError.NotEnoughColumnsInLine"),
+							lineNumber));
+				}
+
+				// Extract and convert values
+				double altitude = extractDoubleAndConvert(values, altIndex, "altitude", altitudeUnit);
+				double speed = extractDoubleAndConvert(values, speedIndex, "speed", speedUnit);
+				double direction = extractDoubleAndConvert(values, dirIndex, "direction", directionUnit);
+
+				// Standard deviation is optional
+				Double stddev = null;
+				if (stddevIndex >= 0 && stddevIndex < values.length && !values[stddevIndex].trim().isEmpty()) {
+					stddev = extractDoubleAndConvert(values, stddevIndex, "standard deviation", stdDeviationUnit);
 				}
 
 				// Add the wind level
-				if (stddev == null) {
-					addWindLevel(altitude, speed, direction);
-				} else {
-					addWindLevel(altitude, speed, direction, stddev);
-				}
+				addWindLevel(altitude, speed, direction, stddev);
 			}
+
+			// Sort levels by altitude
+			sortLevels();
+
+			// Check if we have at least one level
+			if (getLevels().isEmpty()) {
+				throw new IllegalArgumentException(trans.get("MultiLevelPinkNoiseWindModel.msg.importLevelsError.NoValidData"));
+			}
+
 		} catch (IOException e) {
 			throw new IllegalArgumentException(trans.get("MultiLevelPinkNoiseWindModel.msg.importLevelsError.CouldNotLoadFile") + " '"
 					+ file.getName() + "'");
@@ -277,30 +331,52 @@ public class MultiLevelPinkNoiseWindModel implements WindModel {
 				throw e; // Re-throw if no comma found
 			} catch (NumberFormatException ex) {
 				throw new IllegalArgumentException(trans.get("MultiLevelPinkNoiseWindModel.msg.importLevelsError.WrongFormat")
-						+ " Value: '" + values[index] + "'");
+						+ "\nValue: '" + values[index] + "'");
 			}
 		}
 	}
 
 	/**
-	 * Check if the number of columns in a line is correct
-	 * @param fieldSeparator The field separator used in the CSV file
-	 * @param columns The columns in the line
-	 * @param line The line that was read
+	 * Find a column index in a list of headers.
+	 *
+	 * @param headers The list of headers
+	 * @param columnName The column name or index to find
+	 * @param fieldName Display name of the field for error messages
+	 * @param required Whether the column is required
+	 * @return The index of the column
+	 * @throws IllegalArgumentException If the column is required but not found
 	 */
-	private void sanityCheckColumnSize(String fieldSeparator, String[] columns, String line) {
-		int nrOfColumns = columns.length;
-		if (nrOfColumns < REQUIRED_NR_OF_CSV_COLUMNS) {
-			String[] msg = {
-					String.format(trans.get("MultiLevelPinkNoiseWindModel.msg.importLevelsError.NotEnoughColumns1"),
-							nrOfColumns, line),
-					String.format(trans.get("MultiLevelPinkNoiseWindModel.msg.importLevelsError.NotEnoughColumns2"),
-							REQUIRED_NR_OF_CSV_COLUMNS, "alt, speed & dir"),
-					String.format(trans.get("MultiLevelPinkNoiseWindModel.msg.importLevelsError.NotEnoughColumns3"),
-							fieldSeparator),
-			};
-			throw new IllegalArgumentException(String.join("\n", msg));
+	private int findColumnIndex(List<String> headers, String columnName, String fieldName, boolean required) {
+		int index = headers.indexOf(columnName);
+
+		if (index == -1 && required) {
+			throw new IllegalArgumentException(String.format(
+					trans.get("MultiLevelPinkNoiseWindModel.msg.importLevelsError.ColumnNotFound"),
+					fieldName, columnName));
 		}
+
+		return index;
+	}
+
+	/**
+	 * Extract a double value from a string array and convert it to the appropriate unit.
+	 *
+	 * @param values The array of values
+	 * @param index The index of the value to extract
+	 * @param fieldName Display name of the field for error messages
+	 * @param unit The unit of the value as specified in the CSV
+	 * @return The extracted double value in SI units
+	 */
+	private double extractDoubleAndConvert(String[] values, int index, String fieldName, Unit unit) {
+		// Extract the raw value
+		double rawValue = extractDouble(values, index, fieldName);
+
+		// Convert from the input unit to SI units (the internal unit system)
+		if (unit != null) {
+			return unit.fromUnit(rawValue);
+		}
+
+		return rawValue;
 	}
 
 	/**

--- a/core/src/main/java/info/openrocket/core/models/wind/MultiLevelPinkNoiseWindModel.java
+++ b/core/src/main/java/info/openrocket/core/models/wind/MultiLevelPinkNoiseWindModel.java
@@ -16,7 +16,9 @@ import java.util.Objects;
 import info.openrocket.core.l10n.Translator;
 import info.openrocket.core.preferences.ApplicationPreferences;
 import info.openrocket.core.startup.Application;
+import info.openrocket.core.unit.DegreeUnit;
 import info.openrocket.core.unit.Unit;
+import info.openrocket.core.unit.UnitGroup;
 import info.openrocket.core.util.ChangeSource;
 import info.openrocket.core.util.Coordinate;
 import info.openrocket.core.util.ModID;
@@ -294,6 +296,14 @@ public class MultiLevelPinkNoiseWindModel implements WindModel {
 			throw new IllegalArgumentException(trans.get("MultiLevelPinkNoiseWindModel.msg.importLevelsError.CouldNotLoadFile") + " '"
 					+ file.getName() + "'");
 		}
+	}
+
+	public void importLevelsFromCSV(File file, String fieldSeparator) {
+		importLevelsFromCSV(file, fieldSeparator, "alt", "speed", "dir", "stddev",
+				UnitGroup.UNITS_DISTANCE.getSIUnit(),
+				UnitGroup.UNITS_WINDSPEED.getSIUnit(),
+				new DegreeUnit(),	// This is more common in wind data
+				UnitGroup.UNITS_WINDSPEED.getSIUnit(), true);
 	}
 
 	/**

--- a/core/src/main/java/info/openrocket/core/models/wind/MultiLevelPinkNoiseWindModel.java
+++ b/core/src/main/java/info/openrocket/core/models/wind/MultiLevelPinkNoiseWindModel.java
@@ -299,7 +299,7 @@ public class MultiLevelPinkNoiseWindModel implements WindModel {
 	}
 
 	public void importLevelsFromCSV(File file, String fieldSeparator) {
-		importLevelsFromCSV(file, fieldSeparator, "alt", "speed", "dir", "stddev",
+		importLevelsFromCSV(file, fieldSeparator, "altitude", "speed", "direction", "stddev",
 				UnitGroup.UNITS_DISTANCE.getSIUnit(),
 				UnitGroup.UNITS_WINDSPEED.getSIUnit(),
 				new DegreeUnit(),	// This is more common in wind data

--- a/core/src/main/java/info/openrocket/core/preferences/ApplicationPreferences.java
+++ b/core/src/main/java/info/openrocket/core/preferences/ApplicationPreferences.java
@@ -28,6 +28,7 @@ import info.openrocket.core.rocketcomponent.RocketComponent;
 import info.openrocket.core.simulation.RK4SimulationStepper;
 import info.openrocket.core.simulation.SimulationOptionsInterface;
 import info.openrocket.core.startup.Application;
+import info.openrocket.core.unit.DegreeUnit;
 import info.openrocket.core.unit.Unit;
 import info.openrocket.core.unit.UnitGroup;
 import info.openrocket.core.util.BugException;
@@ -1387,7 +1388,7 @@ public abstract class ApplicationPreferences implements ChangeSource, ORPreferen
 	public Unit getMultiLevelWindCsvImportAltitudeUnit() {
 		String unitString = getString(MULTI_LEVEL_WIND_CSV_IMPORT_ALTITUDE_UNIT, null);
 		if (unitString == null) {
-			return UnitGroup.UNITS_DISTANCE.getDefaultUnit();
+			return UnitGroup.UNITS_DISTANCE.getSIUnit();
 		} else {
 			return UnitGroup.UNITS_DISTANCE.getUnit(unitString);
 		}
@@ -1440,7 +1441,7 @@ public abstract class ApplicationPreferences implements ChangeSource, ORPreferen
 	public Unit getMultiLevelWindCsvImportSpeedUnit() {
 		String unitString = getString(MULTI_LEVEL_WIND_CSV_IMPORT_SPEED_UNIT, null);
 		if (unitString == null) {
-			return UnitGroup.UNITS_WINDSPEED.getDefaultUnit();
+			return UnitGroup.UNITS_WINDSPEED.getSIUnit();
 		} else {
 			return UnitGroup.UNITS_WINDSPEED.getUnit(unitString);
 		}
@@ -1493,7 +1494,7 @@ public abstract class ApplicationPreferences implements ChangeSource, ORPreferen
 	public Unit getMultiLevelWindCsvImportDirectionUnit() {
 		String unitString = getString(MULTI_LEVEL_WIND_CSV_IMPORT_DIRECTION_UNIT, null);
 		if (unitString == null) {
-			return UnitGroup.UNITS_ANGLE.getDefaultUnit();
+			return new DegreeUnit();
 		} else {
 			return UnitGroup.UNITS_ANGLE.getUnit(unitString);
 		}
@@ -1546,7 +1547,7 @@ public abstract class ApplicationPreferences implements ChangeSource, ORPreferen
 	public Unit getMultiLevelWindCsvImportStddevUnit() {
 		String unitString = getString(MULTI_LEVEL_WIND_CSV_IMPORT_STDDEV_UNIT, null);
 		if (unitString == null) {
-			return UnitGroup.UNITS_WINDSPEED.getDefaultUnit();
+			return UnitGroup.UNITS_WINDSPEED.getSIUnit();
 		} else {
 			return UnitGroup.UNITS_WINDSPEED.getUnit(unitString);
 		}

--- a/core/src/main/java/info/openrocket/core/preferences/ApplicationPreferences.java
+++ b/core/src/main/java/info/openrocket/core/preferences/ApplicationPreferences.java
@@ -1354,7 +1354,7 @@ public abstract class ApplicationPreferences implements ChangeSource, ORPreferen
 	 * @return the column name for the altitude
 	 */
 	public String getMultiLevelWindCsvImportAltitudeColumn() {
-		return getString(MULTI_LEVEL_WIND_CSV_IMPORT_ALTITUDE_COLUMN, "alt");
+		return getString(MULTI_LEVEL_WIND_CSV_IMPORT_ALTITUDE_COLUMN, "altitude");
 	}
 
 	/**
@@ -1460,7 +1460,7 @@ public abstract class ApplicationPreferences implements ChangeSource, ORPreferen
 	 * @return the column name for the direction
 	 */
 	public String getMultiLevelWindCsvImportDirectionColumn() {
-		return getString(MULTI_LEVEL_WIND_CSV_IMPORT_DIRECTION_COLUMN, "dir");
+		return getString(MULTI_LEVEL_WIND_CSV_IMPORT_DIRECTION_COLUMN, "direction");
 	}
 
 	/**

--- a/core/src/main/java/info/openrocket/core/preferences/ApplicationPreferences.java
+++ b/core/src/main/java/info/openrocket/core/preferences/ApplicationPreferences.java
@@ -28,6 +28,8 @@ import info.openrocket.core.rocketcomponent.RocketComponent;
 import info.openrocket.core.simulation.RK4SimulationStepper;
 import info.openrocket.core.simulation.SimulationOptionsInterface;
 import info.openrocket.core.startup.Application;
+import info.openrocket.core.unit.Unit;
+import info.openrocket.core.unit.UnitGroup;
 import info.openrocket.core.util.BugException;
 import info.openrocket.core.util.BuildProperties;
 import info.openrocket.core.util.ChangeSource;
@@ -82,6 +84,21 @@ public abstract class ApplicationPreferences implements ChangeSource, ORPreferen
 
 	public static final String MATCH_FORE_DIAMETER = "MatchForeDiameter";
 	public static final String MATCH_AFT_DIAMETER = "MatchAftDiameter";
+
+	// Preferences related to multi-level wind CSV import
+	private static final String MULTI_LEVEL_WIND_CSV_IMPORT_HAS_HEADER = "MultiLevelWindCSVImportHasHeader";
+	private static final String MULTI_LEVEL_WIND_CSV_IMPORT_ALTITUDE_COLUMN = "MultiLevelWindCSVImportAltitudeColumn";
+	private static final String MULTI_LEVEL_WIND_CSV_IMPORT_ALTITUDE_COLUMN_INDEX = "MultiLevelWindCSVImportAltitudeColumnIndex";
+	private static final String MULTI_LEVEL_WIND_CSV_IMPORT_ALTITUDE_UNIT = "MultiLevelWindCSVImportAltitudeUnit";
+	private static final String MULTI_LEVEL_WIND_CSV_IMPORT_SPEED_COLUMN = "MultiLevelWindCSVImportSpeedColumn";
+	private static final String MULTI_LEVEL_WIND_CSV_IMPORT_SPEED_COLUMN_INDEX = "MultiLevelWindCSVImportSpeedColumnIndex";
+	private static final String MULTI_LEVEL_WIND_CSV_IMPORT_SPEED_UNIT = "MultiLevelWindCSVImportSpeedUnit";
+	private static final String MULTI_LEVEL_WIND_CSV_IMPORT_DIRECTION_COLUMN = "MultiLevelWindCSVImportDirectionColumn";
+	private static final String MULTI_LEVEL_WIND_CSV_IMPORT_DIRECTION_COLUMN_INDEX = "MultiLevelWindCSVImportDirectionColumnIndex";
+	private static final String MULTI_LEVEL_WIND_CSV_IMPORT_DIRECTION_UNIT = "MultiLevelWindCSVImportDirectionUnit";
+	private static final String MULTI_LEVEL_WIND_CSV_IMPORT_STDDEV_COLUMN = "MultiLevelWindCSVImportStddevColumn";
+	private static final String MULTI_LEVEL_WIND_CSV_IMPORT_STDDEV_COLUMN_INDEX = "MultiLevelWindCSVImportStddevColumnIndex";
+	private static final String MULTI_LEVEL_WIND_CSV_IMPORT_STDDEV_UNIT = "MultiLevelWindCSVImportStddevUnit";
 
 	// Node names
 	public static final String PREFERRED_THRUST_CURVE_MOTOR_NODE = "PreferredThrustCurveMotors";
@@ -1313,6 +1330,234 @@ public abstract class ApplicationPreferences implements ChangeSource, ORPreferen
 	 */
 	public void setSVGStrokeWidth(double width) {
 		putDouble(SVG_STROKE_WIDTH, width);
+	}
+
+	/**
+	 * Returns whether the multi-level wind CSV import has a header row.
+	 * @return true if the CSV import has a header
+	 */
+	public boolean isMultiLevelWindCsvImportHeader() {
+		return getBoolean(MULTI_LEVEL_WIND_CSV_IMPORT_HAS_HEADER, true);
+	}
+
+	/**
+	 * Sets whether the multi-level wind CSV import has a header row.
+	 * @param hasHeader true if the CSV import has a header
+	 */
+	public void setMultiLevelWindCsvImportHeader(boolean hasHeader) {
+		putBoolean(MULTI_LEVEL_WIND_CSV_IMPORT_HAS_HEADER, hasHeader);
+	}
+
+	/**
+	 * Returns the column name used for the altitude in the CSV import for multi-level wind.
+	 * @return the column name for the altitude
+	 */
+	public String getMultiLevelWindCsvImportAltitudeColumn() {
+		return getString(MULTI_LEVEL_WIND_CSV_IMPORT_ALTITUDE_COLUMN, "alt");
+	}
+
+	/**
+	 * Sets the column name used for the altitude in the CSV import for multi-level wind.
+	 * @param columnName the column name for the altitude
+	 */
+	public void setMultiLevelWindCsvImportAltitudeColumn(String columnName) {
+		putString(MULTI_LEVEL_WIND_CSV_IMPORT_ALTITUDE_COLUMN, columnName);
+	}
+
+	/**
+	 * Returns the column index used for the altitude in the CSV import for multi-level wind.
+	 * @return the column index for the altitude
+	 */
+	public int getMultiLevelWindCsvImportAltitudeColumnIndex() {
+		return getInt(MULTI_LEVEL_WIND_CSV_IMPORT_ALTITUDE_COLUMN_INDEX, 0);
+	}
+
+	/**
+	 * Sets the column index used for the altitude in the CSV import for multi-level wind.
+	 * @param columnIndex the column index for the altitude
+	 */
+	public void setMultiLevelWindCsvImportAltitudeColumnIndex(int columnIndex) {
+		putInt(MULTI_LEVEL_WIND_CSV_IMPORT_ALTITUDE_COLUMN_INDEX, columnIndex);
+	}
+
+	/**
+	 * Gets the unit used for the altitude in the CSV import for multi-level wind.
+	 * @return the unit for the altitude
+	 */
+	public Unit getMultiLevelWindCsvImportAltitudeUnit() {
+		String unitString = getString(MULTI_LEVEL_WIND_CSV_IMPORT_ALTITUDE_UNIT, null);
+		if (unitString == null) {
+			return UnitGroup.UNITS_DISTANCE.getDefaultUnit();
+		} else {
+			return UnitGroup.UNITS_DISTANCE.getUnit(unitString);
+		}
+	}
+
+	/**
+	 * Sets the unit used for the altitude in the CSV import for multi-level wind.
+	 * @param unit the unit for the altitude
+	 */
+	public void setMultiLevelWindCsvImportAltitudeUnit(Unit unit) {
+		putString(MULTI_LEVEL_WIND_CSV_IMPORT_ALTITUDE_UNIT, unit.toString());
+	}
+
+	/**
+	 * Returns the column name used for the speed in the CSV import for multi-level wind.
+	 * @return the column name for the speed
+	 */
+	public String getMultiLevelWindCsvImportSpeedColumn() {
+		return getString(MULTI_LEVEL_WIND_CSV_IMPORT_SPEED_COLUMN, "speed");
+	}
+
+	/**
+	 * Sets the column name used for the speed in the CSV import for multi-level wind.
+	 * @param columnName the column name for the speed
+	 */
+	public void setMultiLevelWindCsvImportSpeedColumn(String columnName) {
+		putString(MULTI_LEVEL_WIND_CSV_IMPORT_SPEED_COLUMN, columnName);
+	}
+
+	/**
+	 * Returns the column index used for the speed in the CSV import for multi-level wind.
+	 * @return the column index for the speed
+	 */
+	public int getMultiLevelWindCsvImportSpeedColumnIndex() {
+		return getInt(MULTI_LEVEL_WIND_CSV_IMPORT_SPEED_COLUMN_INDEX, 1);
+	}
+
+	/**
+	 * Sets the column index used for the speed in the CSV import for multi-level wind.
+	 * @param columnIndex the column index for the speed
+	 */
+	public void setMultiLevelWindCsvImportSpeedColumnIndex(int columnIndex) {
+		putInt(MULTI_LEVEL_WIND_CSV_IMPORT_SPEED_COLUMN_INDEX, columnIndex);
+	}
+
+	/**
+	 * Gets the unit used for the speed in the CSV import for multi-level wind.
+	 * @return the unit for the speed
+	 */
+	public Unit getMultiLevelWindCsvImportSpeedUnit() {
+		String unitString = getString(MULTI_LEVEL_WIND_CSV_IMPORT_SPEED_UNIT, null);
+		if (unitString == null) {
+			return UnitGroup.UNITS_WINDSPEED.getDefaultUnit();
+		} else {
+			return UnitGroup.UNITS_WINDSPEED.getUnit(unitString);
+		}
+	}
+
+	/**
+	 * Sets the unit used for the speed in the CSV import for multi-level wind.
+	 * @param unit the unit for the speed
+	 */
+	public void setMultiLevelWindCsvImportSpeedUnit(Unit unit) {
+		putString(MULTI_LEVEL_WIND_CSV_IMPORT_SPEED_UNIT, unit.toString());
+	}
+
+	/**
+	 * Returns the column name used for the direction in the CSV import for multi-level wind.
+	 * @return the column name for the direction
+	 */
+	public String getMultiLevelWindCsvImportDirectionColumn() {
+		return getString(MULTI_LEVEL_WIND_CSV_IMPORT_DIRECTION_COLUMN, "dir");
+	}
+
+	/**
+	 * Sets the column name used for the direction in the CSV import for multi-level wind.
+	 * @param columnName the column name for the direction
+	 */
+	public void setMultiLevelWindCsvImportDirectionColumn(String columnName) {
+		putString(MULTI_LEVEL_WIND_CSV_IMPORT_DIRECTION_COLUMN, columnName);
+	}
+
+	/**
+	 * Returns the column index used for the direction in the CSV import for multi-level wind.
+	 * @return the column index for the direction
+	 */
+	public int getMultiLevelWindCsvImportDirectionColumnIndex() {
+		return getInt(MULTI_LEVEL_WIND_CSV_IMPORT_DIRECTION_COLUMN_INDEX, 2);
+	}
+
+	/**
+	 * Sets the column index used for the direction in the CSV import for multi-level wind.
+	 * @param columnIndex the column index for the direction
+	 */
+	public void setMultiLevelWindCsvImportDirectionColumnIndex(int columnIndex) {
+		putInt(MULTI_LEVEL_WIND_CSV_IMPORT_DIRECTION_COLUMN_INDEX, columnIndex);
+	}
+
+	/**
+	 * Gets the unit used for the direction in the CSV import for multi-level wind.
+	 * @return the unit for the direction
+	 */
+	public Unit getMultiLevelWindCsvImportDirectionUnit() {
+		String unitString = getString(MULTI_LEVEL_WIND_CSV_IMPORT_DIRECTION_UNIT, null);
+		if (unitString == null) {
+			return UnitGroup.UNITS_ANGLE.getDefaultUnit();
+		} else {
+			return UnitGroup.UNITS_ANGLE.getUnit(unitString);
+		}
+	}
+
+	/**
+	 * Sets the unit used for the direction in the CSV import for multi-level wind.
+	 * @param unit the unit for the direction
+	 */
+	public void setMultiLevelWindCsvImportDirectionUnit(Unit unit) {
+		putString(MULTI_LEVEL_WIND_CSV_IMPORT_DIRECTION_UNIT, unit.toString());
+	}
+
+	/**
+	 * Returns the column name used for the stddev in the CSV import for multi-level wind.
+	 * @return the column name for the stddev
+	 */
+	public String getMultiLevelWindCsvImportStddevColumn() {
+		return getString(MULTI_LEVEL_WIND_CSV_IMPORT_STDDEV_COLUMN, "stddev");
+	}
+
+	/**
+	 * Sets the column name used for the stddev in the CSV import for multi-level wind.
+	 * @param columnName the column name for the stddev
+	 */
+	public void setMultiLevelWindCsvImportStddevColumn(String columnName) {
+		putString(MULTI_LEVEL_WIND_CSV_IMPORT_STDDEV_COLUMN, columnName);
+	}
+
+	/**
+	 * Returns the column index used for the std deviation in the CSV import for multi-level wind.
+	 * @return the column index for the std deviation
+	 */
+	public int getMultiLevelWindCsvImportStddevColumnIndex() {
+		return getInt(MULTI_LEVEL_WIND_CSV_IMPORT_STDDEV_COLUMN_INDEX, 3);
+	}
+
+	/**
+	 * Sets the column index used for the std deviation in the CSV import for multi-level wind.
+	 * @param columnIndex the column index for the std deviation
+	 */
+	public void setMultiLevelWindCsvImportStddevColumnIndex(int columnIndex) {
+		putInt(MULTI_LEVEL_WIND_CSV_IMPORT_STDDEV_COLUMN_INDEX, columnIndex);
+	}
+
+	/**
+	 * Gets the unit used for the stddev in the CSV import for multi-level wind.
+	 * @return the unit for the stddev
+	 */
+	public Unit getMultiLevelWindCsvImportStddevUnit() {
+		String unitString = getString(MULTI_LEVEL_WIND_CSV_IMPORT_STDDEV_UNIT, null);
+		if (unitString == null) {
+			return UnitGroup.UNITS_WINDSPEED.getDefaultUnit();
+		} else {
+			return UnitGroup.UNITS_WINDSPEED.getUnit(unitString);
+		}
+	}
+
+	/**
+	 * Sets the unit used for the stddev in the CSV import for multi-level wind.
+	 * @param unit the unit for the stddev
+	 */
+	public void setMultiLevelWindCsvImportStddevUnit(Unit unit) {
+		putString(MULTI_LEVEL_WIND_CSV_IMPORT_STDDEV_UNIT, unit.toString());
 	}
 
 	/*

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -630,8 +630,6 @@ WindProfileEditorDlg.but.exportLevels.ttip = Export wind levels to a CSV file
 WindProfileEditorDlg.dlg.overwriteLevels.title = Overwrite wind levels?
 WindProfileEditorDlg.dlg.overwriteLevels.msg = Your current wind levels will be overwritten. Do you want to continue?
 WindProfileEditorDlg.dlg.importLevels.title = Import wind levels
-WindProfileEditorDlg.dlg.importLevels.accessoryPanel.title = CSV File Requirements
-WindProfileEditorDlg.dlg.importLevels.accessoryPanel.desc = Required Headers:\n\nalt\t- Altitude of the level (meters)\nspeed\t- Wind speed\ndirection\t- Wind direction (degrees)\n\nOptional Headers:\n\nstddev\t- Standard deviation of wind speed (m/s)
 WindProfileEditorDlg.msg.importLevelsError = An issue occurred while importing wind levels:
 WindProfileEditorDlg.msg.importLevelsError.title = Import Wind Levels Failed
 WindProfileEditorDlg.lbl.AltitudeReference = Altitude reference:
@@ -639,15 +637,38 @@ WindProfileEditorDlg.lbl.AltitudeReference.ttip = Set to which altitude the wind
 WindProfileEditorDlg.radio.MSL = Mean Sea Level (MSL)
 WindProfileEditorDlg.radio.AGL = Above Ground Level (AGL)
 
+# CSV Import Settings Dialog
+CSVImportSettingsDialog.title = Wind Data Import Settings
+CSVImportSettingsDialog.description = This dialog configures how the data is structured in your CSV file.
+CSVImportSettingsDialog.hasHeaders = CSV file has a header row
+CSVImportSettingsDialog.hasHeaders.ttip = Select if your CSV file includes column names in the first row
+CSVImportSettingsDialog.columnMappingHelp = Specify which columns in your CSV file contain each required data type and the units used in the file.
+CSVImportSettingsDialog.columnName = Column Name
+CSVImportSettingsDialog.columnIndex = Column Index
+CSVImportSettingsDialog.dataType = Data Type
+CSVImportSettingsDialog.unit = Unit
+CSVImportSettingsDialog.altitude = Altitude
+CSVImportSettingsDialog.speed = Speed
+CSVImportSettingsDialog.direction = Direction
+CSVImportSettingsDialog.stdDev = Standard Deviation (optional)
+CSVImportSettingsDialog.csvSettings = CSV Settings
+CSVImportSettingsDialog.separator = Field Separator
+CSVImportSettingsDialog.preview = CSV Example Contents Preview
+CSVImportSettingsDialog.previewHelp = An example of how the first lines of data in you CSV file should look like for some example data. Make sure the data is correctly separated and that the column names are correct.
+CSVImportSettingsDialog.duplicateColumnError = Duplicate column indices found. Please ensure that each column index is unique.
+CSVImportSettingsDialog.validationError = Incorrect Data Input
+
 ! MultiLevelPinkNoiseWindModel
-MultiLevelPinkNoiseWindModel.msg.importLevelsError.NotEnoughColumns1 = Not enough columns (%d) found on the line: '%s'
-MultiLevelPinkNoiseWindModel.msg.importLevelsError.NotEnoughColumns2 = The file should contain at least %d columns: '%s'
-MultiLevelPinkNoiseWindModel.msg.importLevelsError.NotEnoughColumns3 = Add the correct columns, or ensure that the set CSV field separator ('%s') matches the file's separator.
-MultiLevelPinkNoiseWindModel.msg.importLevelsError.NoHeader = Header not found:
-MultiLevelPinkNoiseWindModel.msg.importLevelsError.MissingColumnValue = Missing value for column '%s'
-MultiLevelPinkNoiseWindModel.msg.importLevelsError.EmptyOrNullValue = Empty or null value found in column: '%s'
-MultiLevelPinkNoiseWindModel.msg.importLevelsError.WrongFormat = <html>Data should be numerical:<br>
-MultiLevelPinkNoiseWindModel.msg.importLevelsError.CouldNotLoadFile = Could not load file:
+MultiLevelPinkNoiseWindModel.msg.importLevelsError.EmptyFile = The CSV file is empty.
+MultiLevelPinkNoiseWindModel.msg.importLevelsError.ColumnNotFound = %s column "%s" not found in header row.
+MultiLevelPinkNoiseWindModel.msg.importLevelsError.InvalidColumnIndex = Invalid column index. Please enter numeric indices when the file has no headers.
+MultiLevelPinkNoiseWindModel.msg.importLevelsError.NotEnoughColumnsInLine = Line %d does not have enough columns.
+MultiLevelPinkNoiseWindModel.msg.importLevelsError.NoValidData = No valid wind data found in the file.
+MultiLevelPinkNoiseWindModel.msg.importLevelsError.WrongFormat = The file is not in the correct format. Make sure the data is correctly formatted as a number.
+MultiLevelPinkNoiseWindModel.msg.importLevelsError.MissingColumnValue = Missing value in column %s.
+MultiLevelPinkNoiseWindModel.msg.importLevelsError.EmptyOrNullValue = Empty or null value in column %s.
+MultiLevelPinkNoiseWindModel.msg.importLevelsError.NoHeader = The file does not have a header row.
+MultiLevelPinkNoiseWindModel.msg.importLevelsError.CouldNotLoadFile = Could not load the file.
 
 ! Simulation Status
 Simulation.Status.UPTODATE = Up To Date

--- a/core/src/test/java/info/openrocket/core/models/wind/MultiLevelWindModelTest.java
+++ b/core/src/test/java/info/openrocket/core/models/wind/MultiLevelWindModelTest.java
@@ -200,7 +200,7 @@ class MultiLevelWindModelTest extends BaseTestCase {
 
 		// Write test data
 		Files.write(tempFile.toPath(), Arrays.asList(
-				"alt,speed,dir,stddev",
+				"altitude,speed,direction,stddev",
 				"0,5,0,1.5",
 				"100,10,45,2.0",
 				"1000,15,90,2.5"
@@ -237,7 +237,7 @@ class MultiLevelWindModelTest extends BaseTestCase {
 
 		// Test different number formats
 		Files.write(tempFile.toPath(), Arrays.asList(
-				"alt,speed,dir,stddev",
+				"altitude,speed,direction,stddev",
 				"0,5.5,0,1.5",      // Standard format
 				"100,10,2,2.0",     // Integer
 				"1000,15.0,90,2.5", // With trailing zero
@@ -263,7 +263,7 @@ class MultiLevelWindModelTest extends BaseTestCase {
 		tempFile.deleteOnExit();
 
 		Files.write(tempFile.toPath(), Arrays.asList(
-				"alt,speed,dir,stddev",
+				"altitude,speed,direction,stddev",
 				"0,-5,0,1.5",      // Negative speed
 				"100,10,-45,2.0",  // Negative direction
 				"1000,-15,-90,2.5"  // Negative speed and direction
@@ -290,7 +290,7 @@ class MultiLevelWindModelTest extends BaseTestCase {
 
 		// Test different number formats
 		Files.write(tempFile.toPath(), Arrays.asList(
-				"alt,speed,dir,stddev",
+				"altitude,speed,direction,stddev",
 				"0,5,0,1.5",
 				"100,10,45",		// Missing value
 				"1000,15,90,2.5"
@@ -308,7 +308,7 @@ class MultiLevelWindModelTest extends BaseTestCase {
 		tempFile.deleteOnExit();
 
 		Files.write(tempFile.toPath(), Arrays.asList(
-				"alt;speed;dir;stddev",
+				"altitude;speed;direction;stddev",
 				"0;5;0;1,5",        // European format with comma
 				"100;10;45;2,0",    // European format
 				"1000;15,2;90;2,5"  // European format with multiple commas
@@ -332,7 +332,7 @@ class MultiLevelWindModelTest extends BaseTestCase {
 
 		// Missing speed column
 		Files.write(tempFile.toPath(), Arrays.asList(
-				"alt,dir,stddev",
+				"altitude,direction,stddev",
 				"0,0,1.5"
 		));
 
@@ -342,7 +342,7 @@ class MultiLevelWindModelTest extends BaseTestCase {
 
 		// Invalid number format
 		Files.write(tempFile.toPath(), Arrays.asList(
-				"alt,speed,dir,stddev",
+				"altitude,speed,direction,stddev",
 				"0,invalid,0,1.5"
 		));
 
@@ -352,7 +352,7 @@ class MultiLevelWindModelTest extends BaseTestCase {
 
 		// Empty value
 		Files.write(tempFile.toPath(), Arrays.asList(
-				"alt,speed,dir,stddev",
+				"altitude,speed,direction,stddev",
 				"0,,0,1.5"
 		));
 
@@ -368,7 +368,7 @@ class MultiLevelWindModelTest extends BaseTestCase {
 		tempFile.deleteOnExit();
 
 		Files.write(tempFile.toPath(), Arrays.asList(
-				"dir,speed,alt,stddev",  // Different order
+				"direction,speed,altitude,stddev",  // Different order
 				"0,5,0,1.5",
 				"45,10,100,2.0"
 		));
@@ -390,7 +390,7 @@ class MultiLevelWindModelTest extends BaseTestCase {
 		tempFile.deleteOnExit();
 
 		Files.write(tempFile.toPath(), Arrays.asList(
-				"alt,speed,dir,stddev,extra1,extra2",  // Extra columns
+				"altitude,speed,direction,stddev,extra1,extra2",  // Extra columns
 				"0,5,0,1.5,100,200",
 				"100,10,45,2.0,300,400"
 		));
@@ -514,7 +514,7 @@ class MultiLevelWindModelTest extends BaseTestCase {
 		File tempFile = tempDir.resolve("custom_units.csv").toFile();
 
 		Files.write(tempFile.toPath(), Arrays.asList(
-				"alt,speed,dir,stddev",
+				"altitude,speed,direction,stddev",
 				// Alt in feet, speed in mph, direction in degrees, stddev in mph
 				"0,11.2,0,3.4",       // 0m, 5m/s, 0rad, 1.5m/s
 				"328,22.4,45,4.5",    // 100m, 10m/s, PI/4rad, 2.0m/s
@@ -527,7 +527,7 @@ class MultiLevelWindModelTest extends BaseTestCase {
 		Unit degreeUnit = new DegreeUnit();
 
 		model.importLevelsFromCSV(tempFile, ",",
-				"alt", "speed", "dir", "stddev",
+				"altitude", "speed", "direction", "stddev",
 				feetUnit,      // altitude in feet
 				mphUnit,       // speed in mph
 				degreeUnit,    // direction in degrees
@@ -556,7 +556,7 @@ class MultiLevelWindModelTest extends BaseTestCase {
 		File tempFile = tempDir.resolve("no_stddev.csv").toFile();
 
 		Files.write(tempFile.toPath(), Arrays.asList(
-				"alt,speed,dir",
+				"altitude,speed,direction",
 				"0,5,0",
 				"100,10,45",
 				"1000,15,90"
@@ -564,7 +564,7 @@ class MultiLevelWindModelTest extends BaseTestCase {
 
 		// Import without stddev column
 		model.importLevelsFromCSV(tempFile, ",",
-				"alt", "speed", "dir", "",  // empty stddev column name
+				"altitude", "speed", "direction", "",  // empty stddev column name
 				UnitGroup.UNITS_DISTANCE.getSIUnit(),
 				UnitGroup.UNITS_WINDSPEED.getSIUnit(),
 				new DegreeUnit(),
@@ -591,7 +591,7 @@ class MultiLevelWindModelTest extends BaseTestCase {
 		File tempFile = tempDir.resolve("invalid_indices.csv").toFile();
 
 		Files.write(tempFile.toPath(), Arrays.asList(
-				"alt,speed,dir,stddev",
+				"altitude,speed,direction,stddev",
 				"0,5,0,1.5"
 		));
 

--- a/core/src/test/java/info/openrocket/core/models/wind/MultiLevelWindModelTest.java
+++ b/core/src/test/java/info/openrocket/core/models/wind/MultiLevelWindModelTest.java
@@ -625,7 +625,7 @@ class MultiLevelWindModelTest extends BaseTestCase {
 		File tempFile = tempDir.resolve("european_format.csv").toFile();
 
 		Files.write(tempFile.toPath(), Arrays.asList(
-				"höhe;geschwindigkeit;richtung;abweichung",
+				"hohe;geschwindigkeit;richtung;abweichung",
 				"0;5,0;0;1,5",
 				"100;10,0;45;2,0",
 				"1000;15,0;90;2,5"
@@ -633,7 +633,7 @@ class MultiLevelWindModelTest extends BaseTestCase {
 
 		// Import with European column names and formatting
 		model.importLevelsFromCSV(tempFile, ";",
-				"höhe", "geschwindigkeit", "richtung", "abweichung",
+				"hohe", "geschwindigkeit", "richtung", "abweichung",
 				UnitGroup.UNITS_DISTANCE.getSIUnit(),
 				UnitGroup.UNITS_WINDSPEED.getSIUnit(),
 				new DegreeUnit(),

--- a/core/src/test/java/info/openrocket/core/models/wind/MultiLevelWindModelTest.java
+++ b/core/src/test/java/info/openrocket/core/models/wind/MultiLevelWindModelTest.java
@@ -1,5 +1,8 @@
 package info.openrocket.core.models.wind;
 
+import info.openrocket.core.unit.DegreeUnit;
+import info.openrocket.core.unit.Unit;
+import info.openrocket.core.unit.UnitGroup;
 import info.openrocket.core.util.BaseTestCase;
 import info.openrocket.core.util.MathUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,10 +12,12 @@ import org.junit.jupiter.api.DisplayName;
 import info.openrocket.core.util.Coordinate;
 import info.openrocket.core.util.ModID;
 import info.openrocket.core.util.StateChangeListener;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 
@@ -24,6 +29,9 @@ class MultiLevelWindModelTest extends BaseTestCase {
 	private static final int SAMPLE_SIZE = 1000;
 
 	private MultiLevelPinkNoiseWindModel model;
+
+	@TempDir
+	Path tempDir;
 
 	@BeforeEach
 	void setUpModel() {
@@ -425,5 +433,258 @@ class MultiLevelWindModelTest extends BaseTestCase {
 			sumCos += Math.cos(angle);
 		}
 		return Math.atan2(sumSin, sumCos);
+	}
+
+	@Test
+	@DisplayName("Import with custom column names")
+	void testImportWithCustomColumnNames() throws IOException {
+		// Create a temporary CSV file with different column names
+		File tempFile = tempDir.resolve("custom_columns.csv").toFile();
+
+		Files.write(tempFile.toPath(), Arrays.asList(
+				"height,velocity,angle,variation",
+				"0,5,0,1.5",
+				"100,10,45,2.0",
+				"1000,15,90,2.5"
+		));
+
+		// Import with custom column names
+		model.importLevelsFromCSV(tempFile, ",",
+				"height", "velocity", "angle", "variation",
+				UnitGroup.UNITS_DISTANCE.getSIUnit(),
+				UnitGroup.UNITS_WINDSPEED.getSIUnit(),
+				new DegreeUnit(),
+				UnitGroup.UNITS_WINDSPEED.getSIUnit(),
+				true);
+
+		// Verify the data was imported correctly
+		List<MultiLevelPinkNoiseWindModel.LevelWindModel> levels = model.getLevels();
+		assertEquals(3, levels.size(), "Should have 3 wind levels");
+
+		assertEquals(0, levels.get(0).getAltitude(), EPSILON);
+		assertEquals(5, levels.get(0).getSpeed(), EPSILON);
+		assertEquals(0, levels.get(0).getDirection(), EPSILON);
+		assertEquals(1.5, levels.get(0).getStandardDeviation(), EPSILON);
+
+		assertEquals(100, levels.get(1).getAltitude(), EPSILON);
+		assertEquals(10, levels.get(1).getSpeed(), EPSILON);
+		assertEquals(Math.PI/4, levels.get(1).getDirection(), EPSILON); // 45 degrees
+		assertEquals(2.0, levels.get(1).getStandardDeviation(), EPSILON);
+	}
+
+	@Test
+	@DisplayName("Import with column indices")
+	void testImportWithColumnIndices() throws IOException {
+		// Create a temporary CSV file without headers
+		File tempFile = tempDir.resolve("no_headers.csv").toFile();
+
+		Files.write(tempFile.toPath(), Arrays.asList(
+				"0,5,0,1.5",
+				"100,10,45,2.0",
+				"1000,15,90,2.5"
+		));
+
+		// Import using column indices without headers
+		model.importLevelsFromCSV(tempFile, ",",
+				"0", "1", "2", "3", // alt=0, speed=1, dir=2, stddev=3
+				UnitGroup.UNITS_DISTANCE.getSIUnit(),
+				UnitGroup.UNITS_WINDSPEED.getSIUnit(),
+				new DegreeUnit(),
+				UnitGroup.UNITS_WINDSPEED.getSIUnit(),
+				false);  // no headers
+
+		// Verify the data was imported correctly
+		List<MultiLevelPinkNoiseWindModel.LevelWindModel> levels = model.getLevels();
+		assertEquals(3, levels.size(), "Should have 3 wind levels");
+
+		assertEquals(0, levels.get(0).getAltitude(), EPSILON);
+		assertEquals(5, levels.get(0).getSpeed(), EPSILON);
+		assertEquals(0, levels.get(0).getDirection(), EPSILON);
+		assertEquals(1.5, levels.get(0).getStandardDeviation(), EPSILON);
+
+		assertEquals(100, levels.get(1).getAltitude(), EPSILON);
+		assertEquals(10, levels.get(1).getSpeed(), EPSILON);
+		assertEquals(Math.PI/4, levels.get(1).getDirection(), EPSILON); // 45 degrees
+	}
+
+	@Test
+	@DisplayName("Import with custom units")
+	void testImportWithCustomUnits() throws IOException {
+		// Create a temporary CSV file with values in different units
+		File tempFile = tempDir.resolve("custom_units.csv").toFile();
+
+		Files.write(tempFile.toPath(), Arrays.asList(
+				"alt,speed,dir,stddev",
+				// Alt in feet, speed in mph, direction in degrees, stddev in mph
+				"0,11.2,0,3.4",       // 0m, 5m/s, 0rad, 1.5m/s
+				"328,22.4,45,4.5",    // 100m, 10m/s, PI/4rad, 2.0m/s
+				"3280,33.6,90,5.6"    // 1000m, 15m/s, PI/2rad, 2.5m/s
+		));
+
+		// Import with custom units
+		Unit feetUnit = UnitGroup.UNITS_DISTANCE.getUnit("ft");
+		Unit mphUnit = UnitGroup.UNITS_WINDSPEED.getUnit("mph");
+		Unit degreeUnit = new DegreeUnit();
+
+		model.importLevelsFromCSV(tempFile, ",",
+				"alt", "speed", "dir", "stddev",
+				feetUnit,      // altitude in feet
+				mphUnit,       // speed in mph
+				degreeUnit,    // direction in degrees
+				mphUnit,       // stddev in mph
+				true);
+
+		// Verify the data was imported and converted correctly
+		List<MultiLevelPinkNoiseWindModel.LevelWindModel> levels = model.getLevels();
+		assertEquals(3, levels.size(), "Should have 3 wind levels");
+
+		// Check conversions (allowing for rounding errors)
+		assertEquals(0, levels.get(0).getAltitude(), EPSILON);
+		assertEquals(5, levels.get(0).getSpeed(), 0.1); // ~5 m/s
+		assertEquals(0, levels.get(0).getDirection(), EPSILON);
+		assertEquals(1.5, levels.get(0).getStandardDeviation(), 0.1); // ~1.5 m/s
+
+		assertEquals(100, levels.get(1).getAltitude(), 0.1); // ~100 m
+		assertEquals(10, levels.get(1).getSpeed(), 0.1); // ~10 m/s
+		assertEquals(Math.PI/4, levels.get(1).getDirection(), EPSILON); // 45 degrees
+	}
+
+	@Test
+	@DisplayName("Import with optional standard deviation column")
+	void testImportWithOptionalStdDevColumn() throws IOException {
+		// Create a temporary CSV file without stddev column
+		File tempFile = tempDir.resolve("no_stddev.csv").toFile();
+
+		Files.write(tempFile.toPath(), Arrays.asList(
+				"alt,speed,dir",
+				"0,5,0",
+				"100,10,45",
+				"1000,15,90"
+		));
+
+		// Import without stddev column
+		model.importLevelsFromCSV(tempFile, ",",
+				"alt", "speed", "dir", "",  // empty stddev column name
+				UnitGroup.UNITS_DISTANCE.getSIUnit(),
+				UnitGroup.UNITS_WINDSPEED.getSIUnit(),
+				new DegreeUnit(),
+				null,  // no unit needed for stddev
+				true);
+
+		// Verify the data was imported correctly
+		List<MultiLevelPinkNoiseWindModel.LevelWindModel> levels = model.getLevels();
+		assertEquals(3, levels.size(), "Should have 3 wind levels");
+
+		// The standard deviation should be the default value from PinkNoiseWindModel
+		double defaultStdDev = new PinkNoiseWindModel().getStandardDeviation();
+
+		assertEquals(0, levels.get(0).getAltitude(), EPSILON);
+		assertEquals(5, levels.get(0).getSpeed(), EPSILON);
+		assertEquals(0, levels.get(0).getDirection(), EPSILON);
+		assertEquals(defaultStdDev, levels.get(0).getStandardDeviation(), EPSILON);
+	}
+
+	@Test
+	@DisplayName("Import with invalid column indices")
+	void testImportWithInvalidColumnIndices() throws IOException {
+		// Create a temporary CSV file
+		File tempFile = tempDir.resolve("invalid_indices.csv").toFile();
+
+		Files.write(tempFile.toPath(), Arrays.asList(
+				"alt,speed,dir,stddev",
+				"0,5,0,1.5"
+		));
+
+		// Try to import with an out-of-bounds index
+		assertThrows(IllegalArgumentException.class, () ->
+				model.importLevelsFromCSV(tempFile, ",",
+						"0", "1", "5", "3",  // dir=5 is out of bounds
+						UnitGroup.UNITS_DISTANCE.getSIUnit(),
+						UnitGroup.UNITS_WINDSPEED.getSIUnit(),
+						new DegreeUnit(),
+						UnitGroup.UNITS_WINDSPEED.getSIUnit(),
+						true)
+		);
+
+		// Try to import with a non-numeric index when headers=false
+		assertThrows(IllegalArgumentException.class, () ->
+				model.importLevelsFromCSV(tempFile, ",",
+						"0", "speed", "2", "3",  // non-numeric "speed" for index
+						UnitGroup.UNITS_DISTANCE.getSIUnit(),
+						UnitGroup.UNITS_WINDSPEED.getSIUnit(),
+						new DegreeUnit(),
+						UnitGroup.UNITS_WINDSPEED.getSIUnit(),
+						false)
+		);
+	}
+
+	@Test
+	@DisplayName("Import with European units and number format")
+	void testImportWithEuropeanUnitsAndFormat() throws IOException {
+		// Create a temporary CSV file with European number format
+		File tempFile = tempDir.resolve("european_format.csv").toFile();
+
+		Files.write(tempFile.toPath(), Arrays.asList(
+				"höhe;geschwindigkeit;richtung;abweichung",
+				"0;5,0;0;1,5",
+				"100;10,0;45;2,0",
+				"1000;15,0;90;2,5"
+		));
+
+		// Import with European column names and formatting
+		model.importLevelsFromCSV(tempFile, ";",
+				"höhe", "geschwindigkeit", "richtung", "abweichung",
+				UnitGroup.UNITS_DISTANCE.getSIUnit(),
+				UnitGroup.UNITS_WINDSPEED.getSIUnit(),
+				new DegreeUnit(),
+				UnitGroup.UNITS_WINDSPEED.getSIUnit(),
+				true);
+
+		// Verify the data was imported correctly
+		List<MultiLevelPinkNoiseWindModel.LevelWindModel> levels = model.getLevels();
+		assertEquals(3, levels.size(), "Should have 3 wind levels");
+
+		assertEquals(0, levels.get(0).getAltitude(), EPSILON);
+		assertEquals(5.0, levels.get(0).getSpeed(), EPSILON);
+		assertEquals(0, levels.get(0).getDirection(), EPSILON);
+		assertEquals(1.5, levels.get(0).getStandardDeviation(), EPSILON);
+	}
+
+	@Test
+	@DisplayName("Import with mixed column references (names and indices)")
+	void testImportWithMixedColumnReferences() throws IOException {
+		// This test is only relevant if the API allows mixing names and indices
+		// Create a temporary CSV file
+		File tempFile = tempDir.resolve("mixed_references.csv").toFile();
+
+		Files.write(tempFile.toPath(), Arrays.asList(
+				"height,velocity,angle,variation",
+				"0,5,0,1.5",
+				"100,10,45,2.0"
+		));
+
+		// Import using a mix of names and indices
+		// Note: This assumes your implementation can handle mixed references
+		// If not, adjust the test accordingly
+		try {
+			model.importLevelsFromCSV(tempFile, ",",
+					"height", "1", "angle", "3",  // mix of names and indices
+					UnitGroup.UNITS_DISTANCE.getSIUnit(),
+					UnitGroup.UNITS_WINDSPEED.getSIUnit(),
+					new DegreeUnit(),
+					UnitGroup.UNITS_WINDSPEED.getSIUnit(),
+					true);
+
+			// If implementation supports mixed references, verify the data
+			List<MultiLevelPinkNoiseWindModel.LevelWindModel> levels = model.getLevels();
+			assertEquals(2, levels.size(), "Should have 2 wind levels");
+
+			assertEquals(0, levels.get(0).getAltitude(), EPSILON);
+			assertEquals(5, levels.get(0).getSpeed(), EPSILON);
+			assertEquals(0, levels.get(0).getDirection(), EPSILON);
+		} catch (IllegalArgumentException e) {
+			// If mixing is not supported, that's fine - the test is informative
+			// No assertion needed
+		}
 	}
 }

--- a/core/src/test/java/info/openrocket/core/models/wind/MultiLevelWindModelTest.java
+++ b/core/src/test/java/info/openrocket/core/models/wind/MultiLevelWindModelTest.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/CSVImportSettingsDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/CSVImportSettingsDialog.java
@@ -764,6 +764,8 @@ public class CSVImportSettingsDialog extends JDialog {
 			e.printStackTrace();
 		}
 
+		// TODO: I'd rather have a way to disable the auto scrolling, but I haven't found a way for it yet.
+		//   using scrollPane.setAutoscrolls(false) doesn't seem to work
 		if (viewportPosition != null) {
 			SwingUtilities.invokeLater(() -> scrollPane.getViewport().setViewPosition(viewportPosition));
 		}

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/CSVImportSettingsDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/CSVImportSettingsDialog.java
@@ -1,0 +1,771 @@
+package info.openrocket.swing.gui.simulation;
+
+import info.openrocket.core.l10n.Translator;
+import info.openrocket.core.preferences.ApplicationPreferences;
+import info.openrocket.core.startup.Application;
+import info.openrocket.core.unit.Unit;
+import info.openrocket.core.unit.UnitGroup;
+import info.openrocket.swing.gui.adaptors.DoubleModel;
+import info.openrocket.swing.gui.components.StyledLabel;
+import info.openrocket.swing.gui.components.UnitSelector;
+import info.openrocket.swing.gui.util.GUIUtil;
+import net.miginfocom.swing.MigLayout;
+
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JSeparator;
+import javax.swing.JSpinner;
+import javax.swing.JTextArea;
+import javax.swing.JTextField;
+import javax.swing.JTextPane;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.SwingUtilities;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.SimpleAttributeSet;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.StyledDocument;
+import java.awt.BorderLayout;
+import java.awt.CardLayout;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Font;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Window;
+import java.util.HashSet;
+import java.util.Set;
+
+import static info.openrocket.swing.gui.components.CsvOptionPanel.SPACE;
+import static info.openrocket.swing.gui.components.CsvOptionPanel.TAB;
+
+/**
+ * Dialog for configuring CSV import settings for wind data
+ */
+public class CSVImportSettingsDialog extends JDialog {
+	private static final Translator trans = Application.getTranslator();
+	private static final ApplicationPreferences prefs = Application.getPreferences();
+
+	// Fields for mapping column names
+	private final JTextField altitudeColumnField;
+	private final JTextField speedColumnField;
+	private final JTextField directionColumnField;
+	private final JTextField stdDeviationColumnField;
+
+	// Spinners for mapping column indices
+	private final JSpinner altitudeColumnSpinner;
+	private final JSpinner speedColumnSpinner;
+	private final JSpinner directionColumnSpinner;
+	private final JSpinner stdDeviationColumnSpinner;
+
+	// Panels to switch between text fields and spinners
+	private final JPanel altitudeColumnPanel;
+	private final JPanel speedColumnPanel;
+	private final JPanel directionColumnPanel;
+	private final JPanel stdDeviationColumnPanel;
+
+	// Unit selectors
+	private final UnitSelector altitudeUnitSelector;
+	private final UnitSelector speedUnitSelector;
+	private final UnitSelector directionUnitSelector;
+	private final UnitSelector stdDeviationUnitSelector;
+
+	private final JComboBox<String> separatorComboBox;
+	private final JCheckBox hasHeaderCheckBox;
+	private final JTextPane previewTextPane;
+	private final JScrollPane scrollPane;
+
+	// Column type label (changes between "Column Name" and "Column Index")
+	private final JLabel columnTypeLabel;
+
+	// Result flag
+	private boolean approved = false;
+
+	public CSVImportSettingsDialog(Window owner) {
+		super(owner, trans.get("CSVImportSettingsDialog.title"), ModalityType.APPLICATION_MODAL);
+
+		// Main panel with MigLayout
+		JPanel mainPanel = new JPanel(new MigLayout("fill, insets dialog, gap para"));
+
+		// Description text
+		JTextArea descriptionArea = new JTextArea(trans.get("CSVImportSettingsDialog.description"));
+		descriptionArea.setEditable(false);
+		descriptionArea.setLineWrap(true);
+		descriptionArea.setWrapStyleWord(true);
+		descriptionArea.setBackground(null);
+		descriptionArea.setOpaque(false);
+		descriptionArea.setFocusable(false);
+		mainPanel.add(descriptionArea, "spanx, growx, wrap para");
+
+		// CSV settings section
+		JPanel csvSettings = new JPanel(new MigLayout());
+		csvSettings.setBorder(BorderFactory.createTitledBorder(trans.get("CSVImportSettingsDialog.csvSettings")));
+		mainPanel.add(csvSettings, "growx, spanx, wrap");
+
+		// Column mapping help text
+		JTextArea columnMappingHelp = new JTextArea(trans.get("CSVImportSettingsDialog.columnMappingHelp"));
+		columnMappingHelp.setEditable(false);
+		columnMappingHelp.setLineWrap(true);
+		columnMappingHelp.setWrapStyleWord(true);
+		columnMappingHelp.setBackground(null);
+		columnMappingHelp.setOpaque(false);
+		columnMappingHelp.setFocusable(false);
+		columnMappingHelp.setFont(columnMappingHelp.getFont().deriveFont(columnMappingHelp.getFont().getSize() - 1f));
+		csvSettings.add(columnMappingHelp, "spanx, growx, wrap para");
+
+		// Header checkbox
+		hasHeaderCheckBox = new JCheckBox(trans.get("CSVImportSettingsDialog.hasHeaders"));
+		hasHeaderCheckBox.setToolTipText(trans.get("CSVImportSettingsDialog.hasHeaders.ttip"));
+		hasHeaderCheckBox.setSelected(prefs.isMultiLevelWindCsvImportHeader());
+		csvSettings.add(hasHeaderCheckBox, "spanx, wrap");
+
+		// Grid header labels
+		csvSettings.add(new StyledLabel(trans.get("CSVImportSettingsDialog.dataType"), StyledLabel.Style.BOLD), "width 120lp");
+		// Use a regular JLabel for the column type so we can change it dynamically
+		columnTypeLabel = new JLabel(trans.get("CSVImportSettingsDialog.columnName"));
+		columnTypeLabel.setFont(columnTypeLabel.getFont().deriveFont(Font.BOLD));
+		csvSettings.add(columnTypeLabel, "growx");
+		csvSettings.add(new StyledLabel(trans.get("CSVImportSettingsDialog.unit"), StyledLabel.Style.BOLD), "width 120lp, wrap");
+
+		//// Altitude mapping
+		csvSettings.add(new JLabel(trans.get("CSVImportSettingsDialog.altitude")));
+
+		// Create both text field and spinner for altitude
+		altitudeColumnField = new JTextField(10);
+		altitudeColumnField.setText(prefs.getMultiLevelWindCsvImportAltitudeColumn());
+
+		altitudeColumnSpinner = new JSpinner(new SpinnerNumberModel(prefs.getMultiLevelWindCsvImportAltitudeColumnIndex(),
+				0, Integer.MAX_VALUE, 1));
+		altitudeColumnSpinner.setEditor(new JSpinner.NumberEditor(altitudeColumnSpinner, "#"));
+
+		// Create panel to hold both components
+		altitudeColumnPanel = new JPanel(new CardLayout());
+		altitudeColumnPanel.add(altitudeColumnField, "text");
+		altitudeColumnPanel.add(altitudeColumnSpinner, "spinner");
+
+		csvSettings.add(altitudeColumnPanel, "growx");
+
+		DoubleModel altitudeModel = new DoubleModel(0, UnitGroup.UNITS_DISTANCE);
+		altitudeModel.setCurrentUnit(prefs.getMultiLevelWindCsvImportAltitudeUnit());
+		altitudeUnitSelector = new UnitSelector(altitudeModel);
+		csvSettings.add(altitudeUnitSelector, "wrap");
+
+		//// Speed mapping
+		csvSettings.add(new JLabel(trans.get("CSVImportSettingsDialog.speed")));
+
+		// Create both text field and spinner for speed
+		speedColumnField = new JTextField(10);
+		speedColumnField.setText(prefs.getMultiLevelWindCsvImportSpeedColumn());
+
+		speedColumnSpinner = new JSpinner(new SpinnerNumberModel(prefs.getMultiLevelWindCsvImportSpeedColumnIndex(),
+				0, Integer.MAX_VALUE, 1));
+		speedColumnSpinner.setEditor(new JSpinner.NumberEditor(speedColumnSpinner, "#"));
+
+		// Create panel to hold both components
+		speedColumnPanel = new JPanel(new CardLayout());
+		speedColumnPanel.add(speedColumnField, "text");
+		speedColumnPanel.add(speedColumnSpinner, "spinner");
+
+		csvSettings.add(speedColumnPanel, "growx");
+
+		DoubleModel speedModel = new DoubleModel(0, UnitGroup.UNITS_WINDSPEED);
+		speedModel.setCurrentUnit(prefs.getMultiLevelWindCsvImportSpeedUnit());
+		speedUnitSelector = new UnitSelector(speedModel);
+		csvSettings.add(speedUnitSelector, "wrap");
+
+		//// Direction mapping
+		csvSettings.add(new JLabel(trans.get("CSVImportSettingsDialog.direction")));
+
+		// Create both text field and spinner for direction
+		directionColumnField = new JTextField(10);
+		directionColumnField.setText(prefs.getMultiLevelWindCsvImportDirectionColumn());
+
+		directionColumnSpinner = new JSpinner(new SpinnerNumberModel(prefs.getMultiLevelWindCsvImportDirectionColumnIndex(),
+				0, Integer.MAX_VALUE, 1));
+		directionColumnSpinner.setEditor(new JSpinner.NumberEditor(directionColumnSpinner, "#"));
+
+		// Create panel to hold both components
+		directionColumnPanel = new JPanel(new CardLayout());
+		directionColumnPanel.add(directionColumnField, "text");
+		directionColumnPanel.add(directionColumnSpinner, "spinner");
+
+		csvSettings.add(directionColumnPanel, "growx");
+
+		DoubleModel directionModel = new DoubleModel(0, UnitGroup.UNITS_ANGLE);
+		directionModel.setCurrentUnit(prefs.getMultiLevelWindCsvImportDirectionUnit());
+		directionUnitSelector = new UnitSelector(directionModel);
+		csvSettings.add(directionUnitSelector, "wrap");
+
+		//// Std Deviation mapping (optional)
+		csvSettings.add(new JLabel(trans.get("CSVImportSettingsDialog.stdDev")));
+
+		// Create both text field and spinner for std deviation
+		stdDeviationColumnField = new JTextField(10);
+		stdDeviationColumnField.setText(prefs.getMultiLevelWindCsvImportStddevColumn());
+
+		stdDeviationColumnSpinner = new JSpinner(new SpinnerNumberModel(prefs.getMultiLevelWindCsvImportStddevColumnIndex(),
+				0, Integer.MAX_VALUE, 1));
+		stdDeviationColumnSpinner.setEditor(new JSpinner.NumberEditor(stdDeviationColumnSpinner, "#"));
+
+		// Create panel to hold both components
+		stdDeviationColumnPanel = new JPanel(new CardLayout());
+		stdDeviationColumnPanel.add(stdDeviationColumnField, "text");
+		stdDeviationColumnPanel.add(stdDeviationColumnSpinner, "spinner");
+
+		csvSettings.add(stdDeviationColumnPanel, "growx");
+
+		DoubleModel stdDevModel = new DoubleModel(0, UnitGroup.UNITS_WINDSPEED);
+		stdDevModel.setCurrentUnit(prefs.getMultiLevelWindCsvImportStddevUnit());
+		stdDeviationUnitSelector = new UnitSelector(stdDevModel);
+		csvSettings.add(stdDeviationUnitSelector, "wrap");
+
+		csvSettings.add(new JSeparator(JSeparator.HORIZONTAL), "spanx, growx, wrap para");
+
+		//// Field separator
+		csvSettings.add(new JLabel(trans.get("CSVImportSettingsDialog.separator")));
+		separatorComboBox = new JComboBox<>(new String[]{",", ";", SPACE, TAB});
+		separatorComboBox.setEditable(true);
+		separatorComboBox.setSelectedItem(prefs.getString(ApplicationPreferences.EXPORT_FIELD_SEPARATOR, ","));
+		csvSettings.add(separatorComboBox, "wrap");
+
+		// CSV file preview panel
+		JPanel previewPanel = new JPanel(new MigLayout("fillx"));
+		previewPanel.setBorder(BorderFactory.createTitledBorder(trans.get("CSVImportSettingsDialog.preview")));
+		mainPanel.add(previewPanel, "growx, spanx, wrap");
+
+		//// Preview help text
+		JTextArea previewHelp = new JTextArea(trans.get("CSVImportSettingsDialog.previewHelp"));
+		previewHelp.setEditable(false);
+		previewHelp.setLineWrap(true);
+		previewHelp.setWrapStyleWord(true);
+		previewHelp.setBackground(null);
+		previewHelp.setOpaque(false);
+		previewHelp.setFocusable(false);
+		previewHelp.setFont(previewHelp.getFont().deriveFont(previewHelp.getFont().getSize() - 1f));
+		previewPanel.add(previewHelp, "spanx, growx, wrap para");
+
+		//// Preview text pane (with styled text)
+		previewTextPane = new JTextPane();
+		previewTextPane.setEditable(false);
+		previewTextPane.setFont(new Font("Monospaced", Font.PLAIN, 12));
+		previewTextPane.setBackground(Color.WHITE);
+		previewTextPane.setMargin(new Insets(5, 5, 5, 5));
+
+		previewPanel.add(previewTextPane, "grow, spanx");
+
+		// Add event listeners for preview updates
+		DocumentListener documentListener = new DocumentListener() {
+			@Override
+			public void insertUpdate(DocumentEvent e) {
+				updatePreview();
+			}
+
+			@Override
+			public void removeUpdate(DocumentEvent e) {
+				updatePreview();
+			}
+
+			@Override
+			public void changedUpdate(DocumentEvent e) {
+				updatePreview();
+			}
+		};
+
+		// Add listeners to all components that affect the preview
+		altitudeColumnField.getDocument().addDocumentListener(documentListener);
+		speedColumnField.getDocument().addDocumentListener(documentListener);
+		directionColumnField.getDocument().addDocumentListener(documentListener);
+		stdDeviationColumnField.getDocument().addDocumentListener(documentListener);
+
+		// Add change listeners to all spinners - validate and update preview
+		altitudeColumnSpinner.addChangeListener(e -> {
+			validateColumnIndices();
+			updatePreview();
+		});
+		speedColumnSpinner.addChangeListener(e -> {
+			validateColumnIndices();
+			updatePreview();
+		});
+		directionColumnSpinner.addChangeListener(e -> {
+			validateColumnIndices();
+			updatePreview();
+		});
+		stdDeviationColumnSpinner.addChangeListener(e -> {
+			validateColumnIndices();
+			updatePreview();
+		});
+
+		// Add header checkbox listener to update column field validation and label
+		hasHeaderCheckBox.addItemListener(e -> {
+			boolean hasHeaders = hasHeaderCheckBox.isSelected();
+
+			// Update the column type label based on whether headers are present
+			columnTypeLabel.setText(hasHeaders ?
+					trans.get("CSVImportSettingsDialog.columnName") :
+					trans.get("CSVImportSettingsDialog.columnIndex"));
+
+			// Update field validation
+			updateColumnFieldValidation();
+
+			// If switching to non-header mode, validate indices immediately
+			if (!hasHeaders) {
+				validateColumnIndices();
+			} else {
+				// When switching to header mode, clear any error outlines
+				resetErrorOutlines();
+			}
+
+			// Update preview
+			updatePreview();
+		});
+
+		separatorComboBox.addItemListener(e -> updatePreview());
+
+		altitudeUnitSelector.addItemListener(e -> updatePreview());
+		speedUnitSelector.addItemListener(e -> updatePreview());
+		directionUnitSelector.addItemListener(e -> updatePreview());
+		stdDeviationUnitSelector.addItemListener(e -> updatePreview());
+
+		// Initial column field validation setup
+		updateColumnFieldValidation();
+
+		// Initial preview update
+		updatePreview();
+
+		// Buttons panel
+		JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+
+		JButton cancelButton = new JButton(trans.get("button.cancel"));
+		cancelButton.addActionListener(e -> dispose());
+
+		JButton okButton = new JButton(trans.get("button.ok"));
+		okButton.addActionListener(e -> {
+			// Validate column indices one final time
+			validateColumnIndices();
+
+			// When headers are not used, check for duplicate column indices
+			if (!hasHeaderCheckBox.isSelected() && hasDuplicateColumnIndices()) {
+				// Show error message
+				JOptionPane.showMessageDialog(
+						this,
+						trans.get("CSVImportSettingsDialog.duplicateColumnError"),
+						trans.get("CSVImportSettingsDialog.validationError"),
+						JOptionPane.ERROR_MESSAGE
+				);
+				return; // Don't close the dialog
+			}
+
+			approved = true;
+			dispose();
+		});
+
+		buttonPanel.add(cancelButton);
+		buttonPanel.add(okButton);
+
+		// Create a scrollpane for the main content
+		scrollPane = new JScrollPane(mainPanel);
+		scrollPane.setBorder(BorderFactory.createEmptyBorder());
+		scrollPane.getVerticalScrollBar().setUnitIncrement(16); // Better scrolling speed
+		SwingUtilities.invokeLater(() -> scrollPane.getVerticalScrollBar().setValue(0)); // Scroll to top
+
+		// Create a container panel with BorderLayout
+		JPanel containerPanel = new JPanel(new BorderLayout());
+		containerPanel.add(scrollPane, BorderLayout.CENTER);   // Scrollable content in center
+		containerPanel.add(buttonPanel, BorderLayout.SOUTH);   // Buttons fixed at bottom
+
+		// Set the container as content pane
+		setContentPane(containerPanel);
+
+		// Set preferred size instead of fixed size
+		setPreferredSize(new Dimension(600, 550));
+		pack();
+		setLocationRelativeTo(owner);
+
+		GUIUtil.installEscapeCloseButtonOperation(this, cancelButton);
+		getRootPane().setDefaultButton(okButton);
+	}
+
+	/**
+	 * Updates the UI based on whether headers are used
+	 */
+	private void updateColumnFieldValidation() {
+		boolean hasHeaders = hasHeaderCheckBox.isSelected();
+
+		// Get the card layout for each panel and show the appropriate component
+		((CardLayout) altitudeColumnPanel.getLayout()).show(altitudeColumnPanel, hasHeaders ? "text" : "spinner");
+		((CardLayout) speedColumnPanel.getLayout()).show(speedColumnPanel, hasHeaders ? "text" : "spinner");
+		((CardLayout) directionColumnPanel.getLayout()).show(directionColumnPanel, hasHeaders ? "text" : "spinner");
+		((CardLayout) stdDeviationColumnPanel.getLayout()).show(stdDeviationColumnPanel, hasHeaders ? "text" : "spinner");
+	}
+
+	/**
+	 * Validates column indices dynamically and applies error styling to duplicates.
+	 * Should be called whenever a spinner value changes or when switching to non-header mode.
+	 */
+	private void validateColumnIndices() {
+		// Only validate if headers are not selected
+		if (hasHeaderCheckBox.isSelected()) {
+			return;
+		}
+
+		// Reset any previous error styling
+		resetErrorOutlines();
+
+		// Get all values
+		int altIndex = (Integer) altitudeColumnSpinner.getValue();
+		int speedIndex = (Integer) speedColumnSpinner.getValue();
+		int dirIndex = (Integer) directionColumnSpinner.getValue();
+		int stdDevIndex = (Integer) stdDeviationColumnSpinner.getValue();
+
+		// Check for duplicates
+		Set<Integer> usedIndices = new HashSet<>();
+		Set<JSpinner> errorSpinners = new HashSet<>();
+
+		// Check altitude index
+		usedIndices.add(altIndex);
+
+		// Check speed index
+		if (!usedIndices.add(speedIndex)) {
+			errorSpinners.add(speedColumnSpinner);
+			// Find the other spinner with this value
+			if (altIndex == speedIndex) errorSpinners.add(altitudeColumnSpinner);
+		}
+
+		// Check direction index
+		if (!usedIndices.add(dirIndex)) {
+			errorSpinners.add(directionColumnSpinner);
+			// Find the other spinners with this value
+			if (altIndex == dirIndex) errorSpinners.add(altitudeColumnSpinner);
+			if (speedIndex == dirIndex) errorSpinners.add(speedColumnSpinner);
+		}
+
+		// Check std deviation index only if the field is being used (non-empty in text mode)
+		if (!stdDeviationColumnField.getText().trim().isEmpty()) {
+			if (!usedIndices.add(stdDevIndex)) {
+				errorSpinners.add(stdDeviationColumnSpinner);
+				// Find the other spinners with this value
+				if (altIndex == stdDevIndex) errorSpinners.add(altitudeColumnSpinner);
+				if (speedIndex == stdDevIndex) errorSpinners.add(speedColumnSpinner);
+				if (dirIndex == stdDevIndex) errorSpinners.add(directionColumnSpinner);
+			}
+		}
+
+		// Mark error spinners
+		for (JSpinner spinner : errorSpinners) {
+			spinner.putClientProperty("JComponent.outline", "error");
+			// Mark the editor component as well for better visibility
+			JComponent editor = spinner.getEditor();
+			if (editor != null) {
+				editor.putClientProperty("JComponent.outline", "error");
+			}
+		}
+	}
+
+	/**
+	 * Checks if there are duplicate column indices when headers are not used.
+	 * This method just calls validateColumnIndices() and then checks if any spinners have errors.
+	 *
+	 * @return true if duplicates are found, false otherwise
+	 */
+	private boolean hasDuplicateColumnIndices() {
+		// Validate columns (this will apply error styling if needed)
+		validateColumnIndices();
+
+		// Check if any spinners have error styling
+		return altitudeColumnSpinner.getClientProperty("JComponent.outline") == "error" ||
+				speedColumnSpinner.getClientProperty("JComponent.outline") == "error" ||
+				directionColumnSpinner.getClientProperty("JComponent.outline") == "error" ||
+				stdDeviationColumnSpinner.getClientProperty("JComponent.outline") == "error";
+	}
+
+	/**
+	 * Resets the error outlines on all column fields
+	 */
+	private void resetErrorOutlines() {
+		// Reset outlines on text fields
+		altitudeColumnField.putClientProperty("JComponent.outline", "");
+		speedColumnField.putClientProperty("JComponent.outline", "");
+		directionColumnField.putClientProperty("JComponent.outline", "");
+		stdDeviationColumnField.putClientProperty("JComponent.outline", "");
+
+		// Reset outlines on spinners
+		altitudeColumnSpinner.putClientProperty("JComponent.outline", "");
+		speedColumnSpinner.putClientProperty("JComponent.outline", "");
+		directionColumnSpinner.putClientProperty("JComponent.outline", "");
+		stdDeviationColumnSpinner.putClientProperty("JComponent.outline", "");
+
+		// Reset outlines on spinner editors
+		JComponent altEditor = altitudeColumnSpinner.getEditor();
+		JComponent speedEditor = speedColumnSpinner.getEditor();
+		JComponent dirEditor = directionColumnSpinner.getEditor();
+		JComponent stdDevEditor = stdDeviationColumnSpinner.getEditor();
+
+		if (altEditor != null) altEditor.putClientProperty("JComponent.outline", "");
+		if (speedEditor != null) speedEditor.putClientProperty("JComponent.outline", "");
+		if (dirEditor != null) dirEditor.putClientProperty("JComponent.outline", "");
+		if (stdDevEditor != null) stdDevEditor.putClientProperty("JComponent.outline", "");
+	}
+
+	/**
+	 * @return The name or index of the altitude column
+	 */
+	public String getAltitudeColumn() {
+		if (hasHeader()) {
+			return getAltitudeColumnName();
+		} else {
+			return getAltitudeColumnIndex().toString();
+		}
+	}
+
+	/**
+	 * @return The name of the altitude column
+	 */
+	public String getAltitudeColumnName() {
+		return altitudeColumnField.getText().trim();
+	}
+
+	/**
+	 * @return The index of the altitude column
+	 */
+	public Integer getAltitudeColumnIndex() {
+		return (Integer) altitudeColumnSpinner.getValue();
+	}
+
+	/**
+	 * @return The name or index of the speed column
+	 */
+	public String getSpeedColumn() {
+		if (hasHeader()) {
+			return getSpeedColumnName();
+		} else {
+			return getSpeedColumnIndex().toString();
+		}
+	}
+
+	/**
+	 * @return The name of the speed column
+	 */
+	public String getSpeedColumnName() {
+		return speedColumnField.getText().trim();
+	}
+
+	/**
+	 * @return The index of the speed column
+	 */
+	public Integer getSpeedColumnIndex() {
+		return (Integer) speedColumnSpinner.getValue();
+	}
+
+	/**
+	 * @return The name or index of the direction column
+	 */
+	public String getDirectionColumn() {
+		if (hasHeader()) {
+			return getDirectionColumnName();
+		} else {
+			return getDirectionColumnIndex().toString();
+		}
+	}
+
+	/**
+	 * @return The name of the direction column, even if the file has no header
+	 */
+	public String getDirectionColumnName() {
+		return directionColumnField.getText().trim();
+	}
+
+	/**
+	 * @return The index of the direction column
+	 */
+	public Integer getDirectionColumnIndex() {
+		return (Integer) directionColumnSpinner.getValue();
+	}
+
+	/**
+	 * @return The name or index of the standard deviation column (can be empty)
+	 */
+	public String getStdDeviationColumn() {
+		if (hasHeader()) {
+			return getStdDeviationColumnName();
+		} else {
+			return getStdDeviationColumnIndex().toString();
+		}
+	}
+
+	/**
+	 * @return The name of the std deviation column, even if the file has no header
+	 */
+	public String getStdDeviationColumnName() {
+		return stdDeviationColumnField.getText().trim();
+	}
+
+	/**
+	 * @return The index of the standard deviation column
+	 */
+	public Integer getStdDeviationColumnIndex() {
+		return (Integer) stdDeviationColumnSpinner.getValue();
+	}
+
+	/**
+	 * @return The selected unit for altitude values
+	 */
+	public Unit getAltitudeUnit() {
+		return altitudeUnitSelector.getSelectedUnit();
+	}
+
+	/**
+	 * @return The selected unit for speed values
+	 */
+	public Unit getSpeedUnit() {
+		return speedUnitSelector.getSelectedUnit();
+	}
+
+	/**
+	 * @return The selected unit for direction values
+	 */
+	public Unit getDirectionUnit() {
+		return directionUnitSelector.getSelectedUnit();
+	}
+
+	/**
+	 * @return The selected unit for standard deviation values
+	 */
+	public Unit getStdDeviationUnit() {
+		return stdDeviationUnitSelector.getSelectedUnit();
+	}
+
+	/**
+	 * @return The selected CSV separator
+	 */
+	public String getSeparator() {
+		return (String) separatorComboBox.getSelectedItem();
+	}
+
+	/**
+	 * @return Whether the CSV file has a header
+	 */
+	public boolean hasHeader() {
+		return hasHeaderCheckBox.isSelected();
+	}
+
+	/**
+	 * @return Whether the user approved the settings (clicked OK)
+	 */
+	public boolean isApproved() {
+		return approved;
+	}
+
+	/**
+	 * Updates the CSV file preview based on current settings while preserving scroll position
+	 */
+	private void updatePreview() {
+		// Store the current viewport position
+		final Point viewportPosition = scrollPane != null ? scrollPane.getViewport().getViewPosition() : null;
+
+		// Clear the existing text
+		previewTextPane.setText("");
+		StyledDocument doc = previewTextPane.getStyledDocument();
+
+		// Create style attributes for normal text
+		SimpleAttributeSet normalStyle = new SimpleAttributeSet();
+		StyleConstants.setForeground(normalStyle, Color.BLACK);
+		StyleConstants.setFontFamily(normalStyle, "Monospaced");
+
+		// Create style attributes for optional fields (gray text)
+		SimpleAttributeSet optionalStyle = new SimpleAttributeSet();
+		StyleConstants.setForeground(optionalStyle, Color.GRAY);
+		StyleConstants.setFontFamily(optionalStyle, "Monospaced");
+
+		// Create style attributes for column indices
+		SimpleAttributeSet indexStyle = new SimpleAttributeSet();
+		StyleConstants.setForeground(indexStyle, new Color(0, 100, 0)); // Dark green
+		StyleConstants.setFontFamily(indexStyle, "Monospaced");
+
+		// Get selected separator
+		String separator = (String) separatorComboBox.getSelectedItem();
+		if (separator == null) separator = ",";  // Default if nothing selected
+
+		// Replace tab and space with their visible representation for display
+		String displaySeparator = separator;
+		if (TAB.equals(separator)) {
+			displaySeparator = "\\t";
+		} else if (SPACE.equals(separator)) {
+			displaySeparator = "\\s";
+		}
+
+		try {
+			// Create header row if CSV has a header
+			if (hasHeaderCheckBox.isSelected()) {
+				doc.insertString(doc.getLength(), getAltitudeColumn() + displaySeparator, normalStyle);
+				doc.insertString(doc.getLength(), getSpeedColumn() + displaySeparator, normalStyle);
+				doc.insertString(doc.getLength(), getDirectionColumn(), normalStyle);
+
+				// Add std deviation column if provided
+				if (!getStdDeviationColumn().isEmpty()) {
+					doc.insertString(doc.getLength(), displaySeparator + getStdDeviationColumn(), optionalStyle);
+				}
+
+				doc.insertString(doc.getLength(), "\n", normalStyle);
+			}
+			// If no header, add a comment showing which column is which
+			else {
+				doc.insertString(doc.getLength(), "# Column mapping: ", normalStyle);
+				doc.insertString(doc.getLength(), getAltitudeColumn() + "=Altitude, ", indexStyle);
+				doc.insertString(doc.getLength(), getSpeedColumn() + "=Speed, ", indexStyle);
+				doc.insertString(doc.getLength(), getDirectionColumn() + "=Direction", indexStyle);
+
+				// Add std deviation column if provided
+				if (!getStdDeviationColumn().isEmpty()) {
+					doc.insertString(doc.getLength(), ", " + getStdDeviationColumn() + "=StdDev", optionalStyle);
+				}
+
+				doc.insertString(doc.getLength(), "\n", normalStyle);
+			}
+
+			// Generate sample data rows
+			double[] altitudes = {100.0, 200.0, 300.0, 400.0};
+			double[] speeds = {5.0, 7.5, 10.0, 12.5};
+			double[] directions = {45.0, 75.0, 105.0, 135.0};
+			double[] stdDevs = {1.0, 1.5, 2.0, 2.5};
+
+			for (int i = 0; i < 4; i++) {
+				// Format values based on selected units - just using raw values for preview
+				doc.insertString(doc.getLength(),
+						altitudeUnitSelector.getSelectedUnit().toString(altitudes[i]) + displaySeparator, normalStyle);
+				doc.insertString(doc.getLength(),
+						speedUnitSelector.getSelectedUnit().toString(speeds[i]) + displaySeparator, normalStyle);
+				doc.insertString(doc.getLength(),
+						directionUnitSelector.getSelectedUnit().toString(directions[i]), normalStyle);
+
+				// Add std deviation if column specified (in gray)
+				if (!getStdDeviationColumn().isEmpty()) {
+					doc.insertString(doc.getLength(),
+							displaySeparator + stdDeviationUnitSelector.getSelectedUnit().toString(stdDevs[i]), optionalStyle);
+				}
+
+				doc.insertString(doc.getLength(), "\n", normalStyle);
+			}
+
+			// Add ellipsis to indicate more data could follow
+			doc.insertString(doc.getLength(), "...", normalStyle);
+
+		} catch (BadLocationException e) {
+			// This shouldn't happen, but log it just in case
+			e.printStackTrace();
+		}
+
+		if (viewportPosition != null) {
+			SwingUtilities.invokeLater(() -> scrollPane.getViewport().setViewPosition(viewportPosition));
+		}
+	}
+}

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/CSVImportSettingsDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/CSVImportSettingsDialog.java
@@ -735,7 +735,7 @@ public class CSVImportSettingsDialog extends JDialog {
 			// Generate sample data rows
 			double[] altitudes = {100.0, 200.0, 300.0, 400.0};
 			double[] speeds = {5.0, 7.5, 10.0, 12.5};
-			double[] directions = {45.0, 75.0, 105.0, 135.0};
+			double[] directions = {Math.PI / 2, Math.PI * 5/12, Math.PI * 7/12, Math.PI * 3/4};
 			double[] stdDevs = {1.0, 1.5, 2.0, 2.5};
 
 			for (int i = 0; i < 4; i++) {

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/MultiLevelWindEditDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/MultiLevelWindEditDialog.java
@@ -258,42 +258,50 @@ public class MultiLevelWindEditDialog extends JDialog {
 		fileChooser.setMultiSelectionEnabled(false);
 
 		int returnVal = fileChooser.showOpenDialog(this);
-		if (returnVal == JFileChooser.APPROVE_OPTION) {
-			File selectedFile = fileChooser.getSelectedFile();
-			selectedFile = FileHelper.forceExtension(selectedFile, "csv");
+		if (returnVal != JFileChooser.APPROVE_OPTION) {
+			return;
+		}
 
-			((SwingPreferences) Application.getPreferences()).setDefaultDirectory(fileChooser.getCurrentDirectory());
+		File selectedFile = fileChooser.getSelectedFile();
+		selectedFile = FileHelper.forceExtension(selectedFile, "csv");
 
-			// Show a warning message that the current levels will be overwritten
-			if (!model.getLevels().isEmpty()) {
-				int result = JOptionPane.showConfirmDialog(this, trans.get("WindProfileEditorDlg.dlg.overwriteLevels.msg"),
-						trans.get("WindProfileEditorDlg.dlg.overwriteLevels.title"), JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
-				if (result != JOptionPane.YES_OPTION) {
-					return;
-				}
+		((SwingPreferences) Application.getPreferences()).setDefaultDirectory(fileChooser.getCurrentDirectory());
+
+		// Show a warning message that the current levels will be overwritten
+		if (!model.getLevels().isEmpty()) {
+			int result = JOptionPane.showConfirmDialog(this, trans.get("WindProfileEditorDlg.dlg.overwriteLevels.msg"),
+					trans.get("WindProfileEditorDlg.dlg.overwriteLevels.title"), JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+			if (result != JOptionPane.YES_OPTION) {
+				return;
 			}
+		}
 
-			// Import the CSV file with the configured settings
-			try {
-				windTable.importLevels(
-						selectedFile,
-						settingsDialog.getSeparator(),
-						settingsDialog.getAltitudeColumn(),
-						settingsDialog.getSpeedColumn(),
-						settingsDialog.getDirectionColumn(),
-						settingsDialog.getStdDeviationColumn(),
-						settingsDialog.getAltitudeUnit(),
-						settingsDialog.getSpeedUnit(),
-						settingsDialog.getDirectionUnit(),
-						settingsDialog.getStdDeviationUnit(),
-						settingsDialog.hasHeader()
-				);
-			} catch (IllegalArgumentException ex) {
-				windTable.resetLevels();
-				JOptionPane.showMessageDialog(this, new String[] {
-						trans.get("WindProfileEditorDlg.msg.importLevelsError"),
-						ex.getMessage() }, trans.get("WindProfileEditorDlg.msg.importLevelsError.title"), JOptionPane.ERROR_MESSAGE);
-			}
+		// Import the CSV file with the configured settings
+		try {
+			windTable.importLevels(
+					selectedFile,
+					settingsDialog.getSeparator(),
+					settingsDialog.getAltitudeColumn(),
+					settingsDialog.getSpeedColumn(),
+					settingsDialog.getDirectionColumn(),
+					settingsDialog.getStdDeviationColumn(),
+					settingsDialog.getAltitudeUnit(),
+					settingsDialog.getSpeedUnit(),
+					settingsDialog.getDirectionUnit(),
+					settingsDialog.getStdDeviationUnit(),
+					settingsDialog.hasHeader()
+			);
+
+			// Update the units from the wind table to match those from the settings dialog
+			windTable.setAltitudeUnit(settingsDialog.getAltitudeUnit());
+			windTable.setSpeedUnit(settingsDialog.getSpeedUnit());
+			windTable.setDirectionUnit(settingsDialog.getDirectionUnit());
+			windTable.setStdDeviationUnit(settingsDialog.getStdDeviationUnit());
+		} catch (IllegalArgumentException ex) {
+			windTable.resetLevels();
+			JOptionPane.showMessageDialog(this, new String[] {
+					trans.get("WindProfileEditorDlg.msg.importLevelsError"),
+					ex.getMessage() }, trans.get("WindProfileEditorDlg.msg.importLevelsError.title"), JOptionPane.ERROR_MESSAGE);
 		}
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/MultiLevelWindTable.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/MultiLevelWindTable.java
@@ -133,21 +133,6 @@ public class MultiLevelWindTable extends JPanel implements ChangeSource {
 		rowsPanel = new JPanel();
 		rowsPanel.setLayout(new BoxLayout(rowsPanel, BoxLayout.Y_AXIS));
 
-		// Calculate total width based on column definitions
-		int totalWidth = 0;
-		for (ColumnDefinition col : COLUMNS) {
-			totalWidth += col.width();
-		}
-		// Add some extra width for separators
-		totalWidth += (COLUMNS.length - 1); // 1px for each separator
-		
-		// Ensure rows panel has its preferred width set but allows vertical scrolling
-		rowsPanel.setMinimumSize(new Dimension(totalWidth, 10));
-		
-		// Set a small preferred height initially to ensure vertical scrolling works
-		// This will be updated when rows are added to match actual content height
-		rowsPanel.setPreferredSize(new Dimension(totalWidth, 10));
-
 		// Populate rows from the wind model
 		windModel.getLevels().forEach(lvl -> {
 			LevelRow row = new LevelRow(lvl);

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/MultiLevelWindTable.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/MultiLevelWindTable.java
@@ -454,9 +454,40 @@ public class MultiLevelWindTable extends JPanel implements ChangeSource {
 		resortRows(null);
 	}
 
-	public void importLevels(File file, String separator) {
-		windModel.importLevelsFromCSV(file, separator);
-		syncRowsFromModel();
+	/**
+	 * Import wind levels from a CSV file with the specified settings.
+	 *
+	 * @param file The CSV file to import
+	 * @param separator The field separator used in the CSV file
+	 * @param altitudeColumn The name or index of the altitude column
+	 * @param speedColumn The name or index of the speed column
+	 * @param directionColumn The name or index of the direction column
+	 * @param stdDeviationColumn The name or index of the standard deviation column (can be empty)
+	 * @param altitudeUnit The unit used for altitude values in the CSV
+	 * @param speedUnit The unit used for speed values in the CSV
+	 * @param directionUnit The unit used for direction values in the CSV
+	 * @param stdDeviationUnit The unit used for standard deviation values in the CSV
+	 * @param hasHeaders Whether the CSV file has headers
+	 */
+	public void importLevels(File file, String separator,
+							 String altitudeColumn, String speedColumn,
+							 String directionColumn, String stdDeviationColumn,
+							 Unit altitudeUnit, Unit speedUnit,
+							 Unit directionUnit, Unit stdDeviationUnit,
+							 boolean hasHeaders) {
+		try {
+			windModel.importLevelsFromCSV(file, separator,
+					altitudeColumn, speedColumn,
+					directionColumn, stdDeviationColumn,
+					altitudeUnit, speedUnit,
+					directionUnit, stdDeviationUnit,
+					hasHeaders);
+			syncRowsFromModel();
+		} catch (Exception e) {
+			// Ensure we reset if any error occurs
+			resetLevels();
+			throw e;
+		}
 	}
 
 	public void resetLevels() {

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/MultiLevelWindTable.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/MultiLevelWindTable.java
@@ -633,12 +633,28 @@ public class MultiLevelWindTable extends JPanel implements ChangeSource {
 	public Unit getAltitudeUnit() {
 		return altitudeUnitSelector.getSelectedUnit();
 	}
+
+	/**
+	 * Set the selected altitude unit
+	 * @param unit the unit to set
+	 */
+	public void setAltitudeUnit(Unit unit) {
+		altitudeUnitSelector.setSelectedUnit(unit);
+	}
 	
 	/**
 	 * Get the selected speed unit
 	 */
 	public Unit getSpeedUnit() {
 		return speedUnitSelector.getSelectedUnit();
+	}
+
+	/**
+	 * Set the selected speed unit
+	 * @param unit the unit to set
+	 */
+	public void setSpeedUnit(Unit unit) {
+		speedUnitSelector.setSelectedUnit(unit);
 	}
 
 	/**
@@ -649,10 +665,26 @@ public class MultiLevelWindTable extends JPanel implements ChangeSource {
 	}
 
 	/**
+	 * Set the selected direction unit
+	 * @param unit the unit to set
+	 */
+	public void setDirectionUnit(Unit unit) {
+		directionUnitSelector.setSelectedUnit(unit);
+	}
+
+	/**
 	 * Get the selected standard deviation unit
 	 */
 	public Unit getStdDeviationUnit() {
 		return stdDeviationUnitSelector.getSelectedUnit();
+	}
+
+	/**
+	 * Set the selected standard deviation unit
+	 * @param unit the unit to set
+	 */
+	public void setStdDeviationUnit(Unit unit) {
+		stdDeviationUnitSelector.setSelectedUnit(unit);
 	}
 
 	@Override


### PR DESCRIPTION
This PR fixes #2715. When clicking the "Import levels" button in the multi-level wind dialog, a new dialog pops up where the user can change settings about how the CSV file is structured: what the column names are and which units are used. The user also has the option to check whether the file has a header row or not. If not, the column names entry is replaced with a column index entry. To further help the user, on the bottom of the dialog is a preview frame of what the contents of the CSV file may look like. Once the user confirms the settings with the "Ok" button, the settings dialog closes and the file chooser dialog appears.

Small notes:
- All settings are stored in preferences.
- After importing, the column units from the wind table in the "Wind profile editor" dialog are updated to match the units set in the "Wind data import settings" dialog. This ensures that when there is a mismatch between the units, the user is not surprised when the values from the CSV file don't match the values in the wind table.
- The default settings are:

| Column             | Column Name | Column Index | Unit |
|--------------------|-------------|--------------|------|
| Altitude           | altitude    | 0            | m    |
| Speed              | speed       | 1            | m/s  |
| Direction          | direction   | 2            | °    |
| Standard Deviation | stddev      | 3            | m/s  |

Originally, the altitude column was named "alt" and the direction column "dir", but I find it more descriptive to use the full names. And if users don't like it, they can now customize the name 🙂.

---

Demo:

https://github.com/user-attachments/assets/3b6c2548-b41c-4559-9535-0e16d59ea720

