### PR TITLE
When loading files, only catch exceptions related to file contents; let others go so we stack traces for get bug reports

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/GeneralRocketLoader.java
+++ b/core/src/main/java/info/openrocket/core/file/GeneralRocketLoader.java
@@ -83,7 +83,8 @@ public class GeneralRocketLoader {
 			load(stream, fileName);
 			return doc;
 
-		} catch (Exception e) {
+		} catch (IOException |
+				 IllegalArgumentException e ) {
 			throw new RocketLoadException("Exception loading file: " + baseFile + " , " + e.getMessage(), e);
 		} finally {
 			if (stream != null) {
@@ -101,7 +102,7 @@ public class GeneralRocketLoader {
 			loadStep1(source, fileName);
 			doc.getRocket().enableEvents();
 			return doc;
-		} catch (Exception e) {
+		} catch (IOException | IllegalArgumentException  e) {
 			throw new RocketLoadException("Exception loading stream: " + e.getMessage(), e);
 		}
 	}

--- a/core/src/main/java/info/openrocket/core/file/openrocket/importt/FlightDataBranchHandler.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/importt/FlightDataBranchHandler.java
@@ -176,7 +176,7 @@ class FlightDataBranchHandler extends AbstractElementHandler {
 			try {
 				event = new FlightEvent(type, time, source, data);
 				branch.addEvent(event);
-			} catch (Exception e) {
+			} catch (IllegalStateException e) {
 				warnings.add("Illegal parameters for FlightEvent: " + e.getMessage());
 			}
 


### PR DESCRIPTION
At present, when loading a .ork file, all exceptions are caught and a RocketLoadException is thrown. The RocketLoadException is then handled, and a simple dialog that only gives the error that caused the exception is shown. This is appropriate for handling errors related to the file system (eg file not found) or the contents of the .ork file (eg SAXExceptions, caused by malformed XML in the .ork file).

For things like null dereferences, this is not appropriate as we need a stack trace to look at.

This PR changes this behavior to only catch appropriate exceptions, and let everything else go uncaught se we have a stack trace.