### PR TITLE
[#2902] Generate preview image when saving ORK file

### DIFF
--- a/core/src/main/java/info/openrocket/core/document/StorageOptions.java
+++ b/core/src/main/java/info/openrocket/core/document/StorageOptions.java
@@ -16,6 +16,7 @@ public class StorageOptions implements Cloneable {
 	private boolean saveSimulationData = false;
 
 	private boolean explicitlySet = false;
+	private byte[] previewImage;		// File preview image data
 
 	public FileType getFileType() {
 		return fileType;
@@ -41,10 +42,37 @@ public class StorageOptions implements Cloneable {
 		this.explicitlySet = explicitlySet;
 	}
 
+	/**
+	 * Get the file preview image data.
+	 * @return byte array containing image data, or null if no preview image is set.
+	 */
+	public byte[] getPreviewImage() {
+		return previewImage;
+	}
+
+	/**
+	 * Set the file preview image data.
+	 * @param previewImage byte array containing image data.
+	 */
+	public void setPreviewImage(byte[] previewImage) {
+		this.previewImage = previewImage;
+	}
+
+	/**
+	 * Clear the file preview image data.
+	 */
+	public void clearPreviewImage() {
+		this.previewImage = null;
+	}
+
 	@Override
 	public StorageOptions clone() {
 		try {
-			return (StorageOptions) super.clone();
+			StorageOptions clone = (StorageOptions) super.clone();
+			if (this.previewImage != null) {
+				clone.previewImage = this.previewImage.clone();
+			}
+			return clone;
 		} catch (CloneNotSupportedException e) {
 			throw new BugException("CloneNotSupportedException?!?", e);
 		}

--- a/core/src/main/java/info/openrocket/core/file/GeneralRocketSaver.java
+++ b/core/src/main/java/info/openrocket/core/file/GeneralRocketSaver.java
@@ -227,6 +227,15 @@ public class GeneralRocketSaver {
 			saveInternal(zos, document, options);
 			zos.closeEntry();
 
+			// Save the file preview image, if any.
+			byte[] previewImage = options.getPreviewImage();
+			if (previewImage != null && previewImage.length > 0) {
+				ZipEntry previewEntry = new ZipEntry("preview.png");
+				zos.putNextEntry(previewEntry);
+				zos.write(previewImage);
+				zos.closeEntry();
+			}
+
 			// Now we write out all the decal images files.
 			for (DecalImage image : decals) {
 				if (image.isIgnored()) {
@@ -248,6 +257,7 @@ public class GeneralRocketSaver {
 			}
 
 			zos.flush();
+			options.clearPreviewImage();
 		}
 
 	}

--- a/core/src/main/java/info/openrocket/core/preferences/ApplicationPreferences.java
+++ b/core/src/main/java/info/openrocket/core/preferences/ApplicationPreferences.java
@@ -68,6 +68,7 @@ public abstract class ApplicationPreferences implements ChangeSource, ORPreferen
 	public static final String EXPORT_COMMENT_CHARACTER = "ExportCommentCharacter";
 	public static final String USER_LOCAL = "locale";
 	public static final String DEFAULT_DIRECTORY = "defaultDirectory";
+	public static final String FILE_PREVIEW_VIEW_TYPE = "FilePreviewViewType";
 
 	public static final String PLOT_SHOW_POINTS = "ShowPlotPoints";
 

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -346,6 +346,7 @@ pref.dlg.opengl.lbl.title = 3D Graphics
 pref.dlg.opengl.but.enableGL = Enable 3D Graphics
 pref.dlg.opengl.but.enableAA = Enable Anti-aliasing
 pref.dlg.opengl.lbl.useFBO = Use Off-screen Rendering
+pref.dlg.lbl.previewSource = File preview design view:
 
 pref.dlg.lbl.DefaultMach = Default Mach Number for C.P. Estimate:
 

--- a/fileformat.txt
+++ b/fileformat.txt
@@ -78,3 +78,4 @@ The following file format versions exist:
 1.11: Introduced with OpenRocket 25.XX.
       Added <simulationsteppermethod> to <simulation> element.
       Added simulation.table.hiddenColumns document preference for simulation table column visibility.
+      Include a file preview image of the 2D side view in the .ork zip file ('preview.png').

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/DesignPreferencesPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/DesignPreferencesPanel.java
@@ -144,6 +144,30 @@ public class DesignPreferencesPanel extends PreferencesPanel {
 				}
 			}
 		});
-		this.add(showMarkers, "wrap, growx, spanx");
+		this.add(showMarkers, "wrap para, growx, spanx");
+
+		// // File preview view type
+		// TODO: uncomment this once 3D preview export is functional (in RocketPanel - capturePreviewImage)
+		/*add(new JLabel(trans.get("pref.dlg.lbl.previewSource")), "growx");
+
+		RocketPanel.VIEW_TYPE[] previewTypes = Arrays.stream(RocketPanel.VIEW_TYPE.values())
+				.filter(v -> v != RocketPanel.VIEW_TYPE.SEPARATOR)
+				.toArray(RocketPanel.VIEW_TYPE[]::new);
+		final JComboBox<RocketPanel.VIEW_TYPE> previewView = new JComboBox<>(previewTypes);
+
+		String savedPreview = preferences.getString(ApplicationPreferences.FILE_PREVIEW_VIEW_TYPE, null);
+		RocketPanel.VIEW_TYPE savedPreviewType = RocketPanel.VIEW_TYPE.fromName(savedPreview);
+		previewView.setSelectedItem(savedPreviewType);
+
+		previewView.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				RocketPanel.VIEW_TYPE selected = (RocketPanel.VIEW_TYPE) previewView.getSelectedItem();
+				if (selected != null) {
+					preferences.putString(ApplicationPreferences.FILE_PREVIEW_VIEW_TYPE, selected.name());
+				}
+			}
+		});
+		add(previewView, "growx, wrap");*/
 	}
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/main/BasicFrame.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/BasicFrame.java
@@ -14,6 +14,8 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -27,6 +29,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import javax.imageio.ImageIO;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
@@ -89,7 +92,6 @@ import info.openrocket.core.util.MemoryManagement.MemoryData;
 import info.openrocket.core.util.Reflection;
 import info.openrocket.core.util.TestRockets;
 
-import info.openrocket.swing.gui.choosers.OBJOptionChooser;
 import info.openrocket.swing.gui.configdialog.SaveDesignInfoPanel;
 import info.openrocket.swing.gui.dialogs.ErrorWarningDialog;
 import info.openrocket.swing.gui.components.StyledLabel;
@@ -129,11 +131,14 @@ import static java.awt.event.InputEvent.SHIFT_DOWN_MASK;
 public class BasicFrame extends JFrame {
 	private static final long serialVersionUID = 948877655223365313L;
 
-	private static final Logger log = LoggerFactory.getLogger(BasicFrame.class);
+private static final Logger log = LoggerFactory.getLogger(BasicFrame.class);
 
-	private static final GeneralRocketSaver ROCKET_SAVER = new GeneralRocketSaver();
+private static final GeneralRocketSaver ROCKET_SAVER = new GeneralRocketSaver();
+private static final int PREVIEW_WIDTH = 1000;
+private static final int PREVIEW_MIN_HEIGHT = 600;
+private static final int PREVIEW_MAX_HEIGHT = 800;
 
-	private static final Translator trans = Application.getTranslator();
+private static final Translator trans = Application.getTranslator();
 	private static final ApplicationPreferences prefs = Application.getPreferences();
 
 	public static final int SHORTCUT_KEY = Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx();
@@ -1853,6 +1858,14 @@ public class BasicFrame extends JFrame {
 			return false;
 		}
 
+		// Generate file preview image
+		byte[] previewImage = generatePreviewImage();
+		if (previewImage != null) {
+			document.getDefaultStorageOptions().setPreviewImage(previewImage);
+		} else {
+			document.getDefaultStorageOptions().clearPreviewImage();
+		}
+
 		document.getDefaultStorageOptions().setFileType(FileType.OPENROCKET);
 		SaveFileWorker worker = new SaveFileWorker(document, file, ROCKET_SAVER);
 
@@ -1900,6 +1913,36 @@ public class BasicFrame extends JFrame {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Generate a file preview image for saving in the design file.
+	 * @return the PNG image data, or null if no preview could be generated
+	 */
+	private byte[] generatePreviewImage() {
+		if (rocketpanel == null) {
+			return null;
+		}
+
+		String viewPreference = prefs.getString(ApplicationPreferences.FILE_PREVIEW_VIEW_TYPE,
+				RocketPanel.VIEW_TYPE.SideView.name());
+		RocketPanel.VIEW_TYPE previewView = RocketPanel.VIEW_TYPE.fromName(viewPreference);
+		if (previewView == null) {
+			previewView = RocketPanel.VIEW_TYPE.SideView;
+		}
+
+		BufferedImage preview = rocketpanel.capturePreviewImage(previewView, PREVIEW_WIDTH, PREVIEW_MIN_HEIGHT, PREVIEW_MAX_HEIGHT);
+		if (preview == null) {
+			return null;
+		}
+
+		try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+			ImageIO.write(preview, "png", output);
+			return output.toByteArray();
+		} catch (IOException e) {
+			log.warn("Unable to generate preview image for save.", e);
+			return null;
+		}
 	}
 
 

--- a/swing/src/main/java/info/openrocket/swing/gui/main/BasicFrame.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/BasicFrame.java
@@ -14,8 +14,6 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.awt.image.BufferedImage;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -29,7 +27,6 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import javax.imageio.ImageIO;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
@@ -1931,18 +1928,11 @@ private static final Translator trans = Application.getTranslator();
 			previewView = RocketPanel.VIEW_TYPE.SideView;
 		}
 
-		BufferedImage preview = rocketpanel.capturePreviewImage(previewView, PREVIEW_WIDTH, PREVIEW_MIN_HEIGHT, PREVIEW_MAX_HEIGHT);
-		if (preview == null) {
+		byte[] previewBytes = rocketpanel.createPreviewPng(previewView, PREVIEW_WIDTH, PREVIEW_MIN_HEIGHT, PREVIEW_MAX_HEIGHT);
+		if (previewBytes == null || previewBytes.length == 0) {
 			return null;
 		}
-
-		try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
-			ImageIO.write(preview, "png", output);
-			return output.toByteArray();
-		} catch (IOException e) {
-			log.warn("Unable to generate preview image for save.", e);
-			return null;
-		}
+		return previewBytes;
 	}
 
 

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
@@ -43,6 +43,7 @@ import info.openrocket.swing.gui.figureelements.RocketInfo;
 import info.openrocket.swing.gui.main.BasicFrame;
 import info.openrocket.swing.gui.main.componenttree.ComponentTreeModel;
 import info.openrocket.swing.gui.simulation.SimulationWorker;
+import info.openrocket.swing.gui.util.GUIUtil;
 import info.openrocket.swing.gui.util.SwingPreferences;
 import info.openrocket.swing.utils.CustomClickCountListener;
 import net.miginfocom.swing.MigLayout;
@@ -71,7 +72,10 @@ import javax.swing.tree.TreeSelectionModel;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.Graphics2D;
 import java.awt.Point;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
@@ -130,6 +134,26 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 
 		public static VIEW_TYPE getDefaultViewType() {
 			return SideView;
+		}
+
+		/**
+		 * Get VIEW_TYPE from its name (string).
+		 * @param name the name of the view type (as returned by name())
+		 * @return the VIEW_TYPE, or null if not found
+		 */
+		public static VIEW_TYPE fromName(String name) {
+			if (name == null) {
+				return null;
+			}
+			for (VIEW_TYPE value : VIEW_TYPE.values()) {
+				if (value == VIEW_TYPE.SEPARATOR) {
+					continue;
+				}
+				if (value.name().equalsIgnoreCase(name)) {
+					return value;
+				}
+			}
+			return null;
 		}
 
 	}
@@ -1131,6 +1155,170 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		//figure3d.addRelativeExtra(extraCG);
 		figure3d.addAbsoluteExtra(extraText);
 
+	}
+
+	/**
+	 * Capture a preview image of the rocket in the specified view type and size.
+	 * @param viewType the view type to capture
+	 * @param targetWidth the target width of the image
+	 * @param minHeight the minimum height of the image
+	 * @param maxHeight the maximum height of the image
+	 * @return the captured image, or null if 3D preview is requested
+	 */
+	public BufferedImage capturePreviewImage(VIEW_TYPE viewType, int targetWidth, int minHeight, int maxHeight) {
+		// TODO: implement 3D preview capture
+		if (viewType.is3d) {
+			return null;
+		}
+
+		BufferedImage source = create2DPreviewFigure(viewType, targetWidth, minHeight, maxHeight);
+		return scaleForPreview(source, targetWidth, minHeight, maxHeight);
+	}
+
+	/**
+	 * Compute the height that should be used when rendering preview images.
+	 * <p>
+	 * The value is anchored to the currently visible design panel so previews match
+	 * what the user sees, yet it is clamped to any caller-specified {@code minHeight}
+	 * or {@code maxHeight} bounds.  A minimum of one pixel is always returned to
+	 * protect downstream scaling math.
+	 */
+	private int resolveRenderHeight(int minHeight, int maxHeight) {
+		int base = figureHolder != null && figureHolder.getHeight() > 0 ? figureHolder.getHeight() : 700;
+		if (maxHeight > 0) {
+			base = Math.min(base, maxHeight);
+		}
+		if (minHeight > 0) {
+			base = Math.max(base, minHeight);
+		}
+		return Math.max(base, 1);
+	}
+
+	/**
+	 * Render the current rocket in a temporary 2D figure for use as a preview image.
+	 * <p>
+	 * The method reuses the live CG/CP carets and {@link RocketInfo} overlay so the preview
+	 * carries the same annotations as the editor.  The figure is scaled to fit the supplied
+	 * width/height bounds and drawn into a translucent {@link BufferedImage}.
+	 */
+	private BufferedImage create2DPreviewFigure(VIEW_TYPE viewType, int targetWidth, int minHeight, int maxHeight) {
+		if (viewType == null || viewType.is3d) {
+			viewType = VIEW_TYPE.getDefaultViewType();
+		}
+
+		// Create a temporary figure for rendering
+		RocketFigure previewFigure = new RocketFigure(document.getRocket());
+		previewFigure.setType(viewType);
+		previewFigure.setDrawCarets(false);
+		previewFigure.addRelativeExtra(extraCP);
+		previewFigure.addRelativeExtra(extraCG);
+		previewFigure.addAbsoluteExtra(extraText);
+
+		// Scale and layout the figure
+		int renderHeight = resolveRenderHeight(minHeight, maxHeight);
+		Dimension renderBounds = new Dimension(targetWidth, renderHeight);
+		previewFigure.scaleTo(renderBounds);
+		previewFigure.updateFigure();
+
+		// Determine canvas size
+		Dimension canvasSize = previewFigure.getPreferredSize();
+		if (canvasSize.width <= 0 || canvasSize.height <= 0) {
+			canvasSize = new Dimension(targetWidth, renderHeight);
+		}
+
+		// Layout the figure at the final size
+		previewFigure.setSize(canvasSize);
+		previewFigure.doLayout();
+
+		// Render the figure into a BufferedImage
+		BufferedImage raw = new BufferedImage(canvasSize.width, canvasSize.height, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D g2 = raw.createGraphics();
+		try {
+			g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+			previewFigure.paint(g2);
+		} finally {
+			g2.dispose();
+		}
+		return raw;
+	}
+
+	/**
+	 * Scale the rendered preview so it fits the requested target size while preserving aspect ratio,
+	 * adding letter-box style padding when needed.
+	 *
+	 * @param source      the raw preview image
+	 * @param targetWidth width the caller wishes to occupy
+	 * @param minHeight   optional minimum canvas height (0 disables)
+	 * @param maxHeight   optional maximum canvas height (0 disables)
+	 * @return an image ready to be embedded in the ORK archive
+	 */
+	private BufferedImage scaleForPreview(BufferedImage source, int targetWidth, int minHeight, int maxHeight) {
+		if (source == null || source.getWidth() <= 0 || source.getHeight() <= 0 || targetWidth <= 0) {
+			return source;
+		}
+
+		// Step 1: scale the image so its width matches the requested target while keeping aspect ratio.
+		double widthScale = targetWidth / (double) source.getWidth();
+		int scaledWidth = targetWidth;
+		int scaledHeight = (int) Math.round(source.getHeight() * widthScale);
+
+		// Step 2: if that height would exceed the allowed maximum, recompute using the max height instead.
+		if (maxHeight > 0 && scaledHeight > maxHeight) {
+			widthScale = maxHeight / (double) source.getHeight();
+			scaledWidth = (int) Math.round(source.getWidth() * widthScale);
+			scaledHeight = maxHeight;
+		}
+
+		if (scaledWidth <= 0) {
+			scaledWidth = 1;
+		}
+		if (scaledHeight <= 0) {
+			scaledHeight = 1;
+		}
+
+		// Perform the actual resampling with high-quality hints.
+		BufferedImage scaled = new BufferedImage(scaledWidth, scaledHeight, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D g2 = scaled.createGraphics();
+		try {
+			g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+			g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+			g2.drawImage(source, 0, 0, scaledWidth, scaledHeight, null);
+		} finally {
+			g2.dispose();
+		}
+
+		// Step 3: determine the final canvas size, padding to meet minHeight/targetWidth when necessary.
+		int canvasWidth = targetWidth;
+		if (scaledWidth > canvasWidth) {
+			canvasWidth = scaledWidth;
+		}
+		int canvasHeight = scaledHeight;
+		if (minHeight > 0 && canvasHeight < minHeight) {
+			canvasHeight = minHeight;
+		}
+
+		if (maxHeight > 0 && canvasHeight > maxHeight) {
+			canvasHeight = maxHeight;
+		}
+
+		if (canvasWidth == scaledWidth && canvasHeight == scaledHeight) {
+			return scaled;
+		}
+
+		// Step 4: center the scaled image on a background tinted to the current UI theme.
+		BufferedImage canvas = new BufferedImage(canvasWidth, canvasHeight, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D canvasGraphics = canvas.createGraphics();
+		try {
+			canvasGraphics.setColor(GUIUtil.getUITheme().getBackgroundColor());
+			canvasGraphics.fillRect(0, 0, canvasWidth, canvasHeight);
+			int x = (canvasWidth - scaledWidth) / 2;
+			int y = (canvasHeight - scaledHeight) / 2;
+			canvasGraphics.drawImage(scaled, x, y, null);
+		} finally {
+			canvasGraphics.dispose();
+		}
+
+		return canvas;
 	}
 
 	/**

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
@@ -1238,7 +1238,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		// Create a temporary figure for rendering
 		RocketFigure previewFigure = new RocketFigure(document.getRocket());
 		previewFigure.setType(viewType);
-		previewFigure.setDrawCarets(false);
+		previewFigure.setDrawCarets(true);
 		previewFigure.addRelativeExtra(extraCP);
 		previewFigure.addRelativeExtra(extraCG);
 		previewFigure.addAbsoluteExtra(extraText);

--- a/swing/src/main/java/info/openrocket/swing/gui/util/Icons.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/util/Icons.java
@@ -182,8 +182,18 @@ public class Icons {
 		}
 
 		Image image = ((ImageIcon) icon).getImage();
-		int width = (int)(image.getWidth(null) * scale);
-		int height = (int)(image.getHeight(null) * scale);
+		if (image == null) {
+			return icon;
+		}
+		int sourceWidth = image.getWidth(null);
+		int sourceHeight = image.getHeight(null);
+
+		if (sourceWidth <= 0 || sourceHeight <= 0) {
+			return icon;
+		}
+
+		int width = Math.max(1, (int) Math.round(sourceWidth * scale));
+		int height = Math.max(1, (int) Math.round(sourceHeight * scale));
 
 		// Create a new scaled image
 		Image scaledImage = image.getScaledInstance(width, height, Image.SCALE_SMOOTH);

--- a/swing/src/test/java/info/openrocket/swing/ServicesForTesting.java
+++ b/swing/src/test/java/info/openrocket/swing/ServicesForTesting.java
@@ -11,6 +11,7 @@ import info.openrocket.core.material.Material;
 import info.openrocket.core.preferences.ApplicationPreferences;
 import info.openrocket.core.preset.ComponentPreset;
 import info.openrocket.core.preset.ComponentPreset.Type;
+import info.openrocket.swing.gui.util.SwingPreferences;
 
 import java.util.Collections;
 import java.util.Locale;
@@ -59,7 +60,7 @@ public class ServicesForTesting extends AbstractModule {
 
 	}
 
-	public static class PreferencesForTesting extends ApplicationPreferences {
+	public static class PreferencesForTesting extends SwingPreferences {
 
 		private static java.util.prefs.Preferences root = null;
 

--- a/swing/src/test/java/info/openrocket/swing/gui/scalefigure/PreviewPersistenceTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/scalefigure/PreviewPersistenceTest.java
@@ -1,0 +1,122 @@
+package info.openrocket.swing.gui.scalefigure;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.GraphicsEnvironment;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import javax.imageio.ImageIO;
+import javax.swing.SwingUtilities;
+
+import info.openrocket.swing.util.BaseTestCase;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import info.openrocket.core.document.OpenRocketDocument;
+import info.openrocket.core.document.OpenRocketDocumentFactory;
+import info.openrocket.core.document.StorageOptions;
+import info.openrocket.core.file.GeneralRocketSaver;
+
+/**
+ * Validates that the generated preview bytes wind up in the saved ORK archive.
+ * <p>
+ * This test does not exercise the Swing rendering pipeline directly (which is hard to
+ * drive in a headless CI environment). Instead it feeds a known PNG payload into the
+ * storage options and verifies that {@link GeneralRocketSaver} persists it as the
+ * {@code preview.png} entry.
+ */
+class PreviewPersistenceTest extends BaseTestCase {
+
+	@Test
+	void previewPngIsEmbeddedInSavedArchive() throws Exception {
+		// Build a vivid 32x32 PNG so we can recognise the exact bytes that should be written.
+		BufferedImage stubPreview = new BufferedImage(32, 32, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D g2 = stubPreview.createGraphics();
+		g2.setColor(new Color(0x3366FF));
+		g2.fillRect(0, 0, 32, 32);
+		g2.setColor(new Color(0xFFCC00));
+		g2.fillOval(4, 4, 24, 24);
+		g2.dispose();
+
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+		assertTrue(ImageIO.write(stubPreview, "png", buffer), "PNG encoding should succeed");
+		byte[] previewBytes = buffer.toByteArray();
+		assertTrue(previewBytes.length > 0, "Encoded PNG must contain data");
+
+		OpenRocketDocument document = OpenRocketDocumentFactory.createNewRocket();
+		StorageOptions options = document.getDefaultStorageOptions();
+		options.setPreviewImage(previewBytes.clone());
+
+		File tempFile = Files.createTempFile("preview-test", ".ork").toFile();
+		tempFile.deleteOnExit();
+
+		new GeneralRocketSaver().save(tempFile, document);
+
+		try (ZipFile zip = new ZipFile(tempFile)) {
+			ZipEntry previewEntry = zip.getEntry("preview.png");
+			assertNotNull(previewEntry, "Saved ORK must contain preview.png");
+
+			try (InputStream previewStream = zip.getInputStream(previewEntry)) {
+				byte[] savedBytes = previewStream.readAllBytes();
+				assertArrayEquals(previewBytes, savedBytes, "Saved preview should match the source PNG exactly");
+			}
+		}
+	}
+
+	@Test
+	void previewGeneratedThroughRocketPanelIsPersisted() throws Exception {
+		Assumptions.assumeFalse(GraphicsEnvironment.isHeadless(),
+				"RocketPanel relies on Swing painting; skip in headless environments");
+
+		String previousFlag = System.getProperty("openrocket.unittest");
+		System.setProperty("openrocket.unittest", "true");
+
+		try {
+			OpenRocketDocument document = OpenRocketDocumentFactory.createNewRocket();
+			AtomicReference<RocketPanel> panelRef = new AtomicReference<>();
+			SwingUtilities.invokeAndWait(() -> panelRef.set(new RocketPanel(document)));
+
+			RocketPanel panel = panelRef.get();
+			assertNotNull(panel, "RocketPanel should be created");
+
+			AtomicReference<Boolean> attachedRef = new AtomicReference<>(Boolean.FALSE);
+			SwingUtilities.invokeAndWait(() -> attachedRef.set(panel.attachPreviewToDocument(
+					document, RocketPanel.VIEW_TYPE.SideView, 640, 480, 720)));
+
+			assertTrue(attachedRef.get(), "Preview image should be attached to the document");
+			byte[] storedPreview = document.getDefaultStorageOptions().getPreviewImage();
+			assertNotNull(storedPreview, "Document storage options should now contain preview bytes");
+			assertTrue(storedPreview.length > 0, "Stored preview data should be non-empty");
+
+			File tempFile = Files.createTempFile("preview-auto", ".ork").toFile();
+			tempFile.deleteOnExit();
+
+			new GeneralRocketSaver().save(tempFile, document);
+
+			try (ZipFile zip = new ZipFile(tempFile)) {
+				ZipEntry previewEntry = zip.getEntry("preview.png");
+				assertNotNull(previewEntry, "Saved ORK must contain preview.png generated via panel");
+
+				try (InputStream previewStream = zip.getInputStream(previewEntry)) {
+					byte[] savedBytes = previewStream.readAllBytes();
+					assertArrayEquals(storedPreview, savedBytes, "Saved preview should match the panel-generated PNG");
+				}
+			}
+		} finally {
+			if (previousFlag == null) {
+				System.clearProperty("openrocket.unittest");
+			} else {
+				System.setProperty("openrocket.unittest", previousFlag);
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes #2902. When saving a design, a file preview image of the 2D side view is generated and included in the .ork as `preview.png`. I attempted to do the same for the 3D view, but that's more tricky... It works if you are already in the 3D view, but to get it working all the time, you would have to do some magic with off-screen buffers and what not. That's for a future implementation... I did already put in the code to change the file preview view type (the code in the preferences panel is commented out).

Unzipped .ork of 'A simple model rocket':
<img width="715" height="318" alt="Screenshot 2025-10-24 at 11 45 13" src="https://github.com/user-attachments/assets/b5af62c8-f972-44dd-92c8-9b937c3de174" />

The image (1000x600 px):

<img width="1000" height="600" alt="preview" src="https://github.com/user-attachments/assets/b133032b-3fd5-44d2-be93-b7d40f0fc9ae" />

Note that I thought it would be helpful to show the flight info too.