### PR TITLE
Fix small dialog width and center slider alignment

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/RocketComponentConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/RocketComponentConfig.java
@@ -276,7 +276,7 @@ public class RocketComponentConfig extends JPanel implements Invalidatable, Inva
 			this.remove(buttonPanel);
 		}
 
-		buttonPanel = new JPanel(new MigLayout("fill, ins 0"));
+		buttonPanel = new JPanel(new MigLayout("fill, ins 0, hidemode 3"));
 
 		//// Component info
 		addComponentInfo(buttonPanel);
@@ -764,7 +764,7 @@ public class RocketComponentConfig extends JPanel implements Invalidatable, Inva
 				Style.BOLD), "wrap");
 		
 		// TODO: LOW:  Changes in comment from other sources not reflected in component
-		commentTextArea = new JTextArea(component.getComment(), 5 , 50);
+		commentTextArea = new JTextArea(component.getComment(), 1, 1);
 		commentTextArea.setBorder(marginBorder);
 		commentTextArea.setLineWrap(true);
 		commentTextArea.setWrapStyleWord(true);

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/RocketComponentConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/RocketComponentConfig.java
@@ -725,13 +725,13 @@ public class RocketComponentConfig extends JPanel implements Invalidatable, Inva
 
 		spin.setEditor(new SpinnerEditor(spin));
 		bm.addEnableComponent(spin, true);
-		panel.add(spin, "top, growx 1");
+		panel.add(spin, "growx 1");
 		order.add(((SpinnerEditor) spin.getEditor()).getTextField());
 		
 		
 		bs = new BasicSlider(m.getSliderModel(-1.0, 1.0));
 		bm.addEnableComponent(bs);
-		panel.add(bs, "top, skip, wrap");
+		panel.add(bs, "skip, wrap");
 
 		if (component.getCDOverriddenBy() != null) {
 			check.setEnabled(false);


### PR DESCRIPTION
this pr fixes #2928.
The commentTextArea had its cols and rows values set too high, which caused the dialog to expand. Additionally, when cols and rows were not set, the dialog could expand infinitely and could not shrink back to its normal size.

### Before
<img width="709" height="552" alt="Screenshot 2025-11-13 122021" src="https://github.com/user-attachments/assets/aa986027-bdcc-424b-9c9d-209e060126e1" />

### After
<img width="537" height="552" alt="Screenshot 2025-11-13 122133" src="https://github.com/user-attachments/assets/ab427eb1-f036-4996-8020-e87500253b9f" />
