### PR TITLE
Ensure there is always at least one active stage when importing a design

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/openrocket/importt/MotorConfigurationHandler.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/importt/MotorConfigurationHandler.java
@@ -21,6 +21,7 @@ class MotorConfigurationHandler extends AbstractElementHandler {
 	private String name = null;
 	private boolean inNameElement = false;
 	private HashMap<Integer, Boolean> stageActiveness = new HashMap<>();
+	private boolean hasActiveStage = false;
 
 	public MotorConfigurationHandler(Rocket rocket, DocumentLoadingContext context) {
 		this.rocket = rocket;
@@ -50,6 +51,7 @@ class MotorConfigurationHandler extends AbstractElementHandler {
 		} else if (element.equals("stage")) {
 			int stageNr = Integer.parseInt(attributes.get("number"));
 			boolean isActive = Boolean.parseBoolean(attributes.get("active"));
+			hasActiveStage = hasActiveStage || isActive;
 			stageActiveness.put(stageNr, isActive);
 		}
 	}
@@ -66,8 +68,13 @@ class MotorConfigurationHandler extends AbstractElementHandler {
 
 		rocket.createFlightConfiguration(fcid);
 
-		if (name != null && name.trim().length() > 0) {
+		if (name != null && !name.trim().isEmpty()) {
 			rocket.getFlightConfiguration(fcid).setName(name);
+		}
+
+		// Ensure there's always at least one stage active
+		if (!hasActiveStage && !stageActiveness.isEmpty()) {
+			stageActiveness.put(0, true);
 		}
 
 		for (Map.Entry<Integer, Boolean> entry : stageActiveness.entrySet()) {


### PR DESCRIPTION
This PR ensures there is always at least one stage active when importing a design. Thanks to #2844, it shouldn't be possible anymore to end up in this situation, but for older designs, you could still have the issue of opening an "empty" design (an issue reported by a user a while ago).