### PR TITLE
Account for zero-thickness and zero-length components in OBJ export

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,8 +88,10 @@ subprojects {
         }
     }
 
-    // Verify code coverage before JAR packaging
-    jar.dependsOn jacocoTestCoverageVerification
+    // Always evaluate coverage as part of the verification lifecycle
+    tasks.named('check') {
+        dependsOn jacocoTestCoverageVerification
+    }
 
     // Common dependencies
     dependencies {
@@ -103,6 +105,10 @@ subprojects {
         testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.10.0'
         testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.10.0'
     }
+}
+
+tasks.named('check') {
+    dependsOn(subprojects.collect { it.tasks.named('check') })
 }
 
 //tasks.register('serializeEngines') {
@@ -180,7 +186,7 @@ tasks.register('jacocoRootReport', JacocoReport) {
 // Package the application for distribution.
 tasks.register('dist') {
     group = 'info.openrocket'
-    dependsOn 'shadowJar'
+    dependsOn 'check', 'shadowJar'
     doLast {
         println "Completed the deployable jar in './build/libs"
     }

--- a/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/OBJExporterFactory.java
+++ b/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/OBJExporterFactory.java
@@ -173,6 +173,11 @@ public class OBJExporterFactory {
             String filePath = entry.getKey();
             obj = entry.getValue();
 
+            if (obj.getNumVertices() == 0) {
+                log.debug("Skipping OBJ export for {} because no geometry was generated", filePath);
+                continue;
+            }
+
             // Triangulate mesh
             if (this.options.isTriangulate()) {
                 ObjUtils.TriangulationMethod triangulationMethod = this.options.getTriangulationMethod();

--- a/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/BodyTubeExporter.java
+++ b/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/BodyTubeExporter.java
@@ -3,6 +3,8 @@ package info.openrocket.core.file.wavefrontobj.export.components;
 import info.openrocket.core.file.wavefrontobj.CoordTransform;
 import info.openrocket.core.file.wavefrontobj.DefaultObj;
 import info.openrocket.core.file.wavefrontobj.ObjUtils;
+import info.openrocket.core.file.wavefrontobj.export.shapes.CylinderExporter;
+import info.openrocket.core.file.wavefrontobj.export.shapes.DiskExporter;
 import info.openrocket.core.file.wavefrontobj.export.shapes.TubeExporter;
 import info.openrocket.core.logging.Warning;
 import info.openrocket.core.logging.WarningSet;
@@ -10,6 +12,9 @@ import info.openrocket.core.rocketcomponent.BodyTube;
 import info.openrocket.core.rocketcomponent.FlightConfiguration;
 import info.openrocket.core.rocketcomponent.InstanceContext;
 import info.openrocket.core.util.Coordinate;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class BodyTubeExporter extends RocketComponentExporter<BodyTube> {
     public BodyTubeExporter(DefaultObj obj, FlightConfiguration config, CoordTransform transformer, BodyTube component,
@@ -22,9 +27,14 @@ public class BodyTubeExporter extends RocketComponentExporter<BodyTube> {
         obj.setActiveGroupNames(groupName);
 
         final float outerRadius = (float) component.getOuterRadius();
-        final float innerRadius = (float) component.getInnerRadius();
+        float innerRadius = (float) component.getInnerRadius();
         final float length = (float) component.getLength();
         final boolean isFilled = component.isFilled();
+        final float thickness = (float) component.getThickness();
+
+        if (isFilled) {
+            innerRadius = 0f;
+        }
 
         if (Double.compare(component.getThickness(), 0) == 0) {
             warnings.add(Warning.OBJ_ZERO_THICKNESS, component);
@@ -32,18 +42,78 @@ public class BodyTubeExporter extends RocketComponentExporter<BodyTube> {
 
         // Generate the mesh
         for (InstanceContext context : getInstanceContexts()) {
-            generateMesh(outerRadius, innerRadius, length, isFilled, context);
+            generateMesh(outerRadius, innerRadius, length, thickness, isFilled, context);
         }
     }
 
-    private void generateMesh(float outerRadius, float innerRadius, float length, boolean isFilled, InstanceContext context) {
+    private void generateMesh(float outerRadius, float innerRadius, float length, float thickness,
+                              boolean isFilled, InstanceContext context) {
         // Generate the mesh
         int startIdx = obj.getNumVertices();
-        TubeExporter.addTubeMesh(obj, transformer, null, outerRadius, isFilled ? 0 : innerRadius, length, LOD);
+        final boolean zeroLength = Float.compare(length, 0f) == 0;
+        final boolean zeroThickness = Float.compare(thickness, 0f) == 0;
+
+        if (zeroLength && zeroThickness) {
+            return;
+        }
+
+        if (zeroLength) {
+            addBodyTubeDiskMesh(outerRadius, innerRadius);
+        } else if (zeroThickness) {
+            addZeroThicknessTubeMesh(outerRadius, length);
+        } else {
+            TubeExporter.addTubeMesh(obj, transformer, null, outerRadius, isFilled ? 0 : innerRadius, length, LOD);
+        }
+
+        if (obj.getNumVertices() == startIdx) {
+            return;
+        }
+
         int endIdx = Math.max(obj.getNumVertices() - 1, startIdx);    // Clamp in case no vertices were added
 
         // Translate the mesh to the position in the rocket
         Coordinate location = context.getLocation();
         ObjUtils.translateVerticesFromComponentLocation(obj, transformer, startIdx, endIdx, location);
+    }
+
+    private void addZeroThicknessTubeMesh(float radius, float length) {
+        if (Float.compare(radius, 0f) <= 0 || Float.compare(length, 0f) == 0) {
+            return;
+        }
+
+        final int numSides = LOD.getNrOfSides(radius);
+        CylinderExporter.addCylinderMesh(obj, transformer, null, radius, radius, length, numSides,
+                false, true, null, null);
+    }
+
+    private void addBodyTubeDiskMesh(float outerRadius, float innerRadius) {
+        if (Float.compare(outerRadius, 0f) <= 0) {
+            return;
+        }
+
+        final int numSides = LOD.getNrOfSides(outerRadius);
+        final List<Integer> outerVertices = new ArrayList<>(numSides);
+        final List<Integer> innerVertices = Float.compare(innerRadius, 0f) > 0 ? new ArrayList<>(numSides) : null;
+
+        for (int i = 0; i < numSides; i++) {
+            final double angle = 2 * Math.PI * i / numSides;
+            final float y = outerRadius * (float) Math.cos(angle);
+            final float z = outerRadius * (float) Math.sin(angle);
+            obj.addVertex(transformer.convertLoc(0, y, z));
+            outerVertices.add(obj.getNumVertices() - 1);
+        }
+
+        if (innerVertices != null) {
+            for (int i = 0; i < numSides; i++) {
+                final double angle = 2 * Math.PI * i / numSides;
+                final float y = innerRadius * (float) Math.cos(angle);
+                final float z = innerRadius * (float) Math.sin(angle);
+                obj.addVertex(transformer.convertLoc(0, y, z));
+                innerVertices.add(obj.getNumVertices() - 1);
+            }
+        }
+
+        DiskExporter.closeDiskMesh(obj, transformer, null, outerVertices, innerVertices, false, true);
+        DiskExporter.closeDiskMesh(obj, transformer, null, outerVertices, innerVertices, false, false);
     }
 }

--- a/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/BodyTubeExporter.java
+++ b/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/BodyTubeExporter.java
@@ -30,7 +30,6 @@ public class BodyTubeExporter extends RocketComponentExporter<BodyTube> {
         float innerRadius = (float) component.getInnerRadius();
         final float length = (float) component.getLength();
         final boolean isFilled = component.isFilled();
-        final float thickness = (float) component.getThickness();
 
         if (isFilled) {
             innerRadius = 0f;
@@ -42,78 +41,21 @@ public class BodyTubeExporter extends RocketComponentExporter<BodyTube> {
 
         // Generate the mesh
         for (InstanceContext context : getInstanceContexts()) {
-            generateMesh(outerRadius, innerRadius, length, thickness, isFilled, context);
+			generateMesh(outerRadius, innerRadius, length, isFilled, context);
         }
     }
 
-    private void generateMesh(float outerRadius, float innerRadius, float length, float thickness,
-                              boolean isFilled, InstanceContext context) {
-        // Generate the mesh
-        int startIdx = obj.getNumVertices();
-        final boolean zeroLength = Float.compare(length, 0f) == 0;
-        final boolean zeroThickness = Float.compare(thickness, 0f) == 0;
+	private void generateMesh(float outerRadius, float innerRadius, float length, boolean isFilled, InstanceContext context) {
+		// Generate the mesh
+		int startIdx = obj.getNumVertices();
+		TubeExporter.addTubeMesh(obj, transformer, null, outerRadius, isFilled ? 0 : innerRadius, length, LOD);
+		if (obj.getNumVertices() == startIdx) {
+			return;
+		}
+		int endIdx = obj.getNumVertices() - 1;    // Clamp in case no vertices were added
 
-        if (zeroLength && zeroThickness) {
-            return;
-        }
-
-        if (zeroLength) {
-            addBodyTubeDiskMesh(outerRadius, innerRadius);
-        } else if (zeroThickness) {
-            addZeroThicknessTubeMesh(outerRadius, length);
-        } else {
-            TubeExporter.addTubeMesh(obj, transformer, null, outerRadius, isFilled ? 0 : innerRadius, length, LOD);
-        }
-
-        if (obj.getNumVertices() == startIdx) {
-            return;
-        }
-
-        int endIdx = Math.max(obj.getNumVertices() - 1, startIdx);    // Clamp in case no vertices were added
-
-        // Translate the mesh to the position in the rocket
-        Coordinate location = context.getLocation();
-        ObjUtils.translateVerticesFromComponentLocation(obj, transformer, startIdx, endIdx, location);
-    }
-
-    private void addZeroThicknessTubeMesh(float radius, float length) {
-        if (Float.compare(radius, 0f) <= 0 || Float.compare(length, 0f) == 0) {
-            return;
-        }
-
-        final int numSides = LOD.getNrOfSides(radius);
-        CylinderExporter.addCylinderMesh(obj, transformer, null, radius, radius, length, numSides,
-                false, true, null, null);
-    }
-
-    private void addBodyTubeDiskMesh(float outerRadius, float innerRadius) {
-        if (Float.compare(outerRadius, 0f) <= 0) {
-            return;
-        }
-
-        final int numSides = LOD.getNrOfSides(outerRadius);
-        final List<Integer> outerVertices = new ArrayList<>(numSides);
-        final List<Integer> innerVertices = Float.compare(innerRadius, 0f) > 0 ? new ArrayList<>(numSides) : null;
-
-        for (int i = 0; i < numSides; i++) {
-            final double angle = 2 * Math.PI * i / numSides;
-            final float y = outerRadius * (float) Math.cos(angle);
-            final float z = outerRadius * (float) Math.sin(angle);
-            obj.addVertex(transformer.convertLoc(0, y, z));
-            outerVertices.add(obj.getNumVertices() - 1);
-        }
-
-        if (innerVertices != null) {
-            for (int i = 0; i < numSides; i++) {
-                final double angle = 2 * Math.PI * i / numSides;
-                final float y = innerRadius * (float) Math.cos(angle);
-                final float z = innerRadius * (float) Math.sin(angle);
-                obj.addVertex(transformer.convertLoc(0, y, z));
-                innerVertices.add(obj.getNumVertices() - 1);
-            }
-        }
-
-        DiskExporter.closeDiskMesh(obj, transformer, null, outerVertices, innerVertices, false, true);
-        DiskExporter.closeDiskMesh(obj, transformer, null, outerVertices, innerVertices, false, false);
-    }
+		// Translate the mesh to the position in the rocket
+		Coordinate location = context.getLocation();
+		ObjUtils.translateVerticesFromComponentLocation(obj, transformer, startIdx, endIdx, location);
+	}
 }

--- a/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/FinSetExporter.java
+++ b/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/FinSetExporter.java
@@ -60,7 +60,7 @@ public class FinSetExporter extends RocketComponentExporter<FinSet> {
         // Generate the instance mesh
         if (isZeroThickness) {
             addZeroThicknessPolygonMesh(floatPoints);
-        } else {
+        } else if (floatPoints.getXCoords().length >= 3) {
             PolygonExporter.addPolygonMesh(obj, transformer, null,
                     floatPoints.getXCoords(), floatPoints.getYCoords(), thickness);
         }
@@ -69,7 +69,7 @@ public class FinSetExporter extends RocketComponentExporter<FinSet> {
         if (hasTabs) {
             if (isZeroThickness) {
                 addZeroThicknessPolygonMesh(floatTabPoints);
-            } else {
+            } else if (floatTabPoints.getXCoords().length >= 3) {
                 PolygonExporter.addPolygonMesh(obj, transformer, null,
                         floatTabPoints.getXCoords(), floatTabPoints.getYCoords(), thickness);
             }

--- a/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/FinSetExporter.java
+++ b/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/FinSetExporter.java
@@ -79,7 +79,7 @@ public class FinSetExporter extends RocketComponentExporter<FinSet> {
             return;    // No geometry generated
         }
 
-        int endIdx = Math.max(obj.getNumVertices() - 1, startIdx);                  // Clamp in case no vertices were added
+        int endIdx = obj.getNumVertices() - 1;                  // Clamp in case no vertices were added
         int normalsEndIdx = Math.max(obj.getNumNormals() - 1, normalsStartIdx);     // Clamp in case no normals were added
 
         // First rotate for the cant angle

--- a/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/FinSetExporter.java
+++ b/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/FinSetExporter.java
@@ -4,6 +4,7 @@ import com.sun.istack.NotNull;
 import de.javagl.obj.FloatTuple;
 import info.openrocket.core.file.wavefrontobj.CoordTransform;
 import info.openrocket.core.file.wavefrontobj.DefaultObj;
+import info.openrocket.core.file.wavefrontobj.DefaultObjFace;
 import info.openrocket.core.file.wavefrontobj.ObjUtils;
 import info.openrocket.core.file.wavefrontobj.export.shapes.PolygonExporter;
 import info.openrocket.core.logging.Warning;
@@ -54,14 +55,28 @@ public class FinSetExporter extends RocketComponentExporter<FinSet> {
         final int startIdx = obj.getNumVertices();
         final int normalsStartIdx = obj.getNumNormals();
 
+        final boolean isZeroThickness = Float.compare(thickness, 0f) == 0;
+
         // Generate the instance mesh
-        PolygonExporter.addPolygonMesh(obj, transformer, null,
-                floatPoints.getXCoords(), floatPoints.getYCoords(), thickness);
+        if (isZeroThickness) {
+            addZeroThicknessPolygonMesh(floatPoints);
+        } else {
+            PolygonExporter.addPolygonMesh(obj, transformer, null,
+                    floatPoints.getXCoords(), floatPoints.getYCoords(), thickness);
+        }
 
         // Generate the fin tabs
         if (hasTabs) {
-            PolygonExporter.addPolygonMesh(obj, transformer, null,
-                    floatTabPoints.getXCoords(), floatTabPoints.getYCoords(), thickness);
+            if (isZeroThickness) {
+                addZeroThicknessPolygonMesh(floatTabPoints);
+            } else {
+                PolygonExporter.addPolygonMesh(obj, transformer, null,
+                        floatTabPoints.getXCoords(), floatTabPoints.getYCoords(), thickness);
+            }
+        }
+
+        if (obj.getNumVertices() == startIdx) {
+            return;    // No geometry generated
         }
 
         int endIdx = Math.max(obj.getNumVertices() - 1, startIdx);                  // Clamp in case no vertices were added
@@ -119,6 +134,82 @@ public class FinSetExporter extends RocketComponentExporter<FinSet> {
         }
 
         return new FloatPoints(xCoords, yCoords);
+    }
+
+    private void addZeroThicknessPolygonMesh(FloatPoints floatPoints) {
+        final float[] pointLocationsX = floatPoints.getXCoords();
+        final float[] pointLocationsY = floatPoints.getYCoords();
+
+        if (pointLocationsX.length < 3) {
+            return;    // Degenerate polygon, nothing to export
+        }
+
+        final int startIdx = obj.getNumVertices();
+        final int normalsStartIdx = obj.getNumNormals();
+        final int texCoordsStartIdx = obj.getNumTexCoords();
+
+        obj.addNormal(transformer.convertLocWithoutOriginOffs(0, 0, -1));
+        obj.addNormal(transformer.convertLocWithoutOriginOffs(0, 0, 1));
+
+        float minX = Float.MAX_VALUE;
+        float maxX = -Float.MAX_VALUE;
+        float minY = Float.MAX_VALUE;
+        float maxY = -Float.MAX_VALUE;
+
+        for (int i = 0; i < pointLocationsX.length; i++) {
+            final float x = pointLocationsX[i];
+            final float y = pointLocationsY[i];
+
+            if (x < minX) {
+                minX = x;
+            }
+            if (x > maxX) {
+                maxX = x;
+            }
+            if (y < minY) {
+                minY = y;
+            }
+            if (y > maxY) {
+                maxY = y;
+            }
+
+            obj.addVertex(transformer.convertLoc(x, y, 0));
+        }
+
+        final float width = maxX - minX;
+        final float height = maxY - minY;
+
+        for (int i = 0; i < pointLocationsX.length; i++) {
+            float u = width > 0 ? (pointLocationsX[i] - minX) / width : 0;
+            u = 1.0f - u;
+            float v = height > 0 ? (pointLocationsY[i] - minY) / height : 0;
+            v = 1.0f - v;
+            obj.addTexCoord(u, v);
+        }
+
+        int[] vertexIndices = new int[pointLocationsX.length];
+        int[] texCoordsIndices = new int[pointLocationsX.length];
+        int[] normalIndices = new int[pointLocationsX.length];
+        for (int i = 0; i < pointLocationsX.length; i++) {
+            vertexIndices[i] = pointLocationsX.length - 1 - i;
+            texCoordsIndices[i] = pointLocationsX.length - 1 - i;
+            normalIndices[i] = normalsStartIdx;
+        }
+        ObjUtils.offsetIndex(vertexIndices, startIdx);
+        ObjUtils.offsetIndex(texCoordsIndices, texCoordsStartIdx);
+        obj.addFace(new DefaultObjFace(vertexIndices, texCoordsIndices, normalIndices));
+
+        vertexIndices = new int[pointLocationsX.length];
+        texCoordsIndices = new int[pointLocationsX.length];
+        normalIndices = new int[pointLocationsX.length];
+        for (int i = 0; i < pointLocationsX.length; i++) {
+            vertexIndices[i] = i;
+            texCoordsIndices[i] = i;
+            normalIndices[i] = normalsStartIdx + 1;
+        }
+        ObjUtils.offsetIndex(vertexIndices, startIdx);
+        ObjUtils.offsetIndex(texCoordsIndices, texCoordsStartIdx);
+        obj.addFace(new DefaultObjFace(vertexIndices, texCoordsIndices, normalIndices));
     }
 
     private record FloatPoints(float[] xCoords, float[] yCoords) {

--- a/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/LaunchLugExporter.java
+++ b/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/LaunchLugExporter.java
@@ -40,7 +40,10 @@ public class LaunchLugExporter extends RocketComponentExporter<LaunchLug> {
         // Generate the mesh
         int startIdx = obj.getNumVertices();
         TubeExporter.addTubeMesh(obj, transformer, null, outerRadius, innerRadius, length, LOD);
-        int endIdx = Math.max(obj.getNumVertices() - 1, startIdx);    // Clamp in case no vertices were added
+        if (obj.getNumVertices() == startIdx) {
+            return;
+        }
+        int endIdx = obj.getNumVertices() - 1;
 
         // Translate the mesh to the position in the rocket
         final Coordinate location = context.getLocation();

--- a/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/MassObjectExporter.java
+++ b/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/MassObjectExporter.java
@@ -97,10 +97,10 @@ public class MassObjectExporter extends RocketComponentExporter<MassObject> {
             }
         }
 
-        int endIdx = Math.max(obj.getNumVertices() - 1, startIdx);        // Clamp in case no vertices were added
         if (obj.getNumVertices() == startIdx) {
             return;
         }
+		int endIdx = obj.getNumVertices() - 1;
 
         // Create top tip faces
         for (int i = 0; i < numSides; i++) {

--- a/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/MassObjectExporter.java
+++ b/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/MassObjectExporter.java
@@ -37,6 +37,13 @@ public class MassObjectExporter extends RocketComponentExporter<MassObject> {
         int startIdx = obj.getNumVertices();
         int texCoordsStartIdx = obj.getNumTexCoords();
         int normalsStartIdx = obj.getNumNormals();
+        if (Double.compare(component.getLength(), 0) == 0 || Double.compare(component.getRadius(), 0) == 0) {
+            return;
+        }
+
+        numStacks = Math.max(numStacks, 2);
+        numSides = Math.max(numSides, 3);
+
         double dx = component.getLength() / numStacks;
         double da = 2.0f * Math.PI / numSides;
 
@@ -91,6 +98,9 @@ public class MassObjectExporter extends RocketComponentExporter<MassObject> {
         }
 
         int endIdx = Math.max(obj.getNumVertices() - 1, startIdx);        // Clamp in case no vertices were added
+        if (obj.getNumVertices() == startIdx) {
+            return;
+        }
 
         // Create top tip faces
         for (int i = 0; i < numSides; i++) {

--- a/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/MotorExporter.java
+++ b/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/MotorExporter.java
@@ -128,7 +128,10 @@ public class MotorExporter {
             obj.addTexCoord(u, 0.0f);
         }
 
-        int endIdx = Math.max(obj.getNumVertices() - 1, startIdx);    // Clamp in case no vertices were added
+		if (obj.getNumVertices() == startIdx) {
+			return;    // No geometry generated
+		}
+        int endIdx = obj.getNumVertices() - 1;
         int normalsEndIdx = Math.max(obj.getNumNormals() - 1, normalsStartIdx);
 
         // Create the cone faces

--- a/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/RailButtonExporter.java
+++ b/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/RailButtonExporter.java
@@ -133,7 +133,7 @@ public class RailButtonExporter extends RocketComponentExporter<RailButton> {
 
         final int endIdx = Math.max(obj.getNumVertices() - 1, startIdx);
         if (obj.getNumVertices() == startIdx) {
-            return;
+            return;		// TODO: maybe this shouldn't happen, as the rest could still generate
         }
         final int normalEndIdx = Math.max(obj.getNumNormals() - 1, normalStartIdx);
 

--- a/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/RailButtonExporter.java
+++ b/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/RailButtonExporter.java
@@ -42,9 +42,15 @@ public class RailButtonExporter extends RocketComponentExporter<RailButton> {
         final float flangeHeight = (float) component.getFlangeHeight();
         final float screwHeight = (float) component.getScrewHeight();
 
+        if (Float.compare(outerRadius, 0f) <= 0) {
+            return;
+        }
+
+        final float clampedInnerRadius = Math.max(0, Math.min(innerRadius, outerRadius));
+
         // Generate the mesh
         for (InstanceContext context : getInstanceContexts()) {
-            generateMesh(outerRadius, innerRadius, baseHeight, innerHeight, flangeHeight, screwHeight, context);
+            generateMesh(outerRadius, clampedInnerRadius, baseHeight, innerHeight, flangeHeight, screwHeight, context);
         }
     }
 
@@ -54,52 +60,81 @@ public class RailButtonExporter extends RocketComponentExporter<RailButton> {
         final int normalStartIdx = obj.getNumNormals();
         final int nrOfSides = LOD.getNrOfSides(outerRadius);
 
+        final boolean hasBase = Float.compare(baseHeight, 0f) > 0;
+        final boolean hasInner = Float.compare(innerRadius, 0f) > 0
+                && Float.compare(innerHeight, 0f) > 0
+                && Float.compare(outerRadius - innerRadius, 0f) > 0;
+        final boolean hasFlange = Float.compare(flangeHeight, 0f) > 0;
+        final boolean hasScrew = Float.compare(screwHeight, 0f) > 0;
+
+        if (!hasBase && !hasInner && !hasFlange && !hasScrew) {
+            return;
+        }
+
         // Generate base cylinder
         List<Integer> baseCylinderForeVertices = new ArrayList<>();
         List<Integer> baseCylinderAftVertices = new ArrayList<>();
-        CylinderExporter.addCylinderMesh(obj, transformer, null, outerRadius, baseHeight, false, nrOfSides,
-                baseCylinderForeVertices, baseCylinderAftVertices);
+        if (hasBase) {
+            CylinderExporter.addCylinderMesh(obj, transformer, null, outerRadius, baseHeight, false, nrOfSides,
+                    baseCylinderForeVertices, baseCylinderAftVertices);
+        }
 
         // Generate inner cylinder
         int tmpStartIdx = obj.getNumVertices();
         List<Integer> innerCylinderForeVertices = new ArrayList<>();
         List<Integer> innerCylinderAftVertices = new ArrayList<>();
-        CylinderExporter.addCylinderMesh(obj, transformer, null, innerRadius, innerHeight, false, nrOfSides,
-                innerCylinderForeVertices, innerCylinderAftVertices);
-        int tmpEndIdx = Math.max(obj.getNumVertices() - 1, tmpStartIdx);
-        FloatTuple locOffs = transformer.convertLocWithoutOriginOffs(baseHeight, 0, 0);
-        ObjUtils.translateVertices(obj, tmpStartIdx, tmpEndIdx, locOffs.getX(), locOffs.getY(), locOffs.getZ());
+        if (hasInner) {
+            CylinderExporter.addCylinderMesh(obj, transformer, null, innerRadius, innerHeight, false, nrOfSides,
+                    innerCylinderForeVertices, innerCylinderAftVertices);
+            int tmpEndIdx = Math.max(obj.getNumVertices() - 1, tmpStartIdx);
+            FloatTuple locOffs = transformer.convertLocWithoutOriginOffs(baseHeight, 0, 0);
+            ObjUtils.translateVertices(obj, tmpStartIdx, tmpEndIdx, locOffs.getX(), locOffs.getY(), locOffs.getZ());
+        }
 
         // Generate flange cylinder
         tmpStartIdx = obj.getNumVertices();
         List<Integer> flangeCylinderForeVertices = new ArrayList<>();
         List<Integer> flangeCylinderAftVertices = new ArrayList<>();
         List<Integer> flangeCylinderAftNormals = new ArrayList<>();
-        CylinderExporter.addCylinderMesh(obj, transformer, null, outerRadius, outerRadius, flangeHeight, nrOfSides,
-                false, true, flangeCylinderForeVertices, flangeCylinderAftVertices, null, flangeCylinderAftNormals);
-        tmpEndIdx = Math.max(obj.getNumVertices() - 1, tmpStartIdx);
-        locOffs = transformer.convertLocWithoutOriginOffs(baseHeight + innerHeight, 0, 0);
-        ObjUtils.translateVertices(obj, tmpStartIdx, tmpEndIdx, locOffs.getX(), locOffs.getY(), locOffs.getZ());
+        if (hasFlange) {
+            CylinderExporter.addCylinderMesh(obj, transformer, null, outerRadius, outerRadius, flangeHeight, nrOfSides,
+                    false, true, flangeCylinderForeVertices, flangeCylinderAftVertices, null, flangeCylinderAftNormals);
+            int tmpEndIdx = Math.max(obj.getNumVertices() - 1, tmpStartIdx);
+            FloatTuple locOffs = transformer.convertLocWithoutOriginOffs(baseHeight + innerHeight, 0, 0);
+            ObjUtils.translateVertices(obj, tmpStartIdx, tmpEndIdx, locOffs.getX(), locOffs.getY(), locOffs.getZ());
+        }
 
         // Generate base disk
-        DiskExporter.closeDiskMesh(obj, transformer, null, baseCylinderForeVertices, false, true);
+        if (!baseCylinderForeVertices.isEmpty()) {
+            DiskExporter.closeDiskMesh(obj, transformer, null, baseCylinderForeVertices, false, true);
+        }
 
         // Generate base inner disk
-        DiskExporter.closeDiskMesh(obj, transformer, null, baseCylinderAftVertices, innerCylinderForeVertices, false, false);
+        if (!baseCylinderAftVertices.isEmpty()) {
+            DiskExporter.closeDiskMesh(obj, transformer, null, baseCylinderAftVertices,
+                    hasInner ? innerCylinderForeVertices : null, false, false);
+        }
 
         // Generate flange inner disk
-        DiskExporter.closeDiskMesh(obj, transformer, null, innerCylinderAftVertices, flangeCylinderForeVertices, true, true);
+        if (hasInner && hasFlange) {
+            DiskExporter.closeDiskMesh(obj, transformer, null, innerCylinderAftVertices, flangeCylinderForeVertices, true, true);
+        }
 
         // Generate flange disk/screw
-        if (Float.compare(screwHeight, 0) == 0) {
-            DiskExporter.closeDiskMesh(obj, transformer, null, flangeCylinderAftVertices, false, false);
-        } else {
-            addScrew(obj, baseHeight, innerHeight, flangeHeight, outerRadius, screwHeight, LOD,
-                    flangeCylinderAftVertices, flangeCylinderAftNormals);
+        if (hasFlange) {
+            if (!hasScrew) {
+                DiskExporter.closeDiskMesh(obj, transformer, null, flangeCylinderAftVertices, false, false);
+            } else {
+                addScrew(obj, baseHeight, innerHeight, flangeHeight, outerRadius, screwHeight, LOD,
+                        flangeCylinderAftVertices, flangeCylinderAftNormals);
+            }
         }
 
 
         final int endIdx = Math.max(obj.getNumVertices() - 1, startIdx);
+        if (obj.getNumVertices() == startIdx) {
+            return;
+        }
         final int normalEndIdx = Math.max(obj.getNumNormals() - 1, normalStartIdx);
 
         // First orient the rail button correctly (upwards, not in the longitudinal direction)
@@ -129,6 +164,10 @@ public class RailButtonExporter extends RocketComponentExporter<RailButton> {
     private void addScrew(DefaultObj obj, float baseHeight, float innerHeight, float flangeHeight, float outerRadius,
                           float screwHeight, ObjUtils.LevelOfDetail LOD,
                           List<Integer> flangeCylinderAftVertices, List<Integer> flangeCylinderAftNormals) {
+        if (flangeCylinderAftVertices.isEmpty() || Float.compare(screwHeight, 0f) <= 0) {
+            return;
+        }
+
         final int nrOfStacks = LOD.getValue() / 10;
         final int nrOfSlices = flangeCylinderAftVertices.size();
         final int startIdx = obj.getNumVertices();

--- a/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/RingComponentExporter.java
+++ b/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/RingComponentExporter.java
@@ -4,6 +4,8 @@ import com.sun.istack.NotNull;
 import info.openrocket.core.file.wavefrontobj.CoordTransform;
 import info.openrocket.core.file.wavefrontobj.DefaultObj;
 import info.openrocket.core.file.wavefrontobj.ObjUtils;
+import info.openrocket.core.file.wavefrontobj.export.shapes.CylinderExporter;
+import info.openrocket.core.file.wavefrontobj.export.shapes.DiskExporter;
 import info.openrocket.core.file.wavefrontobj.export.shapes.TubeExporter;
 import info.openrocket.core.logging.Warning;
 import info.openrocket.core.logging.WarningSet;
@@ -11,6 +13,9 @@ import info.openrocket.core.rocketcomponent.FlightConfiguration;
 import info.openrocket.core.rocketcomponent.InstanceContext;
 import info.openrocket.core.rocketcomponent.RingComponent;
 import info.openrocket.core.util.Coordinate;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class RingComponentExporter extends RocketComponentExporter<RingComponent> {
     public RingComponentExporter(@NotNull DefaultObj obj, FlightConfiguration config, @NotNull CoordTransform transformer,
@@ -40,11 +45,70 @@ public class RingComponentExporter extends RocketComponentExporter<RingComponent
     private void generateMesh(float outerRadius, float innerRadius, float length, InstanceContext context) {
         // Generate the mesh
         int startIdx = obj.getNumVertices();
-        TubeExporter.addTubeMesh(obj, transformer, null, outerRadius, innerRadius, length, LOD);
+        final boolean zeroLength = Float.compare(length, 0f) == 0;
+        final boolean zeroThickness = Float.compare(outerRadius, innerRadius) == 0;
+
+        if (zeroLength && zeroThickness) {
+            return;    // Nothing to export
+        }
+
+        if (zeroLength) {
+            addRingDiskMesh(outerRadius, innerRadius);
+        } else if (zeroThickness) {
+            addZeroThicknessTubeMesh(outerRadius, length);
+        } else {
+            TubeExporter.addTubeMesh(obj, transformer, null, outerRadius, innerRadius, length, LOD);
+        }
+
+        if (obj.getNumVertices() == startIdx) {
+            return;    // No geometry generated
+        }
+
         int endIdx = Math.max(obj.getNumVertices() - 1, startIdx);    // Clamp in case no vertices were added
 
         // Translate the mesh to the position in the rocket
         final Coordinate location = context.getLocation();
         ObjUtils.translateVerticesFromComponentLocation(obj, transformer, startIdx, endIdx, location);
+    }
+
+    private void addZeroThicknessTubeMesh(float radius, float length) {
+        if (Float.compare(radius, 0f) <= 0 || Float.compare(length, 0f) == 0) {
+            return;
+        }
+
+        final int numSides = LOD.getNrOfSides(radius);
+        CylinderExporter.addCylinderMesh(obj, transformer, null, radius, radius, length, numSides,
+                false, true, null, null);
+    }
+
+    private void addRingDiskMesh(float outerRadius, float innerRadius) {
+        if (Float.compare(outerRadius, 0f) <= 0) {
+            return;
+        }
+
+        final int numSides = LOD.getNrOfSides(outerRadius);
+        final List<Integer> outerVertices = new ArrayList<>(numSides);
+        final List<Integer> innerVertices = Float.compare(innerRadius, 0f) > 0 ? new ArrayList<>(numSides) : null;
+
+        for (int i = 0; i < numSides; i++) {
+            final double angle = 2 * Math.PI * i / numSides;
+            final float y = outerRadius * (float) Math.cos(angle);
+            final float z = outerRadius * (float) Math.sin(angle);
+            obj.addVertex(transformer.convertLoc(0, y, z));
+            outerVertices.add(obj.getNumVertices() - 1);
+        }
+
+        if (innerVertices != null) {
+            for (int i = 0; i < numSides; i++) {
+                final double angle = 2 * Math.PI * i / numSides;
+                final float y = innerRadius * (float) Math.cos(angle);
+                final float z = innerRadius * (float) Math.sin(angle);
+                obj.addVertex(transformer.convertLoc(0, y, z));
+                innerVertices.add(obj.getNumVertices() - 1);
+            }
+        }
+
+        DiskExporter.closeDiskMesh(obj, transformer, null, outerVertices, innerVertices, false, true);
+        DiskExporter.closeDiskMesh(obj, transformer, null, outerVertices, innerVertices, false, false);
     }
 }

--- a/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/RingComponentExporter.java
+++ b/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/RingComponentExporter.java
@@ -63,8 +63,7 @@ public class RingComponentExporter extends RocketComponentExporter<RingComponent
         if (obj.getNumVertices() == startIdx) {
             return;    // No geometry generated
         }
-
-        int endIdx = Math.max(obj.getNumVertices() - 1, startIdx);    // Clamp in case no vertices were added
+        int endIdx = obj.getNumVertices() - 1;
 
         // Translate the mesh to the position in the rocket
         final Coordinate location = context.getLocation();

--- a/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/TransitionExporter.java
+++ b/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/TransitionExporter.java
@@ -65,7 +65,7 @@ public class TransitionExporter extends RocketComponentExporter<Transition> {
                 return;
             }
 
-            int endIdx = Math.max(obj.getNumVertices() - 1, startIdx);
+            int endIdx = obj.getNumVertices() - 1;
             final Coordinate location = context.getLocation();
             ObjUtils.translateVerticesFromComponentLocation(obj, transformer, startIdx, endIdx, location);
             return;
@@ -154,7 +154,10 @@ public class TransitionExporter extends RocketComponentExporter<Transition> {
         addShoulders(this.nrOfSides, outsideForeRingVertices, outsideAftRingVertices,
                 insideForeRingVertices, insideAftRingVertices, isFilled || zeroThickness, hasForeShoulder, hasAftShoulder);
 
-        int endIdx = Math.max(obj.getNumVertices() - 1, startIdx);    // Clamp in case no vertices were added
+		if (obj.getNumVertices() == startIdx) {
+			return;    // No geometry generated
+		}
+        int endIdx = obj.getNumVertices() - 1;
 
         // Translate the mesh to the position in the rocket
         final Coordinate location = context.getLocation();

--- a/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/TubeFinSetExporter.java
+++ b/core/src/main/java/info/openrocket/core/file/wavefrontobj/export/components/TubeFinSetExporter.java
@@ -43,8 +43,10 @@ public class TubeFinSetExporter extends RocketComponentExporter<TubeFinSet> {
 
         // Generate the instance mesh
         TubeExporter.addTubeMesh(obj, transformer, null, outerRadius, innerRadius, length, LOD.getValue());
-
-        int endIdx = Math.max(obj.getNumVertices() - 1, startIdx);                  // Clamp in case no vertices were added
+        if (obj.getNumVertices() == startIdx) {
+            return;
+        }
+        int endIdx = obj.getNumVertices() - 1;
 
         // Translate the mesh to the position in the rocket
         //      We will create an offset location that has the same effect as the axial rotation of the launch lug

--- a/core/src/test/java/info/openrocket/core/file/wavefrontobj/export/components/BodyTubeExporterTest.java
+++ b/core/src/test/java/info/openrocket/core/file/wavefrontobj/export/components/BodyTubeExporterTest.java
@@ -1,0 +1,108 @@
+package info.openrocket.core.file.wavefrontobj.export.components;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import info.openrocket.core.ServicesForTesting;
+import info.openrocket.core.file.wavefrontobj.Axis;
+import info.openrocket.core.file.wavefrontobj.CoordTransform;
+import info.openrocket.core.file.wavefrontobj.DefaultObj;
+import info.openrocket.core.file.wavefrontobj.ObjUtils;
+import info.openrocket.core.logging.WarningSet;
+import info.openrocket.core.plugin.PluginModule;
+import info.openrocket.core.rocketcomponent.BodyTube;
+import info.openrocket.core.rocketcomponent.FlightConfiguration;
+import info.openrocket.core.rocketcomponent.InstanceMap;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.startup.Application;
+import info.openrocket.core.util.Coordinate;
+import info.openrocket.core.util.Transformation;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BodyTubeExporterTest {
+
+    private static final float FLOAT_EPSILON = 1.0e-6f;
+
+    @BeforeAll
+    static void setup() {
+        Module applicationModule = new ServicesForTesting();
+        Module pluginModule = new PluginModule();
+        Injector injector = Guice.createInjector(applicationModule, pluginModule);
+        Application.setInjector(injector);
+    }
+
+    @Test
+    void skipsGeometryWhenLengthAndThicknessZero() {
+        BodyTube bodyTube = createBodyTube(0.05, 0.0, 0.0);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(bodyTube);
+
+        newExporter(obj, config, bodyTube, warnings).addToObj();
+
+        assertEquals(0, obj.getNumVertices(), "Degenerate body tube should emit no vertices");
+        assertEquals(0, obj.getNumFaces(), "Degenerate body tube should emit no faces");
+        assertEquals(1, warnings.size(), "Zero-thickness body tube should emit a warning");
+    }
+
+    @Test
+    void exportsDiskWhenLengthZero() {
+        BodyTube bodyTube = createBodyTube(0.05, 0.01, 0.0);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(bodyTube);
+
+        newExporter(obj, config, bodyTube, warnings).addToObj();
+
+        assertTrue(obj.getNumVertices() > 0, "Zero-length body tube should emit vertices");
+        assertTrue(obj.getNumFaces() > 0, "Zero-length body tube should emit faces");
+        assertEquals(0, warnings.size(), "Finite thickness disk should not emit warning");
+
+        for (int i = 0; i < obj.getNumVertices(); i++) {
+            assertEquals(0f, obj.getVertex(i).getX(), FLOAT_EPSILON, "Disk vertices should lie in a plane");
+        }
+    }
+
+    @Test
+    void exportsZeroThicknessTubeWhenLengthPositive() {
+        BodyTube bodyTube = createBodyTube(0.05, 0.0, 0.05);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(bodyTube);
+
+        newExporter(obj, config, bodyTube, warnings).addToObj();
+
+        assertTrue(obj.getNumVertices() > 0, "Zero-thickness tube should emit vertices");
+        assertTrue(obj.getNumFaces() > 0, "Zero-thickness tube should emit faces");
+        assertEquals(1, warnings.size(), "Zero-thickness tube should emit warning");
+    }
+
+    private static BodyTubeExporter newExporter(DefaultObj obj, FlightConfiguration config, BodyTube bodyTube, WarningSet warnings) {
+        CoordTransform transformer = CoordTransform.generateUsingAxialAndForwardAxes(Axis.X, Axis.Y, 0, 0, 0);
+        return new BodyTubeExporter(obj, config, transformer, bodyTube, "bodyTubeGroup", ObjUtils.LevelOfDetail.NORMAL_QUALITY, true, warnings);
+    }
+
+    private static FlightConfiguration prepareConfiguration(BodyTube bodyTube) {
+        Rocket rocket = new Rocket();
+        FlightConfiguration config = rocket.getSelectedConfiguration();
+        InstanceMap map = config.getActiveInstances();
+        map.emplace(bodyTube, 0, Transformation.IDENTITY);
+        return config;
+    }
+
+    private static BodyTube createBodyTube(double outerRadius, double thickness, double length) {
+        BodyTube tube = new BodyTube();
+        tube.setOuterRadius(outerRadius);
+        tube.setThickness(thickness);
+        tube.setLength(length);
+        tube.setFilled(false);
+        return tube;
+    }
+}

--- a/core/src/test/java/info/openrocket/core/file/wavefrontobj/export/components/BodyTubeExporterTest.java
+++ b/core/src/test/java/info/openrocket/core/file/wavefrontobj/export/components/BodyTubeExporterTest.java
@@ -84,6 +84,21 @@ class BodyTubeExporterTest {
         assertEquals(1, warnings.size(), "Zero-thickness tube should emit warning");
     }
 
+    @Test
+    void skipsGeometryWhenOuterRadiusZeroButLengthPositive() {
+        BodyTube bodyTube = createBodyTube(0.0, 0.0, 0.05);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(bodyTube);
+
+        newExporter(obj, config, bodyTube, warnings).addToObj();
+
+        assertEquals(0, obj.getNumVertices(), "Zero-diameter body tube should emit no vertices");
+        assertEquals(0, obj.getNumFaces(), "Zero-diameter body tube should emit no faces");
+        assertEquals(1, warnings.size(), "Zero-diameter body tube retains zero-thickness warning");
+    }
+
     private static BodyTubeExporter newExporter(DefaultObj obj, FlightConfiguration config, BodyTube bodyTube, WarningSet warnings) {
         CoordTransform transformer = CoordTransform.generateUsingAxialAndForwardAxes(Axis.X, Axis.Y, 0, 0, 0);
         return new BodyTubeExporter(obj, config, transformer, bodyTube, "bodyTubeGroup", ObjUtils.LevelOfDetail.NORMAL_QUALITY, true, warnings);

--- a/core/src/test/java/info/openrocket/core/file/wavefrontobj/export/components/FinSetExporterTest.java
+++ b/core/src/test/java/info/openrocket/core/file/wavefrontobj/export/components/FinSetExporterTest.java
@@ -1,0 +1,177 @@
+package info.openrocket.core.file.wavefrontobj.export.components;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import info.openrocket.core.ServicesForTesting;
+import info.openrocket.core.file.wavefrontobj.Axis;
+import info.openrocket.core.file.wavefrontobj.CoordTransform;
+import info.openrocket.core.file.wavefrontobj.DefaultObj;
+import info.openrocket.core.file.wavefrontobj.ObjUtils;
+import info.openrocket.core.logging.WarningSet;
+import info.openrocket.core.plugin.PluginModule;
+import info.openrocket.core.rocketcomponent.FinSet;
+import info.openrocket.core.rocketcomponent.FlightConfiguration;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.rocketcomponent.InstanceMap;
+import info.openrocket.core.startup.Application;
+import info.openrocket.core.util.Coordinate;
+import info.openrocket.core.util.Transformation;
+import de.javagl.obj.FloatTuple;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FinSetExporterTest {
+
+    private static final float FLOAT_EPSILON = 1.0e-6f;
+
+    @BeforeAll
+    static void setup() {
+        Module applicationModule = new ServicesForTesting();
+        Module pluginModule = new PluginModule();
+        Injector injector = Guice.createInjector(applicationModule, pluginModule);
+        Application.setInjector(injector);
+    }
+
+    @Test
+    void exportsZeroThicknessFinAsSinglePlane() {
+        TestFinSet finSet = createFin(0.0,
+                new Coordinate(0.0, 0.0, 0.0),
+                new Coordinate(0.02, 0.03, 0.0),
+                new Coordinate(0.05, 0.03, 0.0),
+                new Coordinate(0.05, 0.0, 0.0));
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(finSet);
+
+        newExporter(obj, config, finSet, warnings).addToObj();
+
+        assertEquals(4, obj.getNumVertices(), "Unexpected vertex count for zero-thickness fin");
+        assertEquals(2, obj.getNumNormals(), "Zero-thickness fin should only create front/back normals");
+        assertEquals(2, obj.getNumFaces(), "Zero-thickness fin should only create two faces");
+        assertEquals(1, warnings.size(), "Zero-thickness fin should emit a warning");
+
+        for (int i = 0; i < obj.getNumVertices(); i++) {
+            FloatTuple vertex = obj.getVertex(i);
+            assertEquals(0.0f, vertex.getZ(), FLOAT_EPSILON, "Zero-thickness fin must lie on a plane");
+        }
+    }
+
+    @Test
+    void skipsDegeneratePolygonWithLessThanThreePoints() {
+        TestFinSet finSet = createFin(0.0,
+                new Coordinate(0.0, 0.0, 0.0),
+                new Coordinate(0.03, 0.0, 0.0));
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(finSet);
+
+        newExporter(obj, config, finSet, warnings).addToObj();
+
+        assertEquals(0, obj.getNumVertices(), "Degenerate fin geometry should be ignored");
+        assertEquals(0, obj.getNumNormals(), "Degenerate fin geometry should not create normals");
+        assertEquals(0, obj.getNumFaces(), "Degenerate fin geometry should not create faces");
+        assertEquals(1, warnings.size(), "Zero-thickness degenerate fin should still register warning");
+    }
+
+    @Test
+    void extrudesConcaveFiniteThicknessFin() {
+        TestFinSet finSet = createFin(0.004,
+                new Coordinate(0.0, 0.0, 0.0),
+                new Coordinate(-0.01, 0.01, 0.0),
+                new Coordinate(-0.005, 0.025, 0.0),
+                new Coordinate(0.015, 0.03, 0.0),
+                new Coordinate(0.03, 0.015, 0.0));
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(finSet);
+
+        newExporter(obj, config, finSet, warnings).addToObj();
+
+        int expectedVertices = finSet.getFinPoints().length * 2;
+        int expectedFaces = finSet.getFinPoints().length + 2; // front/back + one quad per edge
+        int expectedNormals = finSet.getFinPoints().length + 2;
+
+        assertEquals(expectedVertices, obj.getNumVertices(), "Unexpected vertex count for extruded fin");
+        assertEquals(expectedFaces, obj.getNumFaces(), "Unexpected face count for extruded fin");
+        assertEquals(expectedNormals, obj.getNumNormals(), "Unexpected normal count for extruded fin");
+        assertEquals(0, warnings.size(), "Finite thickness fin should not emit zero-thickness warning");
+    }
+
+    private static FinSetExporter newExporter(DefaultObj obj, FlightConfiguration config, TestFinSet finSet, WarningSet warnings) {
+        CoordTransform transformer = CoordTransform.generateUsingAxialAndForwardAxes(Axis.X, Axis.Y, 0, 0, 0);
+        return new FinSetExporter(obj, config, transformer, finSet, "testGroup", ObjUtils.LevelOfDetail.NORMAL_QUALITY, true, warnings);
+    }
+
+    private static FlightConfiguration prepareConfiguration(TestFinSet finSet) {
+        Rocket rocket = new Rocket();
+        FlightConfiguration config = rocket.getSelectedConfiguration();
+        InstanceMap map = config.getActiveInstances();
+        map.emplace(finSet, 0, Transformation.IDENTITY);
+        return config;
+    }
+
+    private static TestFinSet createFin(double thickness, Coordinate... points) {
+        TestFinSet finSet = new TestFinSet(points);
+        finSet.setThickness(thickness);
+        return finSet;
+    }
+
+    private static final class TestFinSet extends FinSet {
+        private Coordinate[] finPoints;
+
+        private TestFinSet(Coordinate[] points) {
+            setFinPoints(points);
+        }
+
+        private void setFinPoints(Coordinate[] points) {
+            this.finPoints = Arrays.copyOf(points, points.length);
+            if (this.finPoints.length > 0) {
+                this.length = this.finPoints[this.finPoints.length - 1].x;
+            } else {
+                this.length = 0;
+            }
+        }
+
+        @Override
+        public Coordinate[] getFinPoints() {
+            return Arrays.copyOf(finPoints, finPoints.length);
+        }
+
+        @Override
+        public Coordinate[] getFinPointsWithRoot() {
+            return getFinPoints();
+        }
+
+        @Override
+        public Coordinate[] getTabPointsWithRoot() {
+            return new Coordinate[0];
+        }
+
+        @Override
+        public double getSpan() {
+            if (finPoints.length == 0) {
+                return 0;
+            }
+            double minY = finPoints[0].y;
+            double maxY = finPoints[0].y;
+            for (Coordinate point : finPoints) {
+                minY = Math.min(minY, point.y);
+                maxY = Math.max(maxY, point.y);
+            }
+            return maxY - minY;
+        }
+
+        @Override
+        public String getComponentName() {
+            return "TestFinSet";
+        }
+    }
+}

--- a/core/src/test/java/info/openrocket/core/file/wavefrontobj/export/components/FinSetExporterTest.java
+++ b/core/src/test/java/info/openrocket/core/file/wavefrontobj/export/components/FinSetExporterTest.java
@@ -81,6 +81,24 @@ class FinSetExporterTest {
     }
 
     @Test
+    void skipsDegeneratePolygonWithLessThanThreePointsWhenThick() {
+        TestFinSet finSet = createFin(0.004,
+                new Coordinate(0.0, 0.0, 0.0),
+                new Coordinate(0.03, 0.0, 0.0));
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(finSet);
+
+        newExporter(obj, config, finSet, warnings).addToObj();
+
+        assertEquals(0, obj.getNumVertices(), "Degenerate fin geometry should be ignored");
+        assertEquals(0, obj.getNumNormals(), "Degenerate fin geometry should not create normals");
+        assertEquals(0, obj.getNumFaces(), "Degenerate fin geometry should not create faces");
+        assertEquals(0, warnings.size(), "No warning expected for finite thickness degenerate fin");
+    }
+
+    @Test
     void extrudesConcaveFiniteThicknessFin() {
         TestFinSet finSet = createFin(0.004,
                 new Coordinate(0.0, 0.0, 0.0),

--- a/core/src/test/java/info/openrocket/core/file/wavefrontobj/export/components/LaunchLugExporterTest.java
+++ b/core/src/test/java/info/openrocket/core/file/wavefrontobj/export/components/LaunchLugExporterTest.java
@@ -1,0 +1,107 @@
+package info.openrocket.core.file.wavefrontobj.export.components;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import info.openrocket.core.ServicesForTesting;
+import info.openrocket.core.file.wavefrontobj.Axis;
+import info.openrocket.core.file.wavefrontobj.CoordTransform;
+import info.openrocket.core.file.wavefrontobj.DefaultObj;
+import info.openrocket.core.file.wavefrontobj.ObjUtils;
+import info.openrocket.core.logging.WarningSet;
+import info.openrocket.core.plugin.PluginModule;
+import info.openrocket.core.rocketcomponent.FlightConfiguration;
+import info.openrocket.core.rocketcomponent.InstanceMap;
+import info.openrocket.core.rocketcomponent.LaunchLug;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.startup.Application;
+import info.openrocket.core.util.Transformation;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LaunchLugExporterTest {
+
+    private static final float FLOAT_EPSILON = 1.0e-6f;
+
+    @BeforeAll
+    static void setup() {
+        Module applicationModule = new ServicesForTesting();
+        Module pluginModule = new PluginModule();
+        Injector injector = Guice.createInjector(applicationModule, pluginModule);
+        Application.setInjector(injector);
+    }
+
+    @Test
+    void skipsGeometryWhenLengthAndThicknessZero() {
+        LaunchLug launchLug = createLaunchLug(0.01, 0.0, 0.0);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(launchLug);
+
+        newExporter(obj, config, launchLug, warnings).addToObj();
+
+        assertEquals(0, obj.getNumVertices(), "Degenerate launch lug should emit no vertices");
+        assertEquals(0, obj.getNumFaces(), "Degenerate launch lug should emit no faces");
+        assertEquals(1, warnings.size(), "Zero-thickness launch lug should emit warning");
+    }
+
+    @Test
+    void exportsRingWhenLengthZeroButThicknessPositive() {
+        LaunchLug launchLug = createLaunchLug(0.01, 0.002, 0.0);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(launchLug);
+
+        newExporter(obj, config, launchLug, warnings).addToObj();
+
+        assertTrue(obj.getNumVertices() > 0, "Zero-length launch lug should emit vertices");
+        assertTrue(obj.getNumFaces() > 0, "Zero-length launch lug should emit faces");
+        assertEquals(0, warnings.size(), "Finite-thickness launch lug should not emit warning");
+
+        for (int i = 0; i < obj.getNumVertices(); i++) {
+            assertEquals(0f, obj.getVertex(i).getX(), FLOAT_EPSILON, "Ring vertices should lie in a plane");
+        }
+    }
+
+    @Test
+    void skipsGeometryWhenOuterRadiusZeroButLengthPositive() {
+        LaunchLug launchLug = createLaunchLug(0.0, 0.0, 0.05);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(launchLug);
+
+        newExporter(obj, config, launchLug, warnings).addToObj();
+
+        assertEquals(0, obj.getNumVertices(), "Zero-diameter launch lug should emit no vertices");
+        assertEquals(0, obj.getNumFaces(), "Zero-diameter launch lug should emit no faces");
+        assertEquals(1, warnings.size(), "Zero-diameter launch lug retains zero-thickness warning");
+    }
+
+    private static LaunchLugExporter newExporter(DefaultObj obj, FlightConfiguration config, LaunchLug launchLug, WarningSet warnings) {
+        CoordTransform transformer = CoordTransform.generateUsingAxialAndForwardAxes(Axis.X, Axis.Y, 0, 0, 0);
+        return new LaunchLugExporter(obj, config, transformer, launchLug, "launchLugGroup", ObjUtils.LevelOfDetail.NORMAL_QUALITY, true, warnings);
+    }
+
+    private static FlightConfiguration prepareConfiguration(LaunchLug launchLug) {
+        Rocket rocket = new Rocket();
+        FlightConfiguration config = rocket.getSelectedConfiguration();
+        InstanceMap map = config.getActiveInstances();
+        map.emplace(launchLug, 0, Transformation.IDENTITY);
+        return config;
+    }
+
+    private static LaunchLug createLaunchLug(double outerRadius, double thickness, double length) {
+        LaunchLug launchLug = new LaunchLug();
+        launchLug.setInstanceCount(1);
+        launchLug.setOuterRadius(outerRadius);
+        launchLug.setThickness(thickness);
+        launchLug.setLength(length);
+        return launchLug;
+    }
+}

--- a/core/src/test/java/info/openrocket/core/file/wavefrontobj/export/components/MassObjectExporterTest.java
+++ b/core/src/test/java/info/openrocket/core/file/wavefrontobj/export/components/MassObjectExporterTest.java
@@ -1,0 +1,98 @@
+package info.openrocket.core.file.wavefrontobj.export.components;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import info.openrocket.core.ServicesForTesting;
+import info.openrocket.core.file.wavefrontobj.Axis;
+import info.openrocket.core.file.wavefrontobj.CoordTransform;
+import info.openrocket.core.file.wavefrontobj.DefaultObj;
+import info.openrocket.core.file.wavefrontobj.ObjUtils;
+import info.openrocket.core.logging.WarningSet;
+import info.openrocket.core.plugin.PluginModule;
+import info.openrocket.core.rocketcomponent.FlightConfiguration;
+import info.openrocket.core.rocketcomponent.InstanceMap;
+import info.openrocket.core.rocketcomponent.MassComponent;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.startup.Application;
+import info.openrocket.core.util.Transformation;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MassObjectExporterTest {
+
+    @BeforeAll
+    static void setup() {
+        Module applicationModule = new ServicesForTesting();
+        Module pluginModule = new PluginModule();
+        Injector injector = Guice.createInjector(applicationModule, pluginModule);
+        Application.setInjector(injector);
+    }
+
+    @Test
+    void skipsGeometryWhenLengthZero() {
+        MassComponent massComponent = createMassComponent(0.0, 0.02);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(massComponent);
+
+        newExporter(obj, config, massComponent, warnings).addToObj();
+
+        assertEquals(0, obj.getNumVertices(), "Zero-length mass object should emit no vertices");
+        assertEquals(0, obj.getNumFaces(), "Zero-length mass object should emit no faces");
+    }
+
+    @Test
+    void skipsGeometryWhenRadiusZero() {
+        MassComponent massComponent = createMassComponent(0.05, 0.0);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(massComponent);
+
+        newExporter(obj, config, massComponent, warnings).addToObj();
+
+        assertEquals(0, obj.getNumVertices(), "Zero-radius mass object should emit no vertices");
+        assertEquals(0, obj.getNumFaces(), "Zero-radius mass object should emit no faces");
+    }
+
+    @Test
+    void exportsNominalMassObject() {
+        MassComponent massComponent = createMassComponent(0.05, 0.02);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(massComponent);
+
+        newExporter(obj, config, massComponent, warnings).addToObj();
+
+        assertTrue(obj.getNumVertices() > 0, "Nominal mass object should emit vertices");
+        assertTrue(obj.getNumFaces() > 0, "Nominal mass object should emit faces");
+    }
+
+    private static MassObjectExporter newExporter(DefaultObj obj, FlightConfiguration config, MassComponent component, WarningSet warnings) {
+        CoordTransform transformer = CoordTransform.generateUsingAxialAndForwardAxes(Axis.X, Axis.Y, 0, 0, 0);
+        return new MassObjectExporter(obj, config, transformer, component, "massComponentGroup",
+                ObjUtils.LevelOfDetail.NORMAL_QUALITY, true, warnings);
+    }
+
+    private static FlightConfiguration prepareConfiguration(MassComponent component) {
+        Rocket rocket = new Rocket();
+        FlightConfiguration config = rocket.getSelectedConfiguration();
+        InstanceMap map = config.getActiveInstances();
+        map.emplace(component, 0, Transformation.IDENTITY);
+        return config;
+    }
+
+    private static MassComponent createMassComponent(double length, double radius) {
+        MassComponent component = new MassComponent();
+        component.setLength(length);
+        component.setRadius(radius);
+        component.setComponentMass(0.1);
+        return component;
+    }
+}

--- a/core/src/test/java/info/openrocket/core/file/wavefrontobj/export/components/RailButtonExporterTest.java
+++ b/core/src/test/java/info/openrocket/core/file/wavefrontobj/export/components/RailButtonExporterTest.java
@@ -1,0 +1,106 @@
+package info.openrocket.core.file.wavefrontobj.export.components;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import info.openrocket.core.ServicesForTesting;
+import info.openrocket.core.file.wavefrontobj.Axis;
+import info.openrocket.core.file.wavefrontobj.CoordTransform;
+import info.openrocket.core.file.wavefrontobj.DefaultObj;
+import info.openrocket.core.file.wavefrontobj.ObjUtils;
+import info.openrocket.core.logging.WarningSet;
+import info.openrocket.core.plugin.PluginModule;
+import info.openrocket.core.rocketcomponent.FlightConfiguration;
+import info.openrocket.core.rocketcomponent.InstanceMap;
+import info.openrocket.core.rocketcomponent.RailButton;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.startup.Application;
+import info.openrocket.core.util.Transformation;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RailButtonExporterTest {
+
+    @BeforeAll
+    static void setup() {
+        Module applicationModule = new ServicesForTesting();
+        Module pluginModule = new PluginModule();
+        Injector injector = Guice.createInjector(applicationModule, pluginModule);
+        Application.setInjector(injector);
+    }
+
+    @Test
+    void skipsGeometryWhenOuterDiameterZero() {
+        RailButton railButton = createRailButton(0.0, 0.0, 0.01, 0.005, 0.002);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(railButton);
+
+        newExporter(obj, config, railButton, warnings).addToObj();
+
+        assertEquals(0, obj.getNumVertices(), "Zero-diameter rail button should emit no vertices");
+        assertEquals(0, obj.getNumFaces(), "Zero-diameter rail button should emit no faces");
+    }
+
+    @Test
+    void exportsNominalRailButton() {
+        RailButton railButton = createRailButton(0.02, 0.01, 0.01, 0.005, 0.002);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(railButton);
+
+        newExporter(obj, config, railButton, warnings).addToObj();
+
+        assertTrue(obj.getNumVertices() > 0, "Nominal rail button should emit vertices");
+        assertTrue(obj.getNumFaces() > 0, "Nominal rail button should emit faces");
+    }
+
+    @Test
+    void handlesZeroBaseHeight() {
+        RailButton railButton = createRailButton(0.02, 0.0, 0.0, 0.004, 0.0);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(railButton);
+
+        newExporter(obj, config, railButton, warnings).addToObj();
+
+        assertTrue(obj.getNumVertices() > 0, "Rail button with zero base height should still emit geometry");
+        assertTrue(obj.getNumFaces() > 0, "Rail button with zero base height should still emit faces");
+    }
+
+    private static RailButtonExporter newExporter(DefaultObj obj, FlightConfiguration config, RailButton railButton, WarningSet warnings) {
+        CoordTransform transformer = CoordTransform.generateUsingAxialAndForwardAxes(Axis.X, Axis.Y, 0, 0, 0);
+        return new RailButtonExporter(obj, config, transformer, railButton, "railButtonGroup",
+                ObjUtils.LevelOfDetail.NORMAL_QUALITY, true, warnings);
+    }
+
+    private static FlightConfiguration prepareConfiguration(RailButton railButton) {
+        Rocket rocket = new Rocket();
+        FlightConfiguration config = rocket.getSelectedConfiguration();
+        InstanceMap map = config.getActiveInstances();
+        map.emplace(railButton, 0, Transformation.IDENTITY);
+        return config;
+    }
+
+    private static RailButton createRailButton(double outerDiameter, double innerDiameter, double baseHeight,
+                                               double flangeHeight, double screwHeight) {
+        RailButton railButton = new RailButton();
+        double cylindricalHeight = Math.max(0, baseHeight) + Math.max(0, flangeHeight);
+        double totalHeight = Math.max(cylindricalHeight + Math.max(0, screwHeight), 0.001);
+
+        railButton.setOuterDiameter(outerDiameter);
+        railButton.setInnerDiameter(innerDiameter);
+        railButton.setBaseHeight(baseHeight);
+        railButton.setFlangeHeight(flangeHeight);
+        railButton.setTotalHeight(totalHeight);
+        railButton.setScrewHeight(screwHeight);
+        railButton.setInstanceCount(1);
+        return railButton;
+    }
+}

--- a/core/src/test/java/info/openrocket/core/file/wavefrontobj/export/components/RingComponentExporterTest.java
+++ b/core/src/test/java/info/openrocket/core/file/wavefrontobj/export/components/RingComponentExporterTest.java
@@ -1,0 +1,123 @@
+package info.openrocket.core.file.wavefrontobj.export.components;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import info.openrocket.core.ServicesForTesting;
+import info.openrocket.core.file.wavefrontobj.Axis;
+import info.openrocket.core.file.wavefrontobj.CoordTransform;
+import info.openrocket.core.file.wavefrontobj.DefaultObj;
+import info.openrocket.core.file.wavefrontobj.ObjUtils;
+import info.openrocket.core.logging.WarningSet;
+import info.openrocket.core.plugin.PluginModule;
+import info.openrocket.core.rocketcomponent.CenteringRing;
+import info.openrocket.core.rocketcomponent.FlightConfiguration;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.rocketcomponent.InstanceMap;
+import info.openrocket.core.startup.Application;
+import info.openrocket.core.util.Transformation;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RingComponentExporterTest {
+
+    private static final float FLOAT_EPSILON = 1.0e-6f;
+
+    @BeforeAll
+    static void setup() {
+        Module applicationModule = new ServicesForTesting();
+        Module pluginModule = new PluginModule();
+        Injector injector = Guice.createInjector(applicationModule, pluginModule);
+        Application.setInjector(injector);
+    }
+
+    @Test
+    void exportsZeroThicknessTubeWhenLengthPositive() {
+        CenteringRing ring = createRing(0.03, 0.03, 0.02);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(ring);
+
+        newExporter(obj, config, ring, warnings).addToObj();
+
+        assertTrue(obj.getNumVertices() > 0, "Zero-thickness tube should emit geometry");
+        assertTrue(obj.getNumFaces() > 0, "Zero-thickness tube should emit faces");
+        assertEquals(1, warnings.size(), "Zero-thickness tube should emit a warning");
+    }
+
+    @Test
+    void exportsTubeForValidRing() {
+        CenteringRing ring = createRing(0.04, 0.02, 0.01);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(ring);
+
+        newExporter(obj, config, ring, warnings).addToObj();
+
+        assertTrue(obj.getNumVertices() > 0, "Valid ring should create vertices");
+        assertTrue(obj.getNumFaces() > 0, "Valid ring should create faces");
+        assertEquals(0, warnings.size(), "No warning expected for valid ring thickness");
+    }
+
+    @Test
+    void exportsRingDiskWhenLengthZero() {
+        CenteringRing ring = createRing(0.04, 0.02, 0.0);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(ring);
+
+        newExporter(obj, config, ring, warnings).addToObj();
+
+        assertTrue(obj.getNumVertices() > 0, "Ring disk should emit vertices");
+        assertTrue(obj.getNumFaces() > 0, "Ring disk should emit faces");
+        assertEquals(0, warnings.size(), "No warning expected for finite thickness ring disk");
+
+        for (int i = 0; i < obj.getNumVertices(); i++) {
+            assertEquals(0f, obj.getVertex(i).getX(), FLOAT_EPSILON, "Ring disk vertices should lie in a plane");
+        }
+    }
+
+    @Test
+    void skipsGeometryWhenLengthAndThicknessZero() {
+        CenteringRing ring = createRing(0.03, 0.03, 0.0);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(ring);
+
+        newExporter(obj, config, ring, warnings).addToObj();
+
+        assertEquals(0, obj.getNumVertices(), "Degenerate ring should emit no vertices");
+        assertEquals(0, obj.getNumFaces(), "Degenerate ring should emit no faces");
+        assertEquals(1, warnings.size(), "Degenerate ring should still emit thickness warning");
+    }
+
+    private static RingComponentExporter newExporter(DefaultObj obj, FlightConfiguration config, CenteringRing ring, WarningSet warnings) {
+        CoordTransform transformer = CoordTransform.generateUsingAxialAndForwardAxes(Axis.X, Axis.Y, 0, 0, 0);
+        return new RingComponentExporter(obj, config, transformer, ring, "ringGroup", ObjUtils.LevelOfDetail.NORMAL_QUALITY, true, warnings);
+    }
+
+    private static FlightConfiguration prepareConfiguration(CenteringRing ring) {
+        Rocket rocket = new Rocket();
+        FlightConfiguration config = rocket.getSelectedConfiguration();
+        InstanceMap map = config.getActiveInstances();
+        map.emplace(ring, 0, Transformation.IDENTITY);
+        return config;
+    }
+
+    private static CenteringRing createRing(double outerRadius, double innerRadius, double length) {
+        CenteringRing ring = new CenteringRing();
+        ring.setOuterRadiusAutomatic(false);
+        ring.setInnerRadiusAutomatic(false);
+        ring.setOuterRadius(outerRadius);
+        ring.setInnerRadius(innerRadius);
+        ring.setLength(length);
+        return ring;
+    }
+}

--- a/core/src/test/java/info/openrocket/core/file/wavefrontobj/export/components/TransitionExporterTest.java
+++ b/core/src/test/java/info/openrocket/core/file/wavefrontobj/export/components/TransitionExporterTest.java
@@ -1,0 +1,105 @@
+package info.openrocket.core.file.wavefrontobj.export.components;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import info.openrocket.core.ServicesForTesting;
+import info.openrocket.core.file.wavefrontobj.Axis;
+import info.openrocket.core.file.wavefrontobj.CoordTransform;
+import info.openrocket.core.file.wavefrontobj.DefaultObj;
+import info.openrocket.core.file.wavefrontobj.ObjUtils;
+import info.openrocket.core.logging.WarningSet;
+import info.openrocket.core.plugin.PluginModule;
+import info.openrocket.core.rocketcomponent.FlightConfiguration;
+import info.openrocket.core.rocketcomponent.InstanceMap;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.rocketcomponent.Transition;
+import info.openrocket.core.startup.Application;
+import info.openrocket.core.util.Transformation;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TransitionExporterTest {
+
+    @BeforeAll
+    static void setup() {
+        Module applicationModule = new ServicesForTesting();
+        Module pluginModule = new PluginModule();
+        Injector injector = Guice.createInjector(applicationModule, pluginModule);
+        Application.setInjector(injector);
+    }
+
+    @Test
+    void exportsDiskWhenLengthZero() {
+        Transition transition = createTransition(0.06, 0.04, 0.01, 0.0);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(transition);
+
+        newExporter(obj, config, transition, warnings).addToObj();
+
+        assertTrue(obj.getNumVertices() > 0, "Zero-length transition should emit vertices");
+        assertTrue(obj.getNumFaces() > 0, "Zero-length transition should emit faces");
+        assertEquals(0, warnings.size(), "No zero-thickness warning expected");
+    }
+
+    @Test
+    void skipsGeometryWhenLengthAndThicknessZero() {
+        Transition transition = createTransition(0.05, 0.05, 0.0, 0.0);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(transition);
+
+        newExporter(obj, config, transition, warnings).addToObj();
+
+        assertEquals(0, obj.getNumVertices(), "Degenerate transition should emit no vertices");
+        assertEquals(0, obj.getNumFaces(), "Degenerate transition should emit no faces");
+        assertEquals(1, warnings.size(), "Zero-thickness transition should emit warning");
+    }
+
+    @Test
+    void exportsZeroThicknessTransition() {
+        Transition transition = createTransition(0.06, 0.03, 0.0, 0.05);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(transition);
+
+        newExporter(obj, config, transition, warnings).addToObj();
+
+        assertTrue(obj.getNumVertices() > 0, "Zero-thickness transition should emit vertices");
+        assertTrue(obj.getNumFaces() > 0, "Zero-thickness transition should emit faces");
+        assertEquals(1, warnings.size(), "Zero-thickness transition should emit warning");
+    }
+
+    private static TransitionExporter newExporter(DefaultObj obj, FlightConfiguration config, Transition transition, WarningSet warnings) {
+        CoordTransform transformer = CoordTransform.generateUsingAxialAndForwardAxes(Axis.X, Axis.Y, 0, 0, 0);
+        return new TransitionExporter(obj, config, transformer, transition, "transitionGroup",
+                ObjUtils.LevelOfDetail.NORMAL_QUALITY, true, warnings);
+    }
+
+    private static FlightConfiguration prepareConfiguration(Transition transition) {
+        Rocket rocket = new Rocket();
+        FlightConfiguration config = rocket.getSelectedConfiguration();
+        InstanceMap map = config.getActiveInstances();
+        map.emplace(transition, 0, Transformation.IDENTITY);
+        return config;
+    }
+
+    private static Transition createTransition(double foreRadius, double aftRadius, double thickness, double length) {
+        Transition transition = new Transition();
+        transition.setForeRadius(foreRadius);
+        transition.setAftRadius(aftRadius);
+        transition.setThickness(thickness);
+        transition.setLength(length);
+        transition.setFilled(false);
+        transition.setForeShoulderLength(0);
+        transition.setAftShoulderLength(0);
+        return transition;
+    }
+}

--- a/core/src/test/java/info/openrocket/core/file/wavefrontobj/export/components/TubeFinSetExporterTest.java
+++ b/core/src/test/java/info/openrocket/core/file/wavefrontobj/export/components/TubeFinSetExporterTest.java
@@ -1,0 +1,102 @@
+package info.openrocket.core.file.wavefrontobj.export.components;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import info.openrocket.core.ServicesForTesting;
+import info.openrocket.core.file.wavefrontobj.Axis;
+import info.openrocket.core.file.wavefrontobj.CoordTransform;
+import info.openrocket.core.file.wavefrontobj.DefaultObj;
+import info.openrocket.core.file.wavefrontobj.ObjUtils;
+import info.openrocket.core.logging.WarningSet;
+import info.openrocket.core.plugin.PluginModule;
+import info.openrocket.core.rocketcomponent.FlightConfiguration;
+import info.openrocket.core.rocketcomponent.InstanceMap;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.rocketcomponent.TubeFinSet;
+import info.openrocket.core.startup.Application;
+import info.openrocket.core.util.Transformation;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TubeFinSetExporterTest {
+
+    @BeforeAll
+    static void setup() {
+        Module applicationModule = new ServicesForTesting();
+        Module pluginModule = new PluginModule();
+        Injector injector = Guice.createInjector(applicationModule, pluginModule);
+        Application.setInjector(injector);
+    }
+
+    @Test
+    void skipsGeometryWhenLengthAndThicknessZero() {
+        TubeFinSet tubeFinSet = createTubeFinSet(0.05, 0.0, 0.0);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(tubeFinSet);
+
+        newExporter(obj, config, tubeFinSet, warnings).addToObj();
+
+        assertEquals(0, obj.getNumVertices(), "Degenerate tube fin set should emit no vertices");
+        assertEquals(0, obj.getNumFaces(), "Degenerate tube fin set should emit no faces");
+        assertEquals(1, warnings.size(), "Zero-thickness tube fin set should emit warning");
+    }
+
+    @Test
+    void exportsRingWhenLengthZeroButThicknessPositive() {
+        TubeFinSet tubeFinSet = createTubeFinSet(0.05, 0.01, 0.0);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(tubeFinSet);
+
+        newExporter(obj, config, tubeFinSet, warnings).addToObj();
+
+        assertTrue(obj.getNumVertices() > 0, "Zero-length tube fin set should emit vertices");
+        assertTrue(obj.getNumFaces() > 0, "Zero-length tube fin set should emit faces");
+        assertEquals(0, warnings.size(), "Finite-thickness tube fin set should not emit warning");
+    }
+
+    @Test
+    void skipsGeometryWhenOuterRadiusZeroButLengthPositive() {
+        TubeFinSet tubeFinSet = createTubeFinSet(0.0, 0.0, 0.1);
+
+        DefaultObj obj = new DefaultObj();
+        WarningSet warnings = new WarningSet();
+        FlightConfiguration config = prepareConfiguration(tubeFinSet);
+
+        newExporter(obj, config, tubeFinSet, warnings).addToObj();
+
+        assertEquals(0, obj.getNumVertices(), "Zero-diameter tube fin set should emit no vertices");
+        assertEquals(0, obj.getNumFaces(), "Zero-diameter tube fin set should emit no faces");
+        assertEquals(1, warnings.size(), "Zero-diameter tube fin set retains zero-thickness warning");
+    }
+
+    private static TubeFinSetExporter newExporter(DefaultObj obj, FlightConfiguration config, TubeFinSet tubeFinSet, WarningSet warnings) {
+        CoordTransform transformer = CoordTransform.generateUsingAxialAndForwardAxes(Axis.X, Axis.Y, 0, 0, 0);
+        return new TubeFinSetExporter(obj, config, transformer, tubeFinSet, "tubeFinSetGroup", ObjUtils.LevelOfDetail.NORMAL_QUALITY, true, warnings);
+    }
+
+    private static FlightConfiguration prepareConfiguration(TubeFinSet tubeFinSet) {
+        Rocket rocket = new Rocket();
+        FlightConfiguration config = rocket.getSelectedConfiguration();
+        InstanceMap map = config.getActiveInstances();
+        map.emplace(tubeFinSet, 0, Transformation.IDENTITY);
+        return config;
+    }
+
+    private static TubeFinSet createTubeFinSet(double outerRadius, double thickness, double length) {
+        TubeFinSet tubeFinSet = new TubeFinSet();
+        tubeFinSet.setOuterRadiusAutomatic(false);
+        tubeFinSet.setOuterRadius(outerRadius);
+        tubeFinSet.setThickness(thickness);
+        tubeFinSet.setLength(length);
+        tubeFinSet.setFinCount(1);
+        return tubeFinSet;
+    }
+}


### PR DESCRIPTION
This PR fixes #2881, fixes #2794, and fixes #2611. OBJ exporting now better accounts for components that have a 0 thickness or length.