### PR TITLE
Attach event causing warning to "event after landing" event when saving .ork

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/GeneralRocketLoader.java
+++ b/core/src/main/java/info/openrocket/core/file/GeneralRocketLoader.java
@@ -83,7 +83,8 @@ public class GeneralRocketLoader {
 			load(stream, fileName);
 			return doc;
 
-		} catch (Exception e) {
+		} catch (IOException |
+				 IllegalArgumentException e ) {
 			throw new RocketLoadException("Exception loading file: " + baseFile + " , " + e.getMessage(), e);
 		} finally {
 			if (stream != null) {
@@ -101,7 +102,7 @@ public class GeneralRocketLoader {
 			loadStep1(source, fileName);
 			doc.getRocket().enableEvents();
 			return doc;
-		} catch (Exception e) {
+		} catch (IOException | IllegalArgumentException  e) {
 			throw new RocketLoadException("Exception loading stream: " + e.getMessage(), e);
 		}
 	}

--- a/core/src/main/java/info/openrocket/core/file/openrocket/OpenRocketSaver.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/OpenRocketSaver.java
@@ -645,7 +645,13 @@ public class OpenRocketSaver extends RocketSaver {
 			}
 
 			if (event.getType() == FlightEvent.Type.SIM_WARN) {
-				eventStr += " warnid=\"" + TextUtil.escapeXML(((Warning) event.getData()).getID()) + "\"";
+				Warning w = (Warning) event.getData();
+				eventStr += " warnid=\"" + TextUtil.escapeXML(w.getID()) + "\"";
+
+				if (w instanceof Warning.EventAfterLanding) {
+					Warning.EventAfterLanding e = (Warning.EventAfterLanding) w;
+					eventStr += " eventid=\"" + TextUtil.escapeXML(e.getEvent().getID()) + "\"";
+				}
 			}
 			
 			if (event.getType() == FlightEvent.Type.SIM_ABORT) {

--- a/core/src/main/java/info/openrocket/core/file/openrocket/OpenRocketSaver.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/OpenRocketSaver.java
@@ -636,8 +636,9 @@ public class OpenRocketSaver extends RocketSaver {
 		
 		// Write events
 		for (FlightEvent event : branch.getEvents()) {
-			String eventStr = "<event time=\"" + TextUtil.doubleToString(event.getTime())
-					+ "\" type=\"" + enumToXMLName(event.getType()) + "\"";
+			String eventStr = "<event time=\"" + TextUtil.doubleToString(event.getTime()) + "\" "
+				+ "type=\"" + enumToXMLName(event.getType()) + "\" "
+				+ "id=\"" + event.getID().toString() + "\"";
 			
 			if (event.getSource() != null) {
 				eventStr += " source=\"" + TextUtil.escapeXML(event.getSource().getID()) + "\"";

--- a/core/src/main/java/info/openrocket/core/file/openrocket/importt/FlightDataBranchHandler.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/importt/FlightDataBranchHandler.java
@@ -137,6 +137,7 @@ class FlightDataBranchHandler extends AbstractElementHandler {
 			Message data = null;
 			RocketComponent source = null;
 			String sourceID;
+			UUID id = null;
 
 			try {
 				time = DocumentConfig.stringToDouble(attributes.get("time"));
@@ -158,6 +159,11 @@ class FlightDataBranchHandler extends AbstractElementHandler {
 				source = rocket.findComponent(UUID.fromString(sourceID));
 			}
 
+			// Get the event's ID
+			if (null != attributes.get("id")) {
+				id = UUID.fromString(attributes.get("id"));
+			}
+
 			// For warning events, get the warning
 			if (type == FlightEvent.Type.SIM_WARN) {
 				String warnid = attributes.get("warnid");
@@ -174,7 +180,7 @@ class FlightDataBranchHandler extends AbstractElementHandler {
 
 			FlightEvent event = null;
 			try {
-				event = new FlightEvent(type, time, source, data);
+				event = new FlightEvent(type, time, source, data, id);
 				branch.addEvent(event);
 			} catch (Exception e) {
 				warnings.add("Illegal parameters for FlightEvent: " + e.getMessage());

--- a/core/src/main/java/info/openrocket/core/logging/Warning.java
+++ b/core/src/main/java/info/openrocket/core/logging/Warning.java
@@ -175,19 +175,14 @@ public abstract class Warning extends Message {
 			this.event = event;
 		}
 
+		// Two EventAfterLanding warnings are only equal if they are in fact the same warning
 		@Override
 		public boolean equals(Object o) {
 			if ((null == o) || !(o instanceof EventAfterLanding)) {
 				return false;
 			}
 
-			EventAfterLanding e = (EventAfterLanding) o;
-			
-			if ((null == event) || (null == e.event)) {
-				return false;
-			}
-			
-			return super.equals(o) && event.equals(e.event);
+			return getID() == ((EventAfterLanding)o).getID();
 		}
 
 		@Override

--- a/core/src/main/java/info/openrocket/core/logging/Warning.java
+++ b/core/src/main/java/info/openrocket/core/logging/Warning.java
@@ -170,6 +170,10 @@ public abstract class Warning extends Message {
 			setPriority(MessagePriority.HIGH);
 		}
 
+		public FlightEvent getEvent() {
+			return event;
+		}
+		
 		// this is only used for patching the data structure while reading the .ork file
 		public void setEvent(FlightEvent event) {
 			this.event = event;

--- a/core/src/main/java/info/openrocket/core/simulation/BasicEventSimulationEngine.java
+++ b/core/src/main/java/info/openrocket/core/simulation/BasicEventSimulationEngine.java
@@ -328,12 +328,6 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 			log.trace("Obtained event from queue:  " + event.toString());
 			log.trace("Remaining EventQueue = " + currentStatus.getEventQueue().toString());
 
-			// If I get an event other than ALTITUDE and SIMULATION_END after I'm on the ground, there's a problem
-			if (currentStatus.isLanded() &&
-				(event.getType() != FlightEvent.Type.ALTITUDE) &&
-				(event.getType() != FlightEvent.Type.SIMULATION_END))
-				currentStatus.addWarning(new Warning.EventAfterLanding(event));
-
 			// Check for motor ignition events, add ignition events to queue
 			for (MotorClusterState state : currentStatus.getActiveMotors() ){
 				if (state.testForIgnition(currentStatus.getConfiguration(), event)) {
@@ -654,7 +648,13 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 				}
 				break;
 			}
-			
+
+			// If I get an event other than ALTITUDE and SIMULATION_END after I'm on the ground, there's a problem
+			if (currentStatus.isLanded() &&
+				(event.getType() != FlightEvent.Type.GROUND_HIT) &&
+				(event.getType() != FlightEvent.Type.ALTITUDE) &&
+				(event.getType() != FlightEvent.Type.SIMULATION_END))
+				currentStatus.addWarning(new Warning.EventAfterLanding(event));
 		}
 
 		if (currentStatus.getSimulationTime() >= simulationConditions.getMaxSimulationTime()) {

--- a/core/src/main/java/info/openrocket/core/simulation/FlightDataBranch.java
+++ b/core/src/main/java/info/openrocket/core/simulation/FlightDataBranch.java
@@ -2,6 +2,7 @@ package info.openrocket.core.simulation;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import info.openrocket.core.rocketcomponent.AxialStage;
 import info.openrocket.core.rocketcomponent.Rocket;
@@ -229,6 +230,21 @@ public class FlightDataBranch extends DataBranch<FlightDataType> {
 		return retval;
 	}
 
+	/**
+	 * Return the event with the given UUID
+	 * @param id
+	 * @return
+	 */
+	public FlightEvent findEvent(UUID id) {
+		for (FlightEvent e : getEvents()) {
+			if (id.equals(e.getID())) {
+				return e;
+			}
+		}
+
+		return null;
+	}
+	
 	/**
 	 * Return the time of the stage separation event.
 	 * @return the time of the stage separation event, or NaN if no separation event has occurred.

--- a/core/src/main/java/info/openrocket/core/simulation/FlightEvent.java
+++ b/core/src/main/java/info/openrocket/core/simulation/FlightEvent.java
@@ -1,5 +1,7 @@
 package info.openrocket.core.simulation;
 
+import java.util.UUID;
+
 import info.openrocket.core.l10n.Translator;
 import info.openrocket.core.logging.SimulationAbort;
 import info.openrocket.core.logging.Warning;
@@ -109,30 +111,36 @@ public class FlightEvent implements Comparable<FlightEvent> {
 			return name;
 		}
 	}
-	
+
+	private final UUID id;
 	private final Type type;
 	private final double time;
 	private final RocketComponent source;
 	private final Object data;
 	
-	
 	public FlightEvent( final Type type, final double time) {
-		this(type, time, null, null);
+		this(type, time, null, null, null);
 	}
 	
 	public FlightEvent( final Type type, final double time, final RocketComponent source) {
-		this(type, time, source, null);
+		this(type, time, source, null, null);
 	}
 	
 	public FlightEvent( final FlightEvent sourceEvent, final RocketComponent source, final Object data) {
-		this(sourceEvent.type, sourceEvent.time, source, data);
+		this(sourceEvent.type, sourceEvent.time, source, data, null);
+	}
+
+	public FlightEvent(final Type type, final double time, final RocketComponent source, final Object data) {
+		this(type, time, source, data, null);
 	}
 	
-	public FlightEvent( final Type type, final double time, final RocketComponent source, final Object data) {
+	public FlightEvent( final Type type, final double time, final RocketComponent source, final Object data, final UUID id) {
 		this.type = type;
 		this.time = time;
 		this.source = source;
 		this.data = data;
+		this.id = (null != id) ? id : UUID.randomUUID();
+		
 		validate();
 	}
 		
@@ -150,6 +158,10 @@ public class FlightEvent implements Comparable<FlightEvent> {
 	
 	public Object getData() {
 		return data;
+	}
+
+	public UUID getID() {
+		return id;
 	}
 	
 	/**


### PR DESCRIPTION
A sim warning event caused by an event after landing ends up having three parts:

The event triggering everything (for instance, a recovery deployment occurring after landing)
A warning about that event
A simulation warning event, caused by the warning.

Nothing was hooking the original event up to either the warning or the warning event in the .ork file; this ended up causing a null pointer exception.

With this PR, the original event and the warning are both hooked up to the sim warning event so the whole chain can be reconstructed. It would in a sense have been tidier to have hooked the original event up to the warning and the warning up to the sim warning event, but since warnings are saved in the .ork before events, this would have required saving the event's UUID with the warning until the event was loaded, which ended up seeming messier.

Note that a .ork file that was saved without hooking the original event up to the warning can be loaded (see @jimmiedave 's  example in the original bug report), but the source of the sim warning doesn't appear in the warnings list.  A .ork file saved with this PR does hook them up, and when the .ork is loaded the original event is reported properly.

Fixes #2804