### PR TITLE
Check for 0 mass transitions, set their moments of inertia to 0 instead of getting a NaN due to dividing by mass

### DIFF
--- a/core/src/main/java/info/openrocket/core/rocketcomponent/SymmetricComponent.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/SymmetricComponent.java
@@ -447,7 +447,7 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 		double cgx = 0;
 
 		// Check length > 0
-		if (getLength() <= 0) {
+		if (getLength() < MathUtil.EPSILON) {
 			return;
 		}
 

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/Transition.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/Transition.java
@@ -764,7 +764,16 @@ public class Transition extends SymmetricComponent implements InsideColorCompone
 				aftCapCG.x * aftCapCG.weight;
 
 			final double mass = foreCapCG.weight + foreShoulderCG.weight + transCG.weight + aftShoulderCG.weight + aftCapCG.weight;
+			
+			// If the mass is 0, so are moments of inertia
+			if (mass < MathUtil.EPSILON) {
+				cg = new Coordinate(0, 0, 0, 0);
+				longitudinalUnitInertia = 0.0;
+				rotationalUnitInertia = 0.0;
 
+				return;
+			}
+			
 			cg = new Coordinate(cgx / mass, 0, 0, mass);
 
 			// need to use parallel axis theorem to move longitudinal MOI to CG of component


### PR DESCRIPTION
Fixes #2785