### PR TITLE
[#2524] Separate BarrowmanCalculator into DragCalculator and StabilityCalculator

### DIFF
--- a/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanCalculator.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanCalculator.java
@@ -1,1087 +1,147 @@
 package info.openrocket.core.aerodynamics;
 
-import static info.openrocket.core.util.MathUtil.pow2;
-
-import info.openrocket.core.logging.Warning;
-import info.openrocket.core.logging.WarningSet;
-import info.openrocket.core.rocketcomponent.AxialStage;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import info.openrocket.core.aerodynamics.barrowman.FinSetCalc;
-import info.openrocket.core.aerodynamics.barrowman.RocketComponentCalc;
-import info.openrocket.core.rocketcomponent.position.AxialMethod;
-import info.openrocket.core.rocketcomponent.ComponentAssembly;
-import info.openrocket.core.rocketcomponent.ExternalComponent;
-import info.openrocket.core.rocketcomponent.ExternalComponent.Finish;
-import info.openrocket.core.rocketcomponent.FinSet;
-import info.openrocket.core.rocketcomponent.FlightConfiguration;
-import info.openrocket.core.rocketcomponent.InstanceContext;
-import info.openrocket.core.rocketcomponent.InstanceMap;
-import info.openrocket.core.rocketcomponent.ParallelStage;
-import info.openrocket.core.rocketcomponent.PodSet;
-import info.openrocket.core.rocketcomponent.Rocket;
-import info.openrocket.core.rocketcomponent.RocketComponent;
-import info.openrocket.core.rocketcomponent.SymmetricComponent;
-import info.openrocket.core.unit.UnitGroup;
-import info.openrocket.core.util.Coordinate;
-import info.openrocket.core.util.MathUtil;
-import info.openrocket.core.util.ModID;
-import info.openrocket.core.util.PolyInterpolator;
-import info.openrocket.core.util.Reflection;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
-import java.util.Queue;
+
+import info.openrocket.core.logging.WarningSet;
+import info.openrocket.core.rocketcomponent.ComponentAssembly;
+import info.openrocket.core.rocketcomponent.FlightConfiguration;
+import info.openrocket.core.rocketcomponent.InstanceMap;
+import info.openrocket.core.rocketcomponent.RocketComponent;
+import info.openrocket.core.util.Coordinate;
+import info.openrocket.core.util.ModID;
 
 /**
- * An aerodynamic calculator that uses the extended Barrowman method to
- * calculate the CP of a rocket.
- * 
- * @author Sampo Niskanen <sampo.niskanen@iki.fi>
+ * An aerodynamic calculator that uses the extended Barrowman method by delegating
+ * stability and drag calculations to dedicated calculators.
  */
 public class BarrowmanCalculator extends AbstractAerodynamicCalculator {
-	private static final Logger log = LoggerFactory.getLogger(BarrowmanCalculator.class);
+	private final StabilityCalculator stabilityCalculator;
+	private final DragCalculator dragCalculator;
 
-	private static final String BARROWMAN_PACKAGE = "info.openrocket.core.aerodynamics.barrowman";
-	private static final String BARROWMAN_SUFFIX = "Calc";
-	
-	private Map<RocketComponent, RocketComponentCalc> calcMap = null;
-	
-	private double cacheDiameter = -1;
-	private double cacheLength = -1;
-
-	private final double stallAngle = 17.5 * Math.PI / 180;
-	private double stallMargin;
-	
 	public BarrowmanCalculator() {
-		
+		this(new BarrowmanStabilityCalculator(), new BarrowmanDragCalculator());
 	}
-	
-	
+
+	public BarrowmanCalculator(StabilityCalculator stabilityCalculator, DragCalculator dragCalculator) {
+		if (stabilityCalculator == null || dragCalculator == null) {
+			throw new IllegalArgumentException("Calculators must not be null");
+		}
+		this.stabilityCalculator = stabilityCalculator;
+		this.dragCalculator = dragCalculator;
+	}
+
 	@Override
 	public BarrowmanCalculator newInstance() {
-		return new BarrowmanCalculator();
+		return new BarrowmanCalculator(stabilityCalculator.newInstance(), dragCalculator.newInstance());
 	}
 
-	/**
-	 * Determine whether calculations are suspect because we are stalling
-	 *
-	 * @return               whether we are stalling, and the margin
-	 *                       between our AOA and a stall
-	 *                       If the return is positive we aren't;
-	 *                       If it's negative we are.
-	 *             
-	 */
 	@Override
 	public double getStallMargin() {
-		return stallMargin;
+		return stabilityCalculator.getStallMargin();
 	}
-	
-	/**
-	 * Calculate the CP according to the extended Barrowman method.
-	 */
+
 	@Override
 	public Coordinate getCP(FlightConfiguration configuration, FlightConditions conditions,
 			WarningSet warnings) {
 		checkCache(configuration);
-		AerodynamicForces forces = calculateNonAxialForces(configuration, conditions, warnings);
-		return forces.getCP();
+		WarningSet actualWarnings = (warnings != null) ? warnings : ignoreWarningSet;
+		return stabilityCalculator.getCP(configuration, conditions, actualWarnings);
 	}
-	
-	
-	
+
 	@Override
 	public Map<RocketComponent, AerodynamicForces> getForceAnalysis(FlightConfiguration configuration,
-			FlightConditions conditions,
-			WarningSet warnings) {
-		if (calcMap == null) {
-			buildCalcMap(configuration);
-		}
+			FlightConditions conditions, WarningSet warnings) {
+		checkCache(configuration);
+
+		WarningSet actualWarnings = (warnings != null) ? warnings : ignoreWarningSet;
+		StabilityForceBreakdown breakdown = stabilityCalculator.getForceAnalysis(configuration, conditions,
+				actualWarnings);
+
+		Map<RocketComponent, AerodynamicForces> eachMap = breakdown.getComponentForces();
+		Map<RocketComponent, AerodynamicForces> assemblyMap = breakdown.getAssemblyForces();
+
+		AerodynamicForces rocketForces = assemblyMap.get(configuration.getRocket());
+		dragCalculator.calculateDrag(configuration, conditions, eachMap, assemblyMap, rocketForces, actualWarnings);
 
 		InstanceMap instMap = configuration.getActiveInstances();
-		Map<RocketComponent, AerodynamicForces> eachMap = new LinkedHashMap<>();
-		Map<RocketComponent, AerodynamicForces> assemblyMap = new LinkedHashMap<>();
-
-		// Calculate non-axial force data
-		calculateForceAnalysis(configuration, conditions, configuration.getRocket(), instMap, eachMap, assemblyMap, warnings);
-
-		// Calculate drag coefficient data
-		AerodynamicForces rocketForces = assemblyMap.get(configuration.getRocket());
-		rocketForces.setFrictionCD(calculateFrictionCD(configuration, conditions, eachMap, warnings));
-		rocketForces.setPressureCD(calculatePressureCD(configuration, conditions, eachMap, warnings));
-		rocketForces.setBaseCD(calculateBaseCD(configuration, conditions, eachMap, warnings));
-		rocketForces.setOverrideCD(calculateOverrideCD(configuration, conditions, eachMap, assemblyMap, warnings));
-
 		Map<RocketComponent, AerodynamicForces> finalMap = new LinkedHashMap<>();
-		for (final RocketComponent comp : instMap.keySet()) {
-
-			AerodynamicForces f;
+		for (RocketComponent comp : instMap.keySet()) {
+			AerodynamicForces forces;
 			if (comp instanceof ComponentAssembly) {
-				f = assemblyMap.get(comp);
+				forces = assemblyMap.get(comp);
 			} else if (comp.isAerodynamic()) {
-				f = eachMap.get(comp);
+				forces = eachMap.get(comp);
 			} else {
 				continue;
 			}
 
-			if (f.getCP().isNaN()) {
-				f.setCP(Coordinate.ZERO);
+			if (forces.getCP().isNaN()) {
+				forces.setCP(Coordinate.ZERO);
+			}
+			if (Double.isNaN(forces.getBaseCD())) {
+				forces.setBaseCD(0);
+			}
+			if (Double.isNaN(forces.getPressureCD())) {
+				forces.setPressureCD(0);
+			}
+			if (Double.isNaN(forces.getFrictionCD())) {
+				forces.setFrictionCD(0);
+			}
+			if (Double.isNaN(forces.getOverrideCD())) {
+				forces.setOverrideCD(0);
 			}
 
-			if (Double.isNaN(f.getBaseCD()))
-				f.setBaseCD(0);
+			double cd = forces.getBaseCD() + forces.getPressureCD() + forces.getFrictionCD() + forces.getOverrideCD();
+			forces.setCD(cd);
+			forces.setCDaxial(dragCalculator.toAxialDrag(conditions, cd));
 
-			if (Double.isNaN(f.getPressureCD()))
-				f.setPressureCD(0);
-
-			if (Double.isNaN(f.getFrictionCD()))
-				f.setFrictionCD(0);
-
-			if (Double.isNaN(f.getOverrideCD()))
-				f.setOverrideCD(0);
-
-			f.setCD(f.getBaseCD() + f.getPressureCD() + f.getFrictionCD() + f.getOverrideCD());
-			f.setCDaxial(calculateAxialCD(conditions, f.getCD()));
-
-			finalMap.put(comp, f);
+			finalMap.put(comp, forces);
 		}
 
 		return finalMap;
-	}
-
-	private AerodynamicForces calculateForceAnalysis(FlightConfiguration configuration,
-			FlightConditions conds,
-			RocketComponent comp,
-			InstanceMap instances,
-			Map<RocketComponent, AerodynamicForces> eachForces,
-			Map<RocketComponent, AerodynamicForces> assemblyForces,
-			WarningSet warnings) {
-		// forces for this component, and all forces below it, in the rocket-tree
-		AerodynamicForces aggregateForces = new AerodynamicForces().zero();
-		aggregateForces.setComponent(comp);
-
-		// forces for this component, _only_
-		if (comp.isAerodynamic() || comp instanceof ComponentAssembly) {
-			RocketComponentCalc calcObj = calcMap.get(comp);
-			if (null == calcObj) {
-				throw new NullPointerException(
-						"Could not find a CalculationObject for aerodynamic Component!: " + comp.getComponentName());
-			} else {
-				List<InstanceContext> contextList = instances.get(comp);
-				// across every instance of this component:
-				AerodynamicForces compForces = calculateComponentNonAxialForces(conds, comp, calcObj, contextList,
-						warnings);
-				eachForces.put(comp, compForces);
-				aggregateForces.merge(compForces);
-			}
-		}
-
-		for (RocketComponent child : comp.getChildren()) {
-			// Ignore inactive stages
-			if (child instanceof AxialStage && !configuration.isStageActive(child.getStageNumber())) {
-				// Check if there are child stages that are active and need to be calculated
-				for (AxialStage childStage : child.getTopLevelChildStages()) {
-					if (configuration.isStageActive(childStage.getStageNumber())) {
-						// forces particular to each component
-						AerodynamicForces childForces = calculateForceAnalysis(configuration, conds, childStage, instances,
-								eachForces, assemblyForces, warnings);
-
-						if (childForces != null) {
-							aggregateForces.merge(childForces);
-						}
-					}
-				}
-				continue;
-			}
-			
-			// forces particular to each component
-			AerodynamicForces childForces = calculateForceAnalysis(configuration, conds, child, instances, eachForces,
-					assemblyForces, warnings);
-
-			if (null != childForces) {
-				aggregateForces.merge(childForces);
-			}
-		}
-
-		assemblyForces.put(comp, aggregateForces);
-
-		return assemblyForces.get(comp);
 	}
 
 	@Override
 	public AerodynamicForces getAerodynamicForces(FlightConfiguration configuration,
 			FlightConditions conditions, WarningSet warnings) {
 		checkCache(configuration);
-		
-		if (warnings == null)
-			warnings = ignoreWarningSet;
-		
-		// Calculate non-axial force data
-		AerodynamicForces total = calculateNonAxialForces(configuration, conditions, warnings);
-		
-		// Calculate friction data
-		total.setFrictionCD(calculateFrictionCD(configuration, conditions, null, warnings));
-		total.setPressureCD(calculatePressureCD(configuration, conditions, null, warnings));
-		total.setBaseCD(calculateBaseCD(configuration, conditions, null, warnings));
-		total.setOverrideCD(calculateOverrideCD(configuration, conditions, null, null, warnings));
-		
-		total.setCD(total.getFrictionCD() + total.getPressureCD() + total.getBaseCD() + total.getOverrideCD());
-		
-		total.setCDaxial(calculateAxialCD(conditions, total.getCD()));
-		
-		// Calculate pitch and yaw damping moments
-		calculateDampingMoments(configuration, conditions, total);
+
+		WarningSet actualWarnings = (warnings != null) ? warnings : ignoreWarningSet;
+
+		AerodynamicForces total = stabilityCalculator.calculateNonAxialForces(configuration, conditions, actualWarnings);
+
+		dragCalculator.calculateDrag(configuration, conditions, null, null, total, actualWarnings);
+
+		stabilityCalculator.calculateDampingMoments(configuration, conditions, total);
 		total.setCm(total.getCm() - total.getPitchDampingMoment());
 		total.setCyaw(total.getCyaw() - total.getYawDampingMoment());
 
-		// How far are we from stalling?
-		stallMargin = stallAngle - conditions.getAOA();
-		
 		return total;
-	}
-
-	private AerodynamicForces calculateComponentNonAxialForces(FlightConditions conditions,
-			RocketComponent comp,
-			RocketComponentCalc calcObj,
-			List<InstanceContext> contextList,
-			WarningSet warnings) {
-		// across every instance of this component:
-		final AerodynamicForces componentForces = new AerodynamicForces().zero();
-
-		// iterate across component instances
-		for (InstanceContext context : contextList) {
-			// specific to this _instance_ of this component:
-			AerodynamicForces instanceForces = new AerodynamicForces().zero();
-			calcObj.calculateNonaxialForces(conditions, context.transform, instanceForces, warnings);
-
-			Coordinate cp_inst = instanceForces.getCP();
-			Coordinate cp_abs = context.transform.transform(cp_inst);
-			cp_abs = cp_abs.setY(0.0).setZ(0.0);
-
-			instanceForces.setCP(cp_abs);
-			double CN_instanced = instanceForces.getCN();
-			instanceForces.setCm(CN_instanced * instanceForces.getCP().x / conditions.getRefLength());
-
-			componentForces.merge(instanceForces);
-		}
-		componentForces.setComponent(comp);
-
-		return componentForces;
-	}
-
-	/**
-	 * Perform the actual CP calculation.
-	 */
-	private AerodynamicForces calculateNonAxialForces(FlightConfiguration configuration, FlightConditions conditions,
-			WarningSet warnings) {
-
-		checkCache(configuration);
-
-		if (warnings == null)
-			warnings = ignoreWarningSet;
-
-		if (calcMap == null)
-			buildCalcMap(configuration);
-
-		checkGeometry(configuration, configuration.getRocket(), warnings);
-		
-		final InstanceMap imap = configuration.getActiveInstances();
-
-		// across the _entire_ assembly -- like a rocket, or a stage
-		final AerodynamicForces assemblyForces = new AerodynamicForces().zero();
-
-		for (Map.Entry<RocketComponent, ArrayList<InstanceContext>> mapEntry : imap.entrySet()) {
-			final RocketComponent comp = mapEntry.getKey();
-			final List<InstanceContext> contextList = mapEntry.getValue();
-
-			RocketComponentCalc calcObj = calcMap.get(comp);
-			if (null != calcObj) {
-				// calculated across all component instances
-				final AerodynamicForces componentForces = calculateComponentNonAxialForces(conditions, comp, calcObj,
-						contextList, warnings);
-
-				assemblyForces.merge(componentForces);
-			}
-		}
-
-		return assemblyForces;
 	}
 
 	@Override
-	public void checkGeometry(FlightConfiguration configuration, final RocketComponent treeRoot, WarningSet warnings) {
-		Queue<RocketComponent> queue = new LinkedList<>();
-
-		// Add the (active) child stages
-		addDirectChildStagesToQueue(configuration, queue, treeRoot);
-
-		SymmetricComponent prevComp = null;
-		if ((treeRoot instanceof ComponentAssembly) &&
-				(!(treeRoot instanceof Rocket)) &&
-				(treeRoot.getChildCount() > 0)) {
-			prevComp = ((SymmetricComponent) (treeRoot.getChild(0))).getPreviousSymmetricComponent();
-		}
-
-		while (null != queue.peek()) {
-			RocketComponent comp = queue.poll();
-			if ((comp instanceof SymmetricComponent) ||
-					((comp instanceof AxialStage) &&
-							!(comp instanceof ParallelStage))) {
-				// Add the (active) child stages
-				addDirectChildStagesToQueue(configuration, queue, comp);
-
-				if (comp instanceof SymmetricComponent) {
-					SymmetricComponent sym = (SymmetricComponent) comp;
-					if (null == prevComp) {
-						if (sym.getForeRadius() - sym.getThickness() > MathUtil.EPSILON) {
-							warnings.add(Warning.OPEN_AIRFRAME_FORWARD, sym);
-						}
-					} else {
-						// Check for radius discontinuity
-						// We're going to say it's discontinuous if it is presented to the user as
-						// having two different
-						// string representations. Hopefully there are enough digits in the string that
-						// it will
-						// present as different if the discontinuity is big enough to matter.
-						if (!UnitGroup.UNITS_LENGTH.getDefaultUnit().toStringUnit(2.0 * sym.getForeRadius())
-								.equals(UnitGroup.UNITS_LENGTH.getDefaultUnit()
-										.toStringUnit(2.0 * prevComp.getAftRadius()))) {
-							warnings.add(Warning.DIAMETER_DISCONTINUITY, prevComp, sym);
-						}
-
-						// Check for phantom tube
-						if ((sym.getLength() < MathUtil.EPSILON) ||
-							(sym.getAftRadius() < MathUtil.EPSILON && sym.getForeRadius() < MathUtil.EPSILON)) {
-							warnings.add(Warning.ZERO_VOLUME_BODY, sym);
-						}
-
-						// check for gap or overlap in airframe. We'll use a textual comparison to see
-						// if there is a
-						// gap or overlap, then use arithmetic comparison to see which it is. This won't
-						// be quite as reliable
-						// as the case for radius, since we never actually display the absolute X
-						// position
-
-						double symXfore = sym.toAbsolute(Coordinate.NUL)[0].x;
-						double prevXfore = prevComp.toAbsolute(Coordinate.NUL)[0].x;
-
-						double symXaft = sym.toAbsolute(new Coordinate(comp.getLength(), 0, 0, 0))[0].x;
-						double prevXaft = prevComp.toAbsolute(new Coordinate(prevComp.getLength(), 0, 0, 0))[0].x;
-
-						if (!UnitGroup.UNITS_LENGTH.getDefaultUnit().toStringUnit(symXfore)
-								.equals(UnitGroup.UNITS_LENGTH.getDefaultUnit().toStringUnit(prevXaft))) {
-							if (symXfore > prevXaft) {
-								warnings.add(Warning.AIRFRAME_GAP, prevComp, sym);
-							} else {
-								// If we only have the component with a single forward compartment bring up
-								// a body component overlap message
-								if ((symXfore >= prevXfore) &&
-										((symXaft >= prevXaft) || (null == sym.getNextSymmetricComponent()))) {
-									warnings.add(Warning.AIRFRAME_OVERLAP, prevComp, sym);
-								} else {
-									// We have a PodSet that is either overlapping or completely forward of its
-									// parent component.
-									// We'll find the forward-most and aft-most components and figure out which
-									SymmetricComponent firstComp = prevComp;
-									SymmetricComponent scout = prevComp;
-									while (null != scout) {
-										firstComp = scout;
-										scout = scout.getPreviousSymmetricComponent();
-									}
-									double firstCompXfore = firstComp.toAbsolute(Coordinate.NUL)[0].x;
-									
-									SymmetricComponent lastComp = sym;
-									scout = sym;
-									while (null != scout) {
-										lastComp = scout;
-										scout = scout.getNextSymmetricComponent();
-									}
-									double lastCompXaft = lastComp
-											.toAbsolute(new Coordinate(lastComp.getLength(), 0, 0, 0))[0].x;
-
-									// completely forward vs. overlap
-									if (lastCompXaft <= firstCompXfore) {
-										warnings.add(Warning.PODSET_FORWARD, comp.getParent());
-									} else {
-										warnings.add(Warning.PODSET_OVERLAP, comp.getParent());
-									}
-								}
-								
-							}
-						} else {
-							/*
-							 * It could be that the component is a child of a PodSet or ParallelStage, and
-							 * it is flush with
-							 * the previous component. In this case, the component is overlapping.
-							 */
-							RocketComponent prevCompParent = prevComp.getParent();
-							RocketComponent compParent = comp.getParent();
-							int prevCompPos = prevCompParent.getChildPosition(prevComp);
-							RocketComponent nextComp = prevCompPos + 1 >= prevCompParent.getChildCount() ? null
-									: prevCompParent.getChild(prevCompPos + 1);
-							if ((compParent instanceof PodSet || compParent instanceof ParallelStage) &&
-									MathUtil.equals(symXfore, prevXaft) && (compParent.getParent() == nextComp)) {
-								warnings.add(Warning.PODSET_OVERLAP, comp.getParent());
-							}
-						}
-					}
-					prevComp = sym;
-				}
-			} else if ((comp instanceof PodSet) ||
-					(comp instanceof ParallelStage)) {
-				checkGeometry(configuration, comp, warnings);
-			}
-		}
+	public void checkGeometry(FlightConfiguration configuration, RocketComponent component, WarningSet warnings) {
+		stabilityCalculator.checkGeometry(configuration, component, warnings);
 	}
 
-	/**
-	 * Add child stages to the queue. Only active stages are added. If a child stages is inactive, but it does have
-	 * active child stages, these are added to the queue.
-	 * @param configuration Rocket configuration
-	 * @param queue Queue to add stages to
-	 * @param comp Component to add stages from
-	 */
-	private void addDirectChildStagesToQueue(FlightConfiguration configuration, Queue<RocketComponent> queue, RocketComponent comp) {
-		for (RocketComponent child : comp.getChildren()) {
-			// Ignore inactive stages
-			if (child instanceof AxialStage && !configuration.isStageActive(child.getStageNumber())) {
-				// Check if there are child stages that are active and need to be calculated
-				for (AxialStage childStage : child.getTopLevelChildStages()) {
-					if (configuration.isStageActive(childStage.getStageNumber())) {
-						queue.add(childStage);
-					}
-				}
-				continue;
-			}
-			queue.add(child);
-		}
-	}
-
-	//////////////// DRAG CALCULATIONS ////////////////
-	/**
-	 * Calculation of drag coefficient due to air friction
-	 * 
-	 * @param configuration Rocket configuration
-	 * @param conditions    Flight conditions taken into account
-	 * @param map           ?
-	 * @param warningSet    Set to handle warnings
-	 * @return friction drag for entire rocket
-	 */
-	private double calculateFrictionCD(FlightConfiguration configuration, FlightConditions conditions,
-			Map<RocketComponent, AerodynamicForces> forceMap, WarningSet warningSet) {
-		
-		double mach = conditions.getMach();
-		double Re = calculateReynoldsNumber(configuration, conditions);
-		double Cf = calculateFrictionCoefficient(configuration, mach, Re);
-		double roughnessCorrection = calculateRoughnessCorrection(mach);
-		
-		if (calcMap == null)
-			buildCalcMap(configuration);
-		
-		/*
-		 * Calculate the friction drag coefficient.
-		 * 
-		 * The body wetted area is summed up and finally corrected with the rocket
-		 * fineness ratio (calculated in the same iteration).  The fins are corrected
-		 * for thickness as we go on.
-		 */
-		
-		double otherFrictionCD = 0;
-		double bodyFrictionCD = 0;
-		double maxR = 0, minX = Double.MAX_VALUE, maxX = 0;
-		
-		double[] roughnessLimited = new double[Finish.values().length];
-		Arrays.fill(roughnessLimited, Double.NaN);
-
-		final InstanceMap imap = configuration.getActiveInstances();
-		for (Map.Entry<RocketComponent, ArrayList<InstanceContext>> entry : imap.entrySet()) {
-			final RocketComponent c = entry.getKey();
-
-			if (!c.isAerodynamic()) {
-				continue;
-			}
-			
-			if (c.isCDOverridden() ||
-					c.isCDOverriddenByAncestor()) {
-				continue;
-			}
-
-			// Calculate the roughness-limited friction coefficient
-			Finish finish = ((ExternalComponent) c).getFinish();
-			if (Double.isNaN(roughnessLimited[finish.ordinal()])) {
-				roughnessLimited[finish.ordinal()] = 0.032
-						* Math.pow(finish.getRoughnessSize() / configuration.getLengthAerodynamic(), 0.2) *
-						roughnessCorrection;
-			}
-			
-			/*
-			 * Actual Cf is maximum of Cf and the roughness-limited value.
-			 * For perfect finish require additionally that Re > 1e6
-			 */
-			double componentCf;
-			if (configuration.getRocket().isPerfectFinish()) {
-				
-				// For perfect finish require Re > 1e6
-				if ((Re > 1.0e6) && (roughnessLimited[finish.ordinal()] > Cf)) {
-					componentCf = roughnessLimited[finish.ordinal()];
-				} else {
-					componentCf = Cf;
-				}
-				
-			} else {
-				
-				// For fully turbulent use simple max
-				componentCf = Math.max(Cf, roughnessLimited[finish.ordinal()]);
-				
-			}
-
-			double componentFrictionCD = calcMap.get(c).calculateFrictionCD(conditions, componentCf, warningSet);
-			int instanceCount = entry.getValue().size();
-			
-			if (c instanceof SymmetricComponent) {
-				SymmetricComponent s = (SymmetricComponent) c;
-
-				bodyFrictionCD += instanceCount * componentFrictionCD;
-				
-				final double componentMinX = c.getAxialOffset(AxialMethod.ABSOLUTE);
-				minX = Math.min(minX, componentMinX);
-
-				final double componentMaxX = componentMinX + c.getLength();
-				maxX = Math.max(maxX, componentMaxX);
-
-				final double componentMaxR = Math.max(s.getForeRadius(), s.getAftRadius());
-				maxR = Math.max(maxR, componentMaxR);
-
-			} else {
-				otherFrictionCD += instanceCount * componentFrictionCD;
-			}
-
-			if (forceMap != null) {
-				if (forceMap.get(c) == null) {
-					System.out.println("No forces for " + c);
-				}
-				forceMap.get(c).setFrictionCD(componentFrictionCD);
-			}
-		}
-		
-		// fB may be POSITIVE_INFINITY, but that's ok for us
-		double fB = (maxX - minX + 0.0001) / maxR;
-		double correction = (1 + 1.0 / (2 * fB));
-		
-		// Correct body data in map
-		if (forceMap != null) {
-			for (Map.Entry<RocketComponent, AerodynamicForces> entry : forceMap.entrySet()) {
-				if (entry.getKey() instanceof SymmetricComponent) {
-					entry.getValue().setFrictionCD(entry.getValue().getFrictionCD() * correction);
-				}
-			}
-		}
-
-		return otherFrictionCD + correction * bodyFrictionCD;
-	}
-
-
-	/**
-	 * Calculation of Reynolds Number
-	 * 
-	 * @param configuration Rocket configuration
-	 * @param conditions    Flight conditions taken into account
-	 * @return Reynolds Number
-	 */
-	private double calculateReynoldsNumber(FlightConfiguration configuration, FlightConditions conditions) {
-		return conditions.getVelocity() * configuration.getLengthAerodynamic() /
-				conditions.getAtmosphericConditions().getKinematicViscosity();
-	}
-	
-	/**
-	 * Calculation of skin friction coefficient
-	 *
-	 *
-	 * return skin friction coefficient
-	 */
-	private double calculateFrictionCoefficient(FlightConfiguration configuration, double mach, double Re) {
-		double Cf;
-		double c1 = 1.0, c2 = 1.0;
-		
-		// Calculate the skin friction coefficient (assume non-roughness limited)
-		if (configuration.getRocket().isPerfectFinish()) {
-
-			// Assume partial laminar layer. Roughness-limitation is checked later.
-			if (Re < 1.0e4) {
-				// Too low, constant
-				Cf = 1.33e-2;
-			} else if (Re < 5.39e5) {
-				// Fully laminar
-				Cf = 1.328 / MathUtil.safeSqrt(Re);
-			} else {
-				// Transitional
-				Cf = 1.0 / pow2(1.50 * Math.log(Re) - 5.6) - 1700 / Re;
-			}
-			
-			// Compressibility correction
-			
-			if (mach < 1.1) {
-				// Below Re=1e6 no correction
-				if (Re > 1.0e6) {
-					if (Re < 3.0e6) {
-						c1 = 1 - 0.1 * pow2(mach) * (Re - 1.0e6) / 2.0e6; // transition to turbulent
-					} else {
-						c1 = 1 - 0.1 * pow2(mach);
-					}
-				}
-			}
-			if (mach > 0.9) {
-				if (Re > 1.0e6) {
-					if (Re < 3.0e6) {
-						c2 = 1 + (1.0 / Math.pow(1 + 0.045 * pow2(mach), 0.25) - 1) * (Re - 1.0e6) / 2.0e6;
-					} else {
-						c2 = 1.0 / Math.pow(1 + 0.045 * pow2(mach), 0.25);
-					}
-				}
-			}
-			
-			// Applying continuously around Mach 1
-			if (mach < 0.9) {
-				Cf *= c1;
-			} else if (mach < 1.1) {
-				Cf *= (c2 * (mach - 0.9) / 0.2 + c1 * (1.1 - mach) / 0.2);
-			} else {
-				Cf *= c2;
-			}
-			
-			
-		} else {
-
-			// Assume fully turbulent. Roughness-limitation is checked later.
-			if (Re < 1.0e4) {
-				// Too low, constant
-				Cf = 1.48e-2;
-			} else {
-				// Turbulent
-				Cf = 1.0 / pow2(1.50 * Math.log(Re) - 5.6);
-			}
-			
-			// Compressibility correction
-			
-			if (mach < 1.1) {
-				c1 = 1 - 0.1 * pow2(mach);
-			}
-			if (mach > 0.9) {
-				c2 = 1 / Math.pow(1 + 0.15 * pow2(mach), 0.58);
-			}
-			// Applying continuously around Mach 1
-			if (mach < 0.9) {
-				Cf *= c1;
-			} else if (mach < 1.1) {
-				Cf *= c2 * (mach - 0.9) / 0.2 + c1 * (1.1 - mach) / 0.2;
-			} else {
-				Cf *= c2;
-			}
-			
-		}
-
-		return Cf;
-	}
-
-	/**
-	 * Calculation of correction for roughness
-	 *
-	 * @param mach
-	 * @return roughness correction
-	 **/
-
-	private double calculateRoughnessCorrection(double mach) {
-		double c1, c2;
-		
-		// Roughness-limited value correction term
-		double roughnessCorrection;
-		if (mach < 0.9) {
-			roughnessCorrection = 1 - 0.1 * pow2(mach);
-		} else if (mach > 1.1) {
-			roughnessCorrection = 1 / (1 + 0.18 * pow2(mach));
-		} else {
-			c1 = 1 - 0.1 * pow2(0.9);
-			c2 = 1.0 / (1 + 0.18 * pow2(1.1));
-			roughnessCorrection = c2 * (mach - 0.9) / 0.2 + c1 * (1.1 - mach) / 0.2;
-		}
-
-		return roughnessCorrection;
-	}
-	
-	/**
-	 * Calculation of drag coefficient due to pressure
-	 * 
-	 * @param configuration Rocket configuration
-	 * @param conditions    Flight conditions taken into account
-	 * @param forceMap
-	 * @param warningSet    all current warnings
-	 * @return
-	 */
-	private double calculatePressureCD(FlightConfiguration configuration, FlightConditions conditions,
-			Map<RocketComponent, AerodynamicForces> forceMap, WarningSet warningSet) {
-
-		double total, stagnation, base;
-		if (calcMap == null)
-			buildCalcMap(configuration);
-		
-		stagnation = calculateStagnationCD(conditions.getMach());
-		base = calculateBaseCD(conditions.getMach());
-
-		total = 0;
-		final InstanceMap imap = configuration.getActiveInstances();
-		for (Map.Entry<RocketComponent, ArrayList<InstanceContext>> entry : imap.entrySet()) {
-			final RocketComponent c = entry.getKey();
-
-			if (!c.isAerodynamic()) {
-				continue;
-			}
-				
-			if (c.isCDOverridden() ||
-				c.isCDOverriddenByAncestor()) {
-				continue;
-			}
-			
-			int instanceCount = entry.getValue().size();
-
-			// Pressure drag of this component
-			double cd = calcMap.get(c).calculatePressureCD(conditions, stagnation, base,
-					warningSet);
-
-			if (forceMap != null) {
-				forceMap.get(c).setPressureCD(cd);
-			}
-				
-			total += cd * instanceCount;
-			
-			// Stagnation drag caused by difference in radius between this component
-			// and previous component (increasing radii. Decreasing radii handled in
-			// base drag calculation
-			if (c instanceof SymmetricComponent) {
-				SymmetricComponent s = (SymmetricComponent) c;
-				double foreRadius = s.getForeRadius();
-				double aftRadius = s.getAftRadius();
-				// If length is zero, the component is a disk, i.e. a zero-length tube, so match
-				// the fore and aft diameter
-				if (s.getLength() == 0) {
-					foreRadius = Math.max(foreRadius, aftRadius);
-				}
-				double radius = 0;
-				final SymmetricComponent prevComponent = s.getPreviousSymmetricComponent();
-				if (prevComponent != null && configuration.isComponentActive(prevComponent))
-					radius = prevComponent.getAftRadius();
-					
-				if (radius < foreRadius) {
-					double area = Math.PI * (pow2(foreRadius) - pow2(radius));
-					cd = stagnation * area / conditions.getRefArea();
-					total += instanceCount * cd;
-						
-					if (forceMap != null) {
-						forceMap.get(c).setPressureCD(forceMap.get(c).getPressureCD() + cd);
-					}
-				}
-			}
-		}
-
-		return total;
-	}
-	
-
-	/**
-	 * Calculation of drag coefficient due to base
-	 * 
-	 * @param configuration Rocket configuration
-	 * @param conditions    Flight conditions taken into account
-	 * @param map           ?
-	 * @param warnings      all current warnings
-	 * @return
-	 */
-	private double calculateBaseCD(FlightConfiguration configuration, FlightConditions conditions,
-			Map<RocketComponent, AerodynamicForces> forceMap, WarningSet warnings) {
-
-		double base, total;
-		
-		if (calcMap == null)
-			buildCalcMap(configuration);
-		
-		base = calculateBaseCD(conditions.getMach());
-		total = 0;
-		
-		final InstanceMap imap = configuration.getActiveInstances();
-		for (Map.Entry<RocketComponent, ArrayList<InstanceContext>> entry : imap.entrySet()) {
-			final RocketComponent c = entry.getKey();
-
-			if (!(c instanceof SymmetricComponent)) {
-				continue;
-			}
-
-			
-			if (c.isCDOverridden() ||
-					c.isCDOverriddenByAncestor()) {
-				continue;
-			}
-			
-			SymmetricComponent s = (SymmetricComponent) c;
-			double foreRadius = s.getForeRadius();
-			double aftRadius = s.getAftRadius();
-			// If length is zero, the component is a disk, i.e. a zero-length tube, so match
-			// the fore and aft diameter
-			if (s.getLength() == 0) {
-				final double componentMaxR = Math.max(foreRadius, aftRadius);
-				foreRadius = aftRadius = componentMaxR;
-			}
-
-			int instanceCount = entry.getValue().size();
-
-			// get forward radius of next component
-			final SymmetricComponent nextComponent = s.getNextSymmetricComponent();
-			double nextRadius;
-			if ((nextComponent != null) && configuration.isComponentActive(nextComponent)) {
-				nextRadius = nextComponent.getForeRadius();
-			} else {
-				nextRadius = 0.0;
-			}
-
-			// if fore radius of next component is less than my aft radius, set my
-			// base CD
-			if (nextRadius < aftRadius) {
-				double area = Math.PI * (pow2(aftRadius) - pow2(nextRadius));
-				double cd = base * area / conditions.getRefArea();
-				total += instanceCount * cd;
-				if (forceMap != null) {
-					forceMap.get(s).setBaseCD(cd);
-				}
-			}
-		}
-		
-		return total;
-	}
-	
-	/**
-	 * gets CD by the speed
-	 *
-	 * @param m Mach number for calculation
-	 * @return Stagnation CD
-	 */
-	public static double calculateStagnationCD(double m) {
-		double pressure;
-		if (m <= 1) {
-			pressure = 1 + pow2(m) / 4 + pow2(pow2(m)) / 40;
-		} else {
-			pressure = 1.84 - 0.76 / pow2(m) + 0.166 / pow2(pow2(m)) + 0.035 / pow2(m * m * m);
-		}
-		return 0.85 * pressure;
-	}
-	
-	
-	/**
-	 * Calculates base CD
-	 *
-	 * @param m Mach number for calculation
-	 * @return Base CD
-	 */
-	public static double calculateBaseCD(double m) {
-		if (m <= 1) {
-			return 0.12 + 0.13 * m * m;
-		} else {
-			return 0.25 / m;
-		}
-	}
-	
-	
-	
-	private static final double[] axialDragPoly1, axialDragPoly2;
-	static {
-		PolyInterpolator interpolator;
-		interpolator = new PolyInterpolator(
-				new double[] { 0, 17 * Math.PI / 180 },
-				new double[] { 0, 17 * Math.PI / 180 });
-		axialDragPoly1 = interpolator.interpolator(1, 1.3, 0, 0);
-		
-		interpolator = new PolyInterpolator(
-				new double[] { 17 * Math.PI / 180, Math.PI / 2 },
-				new double[] { 17 * Math.PI / 180, Math.PI / 2 },
-				new double[] { Math.PI / 2 });
-		axialDragPoly2 = interpolator.interpolator(1.3, 0, 0, 0, 0);
-	}
-	
-	
-	/**
-	 * Calculate the axial drag coefficient from the total drag coefficient.
-	 * 
-	 * @param conditions
-	 * @param cd
-	 * @return
-	 */
-	private double calculateAxialCD(FlightConditions conditions, double cd) {
-		double aoa = MathUtil.clamp(conditions.getAOA(), 0, Math.PI);
-		double mul;
-
-		// double sinaoa = conditions.getSinAOA();
-		// return cd * (1 + Math.min(sinaoa, 0.25));
-
-		if (aoa > Math.PI / 2)
-			aoa = Math.PI - aoa;
-		if (aoa < 17 * Math.PI / 180)
-			mul = PolyInterpolator.eval(aoa, axialDragPoly1);
-		else
-			mul = PolyInterpolator.eval(aoa, axialDragPoly2);
-		
-		if (conditions.getAOA() < Math.PI / 2)
-			return mul * cd;
-		else
-			return -mul * cd;
-	}
-
-	/**
-	 * add together CD overrides for active components
-	 * 
-	 * @param configuration Rocket configuration
-	 * @param conditions    Flight conditions taken into account
-	 * @param forceMap
-	 * @param warningSet    all current warnings
-	 * @return
-	 */
-	private double calculateOverrideCD(FlightConfiguration configuration, FlightConditions conditions,
-			Map<RocketComponent, AerodynamicForces> eachMap,
-			Map<RocketComponent, AerodynamicForces> assemblyMap,
-			WarningSet warningSet) {
-
-		if (calcMap == null)
-			buildCalcMap(configuration);
-
-		double total = 0;
-		final InstanceMap imap = configuration.getActiveInstances();
-		for (Map.Entry<RocketComponent, ArrayList<InstanceContext>> entry : imap.entrySet()) {
-			final RocketComponent c = entry.getKey();
-			int instanceCount = entry.getValue().size();
-
-			if (!c.isAerodynamic() &&
-					!(c instanceof ComponentAssembly)) {
-				continue;
-			}
-
-			if (c.isCDOverridden() &&
-					!c.isCDOverriddenByAncestor()) {
-				double cd = instanceCount * c.getOverrideCD();
-				Map<RocketComponent, AerodynamicForces> forceMap = (c instanceof ComponentAssembly) ? assemblyMap
-						: eachMap;
-				if (forceMap != null) {
-					forceMap.get(c).setOverrideCD(cd);
-				}
-				total += cd;
-			}
-		}
-
-		return total;
-	}
-	
-    /**
-	 * get damping moments from a rocket in a flight
-	 *
-	 * @param configuration Rocket configuration
-	 * @param conditions    flight conditions in consideration
-	 * @param total         acting aerodynamic forces
-	 */
-	private void calculateDampingMoments(FlightConfiguration configuration, FlightConditions conditions,
-			AerodynamicForces total) {
-		
-		// Calculate pitch and yaw damping moments
-		double mul = getDampingMultiplier(configuration, conditions,
-				conditions.getPitchCenter().x);
-		double pitchRate = conditions.getPitchRate();
-		double yawRate = conditions.getYawRate();
-		double velocity = conditions.getVelocity();
-		
-		mul *= 3; // TODO: Higher damping yields much more realistic apogee turn
-		
-		// find magnitude of damping moments, and clamp so they can't
-		// exceed magnitude of pitch and yaw moments
-		double pitchDampingMomentMagnitude = MathUtil.min(mul * pow2(pitchRate / velocity), total.getCm());
-		double yawDampingMomentMagnitude = MathUtil.min(mul * pow2(yawRate / velocity), total.getCyaw());
-
-		// multiply by sign of pitch and yaw rates
-		total.setPitchDampingMoment(MathUtil.sign(pitchRate) * pitchDampingMomentMagnitude);
-		total.setYawDampingMoment(MathUtil.sign(yawRate) * yawDampingMomentMagnitude);
-	}
-
-	private double getDampingMultiplier(FlightConfiguration configuration, FlightConditions conditions,
-			double cgx) {
-		if (cacheDiameter < 0) {
-			double area = 0;
-			cacheLength = 0;
-			cacheDiameter = 0;
-			
-			for (RocketComponent c : configuration.getActiveComponents()) {
-				if (c instanceof SymmetricComponent) {
-					SymmetricComponent s = (SymmetricComponent) c;
-					area += s.getComponentPlanformArea();
-					cacheLength += s.getLength();
-				}
-			}
-			if (cacheLength > 0)
-				cacheDiameter = area / cacheLength;
-		}
-		
-		double mul;
-		
-		// Body
-		mul = 0.275 * cacheDiameter / (conditions.getRefArea() * conditions.getRefLength());
-		mul *= (MathUtil.pow4(cgx) + MathUtil.pow4(cacheLength - cgx));
-		
-		// Fins
-		// TODO: LOW: This could be optimized a lot...
-		for (RocketComponent c : configuration.getActiveComponents()) {
-			if (c instanceof FinSet) {
-				FinSet f = (FinSet) c;
-				mul += 0.6 * Math.min(f.getFinCount(), 4) * f.getPlanformArea() *
-						MathUtil.pow3(Math.abs(f.toAbsolute(new Coordinate(
-								((FinSetCalc) calcMap.get(f)).getMidchordPos()))[0].x
-								- cgx)) /
-						(conditions.getRefArea() * conditions.getRefLength());
-			}
-		}
-		
-		return mul;
-	}
-	
-	
-	
-	////////  The calculator map
-	
 	@Override
 	protected void voidAerodynamicCache() {
 		super.voidAerodynamicCache();
-		
-		calcMap = null;
-		cacheDiameter = -1;
-		cacheLength = -1;
+		stabilityCalculator.voidAerodynamicCache();
+		dragCalculator.voidAerodynamicCache();
 	}
-	
-	
-	private void buildCalcMap(FlightConfiguration configuration) {
-		calcMap = new HashMap<>();
 
-		for (RocketComponent comp : configuration.getAllComponents()) {
-			if (!comp.isAerodynamic() && !(comp instanceof ComponentAssembly)) {
-				continue;
-			}
-
-			RocketComponentCalc calcObj = (RocketComponentCalc) Reflection.construct(BARROWMAN_PACKAGE, comp,
-					BARROWMAN_SUFFIX, comp);
-
-			calcMap.put(comp, calcObj);
-		}
-	}
-	
 	@Override
 	public ModID getModID() {
-		// Only cached data is stored, return constant mod ID
 		return ModID.ZERO;
 	}
-	
+
+	public static double calculateStagnationCD(double m) {
+		return BarrowmanDragCalculator.calculateStagnationCD(m);
+	}
+
+	public static double calculateBaseCD(double m) {
+		return BarrowmanDragCalculator.calculateBaseCD(m);
+	}
 }

--- a/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanDragCalculator.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanDragCalculator.java
@@ -1,0 +1,462 @@
+package info.openrocket.core.aerodynamics;
+
+import static info.openrocket.core.util.MathUtil.pow2;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import info.openrocket.core.aerodynamics.barrowman.RocketComponentCalc;
+import info.openrocket.core.logging.WarningSet;
+import info.openrocket.core.rocketcomponent.ComponentAssembly;
+import info.openrocket.core.rocketcomponent.ExternalComponent;
+import info.openrocket.core.rocketcomponent.ExternalComponent.Finish;
+import info.openrocket.core.rocketcomponent.FlightConfiguration;
+import info.openrocket.core.rocketcomponent.InstanceContext;
+import info.openrocket.core.rocketcomponent.InstanceMap;
+import info.openrocket.core.rocketcomponent.RocketComponent;
+import info.openrocket.core.rocketcomponent.SymmetricComponent;
+import info.openrocket.core.rocketcomponent.position.AxialMethod;
+import info.openrocket.core.util.MathUtil;
+import info.openrocket.core.util.PolyInterpolator;
+import info.openrocket.core.util.Reflection;
+
+/**
+ * Drag portion of the extended Barrowman aerodynamic calculator.
+ */
+public class BarrowmanDragCalculator implements DragCalculator {
+
+	private static final String BARROWMAN_PACKAGE = "info.openrocket.core.aerodynamics.barrowman";
+	private static final String BARROWMAN_SUFFIX = "Calc";
+
+	private final WarningSet ignoreWarningSet = new WarningSet();
+
+	private Map<RocketComponent, RocketComponentCalc> calcMap = null;
+
+	private static final double[] axialDragPoly1;
+	private static final double[] axialDragPoly2;
+
+	static {
+		PolyInterpolator interpolator;
+		interpolator = new PolyInterpolator(
+				new double[] { 0, 17 * Math.PI / 180 },
+				new double[] { 0, 17 * Math.PI / 180 });
+		axialDragPoly1 = interpolator.interpolator(1, 1.3, 0, 0);
+
+		interpolator = new PolyInterpolator(
+				new double[] { 17 * Math.PI / 180, Math.PI / 2 },
+				new double[] { 17 * Math.PI / 180, Math.PI / 2 },
+				new double[] { Math.PI / 2 });
+		axialDragPoly2 = interpolator.interpolator(1.3, 0, 0, 0, 0);
+	}
+
+	@Override
+	public DragCalculator newInstance() {
+		return new BarrowmanDragCalculator();
+	}
+
+	@Override
+	public void calculateDrag(FlightConfiguration configuration,
+			FlightConditions conditions,
+			Map<RocketComponent, AerodynamicForces> componentForces,
+			Map<RocketComponent, AerodynamicForces> assemblyForces,
+			AerodynamicForces totalForces,
+			WarningSet warnings) {
+		ensureCalcMap(configuration);
+		WarningSet actualWarnings = (warnings != null) ? warnings : ignoreWarningSet;
+
+		double frictionCD = calculateFrictionCD(configuration, conditions, componentForces, actualWarnings);
+		double pressureCD = calculatePressureCD(configuration, conditions, componentForces, actualWarnings);
+		double baseCD = calculateBaseCD(configuration, conditions, componentForces, actualWarnings);
+		double overrideCD = calculateOverrideCD(configuration, componentForces, assemblyForces);
+
+		totalForces.setFrictionCD(frictionCD);
+		totalForces.setPressureCD(pressureCD);
+		totalForces.setBaseCD(baseCD);
+		totalForces.setOverrideCD(overrideCD);
+		totalForces.setCD(frictionCD + pressureCD + baseCD + overrideCD);
+		totalForces.setCDaxial(calculateAxialCD(conditions, totalForces.getCD()));
+	}
+
+	@Override
+	public double toAxialDrag(FlightConditions conditions, double cd) {
+		return calculateAxialCD(conditions, cd);
+	}
+
+	@Override
+	public void voidAerodynamicCache() {
+		calcMap = null;
+	}
+
+	private double calculateFrictionCD(FlightConfiguration configuration, FlightConditions conditions,
+			Map<RocketComponent, AerodynamicForces> forceMap, WarningSet warningSet) {
+		double mach = conditions.getMach();
+		double Re = calculateReynoldsNumber(configuration, conditions);
+		double Cf = calculateFrictionCoefficient(configuration, mach, Re);
+		double roughnessCorrection = calculateRoughnessCorrection(mach);
+
+		ensureCalcMap(configuration);
+
+		double otherFrictionCD = 0;
+		double bodyFrictionCD = 0;
+		double maxR = 0;
+		double minX = Double.MAX_VALUE;
+		double maxX = 0;
+
+		double[] roughnessLimited = new double[Finish.values().length];
+		Arrays.fill(roughnessLimited, Double.NaN);
+
+		InstanceMap imap = configuration.getActiveInstances();
+		for (Map.Entry<RocketComponent, ArrayList<InstanceContext>> entry : imap.entrySet()) {
+			RocketComponent c = entry.getKey();
+
+			if (!c.isAerodynamic()) {
+				continue;
+			}
+
+			if (c.isCDOverridden() || c.isCDOverriddenByAncestor()) {
+				continue;
+			}
+
+			Finish finish = ((ExternalComponent) c).getFinish();
+			if (Double.isNaN(roughnessLimited[finish.ordinal()])) {
+				roughnessLimited[finish.ordinal()] = 0.032
+						* Math.pow(finish.getRoughnessSize() / configuration.getLengthAerodynamic(), 0.2)
+						* roughnessCorrection;
+			}
+
+			double componentCf;
+			if (configuration.getRocket().isPerfectFinish()) {
+				if ((Re > 1.0e6) && (roughnessLimited[finish.ordinal()] > Cf)) {
+					componentCf = roughnessLimited[finish.ordinal()];
+				} else {
+					componentCf = Cf;
+				}
+			} else {
+				componentCf = Math.max(Cf, roughnessLimited[finish.ordinal()]);
+			}
+
+			double componentFrictionCD = calcMap.get(c).calculateFrictionCD(conditions, componentCf, warningSet);
+			int instanceCount = entry.getValue().size();
+
+			if (c instanceof SymmetricComponent) {
+				SymmetricComponent s = (SymmetricComponent) c;
+
+				bodyFrictionCD += instanceCount * componentFrictionCD;
+
+				double componentMinX = c.getAxialOffset(AxialMethod.ABSOLUTE);
+				minX = Math.min(minX, componentMinX);
+
+				double componentMaxX = componentMinX + c.getLength();
+				maxX = Math.max(maxX, componentMaxX);
+
+				double componentMaxR = Math.max(s.getForeRadius(), s.getAftRadius());
+				maxR = Math.max(maxR, componentMaxR);
+
+			} else {
+				otherFrictionCD += instanceCount * componentFrictionCD;
+			}
+
+			if (forceMap != null && forceMap.get(c) != null) {
+				forceMap.get(c).setFrictionCD(componentFrictionCD);
+			}
+		}
+
+		double fB = (maxX - minX + 0.0001) / maxR;
+		double correction = (1 + 1.0 / (2 * fB));
+
+		if (forceMap != null) {
+			for (Map.Entry<RocketComponent, AerodynamicForces> entry : forceMap.entrySet()) {
+				if (entry.getKey() instanceof SymmetricComponent) {
+					entry.getValue().setFrictionCD(entry.getValue().getFrictionCD() * correction);
+				}
+			}
+		}
+
+		return otherFrictionCD + correction * bodyFrictionCD;
+	}
+
+	private double calculateReynoldsNumber(FlightConfiguration configuration, FlightConditions conditions) {
+		return conditions.getVelocity() * configuration.getLengthAerodynamic() /
+				conditions.getAtmosphericConditions().getKinematicViscosity();
+	}
+
+	private double calculateFrictionCoefficient(FlightConfiguration configuration, double mach, double Re) {
+		double Cf;
+		double c1 = 1.0;
+		double c2 = 1.0;
+
+		if (configuration.getRocket().isPerfectFinish()) {
+			if (Re < 1.0e4) {
+				Cf = 1.33e-2;
+			} else if (Re < 5.39e5) {
+				Cf = 1.328 / MathUtil.safeSqrt(Re);
+			} else {
+				Cf = 1.0 / pow2(1.50 * Math.log(Re) - 5.6) - 1700 / Re;
+			}
+
+			if (mach < 1.1) {
+				if (Re > 1.0e6) {
+					if (Re < 3.0e6) {
+						c1 = 1 - 0.1 * pow2(mach) * (Re - 1.0e6) / 2.0e6;
+					} else {
+						c1 = 1 - 0.1 * pow2(mach);
+					}
+				}
+			}
+			if (mach > 0.9) {
+				if (Re > 1.0e6) {
+					if (Re < 3.0e6) {
+						c2 = 1 + (1.0 / Math.pow(1 + 0.045 * pow2(mach), 0.25) - 1) * (Re - 1.0e6) / 2.0e6;
+					} else {
+						c2 = 1.0 / Math.pow(1 + 0.045 * pow2(mach), 0.25);
+					}
+				}
+			}
+
+			if (mach < 0.9) {
+				Cf *= c1;
+			} else if (mach < 1.1) {
+				Cf *= (c2 * (mach - 0.9) / 0.2 + c1 * (1.1 - mach) / 0.2);
+			} else {
+				Cf *= c2;
+			}
+
+		} else {
+			if (Re < 1.0e4) {
+				Cf = 1.48e-2;
+			} else {
+				Cf = 1.0 / pow2(1.50 * Math.log(Re) - 5.6);
+			}
+
+			if (mach < 1.1) {
+				c1 = 1 - 0.1 * pow2(mach);
+			}
+			if (mach > 0.9) {
+				c2 = 1 / Math.pow(1 + 0.15 * pow2(mach), 0.58);
+			}
+			if (mach < 0.9) {
+				Cf *= c1;
+			} else if (mach < 1.1) {
+				Cf *= c2 * (mach - 0.9) / 0.2 + c1 * (1.1 - mach) / 0.2;
+			} else {
+				Cf *= c2;
+			}
+		}
+
+		return Cf;
+	}
+
+	private double calculateRoughnessCorrection(double mach) {
+		double roughnessCorrection;
+		if (mach < 0.9) {
+			roughnessCorrection = 1 - 0.1 * pow2(mach);
+		} else if (mach > 1.1) {
+			roughnessCorrection = 1 / (1 + 0.18 * pow2(mach));
+		} else {
+			double c1 = 1 - 0.1 * pow2(0.9);
+			double c2 = 1.0 / (1 + 0.18 * pow2(1.1));
+			roughnessCorrection = c2 * (mach - 0.9) / 0.2 + c1 * (1.1 - mach) / 0.2;
+		}
+		return roughnessCorrection;
+	}
+
+	private double calculatePressureCD(FlightConfiguration configuration, FlightConditions conditions,
+			Map<RocketComponent, AerodynamicForces> forceMap, WarningSet warningSet) {
+		ensureCalcMap(configuration);
+
+		double stagnation = calculateStagnationCD(conditions.getMach());
+		double base = calculateBaseCD(conditions.getMach());
+
+		double total = 0;
+		InstanceMap imap = configuration.getActiveInstances();
+		for (Map.Entry<RocketComponent, ArrayList<InstanceContext>> entry : imap.entrySet()) {
+			RocketComponent c = entry.getKey();
+
+			if (!c.isAerodynamic()) {
+				continue;
+			}
+
+			if (c.isCDOverridden() || c.isCDOverriddenByAncestor()) {
+				continue;
+			}
+
+			int instanceCount = entry.getValue().size();
+
+			double cd = calcMap.get(c).calculatePressureCD(conditions, stagnation, base, warningSet);
+
+			if (forceMap != null && forceMap.get(c) != null) {
+				forceMap.get(c).setPressureCD(cd);
+			}
+
+			total += cd * instanceCount;
+
+			if (c instanceof SymmetricComponent) {
+				SymmetricComponent s = (SymmetricComponent) c;
+				double foreRadius = s.getForeRadius();
+				double aftRadius = s.getAftRadius();
+				if (s.getLength() == 0) {
+					foreRadius = Math.max(foreRadius, aftRadius);
+				}
+				double radius = 0;
+				SymmetricComponent prevComponent = s.getPreviousSymmetricComponent();
+				if (prevComponent != null && configuration.isComponentActive(prevComponent)) {
+					radius = prevComponent.getAftRadius();
+				}
+
+				if (radius < foreRadius) {
+					double area = Math.PI * (pow2(foreRadius) - pow2(radius));
+					double diskCd = stagnation * area / conditions.getRefArea();
+					total += instanceCount * diskCd;
+
+					if (forceMap != null && forceMap.get(c) != null) {
+						forceMap.get(c).setPressureCD(forceMap.get(c).getPressureCD() + diskCd);
+					}
+				}
+			}
+		}
+
+		return total;
+	}
+
+	private double calculateBaseCD(FlightConfiguration configuration, FlightConditions conditions,
+			Map<RocketComponent, AerodynamicForces> forceMap, WarningSet warningSet) {
+		ensureCalcMap(configuration);
+
+		double base = calculateBaseCD(conditions.getMach());
+		double total = 0;
+
+		InstanceMap imap = configuration.getActiveInstances();
+		for (Map.Entry<RocketComponent, ArrayList<InstanceContext>> entry : imap.entrySet()) {
+			RocketComponent c = entry.getKey();
+
+			if (!(c instanceof SymmetricComponent)) {
+				continue;
+			}
+
+			if (c.isCDOverridden() || c.isCDOverriddenByAncestor()) {
+				continue;
+			}
+
+			SymmetricComponent s = (SymmetricComponent) c;
+			double foreRadius = s.getForeRadius();
+			double aftRadius = s.getAftRadius();
+			if (s.getLength() == 0) {
+				double componentMaxR = Math.max(foreRadius, aftRadius);
+				foreRadius = componentMaxR;
+				aftRadius = componentMaxR;
+			}
+
+			int instanceCount = entry.getValue().size();
+
+			SymmetricComponent nextComponent = s.getNextSymmetricComponent();
+			double nextRadius;
+			if ((nextComponent != null) && configuration.isComponentActive(nextComponent)) {
+				nextRadius = nextComponent.getForeRadius();
+			} else {
+				nextRadius = 0.0;
+			}
+
+			if (nextRadius < aftRadius) {
+				double area = Math.PI * (pow2(aftRadius) - pow2(nextRadius));
+				double cd = base * area / conditions.getRefArea();
+				total += instanceCount * cd;
+				if (forceMap != null && forceMap.get(s) != null) {
+					forceMap.get(s).setBaseCD(cd);
+				}
+			}
+		}
+
+		return total;
+	}
+
+	private double calculateOverrideCD(FlightConfiguration configuration,
+			Map<RocketComponent, AerodynamicForces> componentForces,
+			Map<RocketComponent, AerodynamicForces> assemblyForces) {
+		ensureCalcMap(configuration);
+
+		double total = 0;
+		InstanceMap imap = configuration.getActiveInstances();
+		for (Map.Entry<RocketComponent, ArrayList<InstanceContext>> entry : imap.entrySet()) {
+			RocketComponent c = entry.getKey();
+			int instanceCount = entry.getValue().size();
+
+			if (!c.isAerodynamic() && !(c instanceof ComponentAssembly)) {
+				continue;
+			}
+
+			if (c.isCDOverridden() && !c.isCDOverriddenByAncestor()) {
+				double cd = instanceCount * c.getOverrideCD();
+				Map<RocketComponent, AerodynamicForces> targetMap = (c instanceof ComponentAssembly) ? assemblyForces
+						: componentForces;
+				if (targetMap != null && targetMap.get(c) != null) {
+					targetMap.get(c).setOverrideCD(cd);
+				}
+				total += cd;
+			}
+		}
+
+		return total;
+	}
+
+	private double calculateAxialCD(FlightConditions conditions, double cd) {
+		double aoa = MathUtil.clamp(conditions.getAOA(), 0, Math.PI);
+		double mul;
+
+		if (aoa > Math.PI / 2) {
+			aoa = Math.PI - aoa;
+		}
+		if (aoa < 17 * Math.PI / 180) {
+			mul = PolyInterpolator.eval(aoa, axialDragPoly1);
+		} else {
+			mul = PolyInterpolator.eval(aoa, axialDragPoly2);
+		}
+
+		if (conditions.getAOA() < Math.PI / 2) {
+			return mul * cd;
+		}
+		return -mul * cd;
+	}
+
+	public static double calculateStagnationCD(double m) {
+		double pressure;
+		if (m <= 1) {
+			pressure = 1 + pow2(m) / 4 + pow2(pow2(m)) / 40;
+		} else {
+			pressure = 1.84 - 0.76 / pow2(m) + 0.166 / pow2(pow2(m)) + 0.035 / pow2(m * m * m);
+		}
+		return 0.85 * pressure;
+	}
+
+	public static double calculateBaseCD(double m) {
+		if (m <= 1) {
+			return 0.12 + 0.13 * m * m;
+		}
+		return 0.25 / m;
+	}
+
+	private void ensureCalcMap(FlightConfiguration configuration) {
+		if (calcMap == null) {
+			buildCalcMap(configuration);
+		}
+	}
+
+	private void buildCalcMap(FlightConfiguration configuration) {
+		calcMap = new HashMap<>();
+
+		for (RocketComponent comp : configuration.getAllComponents()) {
+			if (!comp.isAerodynamic() && !(comp instanceof ComponentAssembly)) {
+				continue;
+			}
+
+			RocketComponentCalc calcObj = (RocketComponentCalc) Reflection.construct(
+					BARROWMAN_PACKAGE,
+					comp,
+					BARROWMAN_SUFFIX,
+					comp);
+
+			calcMap.put(comp, calcObj);
+		}
+	}
+}

--- a/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanStabilityCalculator.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanStabilityCalculator.java
@@ -1,0 +1,384 @@
+package info.openrocket.core.aerodynamics;
+
+import static info.openrocket.core.util.MathUtil.pow2;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+
+import info.openrocket.core.aerodynamics.barrowman.FinSetCalc;
+import info.openrocket.core.aerodynamics.barrowman.RocketComponentCalc;
+import info.openrocket.core.logging.Warning;
+import info.openrocket.core.logging.WarningSet;
+import info.openrocket.core.rocketcomponent.AxialStage;
+import info.openrocket.core.rocketcomponent.ComponentAssembly;
+import info.openrocket.core.rocketcomponent.FinSet;
+import info.openrocket.core.rocketcomponent.FlightConfiguration;
+import info.openrocket.core.rocketcomponent.InstanceContext;
+import info.openrocket.core.rocketcomponent.InstanceMap;
+import info.openrocket.core.rocketcomponent.ParallelStage;
+import info.openrocket.core.rocketcomponent.PodSet;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.rocketcomponent.RocketComponent;
+import info.openrocket.core.rocketcomponent.SymmetricComponent;
+import info.openrocket.core.unit.UnitGroup;
+import info.openrocket.core.util.Coordinate;
+import info.openrocket.core.util.MathUtil;
+import info.openrocket.core.util.Reflection;
+
+/**
+ * Stability portion of the extended Barrowman aerodynamic calculator.
+ */
+public class BarrowmanStabilityCalculator implements StabilityCalculator {
+
+	private static final double STALL_ANGLE = 17.5 * Math.PI / 180;
+	private static final String BARROWMAN_PACKAGE = "info.openrocket.core.aerodynamics.barrowman";
+	private static final String BARROWMAN_SUFFIX = "Calc";
+
+	private final WarningSet ignoreWarningSet = new WarningSet();
+
+	private Map<RocketComponent, RocketComponentCalc> calcMap = null;
+	private double cacheDiameter = -1;
+	private double cacheLength = -1;
+	private double stallMargin;
+
+	@Override
+	public StabilityCalculator newInstance() {
+		return new BarrowmanStabilityCalculator();
+	}
+
+	@Override
+	public double getStallMargin() {
+		return stallMargin;
+	}
+
+	@Override
+	public Coordinate getCP(FlightConfiguration configuration, FlightConditions conditions, WarningSet warnings) {
+		return calculateNonAxialForces(configuration, conditions, warnings).getCP();
+	}
+
+	@Override
+	public AerodynamicForces calculateNonAxialForces(FlightConfiguration configuration,
+			FlightConditions conditions, WarningSet warnings) {
+		ensureCalcMap(configuration);
+
+		WarningSet actualWarnings = (warnings != null) ? warnings : ignoreWarningSet;
+		checkGeometry(configuration, configuration.getRocket(), actualWarnings);
+
+		InstanceMap imap = configuration.getActiveInstances();
+		AerodynamicForces assemblyForces = new AerodynamicForces().zero();
+
+		for (Map.Entry<RocketComponent, ArrayList<InstanceContext>> entry : imap.entrySet()) {
+			RocketComponent comp = entry.getKey();
+			List<InstanceContext> contextList = entry.getValue();
+
+			RocketComponentCalc calcObj = calcMap.get(comp);
+			if (calcObj == null) {
+				continue;
+			}
+
+			AerodynamicForces componentForces = calculateComponentNonAxialForces(conditions, comp, calcObj,
+					contextList, actualWarnings);
+			assemblyForces.merge(componentForces);
+		}
+
+		return assemblyForces;
+	}
+
+	@Override
+	public StabilityForceBreakdown getForceAnalysis(FlightConfiguration configuration,
+			FlightConditions conditions, WarningSet warnings) {
+		ensureCalcMap(configuration);
+
+		WarningSet actualWarnings = (warnings != null) ? warnings : ignoreWarningSet;
+		InstanceMap instances = configuration.getActiveInstances();
+
+		Map<RocketComponent, AerodynamicForces> eachMap = new LinkedHashMap<>();
+		Map<RocketComponent, AerodynamicForces> assemblyMap = new LinkedHashMap<>();
+
+		calculateForceAnalysis(configuration, conditions, configuration.getRocket(), instances, eachMap,
+				assemblyMap, actualWarnings);
+
+		return new StabilityForceBreakdown(eachMap, assemblyMap);
+	}
+
+	@Override
+	public void calculateDampingMoments(FlightConfiguration configuration, FlightConditions conditions,
+			AerodynamicForces total) {
+		ensureCalcMap(configuration);
+
+		double mul = getDampingMultiplier(configuration, conditions, conditions.getPitchCenter().x);
+		double pitchRate = conditions.getPitchRate();
+		double yawRate = conditions.getYawRate();
+		double velocity = conditions.getVelocity();
+
+		mul *= 3; // Higher damping yields much more realistic apogee turn
+
+		double pitchDampingMomentMagnitude = MathUtil.min(mul * pow2(pitchRate / velocity), total.getCm());
+		double yawDampingMomentMagnitude = MathUtil.min(mul * pow2(yawRate / velocity), total.getCyaw());
+
+		total.setPitchDampingMoment(MathUtil.sign(pitchRate) * pitchDampingMomentMagnitude);
+		total.setYawDampingMoment(MathUtil.sign(yawRate) * yawDampingMomentMagnitude);
+
+		stallMargin = STALL_ANGLE - conditions.getAOA();
+	}
+
+	@Override
+	public void checkGeometry(FlightConfiguration configuration, RocketComponent component, WarningSet warnings) {
+		WarningSet actualWarnings = (warnings != null) ? warnings : ignoreWarningSet;
+
+		Queue<RocketComponent> queue = new LinkedList<>();
+		addDirectChildStagesToQueue(configuration, queue, component);
+
+		SymmetricComponent prevComp = null;
+		if ((component instanceof ComponentAssembly) &&
+				(!(component instanceof Rocket)) &&
+				(component.getChildCount() > 0)) {
+			prevComp = ((SymmetricComponent) (component.getChild(0))).getPreviousSymmetricComponent();
+		}
+
+		while (queue.peek() != null) {
+			RocketComponent comp = queue.poll();
+			if ((comp instanceof SymmetricComponent) ||
+					((comp instanceof AxialStage) &&
+							!(comp instanceof ParallelStage))) {
+				addDirectChildStagesToQueue(configuration, queue, comp);
+
+				if (comp instanceof SymmetricComponent) {
+					SymmetricComponent sym = (SymmetricComponent) comp;
+					if (prevComp == null) {
+						if (sym.getForeRadius() - sym.getThickness() > MathUtil.EPSILON) {
+							actualWarnings.add(Warning.OPEN_AIRFRAME_FORWARD, sym);
+						}
+					} else {
+						if (!UnitGroup.UNITS_LENGTH.getDefaultUnit().toStringUnit(2.0 * sym.getForeRadius())
+								.equals(UnitGroup.UNITS_LENGTH.getDefaultUnit()
+										.toStringUnit(2.0 * prevComp.getAftRadius()))) {
+							actualWarnings.add(Warning.DIAMETER_DISCONTINUITY, prevComp, sym);
+						}
+
+						if ((sym.getLength() < MathUtil.EPSILON) ||
+							(sym.getAftRadius() < MathUtil.EPSILON && sym.getForeRadius() < MathUtil.EPSILON)) {
+							actualWarnings.add(Warning.ZERO_VOLUME_BODY, sym);
+						}
+
+						double symXfore = sym.toAbsolute(Coordinate.NUL)[0].x;
+						double prevXfore = prevComp.toAbsolute(Coordinate.NUL)[0].x;
+
+						double symXaft = sym.toAbsolute(new Coordinate(comp.getLength(), 0, 0, 0))[0].x;
+						double prevXaft = prevComp.toAbsolute(new Coordinate(prevComp.getLength(), 0, 0, 0))[0].x;
+
+						if (!UnitGroup.UNITS_LENGTH.getDefaultUnit().toStringUnit(symXfore)
+								.equals(UnitGroup.UNITS_LENGTH.getDefaultUnit().toStringUnit(prevXaft))) {
+							if (symXfore > prevXaft) {
+								actualWarnings.add(Warning.AIRFRAME_GAP, prevComp, sym);
+							} else {
+								if ((symXfore >= prevXfore) &&
+										((symXaft >= prevXaft) || (sym.getNextSymmetricComponent() == null))) {
+									actualWarnings.add(Warning.AIRFRAME_OVERLAP, prevComp, sym);
+								} else {
+									SymmetricComponent firstComp = prevComp;
+									SymmetricComponent scout = prevComp;
+									while (scout != null) {
+										firstComp = scout;
+										scout = scout.getPreviousSymmetricComponent();
+									}
+									double firstCompXfore = firstComp.toAbsolute(Coordinate.NUL)[0].x;
+
+									SymmetricComponent lastComp = sym;
+									scout = sym;
+									while (scout != null) {
+										lastComp = scout;
+										scout = scout.getNextSymmetricComponent();
+									}
+									double lastCompXaft = lastComp
+											.toAbsolute(new Coordinate(lastComp.getLength(), 0, 0, 0))[0].x;
+
+									if (lastCompXaft <= firstCompXfore) {
+										actualWarnings.add(Warning.PODSET_FORWARD, comp.getParent());
+									} else {
+										actualWarnings.add(Warning.PODSET_OVERLAP, comp.getParent());
+									}
+								}
+
+							}
+						} else {
+							RocketComponent prevCompParent = prevComp.getParent();
+							RocketComponent compParent = comp.getParent();
+							int prevCompPos = prevCompParent.getChildPosition(prevComp);
+							RocketComponent nextComp = prevCompPos + 1 >= prevCompParent.getChildCount() ? null
+									: prevCompParent.getChild(prevCompPos + 1);
+							if ((compParent instanceof PodSet || compParent instanceof ParallelStage) &&
+									MathUtil.equals(symXfore, prevXaft) && (compParent.getParent() == nextComp)) {
+								actualWarnings.add(Warning.PODSET_OVERLAP, comp.getParent());
+							}
+						}
+					}
+					prevComp = sym;
+				}
+			} else if ((comp instanceof PodSet) || (comp instanceof ParallelStage)) {
+				checkGeometry(configuration, comp, actualWarnings);
+			}
+		}
+	}
+
+	@Override
+	public void voidAerodynamicCache() {
+		calcMap = null;
+		cacheDiameter = -1;
+		cacheLength = -1;
+		stallMargin = 0;
+	}
+
+	private AerodynamicForces calculateComponentNonAxialForces(FlightConditions conditions, RocketComponent comp,
+			RocketComponentCalc calcObj, List<InstanceContext> contextList, WarningSet warnings) {
+		AerodynamicForces componentForces = new AerodynamicForces().zero();
+
+		for (InstanceContext context : contextList) {
+			AerodynamicForces instanceForces = new AerodynamicForces().zero();
+			calcObj.calculateNonaxialForces(conditions, context.transform, instanceForces, warnings);
+
+			Coordinate cpInst = instanceForces.getCP();
+			Coordinate cpAbs = context.transform.transform(cpInst);
+			cpAbs = cpAbs.setY(0.0).setZ(0.0);
+
+			instanceForces.setCP(cpAbs);
+			double cNInst = instanceForces.getCN();
+			instanceForces.setCm(cNInst * instanceForces.getCP().x / conditions.getRefLength());
+
+			componentForces.merge(instanceForces);
+		}
+
+		componentForces.setComponent(comp);
+
+		return componentForces;
+	}
+
+	private AerodynamicForces calculateForceAnalysis(FlightConfiguration configuration, FlightConditions conds,
+			RocketComponent comp,
+			InstanceMap instances,
+			Map<RocketComponent, AerodynamicForces> eachForces,
+			Map<RocketComponent, AerodynamicForces> assemblyForces,
+			WarningSet warnings) {
+		AerodynamicForces aggregateForces = new AerodynamicForces().zero();
+		aggregateForces.setComponent(comp);
+
+		if (comp.isAerodynamic() || comp instanceof ComponentAssembly) {
+			RocketComponentCalc calcObj = calcMap.get(comp);
+			if (calcObj == null) {
+				throw new NullPointerException("Could not find a CalculationObject for aerodynamic Component!: "
+						+ comp.getComponentName());
+			} else {
+				List<InstanceContext> contextList = instances.get(comp);
+				AerodynamicForces compForces = calculateComponentNonAxialForces(conds, comp, calcObj, contextList,
+						warnings);
+				eachForces.put(comp, compForces);
+				aggregateForces.merge(compForces);
+			}
+		}
+
+		for (RocketComponent child : comp.getChildren()) {
+			if (child instanceof AxialStage && !configuration.isStageActive(child.getStageNumber())) {
+				for (AxialStage childStage : child.getTopLevelChildStages()) {
+					if (configuration.isStageActive(childStage.getStageNumber())) {
+						AerodynamicForces childForces = calculateForceAnalysis(configuration, conds, childStage, instances,
+								eachForces, assemblyForces, warnings);
+						if (childForces != null) {
+							aggregateForces.merge(childForces);
+						}
+					}
+				}
+				continue;
+			}
+
+			AerodynamicForces childForces = calculateForceAnalysis(configuration, conds, child, instances, eachForces,
+					assemblyForces, warnings);
+
+			if (childForces != null) {
+				aggregateForces.merge(childForces);
+			}
+		}
+
+		assemblyForces.put(comp, aggregateForces);
+
+		return assemblyForces.get(comp);
+	}
+
+	private void addDirectChildStagesToQueue(FlightConfiguration configuration, Queue<RocketComponent> queue,
+			RocketComponent comp) {
+		for (RocketComponent child : comp.getChildren()) {
+			if (child instanceof AxialStage && !configuration.isStageActive(child.getStageNumber())) {
+				for (AxialStage childStage : child.getTopLevelChildStages()) {
+					if (configuration.isStageActive(childStage.getStageNumber())) {
+						queue.add(childStage);
+					}
+				}
+				continue;
+			}
+			queue.add(child);
+		}
+	}
+
+	private double getDampingMultiplier(FlightConfiguration configuration, FlightConditions conditions, double cgx) {
+		if (cacheDiameter < 0) {
+			double area = 0;
+			cacheLength = 0;
+			cacheDiameter = 0;
+
+			for (RocketComponent c : configuration.getActiveComponents()) {
+				if (c instanceof SymmetricComponent) {
+					SymmetricComponent s = (SymmetricComponent) c;
+					area += s.getComponentPlanformArea();
+					cacheLength += s.getLength();
+				}
+			}
+			if (cacheLength > 0) {
+				cacheDiameter = area / cacheLength;
+			}
+		}
+
+		double mul = 0.275 * cacheDiameter / (conditions.getRefArea() * conditions.getRefLength());
+		mul *= (MathUtil.pow4(cgx) + MathUtil.pow4(cacheLength - cgx));
+
+		for (RocketComponent c : configuration.getActiveComponents()) {
+			if (c instanceof FinSet) {
+				FinSet f = (FinSet) c;
+				mul += 0.6 * Math.min(f.getFinCount(), 4) * f.getPlanformArea() *
+						MathUtil.pow3(Math.abs(f.toAbsolute(new Coordinate(
+								((FinSetCalc) calcMap.get(f)).getMidchordPos()))[0].x
+								- cgx)) /
+						(conditions.getRefArea() * conditions.getRefLength());
+			}
+		}
+
+		return mul;
+	}
+
+	private void ensureCalcMap(FlightConfiguration configuration) {
+		if (calcMap == null) {
+			buildCalcMap(configuration);
+		}
+	}
+
+	private void buildCalcMap(FlightConfiguration configuration) {
+		calcMap = new HashMap<>();
+
+		for (RocketComponent comp : configuration.getAllComponents()) {
+			if (!comp.isAerodynamic() && !(comp instanceof ComponentAssembly)) {
+				continue;
+			}
+
+			RocketComponentCalc calcObj = (RocketComponentCalc) Reflection.construct(
+					BARROWMAN_PACKAGE,
+					comp,
+					BARROWMAN_SUFFIX,
+					comp);
+
+			calcMap.put(comp, calcObj);
+		}
+	}
+}

--- a/core/src/main/java/info/openrocket/core/aerodynamics/DragCalculator.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/DragCalculator.java
@@ -1,0 +1,45 @@
+package info.openrocket.core.aerodynamics;
+
+import java.util.Map;
+
+import info.openrocket.core.logging.WarningSet;
+import info.openrocket.core.rocketcomponent.FlightConfiguration;
+import info.openrocket.core.rocketcomponent.RocketComponent;
+
+/**
+ * Calculator responsible for determining the axial drag contributions of a rocket.
+ */
+public interface DragCalculator {
+
+	/**
+	 * @return an independent instance of this drag calculator implementation.
+	 */
+	DragCalculator newInstance();
+
+	/**
+	 * Calculate drag contributions for the supplied configuration.
+	 *
+	 * @param configuration the rocket configuration being analysed
+	 * @param conditions    the current flight conditions
+	 * @param componentForces per-component force data, may be {@code null}
+	 * @param assemblyForces per-assembly force data, may be {@code null}
+	 * @param totalForces   the overall forces object for the rocket
+	 * @param warnings      warning sink, may be {@code null}
+	 */
+	void calculateDrag(FlightConfiguration configuration,
+			FlightConditions conditions,
+			Map<RocketComponent, AerodynamicForces> componentForces,
+			Map<RocketComponent, AerodynamicForces> assemblyForces,
+			AerodynamicForces totalForces,
+			WarningSet warnings);
+
+	/**
+	 * Convert a drag coefficient to an axial drag coefficient for the supplied conditions.
+	 */
+	double toAxialDrag(FlightConditions conditions, double cd);
+
+	/**
+	 * Clear any cached data held by the calculator.
+	 */
+	void voidAerodynamicCache();
+}

--- a/core/src/main/java/info/openrocket/core/aerodynamics/LookupTableDragCalculator.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/LookupTableDragCalculator.java
@@ -1,0 +1,125 @@
+package info.openrocket.core.aerodynamics;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import info.openrocket.core.aerodynamics.lookup.CsvMachAoALookup;
+import info.openrocket.core.aerodynamics.lookup.MachAoALookup;
+import info.openrocket.core.logging.WarningSet;
+import info.openrocket.core.rocketcomponent.FlightConfiguration;
+import info.openrocket.core.rocketcomponent.RocketComponent;
+import info.openrocket.core.util.MathUtil;
+import info.openrocket.core.util.PolyInterpolator;
+
+/**
+ * Drag calculator backed by a CSV lookup table.
+ */
+public class LookupTableDragCalculator implements DragCalculator {
+
+	private static final String COLUMN_CD = "cd";
+	private static final double[] AXIAL_POLY1;
+	private static final double[] AXIAL_POLY2;
+
+	static {
+		PolyInterpolator interpolator = new PolyInterpolator(
+				new double[] { 0, 17 * Math.PI / 180 },
+				new double[] { 0, 17 * Math.PI / 180 });
+		AXIAL_POLY1 = interpolator.interpolator(1, 1.3, 0, 0);
+
+		interpolator = new PolyInterpolator(
+				new double[] { 17 * Math.PI / 180, Math.PI / 2 },
+				new double[] { 17 * Math.PI / 180, Math.PI / 2 },
+				new double[] { Math.PI / 2 });
+		AXIAL_POLY2 = interpolator.interpolator(1.3, 0, 0, 0, 0);
+	}
+
+	private final MachAoALookup table;
+
+	public LookupTableDragCalculator(Path csvPath) {
+		this(CsvMachAoALookup.fromCsv(csvPath, List.of(COLUMN_CD)));
+	}
+
+	public LookupTableDragCalculator(MachAoALookup table) {
+		this.table = table;
+	}
+
+	@Override
+	public DragCalculator newInstance() {
+		return new LookupTableDragCalculator(table);
+	}
+
+	@Override
+	public void calculateDrag(FlightConfiguration configuration,
+			FlightConditions conditions,
+			Map<RocketComponent, AerodynamicForces> componentForces,
+			Map<RocketComponent, AerodynamicForces> assemblyForces,
+			AerodynamicForces totalForces,
+			WarningSet warnings) {
+
+		double mach = conditions.getMach();
+		double aoaDegrees = Math.toDegrees(conditions.getAOA());
+		double cd = table.interpolate(mach, aoaDegrees, COLUMN_CD);
+
+		if (componentForces != null) {
+			for (Map.Entry<RocketComponent, AerodynamicForces> entry : componentForces.entrySet()) {
+				AerodynamicForces forces = entry.getValue();
+				if (forces == null) {
+					continue;
+				}
+				forces.setFrictionCD(0);
+				forces.setPressureCD(0);
+				forces.setBaseCD(0);
+				forces.setOverrideCD(0);
+				forces.setCD(0);
+				forces.setCDaxial(0);
+			}
+		}
+
+		if (assemblyForces != null) {
+			for (Map.Entry<RocketComponent, AerodynamicForces> entry : assemblyForces.entrySet()) {
+				AerodynamicForces forces = entry.getValue();
+				if (forces == null) {
+					continue;
+				}
+				forces.setFrictionCD(0);
+				forces.setPressureCD(0);
+				forces.setBaseCD(0);
+				forces.setOverrideCD(0);
+				forces.setCD(0);
+				forces.setCDaxial(0);
+			}
+		}
+
+		if (totalForces != null) {
+			totalForces.setFrictionCD(cd);
+			totalForces.setPressureCD(0);
+			totalForces.setBaseCD(0);
+			totalForces.setOverrideCD(0);
+			totalForces.setCD(cd);
+			totalForces.setCDaxial(toAxialDrag(conditions, cd));
+		}
+	}
+
+	@Override
+	public double toAxialDrag(FlightConditions conditions, double cd) {
+		double aoa = MathUtil.clamp(conditions.getAOA(), 0, Math.PI);
+		boolean positive = aoa <= Math.PI / 2;
+		if (!positive) {
+			aoa = Math.PI - aoa;
+		}
+		double mul;
+		if (aoa < 17 * Math.PI / 180) {
+			mul = PolyInterpolator.eval(aoa, AXIAL_POLY1);
+		} else {
+			mul = PolyInterpolator.eval(aoa, AXIAL_POLY2);
+		}
+		double axial = mul * cd;
+		return positive ? axial : -axial;
+	}
+
+	@Override
+	public void voidAerodynamicCache() {
+		// no-op
+	}
+}

--- a/core/src/main/java/info/openrocket/core/aerodynamics/LookupTableStabilityCalculator.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/LookupTableStabilityCalculator.java
@@ -1,0 +1,132 @@
+package info.openrocket.core.aerodynamics;
+
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import info.openrocket.core.aerodynamics.lookup.CsvMachAoALookup;
+import info.openrocket.core.aerodynamics.lookup.MachAoALookup;
+import info.openrocket.core.logging.WarningSet;
+import info.openrocket.core.rocketcomponent.ComponentAssembly;
+import info.openrocket.core.rocketcomponent.FlightConfiguration;
+import info.openrocket.core.rocketcomponent.InstanceMap;
+import info.openrocket.core.rocketcomponent.RocketComponent;
+import info.openrocket.core.util.Coordinate;
+
+/**
+ * Stability calculator backed by a CSV lookup table.
+ */
+public class LookupTableStabilityCalculator implements StabilityCalculator {
+
+	private static final String COLUMN_CN = "cn";
+	private static final String COLUMN_CM = "cm";
+	private static final String COLUMN_CP = "cp";
+
+	private final MachAoALookup table;
+	private double stallMargin = Double.POSITIVE_INFINITY;
+
+	public LookupTableStabilityCalculator(Path csvPath) {
+		this(CsvMachAoALookup.fromCsv(csvPath, List.of(COLUMN_CN, COLUMN_CM, COLUMN_CP)));
+	}
+
+	public LookupTableStabilityCalculator(MachAoALookup table) {
+		this.table = table;
+	}
+
+	@Override
+	public StabilityCalculator newInstance() {
+		return new LookupTableStabilityCalculator(table);
+	}
+
+	@Override
+	public double getStallMargin() {
+		return stallMargin;
+	}
+
+	@Override
+	public Coordinate getCP(FlightConfiguration configuration, FlightConditions conditions, WarningSet warnings) {
+		return calculateNonAxialForces(configuration, conditions, warnings).getCP();
+	}
+
+	@Override
+	public AerodynamicForces calculateNonAxialForces(FlightConfiguration configuration,
+			FlightConditions conditions, WarningSet warnings) {
+		double mach = conditions.getMach();
+		double aoaDegrees = Math.toDegrees(conditions.getAOA());
+
+		double cn = table.interpolate(mach, aoaDegrees, COLUMN_CN);
+		double cm = table.interpolate(mach, aoaDegrees, COLUMN_CM);
+		double cp = table.interpolate(mach, aoaDegrees, COLUMN_CP);
+
+		AerodynamicForces forces = new AerodynamicForces().zero();
+		forces.setCN(cn);
+		forces.setCm(cm);
+		forces.setCP(new Coordinate(cp, 0, 0, 1));
+		forces.setCside(0);
+		forces.setCyaw(0);
+		forces.setCroll(0);
+		forces.setCrollDamp(0);
+		forces.setCrollForce(0);
+
+		if (table.hasAoA()) {
+			double maxAoARadians = Math.toRadians(table.getMaxAoA());
+			stallMargin = maxAoARadians - conditions.getAOA();
+		} else {
+			stallMargin = Double.POSITIVE_INFINITY;
+		}
+
+		return forces;
+	}
+
+	@Override
+	public StabilityForceBreakdown getForceAnalysis(FlightConfiguration configuration,
+			FlightConditions conditions, WarningSet warnings) {
+		AerodynamicForces total = calculateNonAxialForces(configuration, conditions, warnings);
+		total.setComponent(configuration.getRocket());
+
+		Map<RocketComponent, AerodynamicForces> eachMap = new LinkedHashMap<>();
+		Map<RocketComponent, AerodynamicForces> assemblyMap = new LinkedHashMap<>();
+
+		InstanceMap instances = configuration.getActiveInstances();
+		for (RocketComponent component : instances.keySet()) {
+			AerodynamicForces zero = new AerodynamicForces().zero();
+			zero.setComponent(component);
+			zero.setCN(0);
+			zero.setCm(0);
+			zero.setCP(Coordinate.ZERO);
+			zero.setCside(0);
+			zero.setCyaw(0);
+			zero.setCroll(0);
+			zero.setCrollDamp(0);
+			zero.setCrollForce(0);
+
+			if (component instanceof ComponentAssembly) {
+				assemblyMap.put(component, zero);
+			} else if (component.isAerodynamic()) {
+				eachMap.put(component, zero);
+			}
+		}
+
+		assemblyMap.put(configuration.getRocket(), total);
+
+		return new StabilityForceBreakdown(eachMap, assemblyMap);
+	}
+
+	@Override
+	public void calculateDampingMoments(FlightConfiguration configuration, FlightConditions conditions,
+			AerodynamicForces total) {
+		total.setPitchDampingMoment(0);
+		total.setYawDampingMoment(0);
+	}
+
+	@Override
+	public void checkGeometry(FlightConfiguration configuration, RocketComponent component, WarningSet warnings) {
+		// Geometry validation is not required for lookup-based data
+	}
+
+	@Override
+	public void voidAerodynamicCache() {
+		// no-op
+	}
+}

--- a/core/src/main/java/info/openrocket/core/aerodynamics/StabilityCalculator.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/StabilityCalculator.java
@@ -1,0 +1,61 @@
+package info.openrocket.core.aerodynamics;
+
+import java.util.Map;
+
+import info.openrocket.core.logging.WarningSet;
+import info.openrocket.core.rocketcomponent.FlightConfiguration;
+import info.openrocket.core.rocketcomponent.RocketComponent;
+import info.openrocket.core.util.Coordinate;
+
+/**
+ * Calculator responsible for the non-axial (stability) aerodynamic behaviour of a rocket.
+ */
+public interface StabilityCalculator {
+
+	/**
+	 * @return an independent instance of this stability calculator implementation.
+	 */
+	StabilityCalculator newInstance();
+
+	/**
+	 * Determine whether the current conditions are close to stall.
+	 *
+	 * @return positive value when not stalled, negative value when stalled
+	 */
+	double getStallMargin();
+
+	/**
+	 * Calculate the centre of pressure for the supplied configuration and conditions.
+	 */
+	Coordinate getCP(FlightConfiguration configuration, FlightConditions conditions, WarningSet warnings);
+
+	/**
+	 * Calculate the non-axial force coefficients for the entire rocket.
+	 */
+	AerodynamicForces calculateNonAxialForces(FlightConfiguration configuration,
+			FlightConditions conditions, WarningSet warnings);
+
+	/**
+	 * Produce per-component and per-assembly non-axial force information.
+	 *
+	 * @return a breakdown of the calculated forces
+	 */
+	StabilityForceBreakdown getForceAnalysis(FlightConfiguration configuration,
+			FlightConditions conditions, WarningSet warnings);
+
+	/**
+	 * Apply pitch and yaw damping moments to the supplied force object.
+	 */
+	void calculateDampingMoments(FlightConfiguration configuration, FlightConditions conditions,
+			AerodynamicForces total);
+
+	/**
+	 * Perform geometric checks for the supplied component tree.
+	 */
+	void checkGeometry(FlightConfiguration configuration, RocketComponent component, WarningSet warnings);
+
+	/**
+	 * Clear any cached data held by the calculator.
+	 */
+	void voidAerodynamicCache();
+}

--- a/core/src/main/java/info/openrocket/core/aerodynamics/StabilityForceBreakdown.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/StabilityForceBreakdown.java
@@ -1,0 +1,28 @@
+package info.openrocket.core.aerodynamics;
+
+import java.util.Map;
+
+import info.openrocket.core.rocketcomponent.RocketComponent;
+
+/**
+ * Container for stability force data broken down by component and assembly.
+ */
+public class StabilityForceBreakdown {
+
+	private final Map<RocketComponent, AerodynamicForces> componentForces;
+	private final Map<RocketComponent, AerodynamicForces> assemblyForces;
+
+	public StabilityForceBreakdown(Map<RocketComponent, AerodynamicForces> componentForces,
+			Map<RocketComponent, AerodynamicForces> assemblyForces) {
+		this.componentForces = componentForces;
+		this.assemblyForces = assemblyForces;
+	}
+
+	public Map<RocketComponent, AerodynamicForces> getComponentForces() {
+		return componentForces;
+	}
+
+	public Map<RocketComponent, AerodynamicForces> getAssemblyForces() {
+		return assemblyForces;
+	}
+}

--- a/core/src/main/java/info/openrocket/core/aerodynamics/lookup/CsvMachAoALookup.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/lookup/CsvMachAoALookup.java
@@ -1,0 +1,125 @@
+package info.openrocket.core.aerodynamics.lookup;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Utility for constructing {@link MachAoALookup} instances from CSV data.
+ */
+public final class CsvMachAoALookup {
+
+	private CsvMachAoALookup() {
+	}
+
+	public static MachAoALookup fromCsv(Path path, Collection<String> requiredValueColumns) {
+		return fromCsv(path, requiredValueColumns, ',');
+	}
+
+	public static MachAoALookup fromCsv(Path path, Collection<String> requiredValueColumns, char separator) {
+		Objects.requireNonNull(path, "path");
+		Objects.requireNonNull(requiredValueColumns, "requiredValueColumns");
+		try {
+			List<String> lines = Files.readAllLines(path);
+			return parse(lines, requiredValueColumns, separator);
+		} catch (IOException e) {
+			throw new UncheckedIOException("Failed to read lookup table from " + path, e);
+		}
+	}
+
+	private static MachAoALookup parse(List<String> lines, Collection<String> requiredValueColumns, char separator) {
+		Set<String> normalizedColumns = MachAoALookup.normalizeColumns(requiredValueColumns);
+		MachAoALookup.Builder builder = MachAoALookup.builder(requiredValueColumns);
+		Map<String, Integer> headerIndex = null;
+		String splitRegex = Pattern.quote(String.valueOf(separator));
+
+		for (String rawLine : lines) {
+			String line = rawLine.trim();
+			if (line.isEmpty() || line.startsWith("#")) {
+				continue;
+			}
+
+			if (headerIndex == null) {
+				headerIndex = parseHeader(line, normalizedColumns, splitRegex);
+				continue;
+			}
+
+			String[] tokens = line.split(splitRegex, -1);
+			double mach = parse(tokens, headerIndex.get("mach"), "mach");
+			Double aoaDegrees = null;
+			if (headerIndex.containsKey("aoa")) {
+				aoaDegrees = parse(tokens, headerIndex.get("aoa"), "aoa");
+			}
+
+			Map<String, Double> values = new HashMap<>();
+			for (String column : normalizedColumns) {
+				if (column.equals("aoa")) {
+					continue;
+				}
+				double value = parse(tokens, headerIndex.get(column), column);
+				values.put(column, value);
+			}
+
+			builder.addData(mach, aoaDegrees, values);
+		}
+
+		if (headerIndex == null) {
+			throw new IllegalArgumentException("Lookup table is missing a header row");
+		}
+
+		return builder.build();
+	}
+
+	private static Map<String, Integer> parseHeader(String headerLine, Collection<String> requiredValueColumns, String splitRegex) {
+		String[] headers = headerLine.split(splitRegex, -1);
+		Map<String, Integer> result = new HashMap<>();
+		for (int i = 0; i < headers.length; i++) {
+			String normalized = MachAoALookup.normalize(headers[i]);
+			if (normalized.equals("angleofattack")) {
+				normalized = "aoa";
+			}
+			if (!normalized.isEmpty()) {
+				result.putIfAbsent(normalized, i);
+			}
+		}
+
+		if (!result.containsKey("mach")) {
+			throw new IllegalArgumentException("Lookup table header must contain a 'mach' column");
+		}
+
+		for (String column : requiredValueColumns) {
+			String normalized = MachAoALookup.normalize(column);
+			if (normalized.equals("angleofattack")) {
+				normalized = "aoa";
+			}
+			if (!result.containsKey(normalized)) {
+				throw new IllegalArgumentException("Lookup table header missing required column '" + column + "'");
+			}
+		}
+
+		return result;
+	}
+
+	private static double parse(String[] tokens, Integer index, String column) {
+		if (index == null) {
+			throw new IllegalArgumentException("Column index missing for '" + column + "'");
+		}
+		if (index >= tokens.length) {
+			throw new IllegalArgumentException("Row missing value for column '" + column + "'");
+		}
+		String token = tokens[index].trim();
+		try {
+			return Double.parseDouble(token);
+		} catch (NumberFormatException e) {
+			throw new IllegalArgumentException("Illegal numeric value '" + token + "' in column '" + column + "'", e);
+		}
+	}
+}

--- a/core/src/main/java/info/openrocket/core/aerodynamics/lookup/MachAoALookup.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/lookup/MachAoALookup.java
@@ -1,0 +1,325 @@
+package info.openrocket.core.aerodynamics.lookup;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Lookup table supporting interpolation in Mach and optional angle-of-attack dimensions.
+ */
+public final class MachAoALookup {
+
+	private static final Logger log = LoggerFactory.getLogger(MachAoALookup.class);
+
+	private final NavigableMap<Double, List<Row>> rowsByMach;
+	private final Set<String> valueColumns;
+	private final boolean hasAoA;
+	private final double minMach;
+	private final double maxMach;
+	private final double minAoA;
+	private final double maxAoA;
+
+	private boolean warnedLowMach;
+	private boolean warnedHighMach;
+	private boolean warnedLowAoA;
+	private boolean warnedHighAoA;
+
+	private MachAoALookup(NavigableMap<Double, List<Row>> rowsByMach,
+			Set<String> valueColumns,
+			boolean hasAoA,
+			double minMach,
+			double maxMach,
+			double minAoA,
+			double maxAoA) {
+		this.rowsByMach = rowsByMach;
+		this.valueColumns = valueColumns;
+		this.hasAoA = hasAoA;
+		this.minMach = minMach;
+		this.maxMach = maxMach;
+		this.minAoA = minAoA;
+		this.maxAoA = maxAoA;
+	}
+
+	public boolean hasAoA() {
+		return hasAoA;
+	}
+
+	public double getMinAoA() {
+		return minAoA;
+	}
+
+	public double getMaxAoA() {
+		return maxAoA;
+	}
+
+	public double interpolate(double mach, double aoaDegrees, String column) {
+		String normalizedColumn = normalize(column);
+		if (!valueColumns.contains(normalizedColumn)) {
+			throw new IllegalArgumentException("Column '" + column + "' is not present in the table");
+		}
+
+		double clampedMach = clampMach(mach);
+
+		Double lowerMach = rowsByMach.floorKey(clampedMach);
+		Double upperMach = rowsByMach.ceilingKey(clampedMach);
+
+		if (lowerMach == null) {
+			lowerMach = rowsByMach.firstKey();
+		}
+		if (upperMach == null) {
+			upperMach = rowsByMach.lastKey();
+		}
+
+		double lowerValue = interpolateAoA(rowsByMach.get(lowerMach), aoaDegrees, normalizedColumn);
+		double upperValue = interpolateAoA(rowsByMach.get(upperMach), aoaDegrees, normalizedColumn);
+
+		if (Double.compare(lowerMach, upperMach) == 0) {
+			return lowerValue;
+		}
+
+		double fraction = (clampedMach - lowerMach) / (upperMach - lowerMach);
+		return lerp(lowerValue, upperValue, fraction);
+	}
+
+	private double interpolateAoA(List<Row> rows, double aoaDegrees, String column) {
+		if (!hasAoA || rows.size() == 1) {
+			return rows.get(0).values.get(column);
+		}
+
+		double clampedAoA = clampAoA(aoaDegrees);
+
+		Row lower = rows.get(0);
+		Row upper = rows.get(rows.size() - 1);
+		for (Row row : rows) {
+			if (row.aoa <= clampedAoA) {
+				lower = row;
+			}
+			if (row.aoa >= clampedAoA) {
+				upper = row;
+				break;
+			}
+		}
+
+		if (Double.compare(lower.aoa, upper.aoa) == 0) {
+			return lower.values.get(column);
+		}
+
+		double fraction = (clampedAoA - lower.aoa) / (upper.aoa - lower.aoa);
+		double lowerVal = lower.values.get(column);
+		double upperVal = upper.values.get(column);
+		return lerp(lowerVal, upperVal, fraction);
+	}
+
+	private double clampMach(double mach) {
+		if (mach < minMach) {
+			if (!warnedLowMach) {
+				log.warn("Requested Mach {} below table minimum {}; clamping", mach, minMach);
+				warnedLowMach = true;
+			}
+			return minMach;
+		}
+		if (mach > maxMach) {
+			if (!warnedHighMach) {
+				log.warn("Requested Mach {} above table maximum {}; clamping", mach, maxMach);
+				warnedHighMach = true;
+			}
+			return maxMach;
+		}
+		return mach;
+	}
+
+	private double clampAoA(double aoa) {
+		if (!hasAoA) {
+			return aoa;
+		}
+		if (aoa < minAoA) {
+			if (!warnedLowAoA) {
+				log.warn("Requested AoA {} below table minimum {}; clamping", aoa, minAoA);
+				warnedLowAoA = true;
+			}
+			return minAoA;
+		}
+		if (aoa > maxAoA) {
+			if (!warnedHighAoA) {
+				log.warn("Requested AoA {} above table maximum {}; clamping", aoa, maxAoA);
+				warnedHighAoA = true;
+			}
+			return maxAoA;
+		}
+		return aoa;
+	}
+
+	private static double lerp(double a, double b, double fraction) {
+		return a + (b - a) * fraction;
+	}
+
+	public static Builder builder(Collection<String> valueColumns) {
+		return new Builder(valueColumns);
+	}
+
+	public static Builder dragBuilder() {
+		return new Builder(Set.of("cd"));
+	}
+
+	public static Builder stabilityBuilder() {
+		return new Builder(Set.of("cn", "cm", "cp"));
+	}
+
+	static String normalize(String value) {
+		String lower = value.trim().toLowerCase(Locale.ROOT);
+		return lower.replaceAll("[\\s_]", "");
+	}
+
+	static Set<String> normalizeColumns(Collection<String> columns) {
+		Set<String> normalized = new LinkedHashSet<>();
+		for (String column : columns) {
+			String name = normalize(column);
+			if (name.equals("angleofattack")) {
+				name = "aoa";
+			}
+			normalized.add(name);
+		}
+		return normalized;
+	}
+
+	private static MachAoALookup buildFromRows(List<Row> parsedRows, Set<String> normalizedColumns, boolean hasAoA) {
+		NavigableMap<Double, List<Row>> byMach = new TreeMap<>();
+		double minMach = Double.POSITIVE_INFINITY;
+		double maxMach = Double.NEGATIVE_INFINITY;
+		double minAoA = Double.POSITIVE_INFINITY;
+		double maxAoA = Double.NEGATIVE_INFINITY;
+
+		for (Row row : parsedRows) {
+			byMach.computeIfAbsent(row.mach, m -> new ArrayList<>()).add(row);
+			minMach = Math.min(minMach, row.mach);
+			maxMach = Math.max(maxMach, row.mach);
+			if (hasAoA) {
+				minAoA = Math.min(minAoA, row.aoa);
+				maxAoA = Math.max(maxAoA, row.aoa);
+			}
+		}
+
+		for (List<Row> rows : byMach.values()) {
+			rows.sort((a, b) -> Double.compare(a.aoa, b.aoa));
+		}
+
+		if (!hasAoA) {
+			minAoA = Double.NaN;
+			maxAoA = Double.NaN;
+		}
+
+		return new MachAoALookup(byMach, Set.copyOf(normalizedColumns), hasAoA, minMach, maxMach, minAoA, maxAoA);
+	}
+
+	public static final class Builder {
+		private final Set<String> valueColumns;
+		private final List<Row> rows = new ArrayList<>();
+		private Boolean usesAoA = null;
+
+		private Builder(Collection<String> valueColumns) {
+			Set<String> normalized = normalizeColumns(valueColumns);
+			if (normalized.isEmpty()) {
+				throw new IllegalArgumentException("At least one value column is required");
+			}
+			this.valueColumns = Set.copyOf(normalized);
+		}
+
+		public Builder addData(double mach, Map<String, Double> values) {
+			return addData(mach, null, values);
+		}
+
+		public Builder addData(double mach, Double aoaDegrees, Map<String, Double> values) {
+			Objects.requireNonNull(values, "values");
+			boolean rowHasAoA = aoaDegrees != null;
+			if (usesAoA == null) {
+				usesAoA = rowHasAoA;
+			} else if (usesAoA.booleanValue() != rowHasAoA) {
+				throw new IllegalArgumentException("Inconsistent AoA usage across data rows");
+			}
+
+			Map<String, Double> normalizedValues = new HashMap<>();
+			for (String column : valueColumns) {
+				Double value = findValue(values, column);
+				if (value == null) {
+					throw new IllegalArgumentException("Value for column '" + column + "' missing");
+				}
+				normalizedValues.put(column, value);
+			}
+
+			double aoa = rowHasAoA ? aoaDegrees.doubleValue() : 0.0;
+			rows.add(new Row(mach, aoa, normalizedValues));
+			return this;
+		}
+
+		public Builder addDragData(double mach, double cd) {
+			ensureColumns(Set.of("cd"));
+			return addData(mach, null, Map.of("cd", cd));
+		}
+
+		public Builder addDragData(double mach, double aoaDegrees, double cd) {
+			ensureColumns(Set.of("cd"));
+			return addData(mach, aoaDegrees, Map.of("cd", cd));
+		}
+
+		public Builder addStabilityData(double mach, double cn, double cm, double cp) {
+			ensureColumns(Set.of("cn", "cm", "cp"));
+			return addData(mach, null, Map.of("cn", cn, "cm", cm, "cp", cp));
+		}
+
+		public Builder addStabilityData(double mach, double aoaDegrees, double cn, double cm, double cp) {
+			ensureColumns(Set.of("cn", "cm", "cp"));
+			return addData(mach, aoaDegrees, Map.of("cn", cn, "cm", cm, "cp", cp));
+		}
+
+		public MachAoALookup build() {
+			if (rows.isEmpty()) {
+				throw new IllegalStateException("No lookup data added");
+			}
+			boolean hasAoA = usesAoA != null && usesAoA.booleanValue();
+			return buildFromRows(new ArrayList<>(rows), valueColumns, hasAoA);
+		}
+
+		private static Double findValue(Map<String, Double> values, String column) {
+			if (values.containsKey(column)) {
+				return values.get(column);
+			}
+			for (Map.Entry<String, Double> entry : values.entrySet()) {
+				if (normalize(entry.getKey()).equals(column)) {
+					return entry.getValue();
+				}
+			}
+			return null;
+		}
+
+		private void ensureColumns(Set<String> expected) {
+			if (!valueColumns.equals(expected)) {
+				throw new IllegalStateException("Builder configured for columns " + valueColumns +
+						" cannot accept data for " + expected);
+			}
+		}
+	}
+
+	private static final class Row {
+		final double mach;
+		final double aoa;
+		final Map<String, Double> values;
+
+		Row(double mach, double aoa, Map<String, Double> values) {
+			this.mach = mach;
+			this.aoa = aoa;
+			this.values = Collections.unmodifiableMap(new HashMap<>(values));
+		}
+	}
+}

--- a/core/src/test/java/info/openrocket/core/aerodynamics/LookupTableDragCalculatorTest.java
+++ b/core/src/test/java/info/openrocket/core/aerodynamics/LookupTableDragCalculatorTest.java
@@ -1,0 +1,49 @@
+package info.openrocket.core.aerodynamics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import info.openrocket.core.aerodynamics.lookup.CsvMachAoALookup;
+import info.openrocket.core.aerodynamics.lookup.MachAoALookup;
+import info.openrocket.core.logging.WarningSet;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class LookupTableDragCalculatorTest {
+
+	@TempDir
+	private Path tempDir;
+
+	private static final double EPSILON = 1e-6;
+
+	@Test
+	public void usesTableCdValue() throws IOException {
+		Path csv = tempDir.resolve("drag.csv");
+		String data = String.join("\n",
+				"mach,aoa,cd",
+				"0,0,0.20",
+				"1,0,0.40",
+				"1,10,0.50",
+				"");
+		Files.writeString(csv, data);
+
+		MachAoALookup table = CsvMachAoALookup.fromCsv(csv, List.of("cd"));
+		LookupTableDragCalculator calculator = new LookupTableDragCalculator(table);
+
+		FlightConditions conditions = new FlightConditions(null);
+		conditions.setMach(0.5);
+		conditions.setAOA(0);
+
+		AerodynamicForces total = new AerodynamicForces().zero();
+		calculator.calculateDrag(null, conditions, null, null, total, new WarningSet());
+
+		assertEquals(0.30, total.getCD(), EPSILON);
+		assertEquals(0.30, total.getCDaxial(), EPSILON);
+		assertEquals(0.30, total.getFrictionCD(), EPSILON);
+		assertEquals(0, total.getPressureCD(), EPSILON);
+		assertEquals(0, total.getBaseCD(), EPSILON);
+	}
+}

--- a/core/src/test/java/info/openrocket/core/aerodynamics/LookupTableStabilityCalculatorTest.java
+++ b/core/src/test/java/info/openrocket/core/aerodynamics/LookupTableStabilityCalculatorTest.java
@@ -1,0 +1,48 @@
+package info.openrocket.core.aerodynamics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import info.openrocket.core.aerodynamics.lookup.CsvMachAoALookup;
+import info.openrocket.core.aerodynamics.lookup.MachAoALookup;
+import info.openrocket.core.logging.WarningSet;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class LookupTableStabilityCalculatorTest {
+
+	@TempDir
+	private Path tempDir;
+
+	private static final double EPSILON = 1e-6;
+
+	@Test
+	public void interpolatesNonAxialCoefficients() throws IOException {
+		Path csv = tempDir.resolve("stability.csv");
+		String data = String.join("\n",
+				"mach,aoa,cn,cm,cp",
+				"0,0,0.10,0.01,0.50",
+				"0,10,0.20,0.02,0.55",
+				"1,0,0.30,0.03,0.60",
+				"1,10,0.40,0.04,0.65",
+				"");
+		Files.writeString(csv, data);
+
+		MachAoALookup table = CsvMachAoALookup.fromCsv(csv, List.of("cn", "cm", "cp"));
+		LookupTableStabilityCalculator calculator = new LookupTableStabilityCalculator(table);
+
+		FlightConditions conditions = new FlightConditions(null);
+		conditions.setMach(0.5);
+		conditions.setAOA(Math.toRadians(5));
+
+		AerodynamicForces forces = calculator.calculateNonAxialForces(null, conditions, new WarningSet());
+
+		assertEquals(0.25, forces.getCN(), EPSILON);
+		assertEquals(0.025, forces.getCm(), EPSILON);
+		assertEquals(0.575, forces.getCP().x, EPSILON);
+		assertEquals(Math.toRadians(10) - Math.toRadians(5), calculator.getStallMargin(), EPSILON);
+	}
+}

--- a/core/src/test/java/info/openrocket/core/aerodynamics/MachAoALookupTest.java
+++ b/core/src/test/java/info/openrocket/core/aerodynamics/MachAoALookupTest.java
@@ -1,0 +1,86 @@
+package info.openrocket.core.aerodynamics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import info.openrocket.core.aerodynamics.lookup.CsvMachAoALookup;
+import info.openrocket.core.aerodynamics.lookup.MachAoALookup;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class MachAoALookupTest {
+
+	@TempDir
+	private Path tempDir;
+
+	private static final double EPSILON = 1e-6;
+
+	@Test
+	public void interpolatesSingleAxis() throws IOException {
+		Path csv = tempDir.resolve("drag.csv");
+		Files.writeString(csv, "mach,cd\n0,0.30\n1,0.50\n");
+
+		MachAoALookup table = CsvMachAoALookup.fromCsv(csv, List.of("cd"));
+
+		double cd = table.interpolate(0.5, 0, "cd");
+		assertEquals(0.40, cd, 1e-9);
+	}
+
+	@Test
+	public void interpolatesMachAndAoA() throws IOException {
+		Path csv = tempDir.resolve("drag_aoa.csv");
+		String data = String.join("\n",
+				"mach,aoa,cd",
+				"0,0,0.20",
+				"0,10,0.40",
+				"1,0,0.30",
+				"1,10,0.50",
+				"");
+		Files.writeString(csv, data);
+
+		MachAoALookup table = CsvMachAoALookup.fromCsv(csv, List.of("cd"));
+
+		double cd = table.interpolate(0.5, 5, "cd");
+		assertEquals(0.35, cd, EPSILON);
+	}
+
+	@Test
+	public void clampsOutsideRange() throws IOException {
+		Path csv = tempDir.resolve("drag_bounds.csv");
+		Files.writeString(csv, "mach,cd\n0.2,0.20\n0.4,0.40\n");
+
+		MachAoALookup table = CsvMachAoALookup.fromCsv(csv, List.of("cd"));
+
+		double low = table.interpolate(0.0, 0, "cd");
+		double high = table.interpolate(0.8, 0, "cd");
+
+		assertEquals(0.20, low, EPSILON);
+		assertEquals(0.40, high, EPSILON);
+		assertFalse(table.hasAoA());
+	}
+
+	@Test
+	public void buildsFromBuilder() {
+		MachAoALookup table = MachAoALookup.builder(List.of("cd"))
+				.addData(0.0, Map.of("cd", 0.2))
+				.addData(1.0, Map.of("cd", 0.6))
+				.build();
+
+		assertEquals(0.4, table.interpolate(0.5, 0, "cd"), EPSILON);
+	}
+
+	@Test
+	public void supportsCustomSeparator() throws IOException {
+		Path csv = tempDir.resolve("drag_semicolon.csv");
+		Files.writeString(csv, "mach;cd\n0;0.20\n1;0.60\n");
+
+		MachAoALookup table = CsvMachAoALookup.fromCsv(csv, List.of("cd"), ';');
+
+		assertEquals(0.40, table.interpolate(0.5, 0, "cd"), EPSILON);
+	}
+}


### PR DESCRIPTION
This PR fixes #2524. `BarrowmanCalculator` is now separated into separate stability and drag calculators. Just for fun, and for further future implementation, I added a `LookupTableDragCalculator` and `LookupTableStabilityCalculator` that lets you map drag and stability data to Mach and AoA values.