### PR TITLE
Allow for comments (#) and blank lines in CSV import

### DIFF
--- a/core/src/main/java/info/openrocket/core/models/wind/MultiLevelPinkNoiseWindModel.java
+++ b/core/src/main/java/info/openrocket/core/models/wind/MultiLevelPinkNoiseWindModel.java
@@ -212,7 +212,7 @@ public class MultiLevelPinkNoiseWindModel implements WindModel {
 
 		try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
 			// Map column indices
-			int altIndex = -1, speedIndex = -1, dirIndex = -1, stddevIndex = -1;
+			int altIndex, speedIndex, dirIndex, stddevIndex = -1;
 
 			if (hasHeaders) {
 				// Read the first line as a header

--- a/core/src/main/java/info/openrocket/core/models/wind/MultiLevelPinkNoiseWindModel.java
+++ b/core/src/main/java/info/openrocket/core/models/wind/MultiLevelPinkNoiseWindModel.java
@@ -11,6 +11,7 @@ import java.util.EventObject;
 import java.util.List;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 
 import info.openrocket.core.l10n.Translator;
@@ -23,6 +24,7 @@ import info.openrocket.core.util.ChangeSource;
 import info.openrocket.core.util.Coordinate;
 import info.openrocket.core.util.ModID;
 import info.openrocket.core.util.StateChangeListener;
+import info.openrocket.core.util.TextLineReader;
 
 public class MultiLevelPinkNoiseWindModel implements WindModel {
 	private List<LevelWindModel> levels;
@@ -211,13 +213,15 @@ public class MultiLevelPinkNoiseWindModel implements WindModel {
 		clearLevels();
 
 		try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+			TextLineReader textLineReader = new TextLineReader(reader);
 			// Map column indices
 			int altIndex, speedIndex, dirIndex, stddevIndex = -1;
 
 			if (hasHeaders) {
 				// Read the first line as a header
-				line = reader.readLine();
-				if (line == null) {
+				try {
+					line = textLineReader.next();
+				} catch (NoSuchElementException e) {
 					throw new IllegalArgumentException(trans.get("MultiLevelPinkNoiseWindModel.msg.importLevelsError.EmptyFile"));
 				}
 
@@ -247,38 +251,43 @@ public class MultiLevelPinkNoiseWindModel implements WindModel {
 
 			// Read data rows
 			int lineNumber = hasHeaders ? 1 : 0;
-			while ((line = reader.readLine()) != null) {
-				lineNumber++;
+			try {
+				while (true) {
+					line = textLineReader.next();
+					lineNumber++;
 
-				// Skip empty lines
-				if (line.trim().isEmpty()) {
-					continue;
+					// Skip empty lines
+					if (line.trim().isEmpty()) {
+						continue;
+					}
+
+					String[] values = line.split(fieldSeparator, -1);  // -1 to keep empty trailing fields
+
+					// Check if we have enough columns
+					int maxColumnIndex = Math.max(Math.max(altIndex, speedIndex),
+							Math.max(dirIndex, Math.max(stddevIndex, 0)));
+					if (maxColumnIndex >= values.length) {
+						throw new IllegalArgumentException(String.format(
+								trans.get("MultiLevelPinkNoiseWindModel.msg.importLevelsError.NotEnoughColumnsInLine"),
+								lineNumber));
+					}
+
+					// Extract and convert values
+					double altitude = extractDoubleAndConvert(values, altIndex, "altitude", altitudeUnit);
+					double speed = extractDoubleAndConvert(values, speedIndex, "speed", speedUnit);
+					double direction = extractDoubleAndConvert(values, dirIndex, "direction", directionUnit);
+
+					// Standard deviation is optional
+					Double stddev = null;
+					if (stddevIndex >= 0 && stddevIndex < values.length && !values[stddevIndex].trim().isEmpty()) {
+						stddev = extractDoubleAndConvert(values, stddevIndex, "standard deviation", stdDeviationUnit);
+					}
+
+					// Add the wind level
+					addWindLevel(altitude, speed, direction, stddev);
 				}
-
-				String[] values = line.split(fieldSeparator, -1);  // -1 to keep empty trailing fields
-
-				// Check if we have enough columns
-				int maxColumnIndex = Math.max(Math.max(altIndex, speedIndex),
-						Math.max(dirIndex, Math.max(stddevIndex, 0)));
-				if (maxColumnIndex >= values.length) {
-					throw new IllegalArgumentException(String.format(
-							trans.get("MultiLevelPinkNoiseWindModel.msg.importLevelsError.NotEnoughColumnsInLine"),
-							lineNumber));
-				}
-
-				// Extract and convert values
-				double altitude = extractDoubleAndConvert(values, altIndex, "altitude", altitudeUnit);
-				double speed = extractDoubleAndConvert(values, speedIndex, "speed", speedUnit);
-				double direction = extractDoubleAndConvert(values, dirIndex, "direction", directionUnit);
-
-				// Standard deviation is optional
-				Double stddev = null;
-				if (stddevIndex >= 0 && stddevIndex < values.length && !values[stddevIndex].trim().isEmpty()) {
-					stddev = extractDoubleAndConvert(values, stddevIndex, "standard deviation", stdDeviationUnit);
-				}
-
-				// Add the wind level
-				addWindLevel(altitude, speed, direction, stddev);
+			} catch (NoSuchElementException ignore) {
+				// Nothing to do here, just means we reached the end of the file
 			}
 
 			// Sort levels by altitude

--- a/core/src/main/java/info/openrocket/core/util/TextLineReader.java
+++ b/core/src/main/java/info/openrocket/core/util/TextLineReader.java
@@ -1,4 +1,4 @@
-package info.openrocket.swing.gui.help.tours;
+package info.openrocket.core.util;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -6,10 +6,9 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-
-import info.openrocket.core.util.BugException;
 
 /**
  * Read from a Reader object one line at a time, ignoring blank lines,
@@ -18,10 +17,7 @@ import info.openrocket.core.util.BugException;
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
 public class TextLineReader implements Iterator<String> {
-	
-	private static final Charset UTF8 = Charset.forName("UTF-8");
-	
-
+	private static final Charset UTF8 = StandardCharsets.UTF_8;
 
 	private final BufferedReader reader;
 	
@@ -94,7 +90,6 @@ public class TextLineReader implements Iterator<String> {
 	
 	
 	private String readLine() throws IOException {
-		
 		while (true) {
 			// Read the next line
 			String line = reader.readLine();
@@ -104,7 +99,7 @@ public class TextLineReader implements Iterator<String> {
 			
 			// Check whether to accept the line
 			line = line.trim();
-			if (line.length() > 0 && line.charAt(0) != '#') {
+			if (!line.isEmpty() && line.charAt(0) != '#') {
 				return line;
 			}
 		}
@@ -116,5 +111,4 @@ public class TextLineReader implements Iterator<String> {
 	public void remove() {
 		throw new UnsupportedOperationException("Remove not supported");
 	}
-	
 }

--- a/core/src/main/java/info/openrocket/core/util/TextLineReader.java
+++ b/core/src/main/java/info/openrocket/core/util/TextLineReader.java
@@ -66,7 +66,7 @@ public class TextLineReader implements Iterator<String> {
 	 * Retrieve the next non-blank, non-comment line.
 	 */
 	@Override
-	public String next() {
+	public String next() throws NoSuchElementException {
 		if (hasNext()) {
 			String ret = next;
 			next = null;

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -660,7 +660,7 @@ CSVImportSettingsDialog.stdDev = Standard Deviation (optional)
 CSVImportSettingsDialog.csvSettings = CSV Settings
 CSVImportSettingsDialog.separator = Field Separator
 CSVImportSettingsDialog.preview = CSV Example Contents Preview
-CSVImportSettingsDialog.previewHelp = An example of how the first lines of data in you CSV file should look like for some example data. Make sure the data is correctly separated and that the column names are correct.
+CSVImportSettingsDialog.previewHelp = An example of how the first lines of data in you CSV file should look like for some example data. Make sure the data is correctly separated and that the column names are correct.\nYou can add blank lines or comment lines starting with a hash (#).
 CSVImportSettingsDialog.duplicateColumnError = Duplicate column indices found. Please ensure that each column index is unique.
 CSVImportSettingsDialog.validationError = Incorrect Data Input
 

--- a/swing/src/main/java/info/openrocket/swing/gui/help/tours/SlideSetLoader.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/help/tours/SlideSetLoader.java
@@ -12,6 +12,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import info.openrocket.core.util.BugException;
+import info.openrocket.core.util.TextLineReader;
 
 /**
  * Class that loads a slide set from a file.

--- a/swing/src/main/java/info/openrocket/swing/gui/help/tours/SlideSetManager.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/help/tours/SlideSetManager.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import javax.swing.text.html.StyleSheet;
 
+import info.openrocket.core.util.TextLineReader;
 import info.openrocket.swing.gui.util.GUIUtil;
 import info.openrocket.swing.gui.theme.UITheme;
 

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/CSVImportSettingsDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/CSVImportSettingsDialog.java
@@ -105,6 +105,7 @@ public class CSVImportSettingsDialog extends JDialog {
 		descriptionArea.setBackground(null);
 		descriptionArea.setOpaque(false);
 		descriptionArea.setFocusable(false);
+		descriptionArea.setBorder(null);
 		mainPanel.add(descriptionArea, "spanx, growx, wrap para");
 
 		// CSV settings section
@@ -120,6 +121,7 @@ public class CSVImportSettingsDialog extends JDialog {
 		columnMappingHelp.setBackground(null);
 		columnMappingHelp.setOpaque(false);
 		columnMappingHelp.setFocusable(false);
+		columnMappingHelp.setBorder(null);
 		columnMappingHelp.setFont(columnMappingHelp.getFont().deriveFont(columnMappingHelp.getFont().getSize() - 1f));
 		csvSettings.add(columnMappingHelp, "spanx, growx, wrap para");
 
@@ -251,6 +253,7 @@ public class CSVImportSettingsDialog extends JDialog {
 		previewHelp.setBackground(null);
 		previewHelp.setOpaque(false);
 		previewHelp.setFocusable(false);
+		previewHelp.setBorder(null);
 		previewHelp.setFont(previewHelp.getFont().deriveFont(previewHelp.getFont().getSize() - 1f));
 		previewPanel.add(previewHelp, "spanx, growx, wrap para");
 

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/CSVImportSettingsDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/CSVImportSettingsDialog.java
@@ -707,6 +707,9 @@ public class CSVImportSettingsDialog extends JDialog {
 		}
 
 		try {
+			doc.insertString(doc.getLength(), "# You can add comments with a hash", optionalStyle);
+			doc.insertString(doc.getLength(), "\n", optionalStyle);
+
 			// Create header row if CSV has a header
 			if (hasHeaderCheckBox.isSelected()) {
 				doc.insertString(doc.getLength(), getAltitudeColumn() + displaySeparator, normalStyle);
@@ -722,7 +725,7 @@ public class CSVImportSettingsDialog extends JDialog {
 			}
 			// If no header, add a comment showing which column is which
 			else {
-				doc.insertString(doc.getLength(), "# Column mapping: ", normalStyle);
+				doc.insertString(doc.getLength(), "# Column mapping: ", optionalStyle);
 				doc.insertString(doc.getLength(), getAltitudeColumn() + "=Altitude, ", indexStyle);
 				doc.insertString(doc.getLength(), getSpeedColumn() + "=Speed, ", indexStyle);
 				doc.insertString(doc.getLength(), getDirectionColumn() + "=Direction", indexStyle);
@@ -760,7 +763,7 @@ public class CSVImportSettingsDialog extends JDialog {
 			}
 
 			// Add ellipsis to indicate more data could follow
-			doc.insertString(doc.getLength(), "...", normalStyle);
+			doc.insertString(doc.getLength(), "\u2026", normalStyle);
 
 		} catch (BadLocationException e) {
 			// This shouldn't happen, but log it just in case


### PR DESCRIPTION
This PR fixes #2830 by allowing comments, starting with a hash (#), and blank lines in multi-level wind CSV files.