### PR TITLE
Removed code apparently copied and pasted from RocketComponentConfig.…

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/SaveDesignInfoPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/SaveDesignInfoPanel.java
@@ -58,19 +58,6 @@ public class SaveDesignInfoPanel extends RocketConfig {
         cancelButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent arg0) {
-                // Don't do anything on cancel if you are editing an existing component, and it is not modified
-                if (!isNewComponent && parent != null && (parent instanceof ComponentConfigDialog && !((ComponentConfigDialog) parent).isModified())) {
-                    disposeDialog();
-                    return;
-                }
-                // Apply the cancel operation if set to auto discard in preferences
-                if (!preferences.isShowDiscardConfirmation()) {
-                    ComponentConfigDialog.clearConfigListeners = false;		// Undo action => config listeners of new component will be cleared
-                    disposeDialog();
-                    document.undo();
-                    return;
-                }
-
                 // Yes/No dialog: Are you sure you want to discard your changes?
                 JPanel msg = createCancelOperationContent();
                 int resultYesNo = JOptionPane.showConfirmDialog(SaveDesignInfoPanel.this, msg,
@@ -78,7 +65,6 @@ public class SaveDesignInfoPanel extends RocketConfig {
                 if (resultYesNo == JOptionPane.YES_OPTION) {
                     ComponentConfigDialog.clearConfigListeners = false;		// Undo action => config listeners of new component will be cleared
                     disposeDialog();
-                    document.undo();
                 }
             }
         });

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConfigDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConfigDialog.java
@@ -60,7 +60,7 @@ public class SimulationConfigDialog extends JDialog {
 	private static final ApplicationPreferences preferences = Application.getPreferences();
 
 
-	private final WindowListener applyChangesToSimsListener;
+	private final WindowListener windowCloseCancelListener;
 	private final Simulation initialSim;		// A copy of the first selected simulation before it was modified
 	private final boolean initialIsSaved;		// Whether the document was saved before the dialog was opened
 	private boolean isModified = false;			// Whether the simulation has been modified
@@ -214,13 +214,13 @@ public class SimulationConfigDialog extends JDialog {
 
 		this.setLocationByPlatform(true);
 
-		this.applyChangesToSimsListener = new WindowAdapter() {
+		this.windowCloseCancelListener = new WindowAdapter() {
 			@Override
 			public void windowClosed(WindowEvent e) {
-				copyChangesToAllSims();
+				cancelClose();
 			}
 		};
-		this.addWindowListener(applyChangesToSimsListener);
+		this.addWindowListener(windowCloseCancelListener);
 
 		GUIUtil.setDisposableDialogOptions(this, null);
 		GUIUtil.rememberWindowPosition(this);
@@ -374,15 +374,7 @@ public class SimulationConfigDialog extends JDialog {
 		this.cancelButton.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				if (tabbedPane.getSelectedIndex() == LAUNCH_CONDITIONS_IDX ||
-						tabbedPane.getSelectedIndex() == SIMULATION_OPTIONS_IDX) {
-					cancelSimEdit();
-				} else {
-					// Normal close action
-					closeDialog();
-				}
-
-				// TODO: include plot/export undo?
+				cancelClose();
 			}
 		});
 		bottomPanel.add(this.cancelButton, "split 2, tag ok, pushx, align right");
@@ -429,6 +421,18 @@ public class SimulationConfigDialog extends JDialog {
 		return bottomPanel;
 	}
 
+	private void cancelClose() {
+		if (tabbedPane.getSelectedIndex() == LAUNCH_CONDITIONS_IDX ||
+				tabbedPane.getSelectedIndex() == SIMULATION_OPTIONS_IDX) {
+			cancelSimEdit();
+		} else {
+			// Normal close action
+			closeDialog();
+		}
+
+		// TODO: include plot/export undo?
+	}
+
 	private void copyChangesToAllSims() {
 		if (isMultiCompEdit()) {
 			for (int i = 1; i < simulationList.length; i++) {
@@ -459,7 +463,7 @@ public class SimulationConfigDialog extends JDialog {
 		SwingUtilities.invokeLater(new Runnable() {
 			@Override
 			public void run() {
-				SimulationConfigDialog.this.removeWindowListener(applyChangesToSimsListener);
+				SimulationConfigDialog.this.removeWindowListener(windowCloseCancelListener);
 				SimulationConfigDialog.this.dispose();
 			}
 		});


### PR DESCRIPTION
Removed code from `SaveDesignInfoPanel.java` which was apparently pasted from `RocketComponentConfig.java`. The removed code was causing misbehavior from an unrelated preference setting (former lines 61-73 of `SaveDesignInfoPanel`) and causing spurious `document.undo()` actions upon dialog cancel (former line 81): there should be nothing to undo re: the `SaveDesignInfoPanel`. This should resolve #2680