### PR TITLE
Stop reverting prior changes by simply cancelling the "Save design info" dialog. Fixes #2680

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/SaveDesignInfoPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/SaveDesignInfoPanel.java
@@ -58,19 +58,6 @@ public class SaveDesignInfoPanel extends RocketConfig {
         cancelButton.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent arg0) {
-                // Don't do anything on cancel if you are editing an existing component, and it is not modified
-                if (!isNewComponent && parent != null && (parent instanceof ComponentConfigDialog && !((ComponentConfigDialog) parent).isModified())) {
-                    disposeDialog();
-                    return;
-                }
-                // Apply the cancel operation if set to auto discard in preferences
-                if (!preferences.isShowDiscardConfirmation()) {
-                    ComponentConfigDialog.clearConfigListeners = false;		// Undo action => config listeners of new component will be cleared
-                    disposeDialog();
-                    document.undo();
-                    return;
-                }
-
                 // Yes/No dialog: Are you sure you want to discard your changes?
                 JPanel msg = createCancelOperationContent();
                 int resultYesNo = JOptionPane.showConfirmDialog(SaveDesignInfoPanel.this, msg,
@@ -78,7 +65,6 @@ public class SaveDesignInfoPanel extends RocketConfig {
                 if (resultYesNo == JOptionPane.YES_OPTION) {
                     ComponentConfigDialog.clearConfigListeners = false;		// Undo action => config listeners of new component will be cleared
                     disposeDialog();
-                    document.undo();
                 }
             }
         });


### PR DESCRIPTION
Removed code from SaveDesignInfoPanel.java which was apparently pasted from RocketComponentConfig.java. The removed code was causing misbehavior from an unrelated preference setting (former lines 61-73 of `SaveDesignInfoPanel`) and causing spurious `document.undo()` actions upon dialog cancel (former line 81): there should be nothing to undo re: the `SaveDesignInfoPanel`. This resolves #2680