### PR TITLE
Fix #2836: increased size of Plot legend color patches for better color visibility

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/plot/Plot.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/Plot.java
@@ -101,6 +101,7 @@ public abstract class Plot<T extends DataType, B extends DataBranch<T>, C extend
 		legend.setFrame(BlockBorder.NONE);
 		legend.setBackgroundPaint(new Color(240, 240, 240));
 		legend.setPosition(RectangleEdge.BOTTOM);
+		legend.setItemLabelPadding(new RectangleInsets(1.0, 6.0, 1.0, 12.0));
 		chart.addSubtitle(legend);
 
 		// Create the data series for both axes
@@ -267,6 +268,8 @@ public abstract class Plot<T extends DataType, B extends DataBranch<T>, C extend
 					Shape itemShape = r.lookupSeriesShape(j);
 					this.legendItems.pointShapes.add(itemShape);
 					Stroke lineStroke = r.getSeriesStroke(j);
+					BasicStroke bs = (BasicStroke) lineStroke;
+					lineStroke = new BasicStroke(12.0f, bs.getEndCap(), bs.getLineJoin(), bs.getMiterLimit(), bs.getDashArray(), bs.getDashPhase());
 					this.legendItems.lineStrokes.add(lineStroke);
 				}
 
@@ -408,7 +411,7 @@ public abstract class Plot<T extends DataType, B extends DataBranch<T>, C extend
 				Stroke lineStroke = lineStrokes.get(i);
 				Paint linePaint = linePaints.get(i);
 
-				Shape legendLine = new Line2D.Double(-7.0, 0.0, 7.0, 0.0);
+				Shape legendLine = new Line2D.Double(-.70, 0.0, .70, 0.0);
 
 				LegendItem result = new LegendItem(label, description, toolTipText,
 						urlText, shapeIsVisible, shape, shapeIsFilled, fillPaint,


### PR DESCRIPTION
Adjusted H and V size of LegendItem lines, and padding of ItemLabel labels for better legibility.

Comparison  old vs. new:

<img width="563" height="304" alt="Screenshot 2025-07-03 at 11 26 11 PM" src="https://github.com/user-attachments/assets/89f74e2b-9fc6-42d6-a07a-c69d8f6f4dd5" />

Default 3 items:
<img width="1621" height="1113" alt="Screenshot 2025-07-11 at 11 15 28 PM" src="https://github.com/user-attachments/assets/14398057-1b08-4e4a-9e46-668949fb3318" />

Maximum 15 items: (maximum bounds test - not supposed to be pretty)
<img width="1621" height="1113" alt="Screenshot 2025-07-11 at 11 13 44 PM" src="https://github.com/user-attachments/assets/bdd8d56d-915e-453b-8541-66e0c585fd42" />

