### PR TITLE
Save and restore launchintowind element in .ork files

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/openrocket/OpenRocketSaver.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/OpenRocketSaver.java
@@ -336,9 +336,10 @@ public class OpenRocketSaver extends RocketSaver {
 		
 		writeElement("configid", simulation.getId().key);
 		writeElement("launchrodlength", cond.getLaunchRodLength());
+		writeElement("launchintowind", cond.getLaunchIntoWind());
 		writeElement("launchrodangle", cond.getLaunchRodAngle() * 180.0 / Math.PI);
 		writeElement("launchroddirection", cond.getLaunchRodDirection() * 360.0 / (2.0 * Math.PI));
-
+		
 		// TODO: remove once support for OR 23.09 and prior is dropped
 		writeElement("windaverage", cond.getAverageWindModel().getAverage());
 		writeElement("windturbulence", cond.getAverageWindModel().getTurbulenceIntensity());

--- a/core/src/main/java/info/openrocket/core/file/openrocket/importt/SimulationConditionsHandler.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/importt/SimulationConditionsHandler.java
@@ -63,6 +63,9 @@ class SimulationConditionsHandler extends AbstractElementHandler {
 					options.setLaunchRodLength(d);
 				}
 			}
+			case "launchintowind" -> {
+				options.setLaunchIntoWind(Boolean.parseBoolean(content));
+			}
 			case "launchrodangle" -> {
 				if (Double.isNaN(d)) {
 					warnings.add("Illegal launch rod angle defined, ignoring.");


### PR DESCRIPTION
When saving a simulation, save the launchintowind flag as an element in the .ork file, eg
        &lt;launchintowind&gt;false&lt;/launchintowind&gt;
 When loading, parse using parseBoolean.
 
 Behavior with old sims saved without the flag is unchanged (ie flag is read from app preferences)

fixes #2802