### PR TITLE
 [#2776] Include super-parent angles in instance rotation 

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/rasaero/export/SimulationDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rasaero/export/SimulationDTO.java
@@ -303,7 +303,7 @@ public class SimulationDTO {
 
         // Calculate the motor CG
         double motorPositionXRel = mount.getMotorPosition(fcid).x; // Motor position relative to the mount
-        double mountLocationX = mount.getLocations()[0].x;
+        double mountLocationX = mount.getComponentLocations()[0].x;
         double motorLocationX = mountLocationX + motorPositionXRel;
         double motorCG = ((ThrustCurveMotor) motor).getCGPoints()[0].x + motorLocationX;
 

--- a/core/src/main/java/info/openrocket/core/file/rasaero/importt/SimulationHandler.java
+++ b/core/src/main/java/info/openrocket/core/file/rasaero/importt/SimulationHandler.java
@@ -513,7 +513,7 @@ public class SimulationHandler extends AbstractElementHandler {
         Coordinate[] CGPoints = motor.getCGPoints();
         if (CGPoints != null && CGPoints.length > 1) {
             double motorPositionXRel = mount.getMotorPosition(fcid).x; // Motor position relative to the mount
-            double mountLocationX = mount.getLocations()[0].x;
+            double mountLocationX = mount.getComponentLocations()[0].x;
             double motorLocationX = mountLocationX + motorPositionXRel; // Front location of the motor
             double motorCG = motorLocationX + CGPoints[0].x;
 

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/InnerBodyTubeDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/InnerBodyTubeDTO.java
@@ -116,7 +116,7 @@ public class InnerBodyTubeDTO extends BodyTubeDTO implements AttachableParts {
 		// coords = it.shiftCoordinates(coords);
 
 		// new version
-		Coordinate[] coords = it.getLocations();
+		Coordinate[] coords = it.getComponentLocations();
 
 		for (int x = 0; x < coords.length; x++) {
 			InnerTube partialClone = InnerTube.makeIndividualClusterComponent(coords[x], it.getName() + " #" + (x + 1),

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/FinSet.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/FinSet.java
@@ -924,7 +924,7 @@ public abstract class FinSet extends ExternalComponent
 			}
 		}
 		
-		Coordinate location = this.getLocations()[0];
+		Coordinate location = this.getComponentLocations()[0];
 		x_max += location.x;
 		
 		if( parent instanceof SymmetricComponent){

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/Instanceable.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/Instanceable.java
@@ -4,9 +4,6 @@ import info.openrocket.core.util.Coordinate;
 
 public interface Instanceable {
 	
-	@Deprecated
-	Coordinate[] getLocations();
-	
 	/**
 	 * Returns vector coordinates of each instance of this component relative to this component's parent
 	 * 

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/MotorMount.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/MotorMount.java
@@ -84,7 +84,7 @@ public interface MotorMount extends ChangeSource, FlightConfigurableComponent {
 	public AxialStage getStage();
 
 	// duplicate of RocketComponent
-	public Coordinate[] getLocations();
+	public Coordinate[] getComponentLocations();
 
 	/**
 	 * Returns the set of motors configured for flight/simulation in this motor

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
@@ -22,6 +22,7 @@ import info.openrocket.core.startup.Application;
 import info.openrocket.core.preferences.ApplicationPreferences;
 import info.openrocket.core.util.ModID;
 import info.openrocket.core.util.ORColor;
+import info.openrocket.core.util.Transformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1602,17 +1603,22 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 			// override <instance>.getInstanceLocations() in each subclass
 			Coordinate[] instanceLocations = this.getInstanceLocations();
 			int instanceCount = instanceLocations.length;
+
+			// We also need to include the parent rotations
+			Coordinate[] parentRotations = this.parent.getComponentAngles();
 			
 			// usual case optimization
 			if ((parentCount == 1) && (instanceCount == 1)) {
-				return new Coordinate[]{parentPositions[0].add(instanceLocations[0])};
+				Transformation rotation = Transformation.getRotationTransform(parentRotations[0], this.position);
+				return new Coordinate[]{parentPositions[0].add(rotation.transform(instanceLocations[0]))};
 			}
 			
 			int thisCount = instanceCount * parentCount;
 			Coordinate[] thesePositions = new Coordinate[thisCount];
 			for (int pi = 0; pi < parentCount; pi++) {
+				Transformation rotation = Transformation.getRotationTransform(parentRotations[pi], this.position);
 				for (int ii = 0; ii < instanceCount; ii++) {
-					thesePositions[pi + parentCount*ii] = parentPositions[pi].add(instanceLocations[ii]);
+					thesePositions[pi + parentCount*ii] = parentPositions[pi].add(rotation.transform(instanceLocations[ii]));
 				}
 			}
 			return thesePositions;

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
@@ -1579,13 +1579,6 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 	public Coordinate[] getInstanceOffsets() {
 		return new Coordinate[] { Coordinate.ZERO };
 	}
-
-	// this is an inefficient way to calculate all of the locations;
-	// it also breaks locality, (i.e. is a rocket-wide calculation )
-	@Deprecated
-	public Coordinate[] getLocations() {
-		return getComponentLocations();
-	}
 	
 	/** 
 	 * Provides locations of all instances of component *accounting for all parent instancing*
@@ -1739,10 +1732,10 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 		
 		// not sure if this will give us an answer, or THE answer... 
 		//final Coordinate sourceLoc = this.getLocation()[0];
-		final Coordinate[] destLocs = dest.getLocations();
+		final Coordinate[] destLocs = dest.getComponentLocations();
 		Coordinate[] toReturn = new Coordinate[destLocs.length];
 		for (int coordIndex = 0; coordIndex < destLocs.length; coordIndex++) {
-			toReturn[coordIndex] = this.getLocations()[0].add(c).sub(destLocs[coordIndex]);
+			toReturn[coordIndex] = this.getComponentLocations()[0].add(c).sub(destLocs[coordIndex]);
 		}
 		
 		mutex.unlock("toRelative");
@@ -3165,7 +3158,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 				final String instancePrefix = String.format("%s    [%2d/%2d]", indent, instanceNumber + 1,
 						getInstanceCount());
 				buffer.append(String.format("%-40s|  %5.3f; %24s; %24s;\n", instancePrefix, getLength(),
-						this.axialOffset, getLocations()[instanceNumber]));
+						this.axialOffset, getComponentLocations()[instanceNumber]));
 			}
 		} else {
 			throw new IllegalStateException(

--- a/core/src/main/java/info/openrocket/core/simulation/MotorClusterState.java
+++ b/core/src/main/java/info/openrocket/core/simulation/MotorClusterState.java
@@ -26,7 +26,7 @@ public class MotorClusterState {
 		this.config = _config;
 
 		this.motor = this.config.getMotor();
-		this.motorCount = this.config.getMount().getLocations().length;
+		this.motorCount = this.config.getMount().getComponentLocations().length;
 		this.thrustDuration = this.motor.getBurnTimeEstimate();
 
 		this.reset();

--- a/core/src/main/java/info/openrocket/core/util/Transformation.java
+++ b/core/src/main/java/info/openrocket/core/util/Transformation.java
@@ -45,6 +45,55 @@ public class Transformation implements java.io.Serializable {
 	}
 
 	/**
+	 * Create a transformation that rotates the coordinate system by the given
+	 * angles.
+	 * @param rotation The rotation angles in radians. For example, [Math.PI/2, 0, Math.PI] rotates 90 deg around the x-axis,
+	 *                 0 deg around the y-axis,and 180 deg around the z-axis.
+	 * @return The transformation.
+	 */
+	static public Transformation getRotationTransform(final Coordinate rotation) {
+		Transformation transformation = new Transformation();
+
+		// Apply rotations in X-Y-Z order
+		if (Math.abs(rotation.x) > ANGLE_EPSILON) {
+			transformation = transformation.applyTransformation(rotate_x(rotation.x));
+		}
+
+		if (Math.abs(rotation.y) > ANGLE_EPSILON) {
+			transformation = transformation.applyTransformation(rotate_y(rotation.y));
+		}
+
+		if (Math.abs(rotation.z) > ANGLE_EPSILON) {
+			transformation = transformation.applyTransformation(rotate_z(rotation.z));
+		}
+
+		return transformation;
+	}
+
+	/**
+	 * Creates a transformation that rotates around a specific origin point.
+	 *
+	 * @param rotation The rotation angles (x, y, z) in radians
+	 * @param origin The point to rotate around
+	 * @return A transformation that rotates around the specified origin
+	 */
+	static public Transformation getRotationTransform(final Coordinate rotation, final Coordinate origin) {
+		// 1. Translate to origin point
+		Transformation translateToOrigin = getTranslationTransform(-origin.x, -origin.y, -origin.z);
+
+		// 2. Apply the rotations
+		Transformation rotateTransform = getRotationTransform(rotation);
+
+		// 3. Translate back from origin
+		Transformation translateBack = getTranslationTransform(origin);
+
+		// Combine the transformations:
+		// First translate to origin, then rotate, then translate back
+		return translateBack.applyTransformation(
+				rotateTransform.applyTransformation(translateToOrigin));
+	}
+
+	/**
 	 * Create identity transformation.
 	 */
 	private Transformation() {
@@ -96,7 +145,6 @@ public class Transformation implements java.io.Serializable {
 	 * Create transformation with given rotation matrix and translation.
 	 * 
 	 * @param rotation
-	 * @param translation
 	 */
 	public Transformation(double[][] rotation) {
 		for (int i = 0; i < 3; i++)

--- a/core/src/test/java/info/openrocket/core/rocketcomponent/LaunchLugTest.java
+++ b/core/src/test/java/info/openrocket/core/rocketcomponent/LaunchLugTest.java
@@ -21,10 +21,10 @@ public class LaunchLugTest extends BaseTestCase {
 		lug.setInstanceSeparation(0.05);
 		lug.setInstanceCount(2);
 
-		double expX = 0.111 + body.getLocations()[0].x;
+		double expX = 0.111 + body.getComponentLocations()[0].x;
 		double expR = -(body.getOuterRadius() + lug.getOuterRadius());
 		Coordinate expPos = new Coordinate(expX, expR, 0, 0);
-		Coordinate[] actPos = lug.getLocations();
+		Coordinate[] actPos = lug.getComponentLocations();
 		assertEquals(expPos.x, actPos[0].x, EPSILON, " LaunchLug has the wrong x value: ");
 		assertEquals(expPos.y, actPos[0].y, EPSILON, " LaunchLug has the wrong y value: ");
 		assertEquals(expPos.z, actPos[0].z, EPSILON, " LaunchLug has the wrong z value: ");
@@ -46,12 +46,12 @@ public class LaunchLugTest extends BaseTestCase {
 		lug.setInstanceSeparation(0.05);
 		lug.setInstanceCount(2);
 
-		double expX = 0.111 + body.getLocations()[0].x;
+		double expX = 0.111 + body.getComponentLocations()[0].x;
 		double expR = 0.015;
 		double expY = Math.cos(startAngle) * expR;
 		double expZ = Math.sin(startAngle) * expR;
 		Coordinate expPos = new Coordinate(expX, expY, expZ, 0);
-		Coordinate[] actPos = lug.getLocations();
+		Coordinate[] actPos = lug.getComponentLocations();
 		assertEquals(expPos.x, actPos[0].x, EPSILON, " LaunchLug has the wrong x value: ");
 		assertEquals(expPos.y, actPos[0].y, EPSILON, " LaunchLug has the wrong y value: ");
 		assertEquals(expPos.z, actPos[0].z, EPSILON, " LaunchLug has the wrong z value: ");

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketFigure.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketFigure.java
@@ -335,9 +335,9 @@ public class RocketFigure extends AbstractScaleFigure {
 				continue;
 			}
 
-			// <component>.getLocation() will return all the parent instances of this owning component,  AND all of it's own instances as well.
+			// <component>.getComponentLocations() will return all the parent instances of this owning component,  AND all of its own instances as well.
 			// so, just draw a motor once for each Coordinate returned... 
-			Coordinate[] mountLocations = mount.getLocations();
+			Coordinate[] mountLocations = mount.getComponentLocations();
 
 			double mountLength = mountComponent.getLength();
 			for (Coordinate curMountLocation : mountLocations) {

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketFigure.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketFigure.java
@@ -339,9 +339,9 @@ public class RocketFigure extends AbstractScaleFigure {
 			// so, just draw a motor once for each Coordinate returned... 
 			Coordinate[] mountLocations = mount.getComponentLocations();
 
-			double mountLength = mountComponent.getLength();
+			Coordinate motorPosition = mount.getMotorPosition(config.getId());
 			for (Coordinate curMountLocation : mountLocations) {
-				Coordinate curMotorLocation = curMountLocation.add(mountLength - motorLength + mount.getMotorOverhang(), 0, 0);
+				Coordinate curMotorLocation = curMountLocation.add(motorPosition);
 
 				// rotate by figure's axial rotation:
 				curMotorLocation = getFigureRotation().transform(curMotorLocation);

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketFigure.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketFigure.java
@@ -320,6 +320,28 @@ public class RocketFigure extends AbstractScaleFigure {
 				RenderingHints.VALUE_STROKE_NORMALIZE);
 	
 		// Draw motors
+		drawMotors(g2);
+
+
+		// Draw relative extras
+		if (drawCarets) {
+			for (FigureElement e : relativeExtra) {
+				e.paint(g2, scale);
+			}
+		}
+
+		
+		// Draw absolute extras
+		g2.setTransform(baseTransform);
+		Rectangle rect = this.getVisibleRect();
+		
+		for (FigureElement e : absoluteExtra) {
+			e.paint(g2, 1.0, rect);
+		}
+		
+	}
+
+	private void drawMotors(Graphics2D g2) {
 		Color fillColor = motorFillColor;
 		Color borderColor = motorBorderColor;
 
@@ -335,7 +357,7 @@ public class RocketFigure extends AbstractScaleFigure {
 			double motorRadius = motor.getDiameter() / 2;
 
 			// <component>.getComponentLocations() will return all the parent instances of this owning component,  AND all of its own instances as well.
-			// so, just draw a motor once for each Coordinate returned... 
+			// so, just draw a motor once for each Coordinate returned...
 			Coordinate[] mountLocations = mount.getComponentLocations();
 
 			Coordinate motorPosition = mount.getMotorPosition(config.getId());
@@ -365,26 +387,8 @@ public class RocketFigure extends AbstractScaleFigure {
 				}
 			}
 		}
-		
-
-		// Draw relative extras
-		if (drawCarets) {
-			for (FigureElement e : relativeExtra) {
-				e.paint(g2, scale);
-			}
-		}
-
-		
-		// Draw absolute extras
-		g2.setTransform(baseTransform);
-		Rectangle rect = this.getVisibleRect();
-		
-		for (FigureElement e : absoluteExtra) {
-			e.paint(g2, 1.0, rect);
-		}
-		
 	}
-	
+
 	public RocketComponent[] getComponentsByPoint(double x, double y) {
 		// Calculate point in shapes' coordinates
 		Point2D.Double p = new Point2D.Double(x, y);

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketFigure.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketFigure.java
@@ -326,14 +326,13 @@ public class RocketFigure extends AbstractScaleFigure {
 		FlightConfiguration config = rocket.getSelectedConfiguration();
 		for (MotorConfiguration curInstance : config.getActiveMotors()) {
 			MotorMount mount = curInstance.getMount();
+			if (!((RocketComponent) mount).isVisible()) {
+				continue;
+			}
+
 			Motor motor = curInstance.getMotor();
 			double motorLength = motor.getLength();
 			double motorRadius = motor.getDiameter() / 2;
-			RocketComponent mountComponent = ((RocketComponent) mount);
-
-			if (!mountComponent.isVisible()) {
-				continue;
-			}
 
 			// <component>.getComponentLocations() will return all the parent instances of this owning component,  AND all of its own instances as well.
 			// so, just draw a motor once for each Coordinate returned... 


### PR DESCRIPTION
This PR fixes #2776. The issue was not just a simple rendering glitch, but a more fundamental issue, namely that rocket component locations (the return value of `getComponentLocations()` in `RocketComponent`) did not account for rotations of super-parents. For example, take this structure:

```
Pod Set 1
├─ Phantom Body Tube
│  ├─ Pod Set 2
│  │  ├─ Body Tube
```

Conditions:
- Pod Set 1 rotation: -90°
- Pod Set 2 rotation: -90°
- Pod Set 2 radial offset: 10 cm

With a total rotation of -180°, you would expect the 10 cm offset to cause the body tube to move 10 cm in the negative y direction. However, it was moving 10 cm in the negative z direction, because only the -90° rotation of Pod Set 2 was taken into account in the pod set instance locations.

A very extreme example with a double-nested pod set:
<img width="1555" alt="Screenshot 2025-04-09 at 02 58 38" src="https://github.com/user-attachments/assets/09721b44-e02b-4768-98a5-87645ef3861f" />

After this PR:
<img width="1555" alt="image" src="https://github.com/user-attachments/assets/de9cef7b-1cba-4f6b-9fe3-6ef70341b6f8" />
