### PR TITLE
Make lateral angle and lateral orientation angle use North 0

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/MotorExporter.java
+++ b/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/MotorExporter.java
@@ -98,7 +98,7 @@ public class MotorExporter {
             final float z = (float) (innerRadius * Math.sin(angle));
             obj.addVertex(transformer.convertLoc(x, y, z));
 
-            final double slopeAngle = Math.atan(coneLength / innerRadius);
+            final double slopeAngle = Math.atan2(coneLength, innerRadius);
             final float nx = (float) Math.cos(slopeAngle);
             final float ny = (float) -Math.cos(angle);
             final float nz = (float) -Math.sin(angle);

--- a/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/TransitionExporter.java
+++ b/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/TransitionExporter.java
@@ -394,7 +394,7 @@ public class TransitionExporter extends RocketComponentExporter<Transition> {
             //// We need special nx normal when the radius changes
             float nx;
             if (Double.compare(r, rNext) != 0) {
-                final double slopeAngle = Math.atan((xNext - x) / (rNext - r));
+                final double slopeAngle = Math.atan2(xNext - x, rNext - r);
                 if (rNext > r) {
                     nx = (float) -Math.cos(slopeAngle);
                 } else {

--- a/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/shapes/CylinderExporter.java
+++ b/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/shapes/CylinderExporter.java
@@ -220,7 +220,7 @@ public class CylinderExporter {
             //// We need special nx normal when the radius changes
             float nx;
             if (Float.compare(radius, nextRadius) != 0) {
-                final double slopeAngle = Math.atan(Math.abs(nextX - x) / (nextRadius - radius));
+                final double slopeAngle = Math.atan2(Math.abs(nextX - x), nextRadius - radius);
                 nx = (float) Math.cos(Math.PI - slopeAngle);
             } else {
                 nx = 0;

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/TrapezoidFinSet.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/TrapezoidFinSet.java
@@ -144,7 +144,7 @@ public class TrapezoidFinSet extends FinSet {
 				return -Math.PI / 2;
 			return 0;
 		}
-		return Math.atan(sweep / height);
+		return Math.atan2(sweep, height);
 	}
 
 	/**

--- a/core/src/main/java/info/openrocket/core/simulation/SimulationStatus.java
+++ b/core/src/main/java/info/openrocket/core/simulation/SimulationStatus.java
@@ -620,7 +620,8 @@ public class SimulationStatus implements Cloneable, Monitorable {
 		
 		Coordinate c = getRocketOrientationQuaternion().rotateZ();
 		double theta = Math.atan2(c.z, MathUtil.hypot(c.x, c.y));
-		double phi = Math.atan2(c.y, c.x);
+		//(x, y) instead of (y, x) because 0 is north
+		double phi = Math.atan2(c.x, c.y);
 		if (phi < -(Math.PI - 0.0001))
 			phi = Math.PI;
 		flightDataBranch.setValue(FlightDataType.TYPE_ORIENTATION_THETA, theta);

--- a/core/src/main/java/info/openrocket/core/simulation/SimulationStatus.java
+++ b/core/src/main/java/info/openrocket/core/simulation/SimulationStatus.java
@@ -607,8 +607,9 @@ public class SimulationStatus implements Cloneable, Monitorable {
 		
 		flightDataBranch.setValue(FlightDataType.TYPE_POSITION_XY,
 					  MathUtil.hypot(getRocketPosition().x, getRocketPosition().y));
+		// (x, y) instead of (y, x) because 0 is north
 		flightDataBranch.setValue(FlightDataType.TYPE_POSITION_DIRECTION,
-					  Math.atan2(getRocketPosition().y, getRocketPosition().x));
+					  Math.atan2(getRocketPosition().x, getRocketPosition().y));
 
 		flightDataBranch.setValue(FlightDataType.TYPE_VELOCITY_XY,
 					  MathUtil.hypot(getRocketVelocity().x, getRocketVelocity().y));

--- a/core/src/main/java/info/openrocket/core/util/GeodeticComputationStrategy.java
+++ b/core/src/main/java/info/openrocket/core/util/GeodeticComputationStrategy.java
@@ -114,7 +114,7 @@ public enum GeodeticComputationStrategy {
 				return new WorldCoordinate(location.getLatitudeDeg(), location.getLongitudeDeg(), newAlt);
 			}
 
-			double bearing = Math.atan(delta.x / delta.y);
+			double bearing = Math.atan2(delta.x, delta.y);
 			if (delta.y < 0)
 				bearing = bearing + Math.PI;
 

--- a/core/src/test/java/info/openrocket/core/rocketcomponent/SymmetricComponentVolumeTest.java
+++ b/core/src/test/java/info/openrocket/core/rocketcomponent/SymmetricComponentVolumeTest.java
@@ -16,7 +16,7 @@ public class SymmetricComponentVolumeTest extends BaseTestCase {
 
 	// project thickness onto yz plane to get height of frustrum wall
 	private double getHeight(double length, double foreRadius, double aftRadius, double thickness) {
-		final double angle = Math.atan((aftRadius - foreRadius) / length);
+		final double angle = Math.atan2(aftRadius - foreRadius, length);
 		return thickness / Math.cos(angle);
 	}
 


### PR DESCRIPTION
In a couple of places, azimuth angles were being computed using atan2(y, x) instead of atan2(x, y), which sets angle 0 facing right instead of north. This PR corrects that.

Also, replaces instances of atan(a/b) with atan2(a, b) to avoid potentiona divide by 0 errors.

Fixes #2811