### PR TITLE
[#2855] Make user-defined thrust curve and component preset loading more foolproof

### DIFF
--- a/core/src/main/java/info/openrocket/core/database/ComponentPresetDatabaseLoader.java
+++ b/core/src/main/java/info/openrocket/core/database/ComponentPresetDatabaseLoader.java
@@ -67,7 +67,7 @@ public class ComponentPresetDatabaseLoader extends AsynchronousDatabaseLoader {
 		SimpleFileFilter orcFilter = new SimpleFileFilter("", false, "orc");
 		int initialCount = presetCount;
 		for (File file : (Application.getPreferences()).getUserComponentPresetFiles()) {
-			if (file.isFile()) {
+			if (file.isFile() && orcFilter.accept(file)) {
 				try {
 					InputStream stream = new FileInputStream(file);
 					loadFile(file.getName(), stream);

--- a/core/src/main/java/info/openrocket/core/database/MotorDatabaseLoader.java
+++ b/core/src/main/java/info/openrocket/core/database/MotorDatabaseLoader.java
@@ -70,6 +70,10 @@ public class MotorDatabaseLoader extends AsynchronousDatabaseLoader {
 		log.info("Starting reading user-defined motors");
 		for (File file : (Application.getPreferences()).getUserThrustCurveFiles()) {
 			if (file.isFile()) {
+				if (!fileFilter.accept(file)) {
+					log.warn("User-defined motor file " + file + " does not have a supported extension");
+					continue;
+				}
 				loadFile(loader, file);
 			} else if (file.isDirectory()) {
 				loadDirectory(loader, fileFilter, file);

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/GeneralPreferencesPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/GeneralPreferencesPanel.java
@@ -145,15 +145,11 @@ public class GeneralPreferencesPanel extends PreferencesPanel {
 						true, "zip"));
 				chooser.setFileFilter(filter);
 				chooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
-				if (defaultDirectory != null) {
-					chooser.setCurrentDirectory(defaultDirectory);
-				}
 				
 				//// Add
 				int returnVal = chooser.showDialog(GeneralPreferencesPanel.this, trans.get("pref.dlg.Add"));
 				if (returnVal == JFileChooser.APPROVE_OPTION) {
 					log.info(Markers.USER_MARKER, "Adding user thrust curve: " + chooser.getSelectedFile());
-					defaultDirectory = chooser.getCurrentDirectory();
 					String text = field.getText().trim();
 					if (text.length() > 0) {
 						text += ";";
@@ -238,15 +234,11 @@ public class GeneralPreferencesPanel extends PreferencesPanel {
 						true, "orc"));
 				chooser.setFileFilter(filter);
 				chooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
-				if (defaultDirectory != null) {
-					chooser.setCurrentDirectory(defaultDirectory);
-				}
 
 				//// Add
 				int returnVal = chooser.showDialog(GeneralPreferencesPanel.this, trans.get("pref.dlg.Add"));
 				if (returnVal == JFileChooser.APPROVE_OPTION) {
 					log.info(Markers.USER_MARKER, "Adding component preset file: " + chooser.getSelectedFile());
-					defaultDirectory = chooser.getCurrentDirectory();
 					String text = fieldCompPres.getText().trim();
 					if (text.length() > 0) {
 						text += ";";

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/GeneralPreferencesPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/GeneralPreferencesPanel.java
@@ -126,6 +126,7 @@ public class GeneralPreferencesPanel extends PreferencesPanel {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				JFileChooser chooser = new JFileChooser();
+				chooser.setAcceptAllFileFilterUsed(false);
 				chooser.setCurrentDirectory(((SwingPreferences) Application.getPreferences()).getDefaultDirectory());
 				SimpleFileFilter filter =
 						new SimpleFileFilter(
@@ -226,6 +227,7 @@ public class GeneralPreferencesPanel extends PreferencesPanel {
 			public void actionPerformed(ActionEvent e) {
 				JFileChooser chooser = new JFileChooser();
 				chooser.setCurrentDirectory(((SwingPreferences) Application.getPreferences()).getDefaultDirectory());
+				chooser.setAcceptAllFileFilterUsed(false);
 				SimpleFileFilter filter =
 						new SimpleFileFilter(
 								trans.get("pref.dlg.AllComponentPresetfiles"),

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/GeneralPreferencesPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/GeneralPreferencesPanel.java
@@ -23,6 +23,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 
+import info.openrocket.core.startup.Application;
 import info.openrocket.swing.gui.util.UpdateInfoRunner;
 import net.miginfocom.swing.MigLayout;
 
@@ -125,6 +126,7 @@ public class GeneralPreferencesPanel extends PreferencesPanel {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				JFileChooser chooser = new JFileChooser();
+				chooser.setCurrentDirectory(((SwingPreferences) Application.getPreferences()).getDefaultDirectory());
 				SimpleFileFilter filter =
 						new SimpleFileFilter(
 								//// All thrust curve files (*.eng; *.rse; *.zip; directories)
@@ -157,6 +159,7 @@ public class GeneralPreferencesPanel extends PreferencesPanel {
 					}
 					text += chooser.getSelectedFile().getAbsolutePath();
 					field.setText(text);
+					((SwingPreferences) Application.getPreferences()).setDefaultDirectory(chooser.getCurrentDirectory());
 				}
 			}
 		});
@@ -222,6 +225,7 @@ public class GeneralPreferencesPanel extends PreferencesPanel {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				JFileChooser chooser = new JFileChooser();
+				chooser.setCurrentDirectory(((SwingPreferences) Application.getPreferences()).getDefaultDirectory());
 				SimpleFileFilter filter =
 						new SimpleFileFilter(
 								trans.get("pref.dlg.AllComponentPresetfiles"),
@@ -247,6 +251,7 @@ public class GeneralPreferencesPanel extends PreferencesPanel {
 					}
 					text += chooser.getSelectedFile().getAbsolutePath();
 					fieldCompPres.setText(text);
+					((SwingPreferences) Application.getPreferences()).setDefaultDirectory(chooser.getCurrentDirectory());
 				}
 			}
 		});

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/PreferencesPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/PreferencesPanel.java
@@ -25,7 +25,6 @@ public abstract class PreferencesPanel extends JPanel {
 	
 	protected final List<DefaultUnitSelector> unitSelectors = new ArrayList<>();
 	
-	protected File defaultDirectory = null;
 	protected static final Translator trans = Application.getTranslator();
 	
 	protected final SwingPreferences preferences = (SwingPreferences) Application.getPreferences();


### PR DESCRIPTION
In light of #2855, this PR makes user-defined thrust curve and component preset loading more foolproof by:
- Disabling the "All files" option in the file chooser
- When loading thrust curves or component preset files, that the file extension is correct 