### PR TITLE
[#2797] Thrust curve serialization optimising

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -93,8 +93,9 @@ tasks.register('serializeEnginesExecute', JavaExec) {
     dependsOn serializeEnginesDelete
     workingDir  new File(projectDir, 'build/tmp')
     classpath = sourceSets.main.runtimeClasspath
-    mainClass.set('info.openrocket.core.thrustcurve.SerializeThrustcurveMotors')
+    mainClass.set('info.openrocket.core.thrustcurve.serialization.SerializeThrustcurveMotors')
     args '../../resources-src/datafiles/thrustcurves/', '../.' + serializedEnginesPath
+    standardInput = System.in
 
     doFirst {
         println "Starting serializeEnginesExecute..."
@@ -111,9 +112,9 @@ tasks.register('serializeEnginesExecuteDist', JavaExec) {
     dependsOn serializeEnginesDelete
     workingDir  new File(projectDir, 'build/tmp')
     classpath = sourceSets.main.runtimeClasspath
-    mainClass.set('info.openrocket.core.thrustcurve.SerializeThrustcurveMotors')
+    mainClass.set('info.openrocket.core.thrustcurve.serialization.SerializeThrustcurveMotors')
     args '../../resources-src/datafiles/thrustcurves/', '../.' + serializedEnginesPathDist
-
+    standardInput = System.in
     doFirst {
         println "Starting serializeEnginesExecuteDist..."
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -12,7 +12,7 @@ java {
 }
 
 def buildProperties = new Properties()
-def threadUtilFraction = project.hasProperty('threadUtil') ? project.threadUtilFraction : 'Default'
+def threadUtilFraction = project.hasProperty('threadUtilFraction') ? project.threadUtilFraction : 'Default'
 file('./src/main/resources/build.properties').withInputStream { buildProperties.load(it) }
 group = 'info.openrocket'
 version = buildProperties['build.version']

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -12,6 +12,7 @@ java {
 }
 
 def buildProperties = new Properties()
+def threadUtilFraction = project.hasProperty('threadUtil') ? project.threadUtilFraction : 'Default'
 file('./src/main/resources/build.properties').withInputStream { buildProperties.load(it) }
 group = 'info.openrocket'
 version = buildProperties['build.version']
@@ -94,7 +95,11 @@ tasks.register('serializeEnginesExecute', JavaExec) {
     workingDir  new File(projectDir, 'build/tmp')
     classpath = sourceSets.main.runtimeClasspath
     mainClass.set('info.openrocket.core.thrustcurve.serialization.SerializeThrustcurveMotors')
-    args '../../resources-src/datafiles/thrustcurves/', '../.' + serializedEnginesPath
+    args = [
+            '../../resources-src/datafiles/thrustcurves/',
+            '../.' + serializedEnginesPath,
+            threadUtilFraction
+    ]
     standardInput = System.in
 
     doFirst {

--- a/core/gradle.properties
+++ b/core/gradle.properties
@@ -1,1 +1,6 @@
 org.gradle.warning.mode=all
+
+# threadUtilFraction sets how much of the CPU to use during certain tasks.
+# Value should be between 0.01 and 1.0 (e.g., 0.75 means 75% CPU usage).
+# threadUtilFraction=0.75
+

--- a/core/src/main/java/info/openrocket/core/thrustcurve/serialization/SerializeThrustcurveMotors.java
+++ b/core/src/main/java/info/openrocket/core/thrustcurve/serialization/SerializeThrustcurveMotors.java
@@ -23,242 +23,309 @@ import info.openrocket.core.util.Pair;
 
 public class SerializeThrustcurveMotors {
 
-	private static final String[] manufacturers = {
-		"AeroTech",
-		"Alpha",
-		"AMW",
-		"Apogee",
-		"Cesaroni",
-		"Contrail",
-		"Ellis",
-		"Estes",
-		"Gorilla",
-		"Hypertek",
-		"KBA",
-		"Kosdon",
-		"Loki",
-		"TSP",
-		"PP",
-		"PML",
-		"Quest",
-		"RATT",
-		"Klima",
-		"Roadrunner",
-		"RV",
-		"SkyR",
-		"SCR",
-		"WCH"
-	};
+    private static final String[] manufacturers = {
+            "AeroTech",
+            "Alpha",
+            "AMW",
+            "Apogee",
+            "Cesaroni",
+            "Contrail",
+            "Ellis",
+            "Estes",
+            "Gorilla",
+            "Hypertek",
+            "KBA",
+            "Kosdon",
+            "Loki",
+            "TSP",
+            "PP",
+            "PML",
+            "Quest",
+            "RATT",
+            "Klima",
+            "Roadrunner",
+            "RV",
+            "SkyR",
+            "SCR",
+            "WCH"
+    };
 
-	public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws Exception {
 
-		double threadUtilFraction = 0.5;
+        double threadUtilFraction = 0.5;
 
-		if (args.length != 3) {
-			System.err.println("Usage: <inputDir> <outputDir> <threadUtilFraction>");
-			System.exit(1);
-		}
-		if (Objects.equals(args[2], "Default")) {
-			System.out.println("No threadUtil specified; using default value of 0.5");
-		}
-		else {
-			try {
-				threadUtilFraction = Double.parseDouble(args[2]);
-				if (threadUtilFraction <= 0 || threadUtilFraction > 1) {
-					System.err.println("Error: threadUtil must be > 0 and <= 1, but got " + threadUtilFraction);
-					System.exit(1);
-				}
-			} catch (NumberFormatException e) {
-				System.err.println("Error: Invalid threadUtil format: " + args[2]);
-				System.exit(1);
-			}
-		}
-
-
-		String inputDir = args[0];
-		String outputFile = args[1];
+        if (args.length != 3) {
+            System.err.println("Usage: <inputDir> <outputDir> <threadUtilFraction>");
+            System.exit(1);
+        }
+        if (Objects.equals(args[2], "Default")) {
+            System.out.println("No threadUtil specified; using default value of 0.5");
+        } else {
+            try {
+                threadUtilFraction = Double.parseDouble(args[2]);
+                if (threadUtilFraction <= 0 || threadUtilFraction > 1) {
+                    System.err.println("Error: threadUtil must be > 0 and <= 1, but got " + threadUtilFraction);
+                    System.exit(1);
+                }
+            } catch (NumberFormatException e) {
+                System.err.println("Error: Invalid threadUtil format: " + args[2]);
+                System.exit(1);
+            }
+        }
 
 
-		final List<Motor> allMotors = new ArrayList<>();
-
-		loadFromLocalMotorFiles(allMotors, inputDir);
-
-		loadFromThrustCurve(allMotors, determineNumberOfThreads(threadUtilFraction));
-
-		File outFile = new File(outputFile);
-
-		FileOutputStream ofs = new FileOutputStream(outFile);
-		final ObjectOutputStream oos = new ObjectOutputStream(ofs);
-
-		oos.writeObject(allMotors);
-
-		oos.flush();
-		ofs.flush();
-		ofs.close();
-
-	}
-
-	public static void loadFromThrustCurve(List<Motor> allMotors, int threads) throws SAXException, IOException {
-		ExecutorService executor = Executors.newFixedThreadPool(threads);
-
-		try {
-			List<CompletableFuture<List<Motor>>> futureMotorLists = new ArrayList<>();
-
-			for (String manufacturer : manufacturers) {
-				System.out.println("Motors for : " + manufacturer);
-
-				SearchRequest searchRequest = new SearchRequest();
-				searchRequest.setManufacturer(manufacturer);
-				SearchResponse res = ThrustCurveAPI.doSearch(searchRequest);
-
-				for (TCMotor tcMotor : res.getResults()) {
-					if (tcMotor.getData_files() == null || tcMotor.getData_files() == 0) {
-						continue;
-					}
-					CompletableFuture<List<Motor>> future = fetchMotorsCompletables(tcMotor, executor);
-					futureMotorLists.add(future);
-				}
-			}
-
-			for (CompletableFuture<List<Motor>> futureList : futureMotorLists) {
-				try {
-					allMotors.addAll(futureList.get());
-				} catch (InterruptedException | ExecutionException e) {
-					e.printStackTrace();
-				}
-			}
-
-		} finally {
-			executor.shutdown();
-		}
-	}
-
-	private static int determineNumberOfThreads(double threadUtilFraction){
-		int availableProcessors = Runtime.getRuntime().availableProcessors();
-		int threads = Math.max(1, (int) Math.floor((threadUtilFraction) * availableProcessors));
-		System.out.println("Available threads: " + threads);
-		return threads;
-	}
-
-	private static CompletableFuture<List<Motor>> fetchMotorsCompletables(TCMotor tcMotor, ExecutorService executor) {
-		System.out.println(formatMotorMessage(tcMotor));
-		Motor.Type type = getType(tcMotor);
-
-		return CompletableFuture.supplyAsync(() -> fetchMotors(tcMotor, type), executor);
-	}
-
-	private static List<Motor> fetchMotors(TCMotor tcMotor, Motor.Type type) {
-		List<Motor> motors = new ArrayList<>();
-		try {
-			List<MotorBurnFile> motorBurnFiles = getThrustCurvesForMotorId(tcMotor.getMotor_id());
-			for (MotorBurnFile burnFile : motorBurnFiles) {
-				try {
-					ThrustCurveMotor.Builder builder = initThrustCurveMotorBuilder(tcMotor, burnFile, type);
-					if (builder != null) {
-						motors.add(builder.build());
-					}
-				} catch (IllegalArgumentException e) {
-					System.out.println("\tError in simFile " + burnFile.getSimfileId() + ": " + e.getMessage());
-					writeBadFile(burnFile);
-				}
-			}
-			System.out.println("\t curves for " + tcMotor.getManufacturer() + " " + tcMotor.getCommon_name()+ ": " + motors.size());
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-		return motors;
-	}
-
-	private static void writeBadFile(MotorBurnFile burnFile) {
-		try (FileOutputStream out = new FileOutputStream("simfile-" + burnFile.getSimfileId())) {
-			out.write(burnFile.getContents().getBytes());
-		} catch (IOException e) {
-			System.out.println("Unable to write bad file: " + e.getMessage());
-		}
-	}
+        String inputDir = args[0];
+        String outputFile = args[1];
 
 
+        final List<Motor> allMotors = new ArrayList<>();
 
-	private static Motor.Type getType(TCMotor tcMotor) {
+        loadFromLocalMotorFiles(allMotors, inputDir);
+
+        loadFromThrustCurves(allMotors, determineNumberOfThreads(threadUtilFraction));
+
+        File outFile = new File(outputFile);
+
+        FileOutputStream ofs = new FileOutputStream(outFile);
+        final ObjectOutputStream oos = new ObjectOutputStream(ofs);
+
+        oos.writeObject(allMotors);
+
+        oos.flush();
+        ofs.flush();
+        ofs.close();
+
+    }
+
+    /**
+     * Adds motors to the data to be serialized from any motors (per manufacturer) retrieved via the ThrustCurveAPI.
+     * This method performs concurrent requests using the specified number of threads.
+     * @param allMotors The list to which fetched motors will be added.
+     * @param threads The number of threads to use for concurrent data fetching.
+     *
+     * @throws SAXException If there is an error parsing XML responses from the API
+     * @throws IOException If a network or I/O error occurs during the API call
+     *
+     * @see <a href="https://www.thrustcurve.org/info/api.html">ThrustCurve API Documentation</a>
+     */
+    public static void loadFromThrustCurves(List<Motor> allMotors, int threads) throws SAXException, IOException {
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+
+        try {
+            List<CompletableFuture<List<Motor>>> futureMotorLists = new ArrayList<>();
+
+            for (String manufacturer : manufacturers) {
+                System.out.println("Motors for : " + manufacturer);
+
+                SearchRequest searchRequest = new SearchRequest();
+                searchRequest.setManufacturer(manufacturer);
+                SearchResponse res = ThrustCurveAPI.doSearch(searchRequest);
+
+                for (TCMotor tcMotor : res.getResults()) {
+                    if (tcMotor.getData_files() == null || tcMotor.getData_files() == 0) {
+                        continue;
+                    }
+                    CompletableFuture<List<Motor>> future = fetchMotorsCompletables(tcMotor, executor);
+                    futureMotorLists.add(future);
+                }
+            }
+
+            for (CompletableFuture<List<Motor>> futureList : futureMotorLists) {
+                try {
+                    allMotors.addAll(futureList.get());
+                } catch (InterruptedException | ExecutionException e) {
+                    e.printStackTrace();
+                }
+            }
+
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    /**
+     * Used to determine how many threads to utilise within concurrent data fetching.
+     * @param threadUtilFraction The fraction (between 0 and 1) of threads to utilise, compared the total number of
+     *                           currently available threads.
+     * @return Amount of threads to utilise in concurrent data fetching.
+     */
+    private static int determineNumberOfThreads(double threadUtilFraction) {
+        int availableProcessors = Runtime.getRuntime().availableProcessors();
+        int threads = Math.max(1, (int) Math.floor((threadUtilFraction) * availableProcessors));
+        System.out.println("Available threads: " + threads);
+        return threads;
+    }
+
+    /**
+     * Asynchronously fetches motor data for the given ThrustCurveAPI derived motor using the provided executor.
+     * This method wraps the synchronous motor fetching logic in a {@link CompletableFuture}, allowing
+     * it to be executed concurrently with other fetch operations.
+     *
+     * @param tcMotor The ThrustCurve derived motor.
+     * @param executor The executor service used to run the task asynchronously.
+     * @return A CompletableFuture that will complete with a list of {@linkplain Motor motors}.
+     */
+    private static CompletableFuture<List<Motor>> fetchMotorsCompletables(TCMotor tcMotor, ExecutorService executor) {
+        System.out.println(formatMotorMessage(tcMotor));
+        Motor.Type type = getType(tcMotor);
+
+        return CompletableFuture.supplyAsync(() -> fetchMotors(tcMotor, type), executor);
+    }
+
+    /**
+     * Fetches and builds a list of {@linkplain Motor motors} for the specified ThrustCurveAPI derived motor,
+     * using all available burn files from the ThrustCurve API.
+     * <p>
+     * This method retrieves thrust curve data, initializes motor builders, and filters out any invalid or un-buildable
+     * entries. Errors in individual burn files are logged and still attempted to be utilized via the writeBadFile()
+     * method, without aborting the entire fetch process.
+     *
+     * @param tcMotor The ThrustCurve derived motor to fetch burn data for.
+     * @param type The motor type used to initialize the builder
+     * @return A list of valid {@linkplain Motor motors} built from the fetched burn files
+     */
+
+    private static List<Motor> fetchMotors(TCMotor tcMotor, Motor.Type type) {
+        List<Motor> motors = new ArrayList<>();
+        try {
+            List<MotorBurnFile> motorBurnFiles = getThrustCurvesForMotorId(tcMotor.getMotor_id());
+            for (MotorBurnFile burnFile : motorBurnFiles) {
+                try {
+                    ThrustCurveMotor.Builder builder = initThrustCurveMotorBuilder(tcMotor, burnFile, type);
+                    if (builder != null) {
+                        motors.add(builder.build());
+                    }
+                } catch (IllegalArgumentException e) {
+                    System.out.println("\tError in simFile " + burnFile.getSimfileId() + ": " + e.getMessage());
+                    writeBadFile(burnFile);
+                }
+            }
+            System.out.println("\t curves for " + tcMotor.getManufacturer() + " " + tcMotor.getCommon_name() + ": " + motors.size());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return motors;
+    }
+
+    private static void writeBadFile(MotorBurnFile burnFile) {
+        try (FileOutputStream out = new FileOutputStream("simfile-" + burnFile.getSimfileId())) {
+            out.write(burnFile.getContents().getBytes());
+        } catch (IOException e) {
+            System.out.println("Unable to write bad file: " + e.getMessage());
+        }
+    }
+
+
+    /**
+     * Gets the {@linkplain Motor.Type motor-type} that corresponds with the {@link TCMotor} metadata.
+     * @param tcMotor The ThrustCurve derived motor to parse the motor-type from.
+     * @return The motor-type of the TCMotor.
+     */
+    private static Motor.Type getType(TCMotor tcMotor) {
         return switch (tcMotor.getType()) {
             case "SU" -> Motor.Type.SINGLE;
             case "reload" -> Motor.Type.RELOAD;
             case "hybrid" -> Motor.Type.HYBRID;
             default -> Motor.Type.UNKNOWN;
         };
-	}
+    }
 
-	private static StringBuilder formatMotorMessage(TCMotor tcMotor) {
-		return new StringBuilder("Starting async fetch (CompletableFuture) for motor: ")
-				.append(tcMotor.getManufacturer_abbr())
-				.append(" ")
-				.append(tcMotor.getCommon_name())
-				.append(" ")
-				.append(tcMotor.getMotor_id());
+    /**
+     * Formats a message that logs the init of an asynchronous fetch of the specified ThrustCurveAPI derived motor's
+     * thrust curves.
+     * @param tcMotor The ThrustCurveAPI derived motor to fetch Thrust Curves for.
+     * @return The formatted message.
+     */
+    private static StringBuilder formatMotorMessage(TCMotor tcMotor) {
+        return new StringBuilder("Starting async fetch (CompletableFuture) for motor: ")
+                .append(tcMotor.getManufacturer_abbr())
+                .append(" ")
+                .append(tcMotor.getCommon_name())
+                .append(" ")
+                .append(tcMotor.getMotor_id());
 
-	}
+    }
+    /**
+     * Initializes a {@link ThrustCurveMotor.Builder} using metadata from the given ThrustCurveAPI derived motor
+     * and its corresponding {@link MotorBurnFile}.
+     * <p>
+     * This method populates the builder with motor specifications such as mass, dimensions,case and propellant
+     * information, and classification details. If the burn file does not provide a builder, {@code null} is returned.
+     *
+     * @param tcMotor The ThrustCurve derived motor.
+     * @param burnFile The burn file containing the thrust curve data.
+     * @param type The motor-type of the ThrustCurve derived motor.
+     * @return a populated {@link ThrustCurveMotor.Builder}, or {@code null} if none could be retrieved from the burn
+     * file.
+     */
 
-	private static ThrustCurveMotor.Builder initThrustCurveMotorBuilder(TCMotor tcMotor, MotorBurnFile burnFile, Motor.Type type) {
-		ThrustCurveMotor.Builder builder = burnFile.getThrustCurveMotor();
-		if (builder == null) {
-			return null;
-		}
-		if (tcMotor.getTot_mass_g() != null) {
-			builder.setInitialMass(tcMotor.getTot_mass_g() / 1000.0);
-		}
+    private static ThrustCurveMotor.Builder initThrustCurveMotorBuilder(TCMotor tcMotor, MotorBurnFile burnFile, Motor.Type type) {
+        ThrustCurveMotor.Builder builder = burnFile.getThrustCurveMotor();
+        if (builder == null) {
+            return null;
+        }
+        if (tcMotor.getTot_mass_g() != null) {
+            builder.setInitialMass(tcMotor.getTot_mass_g() / 1000.0);
+        }
 
-		builder.setCaseInfo(tcMotor.getCase_info());
-		builder.setPropellantInfo(tcMotor.getProp_info());
-		builder.setDiameter(tcMotor.getDiameter() / 1000.0);
-		builder.setLength(tcMotor.getLength() / 1000.0);
-		builder.setMotorType(type);
+        builder.setCaseInfo(tcMotor.getCase_info());
+        builder.setPropellantInfo(tcMotor.getProp_info());
+        builder.setDiameter(tcMotor.getDiameter() / 1000.0);
+        builder.setLength(tcMotor.getLength() / 1000.0);
+        builder.setMotorType(type);
 
-		builder.setCommonName(tcMotor.getCommon_name());
-		builder.setDesignation(tcMotor.getDesignation());
+        builder.setCommonName(tcMotor.getCommon_name());
+        builder.setDesignation(tcMotor.getDesignation());
 
-		if ("OOP".equals(tcMotor.getAvailability())) {
-			builder.setAvailability(false);
-		}
-		return builder;
+        if ("OOP".equals(tcMotor.getAvailability())) {
+            builder.setAvailability(false);
+        }
+        return builder;
 
-	}
-	private static List<MotorBurnFile> getThrustCurvesForMotorId(int motorId) {
-		String[] formats = new String[] { "RASP", "RockSim" };
-		List<MotorBurnFile> b = new ArrayList<>();
-		for (String format : formats) {
-			try {
-				List<MotorBurnFile> motorData = ThrustCurveAPI.downloadData(motorId, format);
-				if (motorData != null) {
-					b.addAll(motorData);
-				}
-			} catch (Exception ex) {
-				System.out.println(
-						"\tError downloading " + format + " for motorID=" + motorId + ": " + ex.getLocalizedMessage());
-			}
-		}
-		return b;
-	}
+    }
 
-	private static void loadFromLocalMotorFiles(List<Motor> allMotors, String inputDir) throws IOException {
-		GeneralMotorLoader loader = new GeneralMotorLoader();
-		FileIterator iterator = DirectoryIterator.findDirectory(inputDir,
-				new SimpleFileFilter("", false, loader.getSupportedExtensions()));
-		if (iterator == null) {
-			System.out.println("Can't find " + inputDir + " directory");
-			System.exit(1);
-		} else {
-			while (iterator.hasNext()) {
-				Pair<File, InputStream> f = iterator.next();
-				String fileName = f.getU().getName();
-				InputStream is = f.getV();
+    /**
+     * Fetches the Thrust-Curves that correspond to the specified ThrustCurveAPI motor id, via the ThrustCurveAPI.
+     * @param motorId The ThrustCurveAPI motor id to fetch Thrust-Curves for.
+     * @return The list of Thrust Curves for the specified motor id.
+     */
+    private static List<MotorBurnFile> getThrustCurvesForMotorId(int motorId) {
+        String[] formats = new String[]{"RASP", "RockSim"};
+        List<MotorBurnFile> b = new ArrayList<>();
+        for (String format : formats) {
+            try {
+                List<MotorBurnFile> motorData = ThrustCurveAPI.downloadData(motorId, format);
+                if (motorData != null) {
+                    b.addAll(motorData);
+                }
+            } catch (Exception ex) {
+                System.out.println(
+                        "\tError downloading " + format + " for motorID=" + motorId + ": " + ex.getLocalizedMessage());
+            }
+        }
+        return b;
+    }
 
-				List<ThrustCurveMotor.Builder> motors = loader.load(is, fileName);
+    private static void loadFromLocalMotorFiles(List<Motor> allMotors, String inputDir) throws IOException {
+        GeneralMotorLoader loader = new GeneralMotorLoader();
+        FileIterator iterator = DirectoryIterator.findDirectory(inputDir,
+                new SimpleFileFilter("", false, loader.getSupportedExtensions()));
+        if (iterator == null) {
+            System.out.println("Can't find " + inputDir + " directory");
+            System.exit(1);
+        } else {
+            while (iterator.hasNext()) {
+                Pair<File, InputStream> f = iterator.next();
+                String fileName = f.getU().getName();
+                InputStream is = f.getV();
 
-				for (ThrustCurveMotor.Builder builder : motors) {
-					allMotors.add(builder.build());
-				}
-			}
-		}
+                List<ThrustCurveMotor.Builder> motors = loader.load(is, fileName);
 
-	}
+                for (ThrustCurveMotor.Builder builder : motors) {
+                    allMotors.add(builder.build());
+                }
+            }
+        }
+
+    }
 }

--- a/core/src/main/java/info/openrocket/core/thrustcurve/serialization/SerializeThrustcurveMotors.java
+++ b/core/src/main/java/info/openrocket/core/thrustcurve/serialization/SerializeThrustcurveMotors.java
@@ -162,7 +162,7 @@ public class SerializeThrustcurveMotors {
 					writeBadFile(burnFile);
 				}
 			}
-			System.out.println("\t curves for " + tcMotor.getManufacturer() + " " + tcMotor.getCommon_name()+ ":" + motors.size());
+			System.out.println("\t curves for " + tcMotor.getManufacturer() + " " + tcMotor.getCommon_name()+ ": " + motors.size());
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -189,14 +189,15 @@ public class SerializeThrustcurveMotors {
 	}
 
 	private static StringBuilder formatMotorMessage(TCMotor tcMotor) {
-		StringBuilder message = new StringBuilder();
-		message.append(tcMotor.getManufacturer_abbr());
-		message.append(" ");
-		message.append(tcMotor.getCommon_name());
-		message.append(" ");
-		message.append(tcMotor.getMotor_id());
-		return message;
+		return new StringBuilder("Starting async fetch (CompletableFuture) for motor: ")
+				.append(tcMotor.getManufacturer_abbr())
+				.append(" ")
+				.append(tcMotor.getCommon_name())
+				.append(" ")
+				.append(tcMotor.getMotor_id());
+
 	}
+
 	private static ThrustCurveMotor.Builder initThrustCurveMotorBuilder(TCMotor tcMotor, MotorBurnFile burnFile, Motor.Type type) {
 		ThrustCurveMotor.Builder builder = burnFile.getThrustCurveMotor();
 		if (builder == null) {

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -100,8 +100,9 @@ open module info.openrocket.core {
 	exports info.openrocket.core.util.enums;
 	exports info.openrocket.core.utils;
 	exports info.openrocket.core.preferences;
+    exports info.openrocket.core.thrustcurve.serialization;
 
-	// Service providers
+    // Service providers
 	// Also edit core/src/main/resources/META-INF/services !! (until gradle-modules-plugin supports service
 	// copying, see https://github.com/java9-modularity/gradle-modules-plugin/issues/85)
 	provides info.openrocket.core.optimization.services.OptimizableParameterService with


### PR DESCRIPTION
This PR introduces asynchronous fetching of motor data from the ThrustCurve API, replacing the original single-threaded implementation.

This significantly reduces the build time of the serializeEnginesExecute Gradle Task. 
_(Cited single-threaded build time: **15 minutes**, Asynchronous Build Time with 16 Threads: around **70 seconds**)_ 

Closes #2797 

