### PR TITLE
Add jacoco code coverage with project-specific thresholds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,17 @@ jobs:
         run: ./gradlew clean check build dist
       # If wanting to serialize all the engines during build
       #        run: ./gradlew clean serializeEnginesDist build dist
+      - name: JaCoCo Coverage Report
+        uses: madrapps/jacoco-report@v1.6.1
+        with:
+          paths: |
+            build/reports/jacoco/jacocoRootReport/jacocoRootReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 30
+          update-comment: true
+          title: '# :lobster: Coverage Report'
+          pass-emoji: ':green_circle:'
+          fail-emoji: ':red_circle:'
       - name: Upload build reports
         uses: actions/upload-artifact@v4
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'checkstyle'
     id 'org.javamodularity.moduleplugin' version '1.8.15'
     id 'application'
+    id 'jacoco'
 }
 
 // Java settings
@@ -41,6 +42,11 @@ file('core/src/main/resources/build.properties').withInputStream { buildProperti
 group = 'info.openrocket'
 version = buildProperties['build.version']
 
+// JaCoCo configuration
+jacoco {
+    toolVersion = "0.8.11"
+}
+
 // Common project configuration
 allprojects {
     repositories {
@@ -53,6 +59,7 @@ allprojects {
 subprojects {
     apply plugin: 'java'
     apply plugin: "org.javamodularity.moduleplugin"
+    apply plugin: 'jacoco'
 
     // Configure the gradle-modules-plugin
     modularity {
@@ -62,6 +69,7 @@ subprojects {
 
     test {
         useJUnitPlatform()
+        finalizedBy jacocoTestReport
 
         testLogging {
             events 'PASSED', 'FAILED', 'SKIPPED', 'STANDARD_OUT'
@@ -70,6 +78,18 @@ subprojects {
             stackTraceFilters = []
         }
     }
+
+    jacocoTestReport {
+        dependsOn test
+        reports {
+            xml.required = true
+            html.required = true
+            csv.required = false
+        }
+    }
+
+    // Verify code coverage before JAR packaging
+    jar.dependsOn jacocoTestCoverageVerification
 
     // Common dependencies
     dependencies {
@@ -135,6 +155,26 @@ shadowJar {
                 'JVM-Args': '-Dapple.awt.application.appearance=system -Dsun.java2d.noddraw=true -Dsun.java2d.d3d=false -Dsun.java2d.ddforcevram=true -Dsun.java2d.ddblit=false -Dswing.useflipBufferStrategy=True'
         )
     }
+}
+
+// jacoco aggregate report for all subprojects
+tasks.register('jacocoRootReport', JacocoReport) {
+    group = 'verification'
+    description = 'Generates an aggregate report from all subprojects'
+
+    dependsOn(subprojects.jacocoTestReport)
+
+    reports {
+        xml.required = true
+        html.required = true
+        csv.required = false
+    }
+
+    // Collect execution data from all subprojects
+    executionData fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec")
+
+    // Collect class directories from all subprojects
+    classDirectories.setFrom(subprojects.sourceSets.main.output.classesDirs)
 }
 
 // Package the application for distribution.

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -230,6 +230,17 @@ tasks.register('externalComponentsValidate') {
     }
 }
 
+jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.6
+            }
+        }
+    }
+}
+
 clean.dependsOn([externalComponentsDelete])
 //compileJava.dependsOn([externalComponentsCopy])
 processResources.dependsOn([externalComponentsCopy])

--- a/docs/source/dev_guide/testing_and_debugging.rst
+++ b/docs/source/dev_guide/testing_and_debugging.rst
@@ -77,6 +77,41 @@ When writing tests for OpenRocket, follow these guidelines:
 5. Test edge cases and error conditions
 6. Keep tests independent of each other
 
+Code Coverage
+=============
+
+OpenRocket uses the `JaCoCo <https://www.jacoco.org/>`_ plugin to track and enforce
+test coverage. Coverage verification is integrated into the build process to ensure
+code quality.
+
+- **Core module:** minimum 60% coverage threshold  
+- **Swing module:** threshold currently disabled (0%) due to limited test coverage  
+- **Aggregate reports:** generated via the ``jacocoRootReport`` task
+
+If coverage thresholds are not met, JAR packaging will fail. This prevents deployment
+of code that does not meet the required quality standards.
+
+Usage
+-----
+
+To generate coverage reports:
+
+.. code-block:: bash
+
+   ./gradlew test jacocoRootReport
+
+To build with coverage verification:
+
+.. code-block:: bash
+
+   ./gradlew build
+
+Coverage verification runs automatically during JAR packaging. Detailed HTML
+reports are available under ``build/reports/jacoco/`` for review. Additionally, 
+a GitHub Action publishes coverage reports for easier tracking in CI.
+
+
+
 Debugging
 =========
 

--- a/swing/build.gradle
+++ b/swing/build.gradle
@@ -93,3 +93,14 @@ dependencies {
 
     testImplementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.0'
 }
+
+jacocoTestCoverageVerification {
+    dependsOn jacocoTestReport
+    violationRules {
+        rule {
+            limit {
+                minimum = 0.0
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Pull Request Description

**Title**: Add jacoco code coverage with project-specific thresholds

**Description**:

This PR adds jacoco code coverage verification to the OpenRocket project

### Changes
- **jacoco Integration**: Added jacoco plugin to both core and swing modules
- **Coverage Verification**: Integrated coverage verification into JAR packaging process
- **Project-specific Thresholds**: 
  - Core module: 60% coverage threshold
  - Swing module: 0% coverage threshold (disabled due to limited test coverage)
- **Aggregate Reports**: Added `jacocoRootReport` task to generate combined coverage reports
- **Build Integration**: JAR packaging now fails if coverage thresholds are not met

### Benefits
- Ensures code quality through automated coverage verification
- Prevents deployment of code that doesn't meet quality standards
- Provides detailed coverage reports for development teams
- Configurable thresholds per module based on project needs

### Notes
- **Swing Module**: Set to 0% threshold as it currently has very limited test coverage
- **Threshold Adjustment**: Coverage thresholds can be adjusted as needed based on project requirements and test coverage improvements

### Usage
```bash
# Generate coverage reports
./gradlew test jacocoRootReport

# Build with coverage verification
./gradlew build
```

The coverage verification is automatically triggered during JAR packaging, ensuring that only code meeting the specified quality standards can be built and deployed.

Related Issue: #2886