### PR TITLE
Store moment calculated from CP and CNa instead of CP itself

### DIFF
--- a/core/src/main/java/info/openrocket/core/aerodynamics/AerodynamicForces.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/AerodynamicForces.java
@@ -17,7 +17,7 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 	private RocketComponent component = null;
 
 	/** CP and CNa. */
-	private Coordinate cp = null;
+	private Coordinate cpCNa = Coordinate.ZERO;
 
 	/**
 	 * Normal force coefficient derivative. At values close to zero angle of attack
@@ -106,16 +106,30 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 		return component;
 	}
 
+	/**
+	 * set cpCNa as the moment defined by cp
+	 */
 	public void setCP(Coordinate cp) {
-		if ((this.cp != null) && this.cp.equals(cp))
+		Coordinate newCpCNa;
+		if (MathUtil.equals(0, cp.weight)) {
+			newCpCNa = Coordinate.ZERO;
+		} else {
+			newCpCNa = new Coordinate(cp.x*cp.weight, cp.y*cp.weight, cp.z*cp.weight, cp.weight);
+		}
+		
+		if ((this.cpCNa != null) && this.cpCNa.equals(newCpCNa))
 			return;
 		
-		this.cp = cp;
+		this.cpCNa = newCpCNa;
 		modID = new ModID();
 	}
 
 	public Coordinate getCP() {
-		return cp;
+		if (MathUtil.equals(0, cpCNa.weight)) {
+			return Coordinate.ZERO;
+		} 
+				
+		return new Coordinate(cpCNa.x / cpCNa.weight, cpCNa.y / cpCNa.weight, cpCNa.z / cpCNa.weight, cpCNa.weight);
 	}
 
 	public void setCNa(double cNa) {
@@ -476,7 +490,7 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 	}
 
 	public AerodynamicForces merge(AerodynamicForces other) {
-		this.cp = cp.average(other.getCP());
+		this.cpCNa = cpCNa.add(other.cpCNa);
 		this.CNa = CNa + other.getCNa();
 		this.CN = CN + other.getCN();
 		this.Cm = Cm + other.getCm();

--- a/core/src/main/java/info/openrocket/core/aerodynamics/AerodynamicForces.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/AerodynamicForces.java
@@ -19,13 +19,6 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 	/** CP and CNa. */
 	private Coordinate cpCNa = Coordinate.ZERO;
 
-	/**
-	 * Normal force coefficient derivative. At values close to zero angle of attack
-	 * this value may be poorly defined or NaN if the calculation method does not
-	 * compute CNa directly.
-	 */
-	private double CNa = Double.NaN;
-
 	/** Normal force coefficient. */
 	private double CN = Double.NaN;
 
@@ -130,18 +123,6 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 		} 
 				
 		return new Coordinate(cpCNa.x / cpCNa.weight, cpCNa.y / cpCNa.weight, cpCNa.z / cpCNa.weight, cpCNa.weight);
-	}
-
-	public void setCNa(double cNa) {
-		if (CNa == cNa)
-			return;
-		
-		CNa = cNa;
-		modID = new ModID();
-	}
-
-	public double getCNa() {
-		return CNa;
 	}
 
 	public void setCN(double cN) {
@@ -370,7 +351,6 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 		setComponent(null);
 
 		setCP(null);
-		setCNa(Double.NaN);
 		setCN(Double.NaN);
 		setCm(Double.NaN);
 		setCside(Double.NaN);
@@ -392,7 +372,6 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 
 		setAxisymmetric(true);
 		setCP(Coordinate.NUL);
-		setCNa(0);
 		setCN(0);
 		setCm(0);
 		setCside(0);
@@ -425,8 +404,7 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 			return false;
 		AerodynamicForces other = (AerodynamicForces) obj;
 
-		return (MathUtil.equals(this.getCNa(), other.getCNa()) &&
-				MathUtil.equals(this.getCN(), other.getCN()) &&
+		return (MathUtil.equals(this.getCN(), other.getCN()) &&
 				MathUtil.equals(this.getCm(), other.getCm()) &&
 				MathUtil.equals(this.getCside(), other.getCside()) &&
 				MathUtil.equals(this.getCyaw(), other.getCyaw()) &&
@@ -445,7 +423,7 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 
 	@Override
 	public int hashCode() {
-		return (int) (1000 * (this.getCD() + this.getCDaxial() + this.getCNa())) + this.getCP().hashCode();
+		return (int) (1000 * (this.getCD() + this.getCDaxial() + this.getCP().weight)) + this.getCP().hashCode();
 	}
 
 	@Override
@@ -456,9 +434,6 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 			text += "component:" + getComponent() + ",";
 		if (getCP() != null)
 			text += "cp:" + getCP() + ",";
-
-		if (!Double.isNaN(getCNa()))
-			text += "CNa:" + getCNa() + ",";
 		if (!Double.isNaN(getCN()))
 			text += "CN:" + getCN() + ",";
 		if (!Double.isNaN(getCm()))
@@ -491,7 +466,6 @@ public class AerodynamicForces implements Cloneable, Monitorable {
 
 	public AerodynamicForces merge(AerodynamicForces other) {
 		this.cpCNa = cpCNa.add(other.cpCNa);
-		this.CNa = CNa + other.getCNa();
 		this.CN = CN + other.getCN();
 		this.Cm = Cm + other.getCm();
 		this.Cside = Cside + other.getCside();

--- a/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanCalculator.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanCalculator.java
@@ -130,9 +130,6 @@ public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
 				continue;
 			}
 
-			if (Double.isNaN(f.getCNa())) {
-				f.setCNa(0.0);
-			}
 			if (f.getCP().isNaN()) {
 				f.setCP(Coordinate.ZERO);
 			}

--- a/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/FinSetCalc.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/FinSetCalc.java
@@ -88,8 +88,7 @@ public class FinSetCalc extends RocketComponentCalc {
 		if (finArea < MathUtil.EPSILON || macSpan < MathUtil.EPSILON) {
 			forces.setCm(0);
 			forces.setCN(0);
-			forces.setCNa(0);
-			forces.setCP(Coordinate.NUL);
+			forces.setCP(Coordinate.ZERO);
 			forces.setCroll(0);
 			forces.setCrollDamp(0);
 			forces.setCrollForce(0);
@@ -179,7 +178,6 @@ public class FinSetCalc extends RocketComponentCalc {
 		forces.setCrollDamp(calculateDampingMoment(conditions));
 		forces.setCroll(forces.getCrollForce() - forces.getCrollDamp());
 		
-		forces.setCNa(cna);
 		forces.setCN(cna * MathUtil.min(conditions.getAOA(), STALL_ANGLE));
 		forces.setCP(new Coordinate(x, 0, 0, cna));
 		forces.setCm(forces.getCN() * x / conditions.getRefLength());

--- a/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/SymmetricComponentCalc.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/SymmetricComponentCalc.java
@@ -141,8 +141,7 @@ public class SymmetricComponentCalc extends RocketComponentCalc {
 		}
 
 		forces.setCP(cp);
-		forces.setCNa(cp.weight);
-		forces.setCN(forces.getCNa() * conditions.getAOA());
+		forces.setCN(forces.getCP().weight * conditions.getAOA());
 		forces.setCm(forces.getCN() * cp.x / conditions.getRefLength());
 		forces.setCroll(0);
 		forces.setCrollDamp(0);

--- a/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/TubeFinSetCalc.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/TubeFinSetCalc.java
@@ -149,8 +149,7 @@ public class TubeFinSetCalc extends TubeCalc {
 		if (outerRadius < 0.001) {
 			forces.setCm(0);
 			forces.setCN(0);
-			forces.setCNa(0);
-			forces.setCP(Coordinate.NUL);
+			forces.setCP(Coordinate.ZERO);
 			forces.setCroll(0);
 			forces.setCrollDamp(0);
 			forces.setCrollForce(0);
@@ -183,7 +182,6 @@ public class TubeFinSetCalc extends TubeCalc {
 
 		forces.setCroll(forces.getCrollForce() - forces.getCrollDamp());
 
-		forces.setCNa(cna);
 		forces.setCN(cna * MathUtil.min(conditions.getAOA(), STALL_ANGLE));
 		forces.setCP(new Coordinate(x, 0, 0, cna));
 		forces.setCm(forces.getCN() * x / conditions.getRefLength());

--- a/core/src/main/java/info/openrocket/core/componentanalysis/CAParameterSweep.java
+++ b/core/src/main/java/info/openrocket/core/componentanalysis/CAParameterSweep.java
@@ -122,7 +122,7 @@ public class CAParameterSweep {
 				double cpx = (component instanceof Rocket && forces.getCP().weight < MathUtil.EPSILON) ?
 						Double.NaN : forces.getCP().x;
 				dataBranch.setValue(CADataType.CP_X, component, cpx);
-				dataBranch.setValue(CADataType.CNa, component, forces.getCNa());
+				dataBranch.setValue(CADataType.CNa, component, forces.getCP().weight);
 			}
 
 			if (!Double.isNaN(forces.getCD())) {
@@ -145,7 +145,7 @@ public class CAParameterSweep {
 		AerodynamicForces totalForces = aeroData.get(rocket);
 		if (totalForces != null && totalForces.getCP() != null) {
 			dataBranch.setValue(CADataType.CP_X, rocket, totalForces.getCP().x);
-			dataBranch.setValue(CADataType.CNa, rocket, totalForces.getCNa());
+			dataBranch.setValue(CADataType.CNa, rocket, totalForces.getCP().weight);
 		}
 	}
 

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
@@ -908,7 +908,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 
 		updateChildrenMassOverriddenBy();
 
-		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE | ComponentChangeEvent.TREE_CHANGE_CHILDREN);
+		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE | ComponentChangeEvent.TREE_CHANGE_CHILDREN);
 	}
 
 	/**
@@ -946,7 +946,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 
 		updateChildrenCGOverriddenBy();
 
-		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE | ComponentChangeEvent.TREE_CHANGE_CHILDREN);
+		fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE | ComponentChangeEvent.TREE_CHANGE_CHILDREN);
 	}
 
 	/**
@@ -986,7 +986,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 
 		overrideSubcomponentsCD(override);
 
-		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE | ComponentChangeEvent.TREE_CHANGE_CHILDREN);
+		fireComponentChangeEvent(ComponentChangeEvent.AERODYNAMIC_CHANGE | ComponentChangeEvent.TREE_CHANGE_CHILDREN);
 	}
 
 	/**

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
@@ -124,9 +124,6 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 	private boolean cdOverridden = false;
 	private boolean overrideSubcomponentsCD = false;
 	private RocketComponent CDOverriddenBy = null;	// The (super-)parent component that overrides the CD of this component
-
-	private boolean cdOverriddenByAncestor = false;
-	
 	
 	// User-given name of the component
     protected String name = null;
@@ -862,7 +859,9 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 	 */
 	public final boolean isCDOverriddenByAncestor() {
 		mutex.verify();
-		return cdOverriddenByAncestor;
+		return (null != parent) &&
+			(parent.isCDOverriddenByAncestor() ||
+			 (parent.isCDOverridden() && parent.isSubcomponentsOverriddenCD()));
 	}
 	
 	
@@ -1008,8 +1007,6 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 	void overrideSubcomponentsCD(boolean override) {
 		for (RocketComponent c : this.children) {
 			if (c.isCDOverriddenByAncestor() != override) {
-
-				c.cdOverriddenByAncestor = override;
 
 				if (!override && c.isCDOverridden() && c.isSubcomponentsOverriddenCD()) {
 					c.overrideSubcomponentsCD(true);
@@ -2982,7 +2979,6 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 		this.massOverridden = src.massOverridden;
 		this.overrideCGX = src.overrideCGX;
 		this.cgOverridden = src.cgOverridden;
-		this.cdOverriddenByAncestor = src.cdOverriddenByAncestor;
 		this.overrideSubcomponentsMass = src.overrideSubcomponentsMass;
 		this.overrideSubcomponentsCG = src.overrideSubcomponentsCG;
 		this.overrideSubcomponentsCD = src.overrideSubcomponentsCD;

--- a/core/src/main/java/info/openrocket/core/simulation/extension/example/DampingMoment.java
+++ b/core/src/main/java/info/openrocket/core/simulation/extension/example/DampingMoment.java
@@ -139,7 +139,7 @@ public class DampingMoment extends AbstractSimulationExtension {
 
 				// System.out.println(comp.toString());
 
-				double CNa = entry.getValue().getCNa(); // ?
+				double CNa = entry.getValue().getCP().weight; // ?
 				double Cp = entry.getValue().getCP().length();
 				double z = comp.getAxialOffset();
 

--- a/core/src/test/java/info/openrocket/core/aerodynamics/FinSetCalcTest.java
+++ b/core/src/test/java/info/openrocket/core/aerodynamics/FinSetCalcTest.java
@@ -80,7 +80,7 @@ public class FinSetCalcTest {
 		double exp_cna_fins = 24.146933;
 		double exp_cpx_fins = 0.0193484;
 
-		assertEquals(exp_cna_fins, forces.getCNa(), EPSILON, " FinSetCalc produces bad CNa: ");
+		assertEquals(exp_cna_fins, forces.getCP().weight, EPSILON, " FinSetCalc produces bad CNa: ");
 		assertEquals(exp_cpx_fins, forces.getCP().x, EPSILON, " FinSetCalc produces bad C_p.x: ");
 		assertEquals(0.0, forces.getCN(), EPSILON, " FinSetCalc produces bad CN: ");
 		assertEquals(0.0, forces.getCm(), EPSILON, " FinSetCalc produces bad C_m: ");
@@ -105,7 +105,7 @@ public class FinSetCalcTest {
 		double exp_cna_fins = 32.195911;
 		double exp_cpx_fins = 0.0193484;
 
-		assertEquals(exp_cna_fins, forces.getCNa(), EPSILON, " FinSetCalc produces bad CNa: ");
+		assertEquals(exp_cna_fins, forces.getCP().weight, EPSILON, " FinSetCalc produces bad CNa: ");
 		assertEquals(exp_cpx_fins, forces.getCP().x, EPSILON, " FinSetCalc produces bad C_p.x: ");
 		assertEquals(0.0, forces.getCN(), EPSILON, " FinSetCalc produces bad CN: ");
 		assertEquals(0.0, forces.getCm(), EPSILON, " FinSetCalc produces bad C_m: ");
@@ -125,7 +125,7 @@ public class FinSetCalcTest {
 		AerodynamicForces forces = sumFins(fins, rocket);
 
 		// Verify all force components are zero and not NaN
-		assertEquals(0.0, forces.getCNa(), EPSILON, "CNa should be zero for zero-area fin");
+		assertEquals(0.0, forces.getCP().weight, EPSILON, "CNa should be zero for zero-area fin");
 		assertEquals(0.0, forces.getCN(), EPSILON, "CN should be zero for zero-area fin");
 		assertEquals(0.0, forces.getCm(), EPSILON, "Cm should be zero for zero-area fin");
 		assertEquals(0.0, forces.getCroll(), EPSILON, "Croll should be zero for zero-area fin");
@@ -141,7 +141,7 @@ public class FinSetCalcTest {
 		forces = sumFins(fins, rocket);
 
 		// Verify all force components are zero and not NaN
-		assertEquals(0.0, forces.getCNa(), EPSILON, "CNa should be zero for canted zero-area fin");
+		assertEquals(0.0, forces.getCP().weight, EPSILON, "CNa should be zero for canted zero-area fin");
 		assertEquals(0.0, forces.getCN(), EPSILON, "CN should be zero for canted zero-area fin");
 		assertEquals(0.0, forces.getCm(), EPSILON, "Cm should be zero for canted zero-area fin");
 		assertEquals(0.0, forces.getCroll(), EPSILON, "Croll should be zero for canted zero-area fin");
@@ -164,7 +164,7 @@ public class FinSetCalcTest {
 		AerodynamicForces forces = sumFins(fins, rocket);
 
 		// Verify results are not NaN
-		assertFalse(Double.isNaN(forces.getCNa()), "CNa should not be NaN for very small fin");
+		assertFalse(Double.isNaN(forces.getCP().weight), "CNa should not be NaN for very small fin");
 		assertFalse(Double.isNaN(forces.getCN()), "CN should not be NaN for very small fin");
 		assertFalse(Double.isNaN(forces.getCm()), "Cm should not be NaN for very small fin");
 		assertFalse(Double.isNaN(forces.getCroll()), "Croll should not be NaN for very small fin");

--- a/core/src/test/java/info/openrocket/core/aerodynamics/SymmetricComponentCalcTest.java
+++ b/core/src/test/java/info/openrocket/core/aerodynamics/SymmetricComponentCalcTest.java
@@ -69,7 +69,7 @@ public class SymmetricComponentCalcTest {
 		double cna_nose = 2;
 		double cpx_nose = 2.0 / 3.0 * nose.getLength();
 
-		assertEquals(cna_nose, forces.getCNa(), EPSILON, " SymmetricComponentCalc produces bad CNa: ");
+		assertEquals(cna_nose, forces.getCP().weight, EPSILON, " SymmetricComponentCalc produces bad CNa: ");
 		assertEquals(cpx_nose, forces.getCP().x, EPSILON, " SymmetricComponentCalc produces bad C_p.x: ");
 		assertEquals(0.0, forces.getCN(), EPSILON, " SymmetricComponentCalc produces bad CN: ");
 		assertEquals(0.0, forces.getCm(), EPSILON, " SymmetricComponentCalc produces bad C_m: ");
@@ -100,7 +100,7 @@ public class SymmetricComponentCalcTest {
 		double l_nose = nose.getLength();
 		double cna_nose = 2;
 		double cpx_nose = 0.46216 * l_nose;
-		assertEquals(cna_nose, forces.getCNa(), EPSILON, " SymmetricComponentCalc produces bad CNa:  ");
+		assertEquals(cna_nose, forces.getCP().weight, EPSILON, " SymmetricComponentCalc produces bad CNa:  ");
 		assertEquals(cpx_nose, forces.getCP().x, EPSILON, " SymmetricComponentCalc produces bad C_p.x:");
 		assertEquals(0.0, forces.getCN(), EPSILON, " SymmetricComponentCalc produces bad CN:   ");
 		assertEquals(0.0, forces.getCm(), EPSILON, " SymmetricComponentCalc produces bad C_m:  ");

--- a/core/src/test/java/info/openrocket/core/rocketcomponent/FreeformFinSetTest.java
+++ b/core/src/test/java/info/openrocket/core/rocketcomponent/FreeformFinSetTest.java
@@ -1365,11 +1365,15 @@ public class FreeformFinSetTest extends BaseTestCase {
 		bt.addChild(fins);
 		FinSetCalc calc = new FinSetCalc(fins);
 		FlightConditions conditions = new FlightConditions(null);
-		Transformation transform = Transformation.IDENTITY;
+		// rotate 90 degrees about the X axis
+		Transformation transform = new Transformation(new double[][] {
+				{1, 0,  0},
+				{0, 0, -1},
+				{0, 1,  1}
+			});
 		AerodynamicForces forces = new AerodynamicForces();
 		WarningSet warnings = new WarningSet();
 		calc.calculateNonaxialForces(conditions, transform, forces, warnings);
-		// System.out.println(forces);
 		assertEquals(0.023409, forces.getCP().x, 0.0001);
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/ComponentAnalysisGeneralPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/ComponentAnalysisGeneralPanel.java
@@ -622,7 +622,7 @@ public class ComponentAnalysisGeneralPanel extends JPanel implements StateChange
 				} else {
 					row.cpx = forces.getCP().x;
 				}
-				row.cna = forces.getCNa();
+				row.cna = forces.getCP().weight;
 			}
 
 			if (!Double.isNaN(forces.getCD())) {


### PR DESCRIPTION
The discontinuity observed in #2751 when a component has a tailcone is caused by a divide-by-zero error when merging CPs for the components in the rocket.

At present, AerodynamicForces contains a member variable cp containing the center of pressure of the component or assembly, with CNa as its weight. It also redundantly stores CNa as a separate variable.

The discontinuity when there is a tailcone comes from the fact that, according to the Barrowman equations, a nose cone has a CNa of 2 and a tail cone has a CNa of -2. When taking the weighted average of the nose and tail cone the weight becomes 0; when dividing by the weight the CP is NaN.

This PR solves this by storing the moment defined by CP * CNa, with a weight of CNa. Now instead of combining CPs by performing a weighted average, we can just sum the moments. When getCP() is called, the moment is divided by the weight to return the CP. If the weight happens to be 0 at this point, a CP of (0, 0, 0) is returned (it doesn't return (NaN, NaN, NaN) because this could cause issues with things like really tiny fins).

It also gets rid of the separate storage of CNa.

Fixes #2751