### PR TITLE
[#2749] Also reset simulation when resetting flight data

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/figureelements/RocketInfo.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/figureelements/RocketInfo.java
@@ -184,6 +184,10 @@ public class RocketInfo implements FigureElement {
 
 	public void setSimulation(Simulation simulation) {
 		this.simulation = simulation;
+		if (simulation == null) {
+			setFlightData(null);
+			return;
+		}
 
 		if (simulation.hasSummaryData()) {
 			setFlightData(simulation.getSimulatedData());

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
@@ -881,7 +881,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 
 		// Check whether to compute or not
 		if (!((SwingPreferences) Application.getPreferences()).computeFlightInBackground()) {
-			extraText.setFlightData(null);
+			extraText.setSimulation(null);
 			extraText.setCalculatingData(false);
 			stopBackgroundSimulation();
 			return;
@@ -900,7 +900,8 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		stopBackgroundSimulation();
 
 		// Check that configuration has motors
-		if (!curConfig.hasMotors()){
+		if (!curConfig.hasMotors()) {
+			extraText.setSimulation(null);
 			extraText.setFlightData(FlightData.NaN_DATA);
 			extraText.setCalculatingData(false);
 			return;


### PR DESCRIPTION
This PR fixes #2749. The issue was that in `RocketPanel` in `updateExtras` that if the current config has no motors or computeFlightInBackground is disabled in preferences, that the flight data of `RocketInfo` was updated, but the simulation variable was not. That's fixed by this PR.

https://github.com/user-attachments/assets/8d44fd64-a1f4-488f-bcde-6a0f491e5dde

