### PR TITLE
Get rid of 10 m/s wind speed and 11km wind level limits

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/MultiLevelWindTable.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/MultiLevelWindTable.java
@@ -733,7 +733,7 @@ public class MultiLevelWindTable extends JPanel implements ChangeSource {
 
 			// Create DoubleModels bound to the level
 			dmAltitude = new DoubleModel(level, "Altitude", UnitGroup.UNITS_DISTANCE, -100, ExtendedISAModel.getMaximumAllowedAltitude());
-			dmSpeed = new DoubleModel(level, "Speed", UnitGroup.UNITS_WINDSPEED, 0, 10.0);
+			dmSpeed = new DoubleModel(level, "Speed", UnitGroup.UNITS_WINDSPEED, 0);
 			dmDirection = new DoubleModel(level, "Direction", UnitGroup.UNITS_ANGLE, 0, 2 * Math.PI);
 			dmStdDeviation = new DoubleModel(level, "StandardDeviation", UnitGroup.UNITS_WINDSPEED, 0, dmSpeed);
 			dmTurbulence = new DoubleModel(level, "TurbulenceIntensity", UnitGroup.UNITS_RELATIVE, 0, 1);

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/MultiLevelWindTable.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/MultiLevelWindTable.java
@@ -732,7 +732,7 @@ public class MultiLevelWindTable extends JPanel implements ChangeSource {
 			setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
 
 			// Create DoubleModels bound to the level
-			dmAltitude = new DoubleModel(level, "Altitude", UnitGroup.UNITS_DISTANCE, -100, ExtendedISAModel.getMaximumAllowedAltitude());
+			dmAltitude = new DoubleModel(level, "Altitude", UnitGroup.UNITS_DISTANCE, -100);
 			dmSpeed = new DoubleModel(level, "Speed", UnitGroup.UNITS_WINDSPEED, 0);
 			dmDirection = new DoubleModel(level, "Direction", UnitGroup.UNITS_ANGLE, 0, 2 * Math.PI);
 			dmStdDeviation = new DoubleModel(level, "StandardDeviation", UnitGroup.UNITS_WINDSPEED, 0, dmSpeed);

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConditionsPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConditionsPanel.java
@@ -421,11 +421,11 @@ public class SimulationConditionsPanel extends JPanel {
 
 		// Wind average
 		final DoubleModel windSpeedAverage = addDoubleModel(panel, "Averwindspeed", trans.get("simedtdlg.lbl.ttip.Averwindspeed"), model, "Average",
-				UnitGroup.UNITS_WINDSPEED, 0, 10.0);
+															UnitGroup.UNITS_WINDSPEED, 0, 10.0, Double.MAX_VALUE);
 
 		// Wind standard deviation
 		final DoubleModel windSpeedDeviation = addDoubleModel(panel, "Stddeviation", trans.get("simedtdlg.lbl.ttip.Stddeviation"),
-				model, "StandardDeviation", UnitGroup.UNITS_WINDSPEED, 0, windSpeedAverage);
+															  model, "StandardDeviation", UnitGroup.UNITS_WINDSPEED, 0, windSpeedAverage, windSpeedAverage);
 
 		windSpeedAverage.addChangeListener(new ChangeListener() {
 			@Override
@@ -441,7 +441,7 @@ public class SimulationConditionsPanel extends JPanel {
 				" " + trans.get("simedtdlg.lbl.ttip.Turbulenceintensity3") + " " +
 				UnitGroup.UNITS_RELATIVE.getDefaultUnit().toStringUnit(0.20) + ".";
 		final DoubleModel windTurbulenceIntensity = addDoubleModel(panel, "Turbulenceintensity", tip, model,
-				"TurbulenceIntensity", UnitGroup.UNITS_RELATIVE, 0, 1.0, true);
+																   "TurbulenceIntensity", UnitGroup.UNITS_RELATIVE, 0, 1.0, 1.0, true);
 
 		final JLabel intensityLabel = new JLabel(target.getAverageWindModel().getIntensityDescription());
 		intensityLabel.setToolTipText(tip);
@@ -462,7 +462,7 @@ public class SimulationConditionsPanel extends JPanel {
 
 		// Wind direction
 		addDoubleModel(panel, "Winddirection", trans.get("simedtdlg.lbl.ttip.Winddirection"), model, "Direction",
-				UnitGroup.UNITS_ANGLE, 0, 2 * Math.PI);
+					   UnitGroup.UNITS_ANGLE, 0, 2 * Math.PI, 2 * Math.PI);
 	}
 
 	private static void addMultiLevelSettings(JPanel panel, SimulationOptionsInterface target) {
@@ -545,7 +545,7 @@ public class SimulationConditionsPanel extends JPanel {
 	}
 
 	private static DoubleModel addDoubleModel(JPanel panel, String labelKey, String tooltipText, Object source, String sourceKey,
-									   UnitGroup unit, double min, Object max, boolean easterEgg) {
+											  UnitGroup unit, double min, Object maxSlider, Object max, boolean easterEgg) {
 		JLabel label = new JLabel(trans.get("simedtdlg.lbl." + labelKey));
 		panel.add(label);
 
@@ -555,7 +555,7 @@ public class SimulationConditionsPanel extends JPanel {
 		} else if (max instanceof DoubleModel) {
 			model = new DoubleModel(source, sourceKey, unit, min, (DoubleModel) max);
 		} else {
-			throw new IllegalArgumentException("Invalid max value");
+			throw new IllegalArgumentException("max value must be Double or DoubleModel");
 		}
 
 		JSpinner spin = new JSpinner(model.getSpinnerModel());
@@ -572,15 +572,22 @@ public class SimulationConditionsPanel extends JPanel {
 		UnitSelector unitSelector = new UnitSelector(model);
 		panel.add(unitSelector, "growx");
 
-		BasicSlider slider = new BasicSlider(model.getSliderModel());
+		BasicSlider slider;
+		if (maxSlider instanceof Double) {
+			slider = new BasicSlider(model.getSliderModel(0, (Double) maxSlider));
+		} else if (maxSlider instanceof DoubleModel) {
+			slider = new BasicSlider(model.getSliderModel(0, (DoubleModel) maxSlider));
+		} else {
+			throw new IllegalArgumentException("maxSlider value must be Double or DoubleModel");
+		}
 		panel.add(slider, "w 75lp, wrap");
 
 		return model;
 	}
 
 	private static DoubleModel addDoubleModel(JPanel panel, String labelKey, String tooltipText, Object source, String sourceKey,
-											  UnitGroup unit, double min, Object max) {
-		return addDoubleModel(panel, labelKey, tooltipText, source, sourceKey, unit, min, max, false);
+											  UnitGroup unit, double min, Object maxSlider, Object max) {
+		return addDoubleModel(panel, labelKey, tooltipText, source, sourceKey, unit, min, maxSlider, max, false);
 	}
 
 


### PR DESCRIPTION
The 10 m/s max wind speed probably came from the NAR, TRA, and UKRA safety code limits of 20 mph max ground wind; it doesn't apply at higher altitudes where the winds are pretty much always higher than that, and we also shouldn't be preventing a user from setting whatever they want.

Note that the slider for the average wind speed now works analogously to the sliders in some of the component configuration dialogs: you can only use the slider to set the wind speed up to 10 m/s, but you can enter any speed you want by typing it in.

There should be a warning that the wind speed exceeds safety codes; I'll make an issue for that so we don't forget it, but I'd rather wait to add it until the upcoming Warning rewrite.

The Extended ISA atmosphere model prohibits setting a launch site above 11km (the limit of the troposphere); the reason for that isn't clear to me, but anything that high isn't realistic anyway. Though the launch site height is limited, the model allows flights above that. This PR leaves the limit on max launch altitude, but allows arbitrary altitudes for the wind levels.

Fixes #2767