### PR TITLE
Improve simulation edit dialog UI for low-resolution screens

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/plot/PlotPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/PlotPanel.java
@@ -62,7 +62,7 @@ public class PlotPanel<T extends DataType & Groupable<G>,
 
 	public PlotPanel(T[] typesX, T[] typesY, C customConfiguration, C[] presets,
 					 C defaultConfiguration, Component[] extraWidgetsX, Component[] extraWidgetsY) {
-		super(new MigLayout("fill"));
+		super(new MigLayout("fill, ins n n 0 n"));
 
 		this.customConfiguration = customConfiguration;
 		this.presetArray = presets;

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConditionsPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConditionsPanel.java
@@ -17,7 +17,6 @@ import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JRadioButton;
-import javax.swing.JScrollPane;
 import javax.swing.JSeparator;
 import javax.swing.JSpinner;
 import javax.swing.JTextField;
@@ -51,7 +50,7 @@ public class SimulationConditionsPanel extends JPanel {
 
 
 	SimulationConditionsPanel(final Simulation simulation) {
-		super(new MigLayout("fill"));
+		super(new MigLayout("fill, ins n n 0 n"));
 
 		SimulationOptions simulationOptions = simulation.getOptions();
 

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConfigDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConfigDialog.java
@@ -224,6 +224,7 @@ public class SimulationConfigDialog extends JDialog {
 
 		GUIUtil.setDisposableDialogOptions(this, null);
 		GUIUtil.rememberWindowPosition(this);
+		GUIUtil.rememberWindowSize(this);
 	}
 
 	private static void initColors() {

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConfigDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConfigDialog.java
@@ -330,7 +330,7 @@ public class SimulationConfigDialog extends JDialog {
 	}
 
 	private JPanel generateBottomPanel() {
-		final JPanel bottomPanel = new JPanel(new MigLayout("fill"));
+		final JPanel bottomPanel = new JPanel(new MigLayout("fill, ins 0 n n n"));
 
 		//// Multi-simulation edit
 		if (isMultiCompEdit()) {

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConfigDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConfigDialog.java
@@ -120,7 +120,7 @@ public class SimulationConfigDialog extends JDialog {
 		warningsScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
 		warningsScrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
 		Dimension d = warningsScrollPane.getPreferredSize();
-		warningsScrollPane.setPreferredSize(new Dimension(d.width, 500));
+		warningsScrollPane.setPreferredSize(new Dimension(d.width, 300));
 		tabbedPane.addTab(trans.get("SimulationConfigDialog.tab.Warnings"), warningsScrollPane);
 
 		if (isMultiCompEdit()) {

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConfigDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConfigDialog.java
@@ -32,6 +32,7 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
+import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Window;
@@ -99,6 +100,8 @@ public class SimulationConfigDialog extends JDialog {
 			}
 		});
 
+		this.setLayout(new BorderLayout());
+
 		final JPanel contentPanel = new JPanel(new MigLayout("fill"));
 
 		// ======== Top panel ========
@@ -120,7 +123,7 @@ public class SimulationConfigDialog extends JDialog {
 		warningsScrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
 		warningsScrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
 		Dimension d = warningsScrollPane.getPreferredSize();
-		warningsScrollPane.setPreferredSize(new Dimension(d.width, 300));
+		warningsScrollPane.setPreferredSize(new Dimension(d.width, 200));
 		tabbedPane.addTab(trans.get("SimulationConfigDialog.tab.Warnings"), warningsScrollPane);
 
 		if (isMultiCompEdit()) {
@@ -155,12 +158,16 @@ public class SimulationConfigDialog extends JDialog {
 			tabbedPane.setToolTipTextAt(EXPORT_IDX, ttip);
 		}
 
-		contentPanel.add(tabbedPane, "grow, wrap");
+		contentPanel.add(tabbedPane, "grow, push, wrap");
 
+		// Create a scroll pane for the content
+		JScrollPane scrollPane = new JScrollPane(contentPanel);
+		scrollPane.setBorder(null);
+		scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+		scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
 
 		// ======== Bottom panel ========
-		addBottomPanel(contentPanel);
-
+		JPanel bottomPanel = generateBottomPanel();
 
 		tabbedPane.addChangeListener(new ChangeListener() {
 
@@ -200,7 +207,8 @@ public class SimulationConfigDialog extends JDialog {
 
 		});
 
-		this.add(contentPanel);
+		this.add(scrollPane, BorderLayout.CENTER);
+		this.add(bottomPanel, BorderLayout.SOUTH);
 		this.validate();
 		this.pack();
 
@@ -317,11 +325,11 @@ public class SimulationConfigDialog extends JDialog {
 		
 		topPanel.add(new JPanel(), "growx, wrap");
 
-		contentPanel.add(topPanel, "growx, wrap");
+		contentPanel.add(topPanel, "growx, height pref, wrap");
 	}
 
-	private void addBottomPanel(JPanel contentPanel) {
-		final JPanel bottomPanel = new JPanel(new MigLayout("fill, ins 0"));
+	private JPanel generateBottomPanel() {
+		final JPanel bottomPanel = new JPanel(new MigLayout("fill"));
 
 		//// Multi-simulation edit
 		if (isMultiCompEdit()) {
@@ -376,7 +384,7 @@ public class SimulationConfigDialog extends JDialog {
 				// TODO: include plot/export undo?
 			}
 		});
-		bottomPanel.add(this.cancelButton, "split 2, tag ok");
+		bottomPanel.add(this.cancelButton, "split 2, tag ok, pushx, align right");
 
 		//// Ok button
 		this.okButton = new JButton(trans.get("dlg.but.ok"));
@@ -417,7 +425,7 @@ public class SimulationConfigDialog extends JDialog {
 		});
 		bottomPanel.add(this.okButton, "tag ok");
 
-		contentPanel.add(bottomPanel, "growx, wrap");
+		return bottomPanel;
 	}
 
 	private void copyChangesToAllSims() {

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationOptionsPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationOptionsPanel.java
@@ -73,7 +73,7 @@ class SimulationOptionsPanel extends JPanel {
 	}
 	
 	SimulationOptionsPanel(OpenRocketDocument document, final Simulation simulation) {
-		super(new MigLayout("fill"));
+		super(new MigLayout("fill, ins n n 0 n"));
 		this.document = document;
 		this.simulation = simulation;
 

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationOptionsPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationOptionsPanel.java
@@ -2,6 +2,7 @@ package info.openrocket.swing.gui.simulation;
 
 import java.awt.Color;
 import java.awt.Dialog.ModalityType;
+import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.Iterator;
@@ -251,8 +252,9 @@ class SimulationOptionsPanel extends JPanel {
 		currentExtensions = new JPanel(new MigLayout("fillx, gap 0 0, ins 0"));
 		JScrollPane scroll = new JScrollPane(currentExtensions);
 		scroll.setForeground(textColor);
+		scroll.setPreferredSize(new Dimension(scroll.getPreferredSize().width, 200));
 		//  &#$%! scroll pane will not honor "growy"...
-		sub.add(scroll, "growx, growy, h 100%");
+		sub.add(scroll, "growx");
 		
 		updateCurrentExtensions();
 		

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationPlotPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationPlotPanel.java
@@ -177,7 +177,7 @@ public class SimulationPlotPanel extends PlotPanel<FlightDataType, FlightDataBra
 		table.addMouseListener(new GUIUtil.BooleanTableClickListener(table));
 		JScrollPane scrollPane = new JScrollPane(table);
 		Dimension d = table.getPreferredSize();
-		scrollPane.setPreferredSize(new Dimension(d.width, 200));
+		scrollPane.setPreferredSize(new Dimension(d.width, 150));
 		selectorPanel.add(scrollPane, "width 200lp, grow 1, wrap rel");
 
 		////  All + None buttons

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationPlotPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationPlotPanel.java
@@ -177,7 +177,7 @@ public class SimulationPlotPanel extends PlotPanel<FlightDataType, FlightDataBra
 		table.addMouseListener(new GUIUtil.BooleanTableClickListener(table));
 		JScrollPane scrollPane = new JScrollPane(table);
 		Dimension d = table.getPreferredSize();
-		scrollPane.setPreferredSize(new Dimension(d.width, 300));
+		scrollPane.setPreferredSize(new Dimension(d.width, 200));
 		selectorPanel.add(scrollPane, "width 200lp, grow 1, wrap rel");
 
 		////  All + None buttons

--- a/swing/src/main/java/info/openrocket/swing/gui/widgets/CSVExportPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/widgets/CSVExportPanel.java
@@ -62,7 +62,7 @@ public class CSVExportPanel<T extends UnitValue> extends JPanel {
 
 		boolean addExtras = createExtraComponent(types[0], 0) != null;
 		JPanel contentPanel = new JPanel(new GridBagLayout());
-		contentPanel.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+		contentPanel.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
 		GridBagConstraints c = new GridBagConstraints();
 		c.insets = new Insets(0, 0, 0, 0);		// No padding
 		c.fill = GridBagConstraints.BOTH;
@@ -100,8 +100,8 @@ public class CSVExportPanel<T extends UnitValue> extends JPanel {
 		JScrollPane scrollPane = new JScrollPane(contentPanel);
 		scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
 		scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-		scrollPane.setPreferredSize(new Dimension(300, 400));
-		exportPanel.add(scrollPane, "grow, wrap");
+		scrollPane.setPreferredSize(new Dimension(200, 200));
+		exportPanel.add(scrollPane, "grow, push, wrap");
 
 		// Select all/none buttons
 		JPanel buttonPanel = new JPanel(new MigLayout("insets 0"));
@@ -149,7 +149,7 @@ public class CSVExportPanel<T extends UnitValue> extends JPanel {
 	private void addHeaderRowLabel(JPanel contentPanel, String lblKey, GridBagConstraints c, int x) {
 		c.gridx = x;
 
-		JPanel panel = new JPanel(new MigLayout("fill, ins 4 5 4 5"));
+		JPanel panel = new JPanel(new MigLayout("fill, ins 2 3 2 3"));
 		panel.setBorder(BorderFactory.createMatteBorder(0, 0, 1, 0, UIManager.getColor("Table.gridColor")));
 		panel.add(new JLabel("<html><b>" + trans.get(lblKey) + "</b></html>"), "growx");
 		contentPanel.add(panel, c);
@@ -158,7 +158,7 @@ public class CSVExportPanel<T extends UnitValue> extends JPanel {
 	private void addDataRowWidget(JPanel contentPanel, Component widget, GridBagConstraints c, Color bgColor, int x) {
 		c.gridx = x;
 
-		JPanel panel = new JPanel(new MigLayout("fill, ins 4 5 4 5"));
+		JPanel panel = new JPanel(new MigLayout("fill, ins 2 3 2 3"));
 		panel.setBackground(bgColor);
 		if (widget instanceof JPanel) {
 			widget.setBackground(bgColor);

--- a/swing/src/main/java/info/openrocket/swing/gui/widgets/CSVExportPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/widgets/CSVExportPanel.java
@@ -47,7 +47,7 @@ public class CSVExportPanel<T extends UnitValue> extends JPanel {
 
 	public CSVExportPanel(T[] types, boolean[] selected, CsvOptionPanel csvOptions, boolean separateRowForOptions,
 						  Component... extraComponents) {
-		super(new MigLayout("fill, wrap 2", "[grow,fill][]", "[grow,fill][]"));
+		super(new MigLayout("fill, ins n n 0 n, wrap 2", "[grow,fill][]", "[grow,fill][]"));
 
 		this.types = types;
 		this.selected = selected;

--- a/swing/src/main/java/info/openrocket/swing/gui/widgets/CSVExportPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/widgets/CSVExportPanel.java
@@ -113,12 +113,12 @@ public class CSVExportPanel<T extends UnitValue> extends JPanel {
 		selectNoneButton.addActionListener(e -> selectNone());
 		buttonPanel.add(selectNoneButton, "growx");
 
-		exportPanel.add(buttonPanel, "growx, wrap");
-
 		// Selected count label
 		selectedCountLabel = new JLabel();
 		updateSelectedCount();
-		exportPanel.add(selectedCountLabel, "growx");
+		buttonPanel.add(selectedCountLabel, "gapleft para, growx");
+
+		exportPanel.add(buttonPanel, "growx, wrap");
 		add(exportPanel, "grow, gapright para" + (separateRowForOptions ? ", spanx, wrap" : ""));
 
 		// CSV options and extra components


### PR DESCRIPTION
This PR is a first attempt at improving OpenRocket's UI for users that have a low resolution screen setting. We recently received feedback from a user who simply couldn't access some items in the dialog because they got out of screen.

This PR makes the following changes:
- Overall reduces the default size of the sim edit dialog
- Add a scrollpane so that when you resize the sim edit dialog to make it smaller, you can still scroll through the rest of the contents. Note that the window size is saved in the preferences, so the user would only have to do this once

<img width="1641" alt="image" src="https://github.com/user-attachments/assets/838d2c2f-04ac-4255-93f0-6347878e29ba" />


https://github.com/user-attachments/assets/b859de1f-ae62-4439-87c3-5afff54aa26e



---

The dialog scrollpane behavior should eventually be implemented in every dialog, especially larger sized ones. I'll make an issue for it so we don't forget.

In the future, I also envisage to replace the standard JDialog with a custom Dialog class that detects if the window-size is larger than the screen resolution. If it is, it resizes the window automatically. But that should not be a priority right now.