### PR TITLE
Make warning source text more robust if source is null

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/openrocket/OpenRocketSaver.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/OpenRocketSaver.java
@@ -10,6 +10,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.UUID;
 
 import info.openrocket.core.file.openrocket.savers.PhotoStudioSaver;
 import info.openrocket.core.logging.ErrorSet;
@@ -444,7 +445,8 @@ public class OpenRocketSaver extends RocketSaver {
 
 				if (null != w.getSources()) {
 					for (RocketComponent c : w.getSources()) {
-						writeElement("source", c.getID());
+						// Save component ID if it's still in the tree, else nil UUID
+						writeElement("source", null != simulation.getRocket().findComponent(c.getID()) ? c.getID() : new UUID(0, 0));
 					}
 				}
 

--- a/core/src/main/java/info/openrocket/core/file/openrocket/importt/WarningHandler.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/importt/WarningHandler.java
@@ -62,6 +62,7 @@ class WarningHandler extends AbstractElementHandler {
 		if (null == type) {
 			type = "Other";
 		}
+		
 		if (null == warningText) {
 			warningText = content.trim();
 		}
@@ -78,7 +79,7 @@ class WarningHandler extends AbstractElementHandler {
 		} else if (type.equals("EventAfterLanding")) {
 			warning = new Warning.EventAfterLanding(null);
 		} else {
-			warning = Warning.fromString(content.trim());
+			warning = Warning.fromString(warningText);
 		}
 
 		if (null != id) {

--- a/core/src/main/java/info/openrocket/core/logging/Message.java
+++ b/core/src/main/java/info/openrocket/core/logging/Message.java
@@ -45,7 +45,10 @@ public abstract class Message implements Cloneable {
 		if (sources != null && sources.length > 0) {
 			String[] sourceNames = new String[sources.length];
 			for (int i = 0; i < sources.length; i++) {
-				sourceNames[i] = "\"" + sources[i].getName() + "\"";
+				sourceNames[i] =
+					(null != sources[i]) ?
+					("\"" + sources[i].getName() + "\"") :
+					("<i>&lt;component deleted&gt;</i>");
 			}
 			return text + ":  " + String.join(", ", sourceNames);
 		}

--- a/core/src/main/java/info/openrocket/core/logging/Message.java
+++ b/core/src/main/java/info/openrocket/core/logging/Message.java
@@ -4,12 +4,16 @@ import java.lang.UnsupportedOperationException;
 import java.util.Arrays;
 import java.util.UUID;
 
+import info.openrocket.core.l10n.Translator;
 import info.openrocket.core.rocketcomponent.RocketComponent;
+import info.openrocket.core.startup.Application;
 
 /**
  * Baseclass for logging messages (warnings, errors...)
  */
 public abstract class Message implements Cloneable {
+	private static final Translator trans = Application.getTranslator();
+	
 	/** Message ID **/
 	UUID id;
 	
@@ -48,7 +52,7 @@ public abstract class Message implements Cloneable {
 				sourceNames[i] =
 					(null != sources[i]) ?
 					("\"" + sources[i].getName() + "\"") :
-					("<i>&lt;component deleted&gt;</i>");
+					(trans.get("Message.SOURCE_REMOVED"));
 			}
 			return text + ":  " + String.join(", ", sourceNames);
 		}

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -2443,6 +2443,8 @@ Warning.SEPARATION_ORDER = Stages separated in an unreasonable order
 Warning.EARLY_SEPARATION = Stages separated before clearing launch rod/rail
 Warning.OBJ_ZERO_THICKNESS = Zero-thickness component can cause issues for 3D printing
 
+Message.SOURCE_REMOVED = <i>&lt;component deleted&gt;</i>
+
 ! Scale dialog
 ScaleDialog.lbl.scaleRocket = Entire rocket
 ScaleDialog.lbl.scaleSubselection = Selection and all subcomponents


### PR DESCRIPTION
Also, when saving a warning with a removed component, give component a nil UUID to help later developers see what happened.

Minor bugfix; make sure to use text from warning description element in file when present, not content.

Fixes #2777