### PR TITLE
Work around invalid IDs in .ork file

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/openrocket/OpenRocketSaver.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/OpenRocketSaver.java
@@ -443,7 +443,9 @@ public class OpenRocketSaver extends RocketSaver {
 
 				if (null != w.getSources()) {
 					for (RocketComponent c : w.getSources()) {
-						writeElement("source", c.getID());
+						if (c != null) {
+							writeElement("source", c.getID());
+						}
 					}
 				}
 

--- a/core/src/main/java/info/openrocket/core/logging/Message.java
+++ b/core/src/main/java/info/openrocket/core/logging/Message.java
@@ -44,8 +44,11 @@ public abstract class Message implements Cloneable {
 	protected static String addSourcesToMessageText(String text, RocketComponent[] sources) {
 		if (sources != null && sources.length > 0) {
 			String[] sourceNames = new String[sources.length];
+			int j = 0;
 			for (int i = 0; i < sources.length; i++) {
-				sourceNames[i] = "\"" + sources[i].getName() + "\"";
+				if (sources[i] != null) {
+					sourceNames[j++] = "\"" + sources[i].getName() + "\"";
+				}
 			}
 			return text + ":  " + String.join(", ", sourceNames);
 		}


### PR DESCRIPTION
Under circumstances I haven't been able to duplicate, a .ork file can have a bad UUID for a component in a warning. This works around the error by checking that components are non-null before extracting their name (on file read) or UUID (on file write).

Works around (doesn't fix) #2777