### PR TITLE
 [#2704] Allow toggling of simulation table column visibility 

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/openrocket/OpenRocketSaver.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/OpenRocketSaver.java
@@ -229,7 +229,7 @@ public class OpenRocketSaver extends RocketSaver {
 		/*
 		 * NOTE:  Remember to update the supported versions in DocumentConfig as well!
 		 */
-		return FILE_VERSION_DIVISOR + 10;
+		return FILE_VERSION_DIVISOR + 11;
 		
 	}
 	

--- a/core/src/main/java/info/openrocket/core/file/openrocket/importt/DocumentConfig.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/importt/DocumentConfig.java
@@ -53,7 +53,8 @@ import info.openrocket.core.util.Reflection;
 class DocumentConfig {
 	
 	/* Remember to update OpenRocketSaver as well! */
-	public static final String[] SUPPORTED_VERSIONS = { "1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "1.10" };
+	public static final String[] SUPPORTED_VERSIONS = { "1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8",
+			"1.9", "1.10" , "1.11"};
 	
 	/**
 	 * Divisor used in converting an integer version to the point-represented version.

--- a/core/src/main/resources/build.properties
+++ b/core/src/main/resources/build.properties
@@ -1,6 +1,6 @@
 
 # The OpenRocket build version
-build.version=24.12
+build.version=25.xx.SNAPSHOT
 
 # The copyright year for the build. Displayed in the about dialog.
 # Will show as Copyright 2013-${build.copyright}

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -813,6 +813,8 @@ simpanel.ttip.CriticalWarnings = Critical(s):
 simpanel.ttip.NormalWarnings = Warning(s):
 simpanel.ttip.InformationalWarnings = Informational(s):
 simpanel.msg.invalidCopySelection = Invalid copy selection
+simpanel.btn.SaveAsDefault = Save as default
+simpanel.btn.SaveAsDefault.ttip = Save the selected visibility settings for all new designs
 
 ! SimulationRunDialog
 SimuRunDlg.title.RunSim = Running simulations\u2026

--- a/core/src/test/java/info/openrocket/core/file/openrocket/OpenRocketSaverTest.java
+++ b/core/src/test/java/info/openrocket/core/file/openrocket/OpenRocketSaverTest.java
@@ -328,13 +328,13 @@ public class OpenRocketSaverTest {
 	}
 	
 	////////////////////////////////
-	// Tests for File Version 1.10 //
+	// Tests for File Version 1.11 //
 	////////////////////////////////
 	
 	@Test
-	public void testFileVersion110_withSimulationExtension() {
+	public void testFileVersion111_withSimulationExtension() {
 		OpenRocketDocument rocketDoc = TestRockets.makeTestRocket_v110_withSimulationExtension(SIMULATION_EXTENSION_SCRIPT);
-		assertEquals(110, getCalculatedFileVersion(rocketDoc));
+		assertEquals(111, getCalculatedFileVersion(rocketDoc));
 	}
 	
 

--- a/fileformat.txt
+++ b/fileformat.txt
@@ -77,3 +77,4 @@ The following file format versions exist:
 
 1.11: Introduced with OpenRocket 25.XX.
       Added <simulationsteppermethod> to <simulation> element.
+      Added simulation.table.hiddenColumns document preference for simulation table column visibility.

--- a/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
@@ -15,13 +15,19 @@ import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
+import java.awt.event.ItemEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serial;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
@@ -30,6 +36,7 @@ import javax.swing.BoxLayout;
 import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
+import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JComponent;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
@@ -44,6 +51,8 @@ import javax.swing.SwingUtilities;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.DefaultTableCellRenderer;
+import javax.swing.table.TableColumn;
+import javax.swing.table.TableColumnModel;
 
 import info.openrocket.core.arch.SystemInfo;
 import info.openrocket.core.logging.Message;
@@ -58,6 +67,7 @@ import info.openrocket.core.document.events.SimulationChangeEvent;
 import info.openrocket.core.formatting.RocketDescriptor;
 import info.openrocket.core.l10n.Translator;
 import info.openrocket.core.preferences.ApplicationPreferences;
+import info.openrocket.core.preferences.DocumentPreferences;
 import info.openrocket.core.rocketcomponent.ComponentChangeEvent;
 import info.openrocket.core.rocketcomponent.ComponentChangeListener;
 import info.openrocket.core.rocketcomponent.FlightConfigurationId;
@@ -115,6 +125,7 @@ public class SimulationPanel extends JPanel {
 	private final JButton plotButton;
 	private final JButton simTableExportButton;
 	private final JPopupMenu pm;
+	private final ColumnVisibilityController columnVisibilityController;
 
 	private final SimulationAction editSimulationAction;
 	private final SimulationAction cutSimulationAction;
@@ -129,6 +140,37 @@ public class SimulationPanel extends JPanel {
 
 	private int[] previousSelection = null;
 
+	private static final String PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simulation.table.hiddenColumns";
+	private static final String COLUMN_ID_STATUS = "status";
+	private static final String COLUMN_ID_WARNINGS = "warnings";
+	private static final String COLUMN_ID_NAME = "name";
+	private static final String COLUMN_ID_CONFIGURATION = "configuration";
+	private static final String COLUMN_ID_SIMULATION_STEPPER = "simulationStepper";
+	private static final String COLUMN_ID_LAUNCH_ROD_VELOCITY = "launchRodVelocity";
+	private static final String COLUMN_ID_APOGEE = "apogee";
+	private static final String COLUMN_ID_DEPLOYMENT_VELOCITY = "deploymentVelocity";
+	private static final String COLUMN_ID_OPTIMUM_COAST_TIME = "optimumCoastTime";
+	private static final String COLUMN_ID_MAX_VELOCITY = "maxVelocity";
+	private static final String COLUMN_ID_MAX_ACCELERATION = "maxAcceleration";
+	private static final String COLUMN_ID_TIME_TO_APOGEE = "timeToApogee";
+	private static final String COLUMN_ID_FLIGHT_TIME = "flightTime";
+	private static final String COLUMN_ID_GROUND_HIT_VELOCITY = "groundHitVelocity";
+	private static final String[] SIMULATION_TABLE_COLUMN_IDS = {
+		COLUMN_ID_STATUS,
+		COLUMN_ID_WARNINGS,
+		COLUMN_ID_NAME,
+		COLUMN_ID_CONFIGURATION,
+		COLUMN_ID_SIMULATION_STEPPER,
+		COLUMN_ID_LAUNCH_ROD_VELOCITY,
+		COLUMN_ID_APOGEE,
+		COLUMN_ID_DEPLOYMENT_VELOCITY,
+		COLUMN_ID_OPTIMUM_COAST_TIME,
+		COLUMN_ID_MAX_VELOCITY,
+		COLUMN_ID_MAX_ACCELERATION,
+		COLUMN_ID_TIME_TO_APOGEE,
+		COLUMN_ID_FLIGHT_TIME,
+		COLUMN_ID_GROUND_HIT_VELOCITY
+	};
 
 	private static Color dimTextColor;
 	private static Color warningColor;
@@ -231,6 +273,20 @@ public class SimulationPanel extends JPanel {
 		pm.add(runSimulationAction);
 		pm.add(plotSimulationAction);
 		pm.add(selectedSimsExportAction);
+
+		columnVisibilityController = new ColumnVisibilityController(simulationTable, document.getDocumentPreferences());
+
+		simulationTable.getTableHeader().addMouseListener(new MouseAdapter() {
+			@Override
+			public void mousePressed(MouseEvent e) {
+				columnVisibilityController.handleHeaderMouseEvent(e);
+			}
+
+			@Override
+			public void mouseReleased(MouseEvent e) {
+				columnVisibilityController.handleHeaderMouseEvent(e);
+			}
+		});
 
 		// The normal left/right and tab/shift-tab key action traverses each cell/column of the table instead of going to the next row.
 		TableRowTraversalPolicy.setTableRowTraversalPolicy(simulationTable);
@@ -1640,5 +1696,209 @@ public class SimulationPanel extends JPanel {
 				updateActions();
 			}
 		});
+	}
+
+	private static class ColumnVisibilityController {
+		private final ColumnTable table;
+		private final DocumentPreferences preferences;
+		private final List<ColumnDescriptor> descriptors = new ArrayList<>();
+		private final Map<String, ColumnDescriptor> descriptorById = new LinkedHashMap<>();
+		private final Set<String> hiddenColumnIds = new LinkedHashSet<>();
+
+		ColumnVisibilityController(ColumnTable table, DocumentPreferences preferences) {
+			this.table = table;
+			this.preferences = preferences;
+			captureColumns();
+			loadHiddenColumnsPreference();
+			applyHiddenColumnsFromPreferences();
+		}
+
+		void handleHeaderMouseEvent(MouseEvent e) {
+			if (!e.isPopupTrigger()) {
+				return;
+			}
+			e.consume();
+			createMenu().show(e.getComponent(), e.getX(), e.getY());
+		}
+
+		private void captureColumns() {
+			descriptors.clear();
+			descriptorById.clear();
+			TableColumnModel model = table.getColumnModel();
+			int columnCount = model.getColumnCount();
+			int limit = Math.min(columnCount, SIMULATION_TABLE_COLUMN_IDS.length);
+			for (int i = 0; i < limit; i++) {
+				addDescriptor(SIMULATION_TABLE_COLUMN_IDS[i], model.getColumn(i));
+			}
+			for (int i = limit; i < columnCount; i++) {
+				addDescriptor("column" + i, model.getColumn(i));
+			}
+		}
+
+		private void addDescriptor(String id, TableColumn column) {
+			column.setIdentifier(id);
+			ColumnDescriptor descriptor = new ColumnDescriptor(id, column);
+			descriptors.add(descriptor);
+			descriptorById.put(id, descriptor);
+		}
+
+		private void loadHiddenColumnsPreference() {
+			hiddenColumnIds.clear();
+			String prefValue = preferences.getString(PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS, "");
+
+			// Add default hidden columns if no preference is set
+			if (StringUtils.isEmpty(prefValue)) {
+				hiddenColumnIds.add(COLUMN_ID_SIMULATION_STEPPER);
+				return;
+			}
+
+			String[] ids = prefValue.split(",");
+			for (String raw : ids) {
+				String id = raw.trim();
+				if (id.isEmpty()) {
+					continue;
+				}
+				if (descriptorById.containsKey(id)) {
+					hiddenColumnIds.add(id);
+				}
+			}
+		}
+
+		private void applyHiddenColumnsFromPreferences() {
+			TableColumnModel model = table.getColumnModel();
+			for (ColumnDescriptor descriptor : descriptors) {
+				if (hiddenColumnIds.contains(descriptor.id) && isDescriptorInModel(descriptor, model)) {
+					model.removeColumn(descriptor.column);
+				}
+			}
+			if (model.getColumnCount() == 0 && !descriptors.isEmpty()) {
+				ColumnDescriptor first = descriptors.get(0);
+				hiddenColumnIds.remove(first.id);
+				model.addColumn(first.column);
+			}
+			refreshTable();
+		}
+
+		private JPopupMenu createMenu() {
+			JPopupMenu menu = new JPopupMenu();
+			int visibleCount = table.getColumnModel().getColumnCount();
+			for (ColumnDescriptor descriptor : descriptors) {
+				boolean visible = isDescriptorInModel(descriptor, table.getColumnModel());
+				JCheckBoxMenuItem item = new JCheckBoxMenuItem(descriptor.getDisplayName(), visible);
+				item.putClientProperty("columnId", descriptor.id);
+				if (visible && visibleCount <= 1) {
+					item.setEnabled(false);
+				}
+				item.addItemListener(event -> {
+					boolean selected = event.getStateChange() == ItemEvent.SELECTED;
+					toggleColumn(descriptor, selected);
+				});
+				menu.add(item);
+			}
+			return menu;
+		}
+
+		private void toggleColumn(ColumnDescriptor descriptor, boolean makeVisible) {
+			if (makeVisible) {
+				showColumn(descriptor, true);
+			} else {
+				hideColumn(descriptor, true);
+			}
+		}
+
+		private void hideColumn(ColumnDescriptor descriptor, boolean persistPreference) {
+			TableColumnModel model = table.getColumnModel();
+			if (!isDescriptorInModel(descriptor, model)) {
+				if (persistPreference && hiddenColumnIds.add(descriptor.id)) {
+					saveHiddenColumnsPreference();
+				}
+				return;
+			}
+			if (model.getColumnCount() <= 1) {
+				return;
+			}
+			model.removeColumn(descriptor.column);
+			hiddenColumnIds.add(descriptor.id);
+			if (persistPreference) {
+				saveHiddenColumnsPreference();
+			}
+			refreshTable();
+		}
+
+		private void showColumn(ColumnDescriptor descriptor, boolean persistPreference) {
+			TableColumnModel model = table.getColumnModel();
+			if (isDescriptorInModel(descriptor, model)) {
+				if (persistPreference && hiddenColumnIds.remove(descriptor.id)) {
+					saveHiddenColumnsPreference();
+				}
+				return;
+			}
+			hiddenColumnIds.remove(descriptor.id);
+			model.addColumn(descriptor.column);
+			int targetIndex = calculateInsertionIndex(descriptor, model);
+			int currentIndex = model.getColumnCount() - 1;
+			if (targetIndex >= 0 && targetIndex < model.getColumnCount()) {
+				model.moveColumn(currentIndex, targetIndex);
+			}
+			if (persistPreference) {
+				saveHiddenColumnsPreference();
+			}
+			refreshTable();
+		}
+
+		private int calculateInsertionIndex(ColumnDescriptor descriptor, TableColumnModel model) {
+			int index = 0;
+			for (ColumnDescriptor current : descriptors) {
+				if (current == descriptor) {
+					break;
+				}
+				if (isDescriptorInModel(current, model)) {
+					index++;
+				}
+			}
+			return index;
+		}
+
+		private boolean isDescriptorInModel(ColumnDescriptor descriptor, TableColumnModel model) {
+			try {
+				model.getColumnIndex(descriptor.id);
+				return true;
+			} catch (IllegalArgumentException e) {
+				return false;
+			}
+		}
+
+		private void saveHiddenColumnsPreference() {
+			StringBuilder builder = new StringBuilder();
+			for (String id : hiddenColumnIds) {
+				if (!descriptorById.containsKey(id)) {
+					continue;
+				}
+				if (!builder.isEmpty()) {
+					builder.append(',');
+				}
+				builder.append(id);
+			}
+			preferences.putString(PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS, builder.toString());
+		}
+
+		private void refreshTable() {
+			table.getTableHeader().resizeAndRepaint();
+			table.revalidate();
+			table.repaint();
+		}
+
+		private record ColumnDescriptor(String id, TableColumn column) {
+			private String getDisplayName() {
+						Object headerValue = column.getHeaderValue();
+						if (headerValue instanceof String header && !StringUtils.isEmpty(header)) {
+							return header;
+						}
+						if (COLUMN_ID_STATUS.equals(id)) {
+							return trans.get("simpanel.col.Status");
+						}
+						return id;
+					}
+				}
 	}
 }


### PR DESCRIPTION
This PR fixes one part of #2704, namely allowing you to toggle the column visibility in the simulation table. The visibility settings are stored in the document preferences, so you can have different configurations per document.

There is also a "Save as Default" option that uses the current settings for all new designs.
<img width="1543" height="596" alt="image" src="https://github.com/user-attachments/assets/83765d70-c36a-466b-90e1-f751eb6c791f" />

By default, the simulation stepper column is hidden, as I don't think a lot of users need this information visible all the time.