### PR TITLE
Adding 'clone' helper methods to WorldCoordinate, Quaternion, SimulationStatus

### DIFF
--- a/core/src/main/java/info/openrocket/core/simulation/SimulationStatus.java
+++ b/core/src/main/java/info/openrocket/core/simulation/SimulationStatus.java
@@ -555,6 +555,30 @@ public class SimulationStatus implements Cloneable, Monitorable {
 		}
 	}
 
+
+	/**
+	 * Copies simulation status data from the specified {@code SimulationStatus} object <code>orig</code>
+	 * to this instance, in particular the physical kinematics as well as boolean flags of <code>motorIgnited</code>, etc.
+	 *
+	 * @param orig the {@code SimulationStatus} object from which to copy data
+	 */
+	public void copyProperties(SimulationStatus orig) {
+		this.position = orig.position.clone();
+		this.worldPosition = orig.worldPosition;
+		this.velocity = orig.velocity.clone();
+		this.orientation = orig.orientation.clone();
+		this.rotationVelocity = orig.rotationVelocity.clone();
+		// these are booleans, so no cloning (primitives).
+		this.motorIgnited = orig.motorIgnited;
+		this.liftoff = orig.liftoff;
+		this.launchRodCleared = orig.launchRodCleared;
+		this.apogeeReached = orig.apogeeReached;
+	}
+
+
+
+
+
 	@Override
 	public ModID getModID() {
 		return modID;

--- a/core/src/main/java/info/openrocket/core/util/Quaternion.java
+++ b/core/src/main/java/info/openrocket/core/util/Quaternion.java
@@ -305,4 +305,18 @@ public class Quaternion {
 		return String.format("Quaternion[%f,%f,%f,%f,norm=%f]", w, x, y, z, this.norm());
 	}
 
+
+	/**
+	 * Creates and returns a copy of this quaternion.
+	 * Being an immutable class, this method returns a new Quaternion instance
+	 * containing the same w, x, y, z component values as this quaternion.
+	 *
+	 * @return a new Quaternion instance with identical component values
+	 */
+	@Override
+    public Quaternion clone() {
+		return new Quaternion(w, x, y, z);
+	}
+
+
 }

--- a/core/src/main/java/info/openrocket/core/util/WorldCoordinate.java
+++ b/core/src/main/java/info/openrocket/core/util/WorldCoordinate.java
@@ -63,6 +63,18 @@ public class WorldCoordinate {
 		return Math.toDegrees(this.lat);
 	}
 
+
+	/**
+	 * Creates and returns a copy of this WorldCoordinate object.
+	 *
+	 * @return A new WorldCoordinate instance with the same latitude, longitude and altitude values
+	 */
+	public WorldCoordinate clone() {
+		return new WorldCoordinate(getLatitudeDeg(), getLongitudeDeg(), getAltitude());
+	}
+	
+
+
 	@Override
 	public String toString() {
 		return "WorldCoordinate[lat=" + getLatitudeDeg() + ", lon=" + getLongitudeDeg() + ", alt=" + getAltitude()


### PR DESCRIPTION
Here I add `clone` helper methods to the `WorldCoordinate`, `Quaternion`, and `SimulationStatus` classes. These are quite useful for a Python binding I am using locally (and hope to prepare as an addition), and I believe they would be quite useful for others developing `SimulationExtensions` or `SimulationListeners` that seek to tweak the simulation algorithm.

Sincerely,
Marc D NICHITIU