### PR TITLE
[#2607] Add checkbox in plot to toggle visibility of flight events

### DIFF
--- a/core/src/main/java/info/openrocket/core/preferences/ApplicationPreferences.java
+++ b/core/src/main/java/info/openrocket/core/preferences/ApplicationPreferences.java
@@ -70,6 +70,7 @@ public abstract class ApplicationPreferences implements ChangeSource, ORPreferen
 	public static final String DEFAULT_DIRECTORY = "defaultDirectory";
 
 	public static final String PLOT_SHOW_POINTS = "ShowPlotPoints";
+    public static final String PLOT_SHOW_EVENTS = "ShowPlotEvents";
 
 	private static final String IGNORE_WELCOME = "IgnoreWelcome";
 

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -1895,6 +1895,7 @@ TCMotorSelPan.btn.close = Close
 
 ! PlotDialog
 PlotDialog.CheckBox.Showdatapoints = Show data points
+PlotDialog.CheckBox.ShowEvents = Show events
 PlotDialog.CheckBox.ShowErrors = Show errors
 
 PlotDialog.lbl.Chart = left click drag to zoom area. mouse wheel to zoom. ctrl-mouse wheel to zoom x axis only. ctrl-left click drag to pan.  right click drag to zoom dynamically.

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/CAPlotDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/CAPlotDialog.java
@@ -10,14 +10,15 @@ import java.awt.Window;
 import java.util.List;
 
 public class CAPlotDialog extends PlotDialog<CADataType, CADataBranch, CAPlotConfiguration, CAPlot> {
-	private CAPlotDialog(Window parent, String name, CAPlot plot, CAPlotConfiguration config, List<CADataBranch> allBranches, boolean initialShowPoints) {
-		super(parent, name, plot, config, allBranches, initialShowPoints);
+	private CAPlotDialog(Window parent, String name, CAPlot plot, CAPlotConfiguration config, List<CADataBranch> allBranches, boolean initialShowPoints, boolean initialShowEvents) {
+		super(parent, name, plot, config, allBranches, initialShowPoints, initialShowEvents);
 	}
 
 	public static CAPlotDialog create(Window parent, String name, CAPlotConfiguration config, List<CADataBranch> allBranches) {
 		final boolean initialShowPoints = Application.getPreferences().getBoolean(ApplicationPreferences.PLOT_SHOW_POINTS, false);
+        final boolean initialShowEvents = Application.getPreferences().getBoolean(ApplicationPreferences.PLOT_SHOW_EVENTS, true);
 		final CAPlot plot = new CAPlot(name, allBranches.get(0), config, allBranches, initialShowPoints);
 
-		return new CAPlotDialog(parent, name, plot, config, allBranches, initialShowPoints);
+		return new CAPlotDialog(parent, name, plot, config, allBranches, initialShowPoints, initialShowEvents);
 	}
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/plot/Plot.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/Plot.java
@@ -431,6 +431,10 @@ public abstract class Plot<T extends DataType, B extends DataBranch<T>, C extend
 		}
 	}
 
+    public void setShowEvents(boolean showEvents) {
+        // Default implementation does nothing
+    }
+
 	/**
 	 * A modification to the standard renderer that renders the domain marker
 	 * labels vertically instead of horizontally.

--- a/swing/src/main/java/info/openrocket/swing/gui/plot/PlotDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/PlotDialog.java
@@ -71,8 +71,21 @@ public abstract class PlotDialog<T extends DataType, B extends DataBranch<T>, C 
 		});
 		panel.add(checkData, "split, left");
 
-		// Show errors checkbox
-		showErrorsCheckbox(panel, plot);
+        //// Show events
+        final JCheckBox checkEvents = new JCheckBox(trans.get("PlotDialog.CheckBox.ShowEvents"));
+        checkEvents.setSelected(initialShowPoints);
+        checkEvents.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                boolean show = checkEvents.isSelected();
+                Application.getPreferences().putBoolean(ApplicationPreferences.PLOT_SHOW_EVENTS, show);
+                plot.setShowEvents(show);
+            }
+        });
+        panel.add(checkEvents, "split, left");
+
+        // Show errors checkbox
+        showErrorsCheckbox(panel, plot);
 
 		// Add series selection box
 		addSeriesSelectionBox(panel, plot, allBranches);

--- a/swing/src/main/java/info/openrocket/swing/gui/plot/PlotDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/PlotDialog.java
@@ -33,7 +33,7 @@ public abstract class PlotDialog<T extends DataType, B extends DataBranch<T>, C 
 		P extends Plot<T, B, C>> extends JDialog {
 	protected static final Translator trans = Application.getTranslator();
 
-	public PlotDialog(Window parent, String name, P plot, C config, List<B> allBranches, boolean initialShowPoints) {
+	public PlotDialog(Window parent, String name, P plot, C config, List<B> allBranches, boolean initialShowPoints, boolean initialShowEvents) {
 		super(parent, name);
 		this.setModalityType(ModalityType.DOCUMENT_MODAL);
 
@@ -73,7 +73,8 @@ public abstract class PlotDialog<T extends DataType, B extends DataBranch<T>, C 
 
         //// Show events
         final JCheckBox checkEvents = new JCheckBox(trans.get("PlotDialog.CheckBox.ShowEvents"));
-        checkEvents.setSelected(initialShowPoints);
+        checkEvents.setSelected(initialShowEvents);
+        plot.setShowEvents(initialShowEvents); // Initialize the show state of events
         checkEvents.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {

--- a/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationPlot.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationPlot.java
@@ -57,9 +57,6 @@ public class SimulationPlot extends Plot<FlightDataType, FlightDataBranch, Simul
 		// Create list of events to show (combine event too close to each other)
 		this.eventList = buildEventInfo();
 
-		// Create the event markers
-		drawDomainMarkers(-1);
-
 		errorAnnotations = new ErrorAnnotationSet(branchCount);
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationPlot.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationPlot.java
@@ -341,6 +341,18 @@ public class SimulationPlot extends Plot<FlightDataType, FlightDataBranch, Simul
 		}
 	}
 
+    @Override
+    public void setShowEvents(boolean showEvents) {
+        if (showEvents) {
+            drawDomainMarkers(-1); // show all added events
+        } else {
+            // Clean up the plot of its events
+            XYPlot plot = chart.getXYPlot();
+            plot.clearDomainMarkers();
+            plot.clearAnnotations();
+        }
+    }
+
 	private List<EventDisplayInfo> buildEventInfo() {
 		ArrayList<EventDisplayInfo> eventList = new ArrayList<>();
 

--- a/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationPlotDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationPlotDialog.java
@@ -44,8 +44,8 @@ public class SimulationPlotDialog extends PlotDialog<FlightDataType, FlightDataB
 	}
 
 	private SimulationPlotDialog(Window parent, Simulation simulation, SimulationPlotConfiguration config,
-								 SimulationPlot plot, boolean initialShowPoints) {
-		super(parent, simulation.getName(), plot, config, simulation.getSimulatedData().getBranches(), initialShowPoints);
+								 SimulationPlot plot, boolean initialShowPoints, boolean initialShowEvents) {
+		super(parent, simulation.getName(), plot, config, simulation.getSimulatedData().getBranches(), initialShowPoints, initialShowEvents);
 		this.simulation = simulation;
 		this.checkErrors.setVisible(this.simulation.hasErrors());
 	}
@@ -59,9 +59,10 @@ public class SimulationPlotDialog extends PlotDialog<FlightDataType, FlightDataB
 	 */
 	public static SimulationPlotDialog getPlot(Window parent, Simulation simulation, SimulationPlotConfiguration config) {
 		final boolean initialShowPoints = Application.getPreferences().getBoolean(ApplicationPreferences.PLOT_SHOW_POINTS, false);
+        final boolean initialShowEvents = Application.getPreferences().getBoolean(ApplicationPreferences.PLOT_SHOW_EVENTS, true);
 		final SimulationPlot plot = SimulationPlot.create(simulation, config, initialShowPoints);
 
-		return new SimulationPlotDialog(parent, simulation, config, plot, initialShowPoints);
+		return new SimulationPlotDialog(parent, simulation, config, plot, initialShowPoints, initialShowEvents);
 	}
 
 	@Override


### PR DESCRIPTION
This PR fixes [#2607](https://github.com/openrocket/openrocket/issues/2607), in which the user requested a checkbox in the simulation plot window to toggle the visibility of flight events.

The idea was that originally the user could either check or uncheck all of the flight events on the edit simulation window based on what they wanted to display on the plot window. But once in the plot window, the user would be unable to declutter their window without having to close it and then open it again.

What we did: in the PlotDialog file, we added a checkbox that changes the visibility of all shown events in the plot window. By default, the event visibility is set to true.

For our implementation, we found that the Show data points checkbox had a similar function to what we wanted to do, so the developed code was heavily inspired by what had already been put in place.
