### PR TITLE
StorageOptions dialog being shown twice fix / OptionChooser Refactor

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/choosers/OBJOptionChooser.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/choosers/OBJOptionChooser.java
@@ -1,5 +1,7 @@
-package info.openrocket.swing.file.wavefrontobj;
+package info.openrocket.swing.gui.choosers;
 
+import info.openrocket.core.document.OpenRocketDocument;
+import info.openrocket.core.preferences.ApplicationPreferences;
 import net.miginfocom.swing.MigLayout;
 import info.openrocket.core.file.wavefrontobj.export.OBJExportOptions;
 import info.openrocket.swing.gui.SpinnerEditor;
@@ -45,7 +47,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-public class OBJOptionChooser extends JPanel {
+public class OBJOptionChooser extends JPanel implements OptionChooser {
     private static final Translator trans = Application.getTranslator();
     private final JComponent parent;
 
@@ -614,6 +616,15 @@ public class OBJOptionChooser extends JPanel {
                     trans.get("OBJOptionChooser.easterEgg.title"), JOptionPane.INFORMATION_MESSAGE);
             totallyNormalCounter = 0;
         }
+    }
+
+    @Override
+    public void storeOptions(OpenRocketDocument document, ApplicationPreferences preferences) {
+        this.storeOptions(document.getDefaultOBJOptions(),true);
+        OBJExportOptions prefOptions = new OBJExportOptions(document.getRocket());
+        storeOptions(prefOptions, false);
+        preferences.saveOBJExportOptions(prefOptions);
+
     }
 
     private static class TriangulationMethodRenderer extends DefaultListCellRenderer {

--- a/swing/src/main/java/info/openrocket/swing/gui/choosers/OptionChooser.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/choosers/OptionChooser.java
@@ -3,6 +3,15 @@ package info.openrocket.swing.gui.choosers;
 import info.openrocket.core.document.OpenRocketDocument;
 import info.openrocket.core.preferences.ApplicationPreferences;
 
+/**
+ * Interface representing any instance that is responsible for the Options chosen within an OpenRocketDocument. Examples
+ * include {@link OBJOptionChooser} & {@link StorageOptionChooser}.
+ */
 public interface OptionChooser {
+    /**
+     * Store the options this chooser is responsible for to the specified document.
+     * @param document The document to store the options for.
+     * @param preferences Application preferences that may need alteration due to the newly stored options.
+     */
     void storeOptions(OpenRocketDocument document, ApplicationPreferences preferences);
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/choosers/OptionChooser.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/choosers/OptionChooser.java
@@ -1,0 +1,8 @@
+package info.openrocket.swing.gui.choosers;
+
+import info.openrocket.core.document.OpenRocketDocument;
+import info.openrocket.core.preferences.ApplicationPreferences;
+
+public interface OptionChooser {
+    void storeOptions(OpenRocketDocument document, ApplicationPreferences preferences);
+}

--- a/swing/src/main/java/info/openrocket/swing/gui/choosers/StorageOptionChooser.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/choosers/StorageOptionChooser.java
@@ -1,4 +1,4 @@
-package info.openrocket.swing.gui.main;
+package info.openrocket.swing.gui.choosers;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -12,6 +12,7 @@ import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JSpinner;
 
+import info.openrocket.core.preferences.ApplicationPreferences;
 import net.miginfocom.swing.MigLayout;
 
 import info.openrocket.core.document.OpenRocketDocument;
@@ -23,7 +24,7 @@ import info.openrocket.core.simulation.FlightDataBranch;
 import info.openrocket.core.startup.Application;
 
 @SuppressWarnings("serial")
-public class StorageOptionChooser extends JPanel {
+public class StorageOptionChooser extends JPanel implements OptionChooser {
 	
 	public static final double DEFAULT_SAVE_TIME_SKIP = 0.20;
 
@@ -172,7 +173,7 @@ public class StorageOptionChooser extends JPanel {
 		
 		
 		StorageOptionChooser chooser = new StorageOptionChooser(document, options);
-		
+
 		//// Save options
 		if (JOptionPane.showConfirmDialog(parent, chooser, trans.get("StorageOptChooser.lbl.Saveopt"), 
 				JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE) !=
@@ -184,5 +185,9 @@ public class StorageOptionChooser extends JPanel {
 		chooser.storeOptions(options);
 		return true;
 	}
-	
+
+	@Override
+	public void storeOptions(OpenRocketDocument document, ApplicationPreferences preferences) {
+		this.storeOptions(document.getDefaultStorageOptions());
+	}
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/main/BasicFrame.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/BasicFrame.java
@@ -50,6 +50,8 @@ import javax.swing.tree.TreePath;
 import javax.swing.tree.TreeSelectionModel;
 
 import info.openrocket.core.preferences.ApplicationPreferences;
+import info.openrocket.swing.gui.choosers.OptionChooser;
+import info.openrocket.swing.gui.choosers.StorageOptionChooser;
 import info.openrocket.swing.gui.util.UpdateInfoRunner;
 import net.miginfocom.swing.MigLayout;
 
@@ -82,7 +84,7 @@ import info.openrocket.core.util.MemoryManagement.MemoryData;
 import info.openrocket.core.util.Reflection;
 import info.openrocket.core.util.TestRockets;
 
-import info.openrocket.swing.file.wavefrontobj.OBJOptionChooser;
+import info.openrocket.swing.gui.choosers.OBJOptionChooser;
 import info.openrocket.swing.gui.configdialog.SaveDesignInfoPanel;
 import info.openrocket.swing.gui.dialogs.ErrorWarningDialog;
 import info.openrocket.swing.gui.components.StyledLabel;
@@ -1447,27 +1449,15 @@ public class BasicFrame extends JFrame {
 	 */
 	private File openFileSaveAsDialog(FileType fileType, List<RocketComponent> selectedComponents) {
 		final DesignFileSaveAsFileChooser chooser = DesignFileSaveAsFileChooser.build(document, fileType, selectedComponents);
-		OBJOptionChooser objChooser = null;
-		if (chooser.getAccessory() instanceof OBJOptionChooser) {
-			objChooser = (OBJOptionChooser) chooser.getAccessory();
-		}
+
 		int option = chooser.showSaveDialog(BasicFrame.this);
 
 		if (option != JFileChooser.APPROVE_OPTION) {
 			log.info(Markers.USER_MARKER, "User decided not to save, option=" + option);
 			return null;
 		}
-
-		// Store the OBJ options
-		if (objChooser != null) {
-			objChooser.storeOptions(document.getDefaultOBJOptions(), true);
-
-			// We need to separately store the preference options, because the export children option can be
-			// automatically selected based on whether only component assemblies are selected. We don't want to
-			// store that state in the preferences.
-			OBJExportOptions prefOptions = new OBJExportOptions(rocket);
-			objChooser.storeOptions(prefOptions, false);
-			prefs.saveOBJExportOptions(prefOptions);
+		if(chooser.getAccessory() instanceof OptionChooser optionChooser){
+			optionChooser.storeOptions(document,prefs);
 		}
 
 		File file = chooser.getSelectedFile();

--- a/swing/src/main/java/info/openrocket/swing/gui/main/DesignFileSaveAsFileChooser.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/DesignFileSaveAsFileChooser.java
@@ -20,7 +20,8 @@ import info.openrocket.core.startup.Application;
 import info.openrocket.core.preferences.ApplicationPreferences;
 import info.openrocket.core.util.FileUtils;
 
-import info.openrocket.swing.file.wavefrontobj.OBJOptionChooser;
+import info.openrocket.swing.gui.choosers.OBJOptionChooser;
+import info.openrocket.swing.gui.choosers.StorageOptionChooser;
 import info.openrocket.swing.gui.util.FileHelper;
 import info.openrocket.swing.gui.util.GUIUtil;
 import info.openrocket.swing.gui.util.SwingPreferences;


### PR DESCRIPTION
Fixing the bug where storage options dialog would pop up, regardless of save as options being selected. 

Also done refactor of 2 of the Option Chooser classes to a new interface to allow for ease of scalability in the future. 

Resolves #2805 