### PR TITLE
Motor Manufacturer determination via ThrustCurveAPI

### DIFF
--- a/core/src/main/java/info/openrocket/core/thrustcurve/ThrustCurveAPI.java
+++ b/core/src/main/java/info/openrocket/core/thrustcurve/ThrustCurveAPI.java
@@ -37,7 +37,6 @@ public abstract class ThrustCurveAPI {
         return SearchResponseParser.parse(is);
 	}
 
-	//TODO might be ideal to have a fallback, incase there are issues with the ThrustCurveAPI metadata?
 	/**
 	 * Utilises the ThrustCurveAPI to get the Manufacturer abbreviations, for the purpose of being used to obtain the
 	 * rest of the Motor Data per manufacturer.
@@ -86,7 +85,7 @@ public abstract class ThrustCurveAPI {
 			// _wish to contribute to this class in the future. This could be subject to change in future versions of_
 			// _the ThrustCurveAPI.
 			int literalStringLength = 9;
-			int quoteStart = entry.indexOf("\"", literalStringLength + 9);
+			int quoteStart = entry.indexOf("\"", nameIndex + literalStringLength);
 			int quoteEnd = entry.indexOf("\"", quoteStart + 1);
 			if (quoteStart != -1 && quoteEnd != -1) {
 				String name = entry.substring(quoteStart + 1, quoteEnd);

--- a/core/src/main/java/info/openrocket/core/thrustcurve/ThrustCurveAPI.java
+++ b/core/src/main/java/info/openrocket/core/thrustcurve/ThrustCurveAPI.java
@@ -1,6 +1,10 @@
 package info.openrocket.core.thrustcurve;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;

--- a/core/src/main/java/info/openrocket/core/thrustcurve/ThrustCurveAPI.java
+++ b/core/src/main/java/info/openrocket/core/thrustcurve/ThrustCurveAPI.java
@@ -1,11 +1,10 @@
 package info.openrocket.core.thrustcurve;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -35,10 +34,69 @@ public abstract class ThrustCurveAPI {
 
 		InputStream is = conn.getInputStream();
 
-		SearchResponse result = SearchResponseParser.parse(is);
-
-		return result;
+        return SearchResponseParser.parse(is);
 	}
+
+	//TODO might be ideal to have a fallback, incase there are issues with the ThrustCurveAPI metadata?
+	/**
+	 * Utilises the ThrustCurveAPI to get the Manufacturer abbreviations, for the purpose of being used to obtain the
+	 * rest of the Motor Data per manufacturer.
+	 * @return Array of Motor Manufacturer abbreviations.
+	 */
+	public static String[] downloadManufacturers() throws IOException {
+		URL url = new URL("https", "www.thrustcurve.org", "/api/v1/metadata.json");
+		HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+		conn.setRequestMethod("GET");
+		conn.setRequestProperty("Accept", "application/json");
+
+		StringBuilder response = new StringBuilder();
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getInputStream()))) {
+			String line;
+			while ((line = reader.readLine()) != null) {
+				response.append(line);
+			}
+		} finally {
+			conn.disconnect();
+		}
+
+		String jsonString = response.toString();
+		return parseManufacturerAbbreviations(jsonString);
+	}
+
+	/**
+	 * Parses the manufacturer abbreviations from the metadata JSON of the ThrustCurveAPI.
+	 * @param jsonString The String representation of the ThrustCurveAPI metadata.
+	 * @return Array of Motor Abbreviations.
+	 */
+	private static String[] parseManufacturerAbbreviations(String jsonString){
+		int start = jsonString.indexOf("\"manufacturers\":");
+		if (start == -1) return new String[0];
+
+		start = jsonString.indexOf("[", start);
+		int end = jsonString.indexOf("]", start);
+		if (start == -1 || end == -1) return new String[0];
+
+		String manufacturersArray = jsonString.substring(start + 1, end);
+
+		List<String> names = new ArrayList<>();
+		for (String entry : manufacturersArray.split("\\{")) {
+			int nameIndex = entry.indexOf("\"abbrev\":");
+			if (nameIndex == -1) continue;
+			// Developer Note (Jordan Senft): Added the "9" as its own declared value to avoid confusion if others_
+			// _wish to contribute to this class in the future. This could be subject to change in future versions of_
+			// _the ThrustCurveAPI.
+			int literalStringLength = 9;
+			int quoteStart = entry.indexOf("\"", literalStringLength + 9);
+			int quoteEnd = entry.indexOf("\"", quoteStart + 1);
+			if (quoteStart != -1 && quoteEnd != -1) {
+				String name = entry.substring(quoteStart + 1, quoteEnd);
+				names.add(name);
+			}
+		}
+
+		return names.toArray(new String[0]);
+	}
+
 
 	public static List<MotorBurnFile> downloadData(Integer motor_id, String format) throws IOException, SAXException {
 

--- a/core/src/main/java/info/openrocket/core/thrustcurve/serialization/SerializeThrustcurveMotors.java
+++ b/core/src/main/java/info/openrocket/core/thrustcurve/serialization/SerializeThrustcurveMotors.java
@@ -8,9 +8,6 @@ import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import info.openrocket.core.thrustcurve.*;
-import org.xml.sax.SAXException;
-
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -24,6 +21,13 @@ import info.openrocket.core.gui.util.SimpleFileFilter;
 import info.openrocket.core.motor.Motor;
 import info.openrocket.core.motor.ThrustCurveMotor;
 import info.openrocket.core.util.Pair;
+import info.openrocket.core.thrustcurve.SearchRequest;
+import info.openrocket.core.thrustcurve.SearchResponse;
+import info.openrocket.core.thrustcurve.TCMotor;
+import info.openrocket.core.thrustcurve.ThrustCurveAPI;
+import info.openrocket.core.thrustcurve.MotorBurnFile;
+
+import org.xml.sax.SAXException;
 
 public class SerializeThrustcurveMotors {
     public static void main(String[] args) throws Exception {

--- a/core/src/main/java/info/openrocket/core/thrustcurve/serialization/SerializeThrustcurveMotors.java
+++ b/core/src/main/java/info/openrocket/core/thrustcurve/serialization/SerializeThrustcurveMotors.java
@@ -22,36 +22,6 @@ import info.openrocket.core.motor.ThrustCurveMotor;
 import info.openrocket.core.util.Pair;
 
 public class SerializeThrustcurveMotors {
-
-
-    //TODO implement fallback method using the legacy manufacturers array.
-    private static final String[] manufacturers = {
-            "AeroTech",
-            "Alpha",
-            "AMW",
-            "Apogee",
-            "Cesaroni",
-            "Contrail",
-            "Ellis",
-            "Estes",
-            "Gorilla",
-            "Hypertek",
-            "KBA",
-            "Kosdon",
-            "Loki",
-            "TSP",
-            "PP",
-            "PML",
-            "Quest",
-            "RATT",
-            "Klima",
-            "Roadrunner",
-            "RV",
-            "SkyR",
-            "SCR",
-            "WCH"
-    };
-
     public static void main(String[] args) throws Exception {
 
         double threadUtilFraction = 0.5;
@@ -119,8 +89,13 @@ public class SerializeThrustcurveMotors {
      *
      * @see <a href="https://www.thrustcurve.org/info/api.html">ThrustCurve API Documentation</a>
      */
-    public static void loadFromThrustCurves(List<Motor> allMotors, int threads) throws SAXException, IOException {
+    public static void loadFromThrustCurves(List<Motor> allMotors, int threads) throws SAXException, IOException, IllegalStateException {
         ExecutorService executor = Executors.newFixedThreadPool(threads);
+        String[] manufacturers = getManufacturers();
+
+        if(manufacturers.length == 0) {
+            throw new IllegalStateException("No manufacturers parsed from ThrustCurveAPI metadata");
+        }
 
         try {
             List<CompletableFuture<List<Motor>>> futureMotorLists = new ArrayList<>();

--- a/core/src/main/java/info/openrocket/core/thrustcurve/serialization/SerializeThrustcurveMotors.java
+++ b/core/src/main/java/info/openrocket/core/thrustcurve/serialization/SerializeThrustcurveMotors.java
@@ -12,7 +12,11 @@ import info.openrocket.core.thrustcurve.*;
 import org.xml.sax.SAXException;
 
 import java.util.Objects;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import info.openrocket.core.file.iterator.DirectoryIterator;
 import info.openrocket.core.file.iterator.FileIterator;
 import info.openrocket.core.file.motor.GeneralMotorLoader;

--- a/core/src/main/java/info/openrocket/core/thrustcurve/serialization/SerializeThrustcurveMotors.java
+++ b/core/src/main/java/info/openrocket/core/thrustcurve/serialization/SerializeThrustcurveMotors.java
@@ -23,6 +23,8 @@ import info.openrocket.core.util.Pair;
 
 public class SerializeThrustcurveMotors {
 
+
+    //TODO implement fallback method using the legacy manufacturers array.
     private static final String[] manufacturers = {
             "AeroTech",
             "Alpha",
@@ -97,6 +99,15 @@ public class SerializeThrustcurveMotors {
 
     }
 
+    private static String[] getManufacturers(){
+        try{
+            return ThrustCurveAPI.downloadManufacturers();
+        }
+        catch (Exception e) {
+            return new String[]{};
+        }
+    }
+
     /**
      * Adds motors to the data to be serialized from any motors (per manufacturer) retrieved via the ThrustCurveAPI.
      * This method performs concurrent requests using the specified number of threads.
@@ -114,7 +125,7 @@ public class SerializeThrustcurveMotors {
         try {
             List<CompletableFuture<List<Motor>>> futureMotorLists = new ArrayList<>();
 
-            for (String manufacturer : manufacturers) {
+            for (String manufacturer : getManufacturers()) {
                 System.out.println("Motors for : " + manufacturer);
 
                 SearchRequest searchRequest = new SearchRequest();


### PR DESCRIPTION
Retrieves the Manufacturers directly from an GET call to the ThrustCurveAPI. 

Removes need to hardcode a manufacturers String array within the Serialization Code. 

_Dev Note: Not sure why my other commits were not verified via my GPG key, issue seems to be resolved._

Closes #2721 