### PR TITLE
Make mass components dialog more compact with scroll pane 

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/ParachuteConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/ParachuteConfig.java
@@ -54,11 +54,11 @@ public class ParachuteConfig extends RecoveryDeviceConfig {
 		Parachute parachute = (Parachute) component;
 
 		// Left Side
-		JPanel primary = new JPanel(new MigLayout());
-		JPanel panel = new JPanel(new MigLayout("gap rel unrel, ins 0", "[][65lp::][30lp::][]", ""));
+		JPanel primary = new JPanel(new MigLayout("fill, ins n n 0 n"));
+		JPanel panel = new JPanel(new MigLayout("fillx, gap rel unrel, ins 0", "[][65lp::][30lp::][]", ""));
 
 		// ---------------------------- Canopy ----------------------------
-		JPanel canopyPanel = new JPanel(new MigLayout("gap rel unrel", "[][65lp::][30lp::][]"));
+		JPanel canopyPanel = new JPanel(new MigLayout("fill, gap rel unrel", "[][65lp::][30lp::][]"));
 		canopyPanel.setBorder(BorderFactory.createTitledBorder(trans.get("ParachuteCfg.lbl.Canopy")));
 
 		//// Diameter:
@@ -131,11 +131,11 @@ public class ParachuteConfig extends RecoveryDeviceConfig {
 		canopyPanel.add(button, "spanx");
 		order.add(button);
 
-		panel.add(canopyPanel, "spanx, growx, wrap 10lp");
+		panel.add(canopyPanel, "spanx, grow, wrap 10lp");
 
 
 		//  ---------------------------- Shroud lines ----------------------------
-		JPanel shroudPanel = new JPanel(new MigLayout("gap rel unrel", "[][65lp::][30lp::][]"));
+		JPanel shroudPanel = new JPanel(new MigLayout("fill, gap rel unrel", "[][65lp::][30lp::][]"));
 		shroudPanel.setBorder(BorderFactory.createTitledBorder(trans.get("ParachuteCfg.lbl.Shroudlines")));
 
 		//// Number of lines:
@@ -170,11 +170,11 @@ public class ParachuteConfig extends RecoveryDeviceConfig {
 		shroudPanel.add(shroudMaterialCombo, "spanx, growx");
 		order.add(shroudMaterialCombo);
 
-		panel.add(shroudPanel, "spanx, wrap");
+		panel.add(shroudPanel, "spanx, grow, wrap");
 		primary.add(panel, "grow, gapright 20lp");
 
 		// Right side
-		panel = new JPanel(new MigLayout("gap rel unrel, ins 0", "[][65lp::][30lp::][]", ""));
+		panel = new JPanel(new MigLayout("fillx, gap rel unrel, ins 0", "[][65lp::][30lp::][]", ""));
 
 		{// ---------------------------- Placement ----------------------------
 			//// Position relative to:
@@ -226,7 +226,7 @@ public class ParachuteConfig extends RecoveryDeviceConfig {
 		}
 
 		{// ---------------------------- Deployment ----------------------------
-			JPanel deploymentPanel = new JPanel(new MigLayout("gap rel unrel", "[][65lp::][30lp::][]"));
+			JPanel deploymentPanel = new JPanel(new MigLayout("fill", "[][65lp::][30lp::][]"));
 			deploymentPanel.setBorder(BorderFactory.createTitledBorder(trans.get("ParachuteCfg.lbl.Deployment")));
 
 			//// Deploys at:

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/PlacementPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/PlacementPanel.java
@@ -33,7 +33,7 @@ public class PlacementPanel extends JPanel implements Invalidatable, Invalidatin
     private final List<Invalidatable> invalidatables = new ArrayList<>();
 
     public PlacementPanel(RocketComponent component, List<Component> order) {
-        super(new MigLayout("gap rel unrel", "[][65lp::][30lp::]"));
+        super(new MigLayout("fill, gap rel unrel", "[][65lp::][30lp::]"));
         this.setBorder(BorderFactory.createTitledBorder(trans.get("PlacementPanel.title.Placement")));
 
         this.add(new JLabel(trans.get("PlacementPanel.lbl.PosRelativeTo")));

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/RocketComponentConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/RocketComponentConfig.java
@@ -173,7 +173,6 @@ public class RocketComponentConfig extends JPanel implements Invalidatable, Inva
 		}
 
 		tabbedPane = new JTabbedPane();
-		this.add(tabbedPane, "newline, span, growx, growy 100, wrap");
 		order.add(tabbedPane);
 		tabbedPane.addChangeListener(new ChangeListener() {
 			@Override
@@ -196,6 +195,13 @@ public class RocketComponentConfig extends JPanel implements Invalidatable, Inva
 		//// Comment and Specify a comment for the component
 		tabbedPane.addTab(trans.get("RocketCompCfg.tab.Comment"), null, commentTab(),
 				trans.get("RocketCompCfg.tab.Comment.ttip"));
+
+    JScrollPane scrollPane = new JScrollPane(tabbedPane);
+    scrollPane.setBorder(null);
+    scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+    scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+
+    this.add(scrollPane, "newline, grow, push, wrap");
 
 		addButtons();
 
@@ -269,8 +275,8 @@ public class RocketComponentConfig extends JPanel implements Invalidatable, Inva
 		if (buttonPanel != null) {
 			this.remove(buttonPanel);
 		}
-		
-		buttonPanel = new JPanel(new MigLayout("fill, ins 5, hidemode 3"));
+
+		buttonPanel = new JPanel(new MigLayout("fill, ins 0"));
 
 		//// Component info
 		addComponentInfo(buttonPanel);
@@ -339,8 +345,8 @@ public class RocketComponentConfig extends JPanel implements Invalidatable, Inva
 		buttonPanel.add(okButton);
 
 		updateFields();
-		
-		this.add(buttonPanel, "newline, spanx, growx");
+
+		this.add(buttonPanel, "spanx, growx");
 	}
 
 	protected void disposeDialog() {
@@ -758,7 +764,7 @@ public class RocketComponentConfig extends JPanel implements Invalidatable, Inva
 				Style.BOLD), "wrap");
 		
 		// TODO: LOW:  Changes in comment from other sources not reflected in component
-		commentTextArea = new JTextArea(component.getComment());
+		commentTextArea = new JTextArea(component.getComment(), 5 , 50);
 		commentTextArea.setBorder(marginBorder);
 		commentTextArea.setLineWrap(true);
 		commentTextArea.setWrapStyleWord(true);

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/StreamerConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/StreamerConfig.java
@@ -52,10 +52,10 @@ public class StreamerConfig extends RecoveryDeviceConfig {
 		super(d, component, parent);
 		Streamer streamer = (Streamer) component;
 
-		JPanel primary = new JPanel(new MigLayout());
+		JPanel primary = new JPanel(new MigLayout("fill, ins n n 0 n"));
 
 		//	Left side
-		JPanel panel = new JPanel(new MigLayout("gap rel unrel, ins 0", "[][65lp::][30lp::][]"));
+		JPanel panel = new JPanel(new MigLayout("fillx, ins 0", "[][65lp::][30lp::][]"));
 		
 		//// ---------------------------- Attributes ----------------------------
 
@@ -155,7 +155,7 @@ public class StreamerConfig extends RecoveryDeviceConfig {
 		primary.add(panel, "grow, gapright 20lp");
 
 		//	Right side
-		panel = new JPanel(new MigLayout("ins 0"));
+		panel = new JPanel(new MigLayout("fillx, ins 0"));
 
 
 		{//// ---------------------------- Placement ----------------------------


### PR DESCRIPTION
This PR adds a scroll pane to `RocketComponentConfig` and makes the layout for mass component group more compact, applying changes to Parachute and Streamer while leaving Shock Cord and Mass Component unchanged due to their smaller content for #2789.

### **Video**:
Parachute config:

https://github.com/user-attachments/assets/1ae40676-c838-4afc-9c6d-1ea549adcb69

Streamer config:


https://github.com/user-attachments/assets/521c648f-6e26-4a7a-b8fe-bf0f61cb2942

### **Know Issue**:
- In the Appearance tab, scroll bars appear too early for small dialogs (Shock Cord, Mass Component, Body Tube).