### PR TITLE
 [#2795] Properly format and escape warnings in the CSV export 

### DIFF
--- a/core/src/main/java/info/openrocket/core/util/StringUtils.java
+++ b/core/src/main/java/info/openrocket/core/util/StringUtils.java
@@ -73,35 +73,34 @@ public class StringUtils {
 	/**
 	 * Returns an escaped version of the String so that it can be safely used as a
 	 * value in a CSV file.
-	 * The goal is to surround the input string in double quotes if it contains any
-	 * double quotes, commas,
-	 * newlines, or carriage returns, and to escape any double quotes within the
-	 * string by doubling them up.
-	 * 
+	 * The method follows standard CSV escaping rules:
+	 * 1. If the input contains any double quotes, commas, newlines, or carriage returns,
+	 *    the entire string is surrounded by double quotes
+	 * 2. Any double quotes within the string are escaped by doubling them
+	 *
 	 * @param input the string to escape
 	 * @return the escaped string that can be safely used in a CSV file
 	 */
 	public static String escapeCSV(String input) {
-		final List<Character> CSV_SEARCH_CHARS = new ArrayList<>(Arrays.asList(',', '"', '\r', '\n'));
+		if (input == null) {
+			return "";
+		}
 
-		StringBuilder sb = new StringBuilder();
-		boolean quoted = false;
-		for (int i = 0; i < input.length(); i++) {
-			char c = input.charAt(i);
-			if (CSV_SEARCH_CHARS.contains(c)) {
-				quoted = true;
-				sb.append('\"');
-			}
-			if (c == '\"') {
-				sb.append('\"');
-			}
-			sb.append(c);
+		// Check if we need to quote the string
+		boolean needsQuoting = input.contains("\"") ||
+				input.contains(",") ||
+				input.contains("\r") ||
+				input.contains("\n");
+
+		if (!needsQuoting) {
+			return input;
 		}
-		if (quoted) {
-			sb.insert(0, '\"');
-			sb.append('\"');
-		}
-		return sb.toString();
+
+		// Replace all double quotes with doubled double quotes
+		String escaped = input.replace("\"", "\"\"");
+
+		// Surround with quotes
+		return "\"" + escaped + "\"";
 	}
 
 	public static String removeHTMLTags(String input) {

--- a/core/src/main/java/info/openrocket/core/util/StringUtils.java
+++ b/core/src/main/java/info/openrocket/core/util/StringUtils.java
@@ -105,6 +105,9 @@ public class StringUtils {
 	}
 
 	public static String removeHTMLTags(String input) {
+		if (input == null) {
+			return null;
+		}
 		return input.replaceAll("<[^>]*>", "");
 	}
 }

--- a/swing/src/main/java/info/openrocket/swing/file/SimulationTableCSVExport.java
+++ b/swing/src/main/java/info/openrocket/swing/file/SimulationTableCSVExport.java
@@ -91,7 +91,7 @@ public class SimulationTableCSVExport {
 	 * @param onlySelected If true, only export the selected rows in the table.
 	 * @return The CSV data as one string block.
 	 */
-	public String generateCSVDate(String fieldSep, int precision, boolean isExponentialNotation, boolean onlySelected) {
+	public String generateCSVData(String fieldSep, int precision, boolean isExponentialNotation, boolean onlySelected) {
 		int modelColumnCount = simulationTableModel.getColumnCount();
 		int modelRowCount = simulationTableModel.getRowCount();
 		populateColumnNameToUnitsHashTable();
@@ -196,7 +196,7 @@ public class SimulationTableCSVExport {
 			return;
 		}
 
-		String CSVData = generateCSVDate(fieldSep, precision, isExponentialNotation, onlySelected);
+		String CSVData = generateCSVData(fieldSep, precision, isExponentialNotation, onlySelected);
 		this.dumpDataToFile(CSVData, file);
 		log.info("Simulation table data exported to " + file.getAbsolutePath());
 	}

--- a/swing/src/main/java/info/openrocket/swing/file/SimulationTableCSVExport.java
+++ b/swing/src/main/java/info/openrocket/swing/file/SimulationTableCSVExport.java
@@ -232,8 +232,8 @@ public class SimulationTableCSVExport {
 
 		for (Warning warning : warnings) {
 			if (warning != null) {
-				String escapedWarning = StringUtils.escapeCSV(warning.toString());
-				warningsText.append(escapedWarning);
+				String warningString = warning.toString();
+				warningsText.append(warningString);
 
 				if (warningIndex < warnings.size() - 1) {
 					warningsText.append(warningDelimiter);
@@ -242,7 +242,7 @@ public class SimulationTableCSVExport {
 			warningIndex++;
 		}
 
-		return warningsText.toString();
+		return StringUtils.escapeCSV(warningsText.toString());
 	}
 
 	/**

--- a/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
@@ -67,6 +67,7 @@ import info.openrocket.core.startup.Application;
 import info.openrocket.core.unit.UnitGroup;
 import info.openrocket.core.util.AlphanumComparator;
 
+import info.openrocket.core.util.StringUtils;
 import info.openrocket.swing.gui.components.CsvOptionPanel;
 import info.openrocket.swing.gui.simulation.SimulationConfigDialog;
 import info.openrocket.swing.gui.util.ColorConversion;
@@ -102,7 +103,6 @@ public class SimulationPanel extends JPanel {
 	private RocketDescriptor descriptor = Application.getInjector().getInstance(RocketDescriptor.class);
 
 
-	private final Window parent;
 	private final OpenRocketDocument document;
 
 	private final ColumnTableModel simulationTableModel;
@@ -141,7 +141,6 @@ public class SimulationPanel extends JPanel {
 	public SimulationPanel(Window parent, OpenRocketDocument doc) {
 		super(new MigLayout("fill", "[grow][][][][][][grow]"));
 
-		this.parent = parent;
 		this.document = doc;
 
 
@@ -615,14 +614,13 @@ public class SimulationPanel extends JPanel {
 		}
 
 		OpenRocketClipboard.setClipboard(simsCopy);
-		copySimulationValues();
+		copySimulationValues(Application.getPreferences().getString(ApplicationPreferences.EXPORT_FIELD_SEPARATOR, ","));
 	}
 
 	/**
 	 * Only copy the simulation table values to the clipboard. (not actual Simulation copying)
 	 */
-	public void copySimulationValues() {
-		int numCols = simulationTable.getColumnCount();
+	public void copySimulationValues(String separator) {
 		int numRows = simulationTable.getSelectedRowCount();
 		int[] rowsSelected = simulationTable.getSelectedRows();
 
@@ -632,34 +630,54 @@ public class SimulationPanel extends JPanel {
 			return;
 		}
 
-		StringBuilder valuesStr = new StringBuilder();
+		// Create a CSV exporter
+		SimulationTableCSVExport exporter = new SimulationTableCSVExport(document, simulationTable, simulationTableModel);
 
-		// Copy the column names
-		valuesStr.append(trans.get("simpanel.col.Status")).append("\t");
-		for (int i = 1; i < numCols; i++) {
-			valuesStr.append(simulationTable.getColumnName(i));
-			if (i < numCols-1) {
-				valuesStr.append("\t");
-			}
-		}
-		valuesStr.append("\n");
+		// Get precision and notation settings from preferences
+		int precision = 6; // Default value - could be obtained from preferences
+		boolean isExponentialNotation = false; // Default value - could be obtained from preferences
 
-		// Copy the values
-		for (int i = 0; i < numRows; i++) {
-			for (int j = 0; j < numCols; j++) {
-				Object value = simulationTable.getValueAt(rowsSelected[i], j);
-				valuesStr.append(value == null ? "" : value.toString());
-				if (j < numCols-1) {
-					valuesStr.append("\t");
-				}
-			}
-			valuesStr.append("\n");
-		}
+		// Generate CSV data only for selected rows
+		String clipboardText = exporter.generateCSVData(separator, precision, isExponentialNotation, true);
 
-		StringSelection sel = new StringSelection(valuesStr.toString());
+		// Add the Status column which is missing from the exporter output
+		clipboardText = addStatusColumn(clipboardText, rowsSelected, separator);
 
+		// Copy to clipboard
+		StringSelection sel = new StringSelection(clipboardText);
 		Clipboard cb = Toolkit.getDefaultToolkit().getSystemClipboard();
 		cb.setContents(sel, sel);
+	}
+
+
+	/**
+	 * Adds the Status column to the CSV output, which is not included by default in the exporter.
+	 *
+	 * @param csvText The CSV text without Status column
+	 * @param selectedRows The selected rows in the table
+	 * @param separator The separator used in the  text
+	 * @return CSV text with Status column added
+	 */
+	private String addStatusColumn(String csvText, int[] selectedRows, String separator) {
+		// Split into lines
+		String[] lines = csvText.split("\n");
+
+		// First add Status column to header line
+		StringBuilder result = new StringBuilder(trans.get("simpanel.col.Status") + separator + lines[0]);
+
+		// For each data row, prepend the simulation status
+		for (int i = 0; i < selectedRows.length && i < lines.length - 1; i++) {
+			int modelRow = simulationTable.convertRowIndexToModel(selectedRows[i]);
+			Simulation simulation = document.getSimulation(modelRow);
+
+			// Get status text
+			String statusText = StringUtils.removeHTMLTags(simulation.getStatusDescription());
+
+			// Add status column and original line
+			result.append("\n").append(statusText).append(separator).append(lines[i + 1]);
+		}
+
+		return result.toString();
 	}
 
 	private void pasteSimulationsAction() {


### PR DESCRIPTION
This PR fixes #2795. Example output:

```
Warnings,Name,Configuration,Velocity off rod (m/s),Apogee (m),Velocity at deployment (m/s),Optimum delay (s),Max. velocity (m/s),Max. acceleration (m/s²),Time to apogee (s),Flight time (s),Ground hit velocity (m/s)
"Recovery device deployment at high speed (27.9 m/s):  ""Parachute, plastic, preassembled, 10 in., PN 2262"" | Recovery device deployment at high speed (27.9 m/s):  ""Parachute kit, plastic, 8 in., PN 2260""",Simulation 3 - too short delay,[None; C6-3],15.442,230.485,27.934,4.87,77.228,151.709,5.377,63.695,4.587
```

Note that the warnings are correctly escaped with double quotes. Tested an import in Excel and it works fine.