### PR TITLE
make TubeCalc logger reference correct class

### DIFF
--- a/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/TubeCalc.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/TubeCalc.java
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
 
 public abstract class TubeCalc extends RocketComponentCalc {
 
-	private final static Logger log = LoggerFactory.getLogger(TubeFinSetCalc.class);
+	private final static Logger log = LoggerFactory.getLogger(TubeCalc.class);
 
 	private final Tube tube;
 	private final double diameter;


### PR DESCRIPTION
It was using TubeFinSetCalc.class. It doesn't really matter since there aren't actually any logger calls in the class, but if one is ever added it'll avoid some confusion.