### PR TITLE
[#2100] Allow for decal deletion + add decal previews

### DIFF
--- a/core/src/main/java/info/openrocket/core/document/DecalRegistry.java
+++ b/core/src/main/java/info/openrocket/core/document/DecalRegistry.java
@@ -119,6 +119,13 @@ public class DecalRegistry {
 
 		return decals;
 	}
+	
+	boolean removeDecal(DecalImage decal) {
+		if (decal == null) {
+			return false;
+		}
+		return registeredDecals.remove(decal.getName()) != null;
+	}
 
 	public class DecalImageImpl implements DecalImage, Cloneable, Comparable<DecalImage>, ChangeSource {
 

--- a/core/src/main/java/info/openrocket/core/document/OpenRocketDocument.java
+++ b/core/src/main/java/info/openrocket/core/document/OpenRocketDocument.java
@@ -22,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import info.openrocket.core.appearance.Appearance;
+import info.openrocket.core.appearance.AppearanceBuilder;
 import info.openrocket.core.appearance.Decal;
 import info.openrocket.core.appearance.DecalImage;
 import info.openrocket.core.document.events.DocumentChangeEvent;
@@ -307,6 +308,18 @@ public class OpenRocketDocument implements ComponentChangeListener, StateChangeL
 		}
 		return count;
 	}
+
+	public boolean removeDecal(DecalImage decal) {
+		if (decal == null) {
+			return false;
+		}
+		boolean clearedUsage = clearDecalUsage(decal);
+		boolean removed = decalRegistry.removeDecal(decal);
+		if (clearedUsage || removed) {
+			fireDocumentChangeEvent(new DocumentChangeEvent(this));
+		}
+		return clearedUsage || removed;
+	}
 	
 	//TODO: LOW: move this method to rocketComponent, Appearance and decal
 	//I see 3 layers of object accessed, seems unsafe
@@ -349,6 +362,48 @@ public class OpenRocketDocument implements ComponentChangeListener, StateChangeL
 			return false;
 		}
 		return false;
+	}
+
+	private boolean clearDecalUsage(DecalImage decal) {
+		boolean updated = false;
+		for (RocketComponent component : rocket) {
+			updated |= clearOutsideDecal(component, decal);
+			updated |= clearInsideDecal(component, decal);
+		}
+		return updated;
+	}
+
+	private boolean clearOutsideDecal(RocketComponent component, DecalImage decal) {
+		Appearance appearance = component.getAppearance();
+		if (appearance == null) {
+			return false;
+		}
+		Decal texture = appearance.getTexture();
+		if (texture == null || !decal.equals(texture.getImage())) {
+			return false;
+		}
+		AppearanceBuilder builder = new AppearanceBuilder(appearance);
+		builder.setImage(null);
+		component.setAppearance(builder.getAppearance());
+		return true;
+	}
+
+	private boolean clearInsideDecal(RocketComponent component, DecalImage decal) {
+		if (!(component instanceof InsideColorComponent)) {
+			return false;
+		}
+		Appearance appearance = ((InsideColorComponent) component).getInsideColorComponentHandler().getInsideAppearance();
+		if (appearance == null) {
+			return false;
+		}
+		Decal texture = appearance.getTexture();
+		if (texture == null || !decal.equals(texture.getImage())) {
+			return false;
+		}
+		AppearanceBuilder builder = new AppearanceBuilder(appearance);
+		builder.setImage(null);
+		((InsideColorComponent) component).getInsideColorComponentHandler().setInsideAppearance(builder.getAppearance());
+		return true;
 	}
 	
 	/**

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -2749,6 +2749,11 @@ DecalModel.preview.none = Not used by any components
 DecalModel.preview.imageUnavailable = Preview not available
 DecalModel.preview.componentOutside = {0} (outside)
 DecalModel.preview.componentInside = {0} (inside)
+DecalModel.but.delete = Delete
+DecalModel.msg.deleteTitle = Delete texture
+DecalModel.msg.deleteConfirm = Delete texture ''{0}''?\nThis removes it from all components.
+DecalModel.msg.noSelection = Select a texture before deleting.
+DecalModel.msg.deleteFailed = Unable to delete the selected texture.
 
 ! Export Decal Dialog
 ExportDecalDialog.title = Export Decal

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -2742,6 +2742,13 @@ PresetModel.lbl.partsLib.ttip = Select a preset model for this rocket component 
 
 DecalModel.lbl.select = <none>
 DecalModel.lbl.choose = Select file\u2026
+DecalModel.preview.placeholder = Hover over a texture to preview it
+DecalModel.preview.noneSelected = No texture applied (solid color only)
+DecalModel.preview.usedBy = Used by
+DecalModel.preview.none = Not used by any components
+DecalModel.preview.imageUnavailable = Preview not available
+DecalModel.preview.componentOutside = {0} (outside)
+DecalModel.preview.componentInside = {0} (inside)
 
 ! Export Decal Dialog
 ExportDecalDialog.title = Export Decal

--- a/swing/src/main/java/info/openrocket/swing/gui/adaptors/DecalModel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/adaptors/DecalModel.java
@@ -1,44 +1,73 @@
 package info.openrocket.swing.gui.adaptors;
 
 import java.awt.Component;
+import java.awt.Image;
+import java.awt.image.BufferedImage;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+import javax.imageio.ImageIO;
 import javax.swing.AbstractListModel;
 import javax.swing.ComboBoxModel;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
 import javax.swing.JFileChooser;
 import javax.swing.SwingUtilities;
 
+import info.openrocket.core.appearance.Appearance;
 import info.openrocket.core.appearance.AppearanceBuilder;
+import info.openrocket.core.appearance.Decal;
 import info.openrocket.core.appearance.DecalImage;
+import info.openrocket.core.appearance.defaults.ResourceDecalImage;
 import info.openrocket.core.document.Attachment;
 import info.openrocket.core.document.OpenRocketDocument;
+import info.openrocket.core.document.events.DocumentChangeEvent;
+import info.openrocket.core.document.events.DocumentChangeListener;
 import info.openrocket.core.file.FileSystemAttachmentFactory;
 import info.openrocket.core.l10n.Translator;
+import info.openrocket.core.rocketcomponent.InsideColorComponent;
+import info.openrocket.core.rocketcomponent.RocketComponent;
 import info.openrocket.core.startup.Application;
-import info.openrocket.core.appearance.defaults.ResourceDecalImage;
-
+import info.openrocket.core.util.DecalNotFoundException;
 import info.openrocket.swing.gui.util.FileHelper;
 import info.openrocket.swing.gui.util.SwingPreferences;
 
 public class DecalModel extends AbstractListModel<DecalImage> implements ComboBoxModel<DecalImage> {
 	private static final long serialVersionUID = -3922419344990421156L;
 	private static final Translator trans = Application.getTranslator();
+	private static final int PREVIEW_MAX_SIZE = 140;
 	
 	private static final ResourceDecalImage NONE_SELECTED = new ResourceDecalImage(trans.get("lbl.select"));
 	
 	private final OpenRocketDocument document;
 	private final Component parent;
 	private final AppearanceBuilder ab;
+	private final DocumentChangeListener documentChangeListener;
 	
 	private static File lastImageDir = null;
 	
 	private DecalImage[] decals;
+	private final Map<DecalImage, Icon> previewCache = new HashMap<>();
+	private final Map<DecalImage, List<String>> usageCache = new HashMap<>();
 	
 	public DecalModel(Component parent, OpenRocketDocument document, AppearanceBuilder ab) {
 		this.document = document;
 		this.parent = parent;
 		this.ab = ab;
 		decals = document.getDecalList().toArray(new DecalImage[0]);
+		documentChangeListener = new DocumentChangeListener() {
+			@Override
+			public void documentChanged(DocumentChangeEvent event) {
+				clearCaches();
+			}
+		};
+		document.addDocumentChangeListener(documentChangeListener);
 	}
 	
 	@Override
@@ -62,6 +91,18 @@ public class DecalModel extends AbstractListModel<DecalImage> implements ComboBo
 		} else {
 			ab.setImage((DecalImage) item);
 		}
+	}
+
+	public DecalPreviewData getPreviewData(DecalImage decal) {
+		if (decal == null) {
+			return DecalPreviewData.placeholder(trans.get("DecalModel.preview.placeholder"));
+		}
+		if (decal.equals(NONE_SELECTED)) {
+			return DecalPreviewData.placeholder(trans.get("DecalModel.preview.noneSelected"));
+		}
+		Icon preview = previewCache.computeIfAbsent(decal, this::loadPreviewIcon);
+		List<String> usage = usageCache.computeIfAbsent(decal, this::buildUsageList);
+		return new DecalPreviewData(decal.getName(), preview, usage);
 	}
 
 	public void promptForFileSelection() {
@@ -97,6 +138,141 @@ public class DecalModel extends AbstractListModel<DecalImage> implements ComboBo
 	
 	public void refresh() {
 		decals = document.getDecalList().toArray(new DecalImage[0]);
+		clearCaches();
 		fireContentsChanged(this, 0, decals.length);
+	}
+
+	public void dispose() {
+		document.removeDocumentChangeListener(documentChangeListener);
+		clearCaches();
+	}
+
+	private void clearCaches() {
+		previewCache.clear();
+		usageCache.clear();
+	}
+
+	private Icon loadPreviewIcon(DecalImage decal) {
+		if (decal == null) {
+			return null;
+		}
+		try (InputStream is = decal.getBytes()) {
+			if (is == null) {
+				return null;
+			}
+			BufferedImage image = ImageIO.read(is);
+			if (image == null) {
+				return null;
+			}
+			return new ImageIcon(scaleImage(image, PREVIEW_MAX_SIZE, PREVIEW_MAX_SIZE));
+		} catch (IOException | DecalNotFoundException ex) {
+			Application.getExceptionHandler().handleErrorCondition(ex);
+			return null;
+		}
+	}
+
+	private static BufferedImage scaleImage(BufferedImage source, int maxWidth, int maxHeight) {
+		int originalWidth = source.getWidth();
+		int originalHeight = source.getHeight();
+		double scale = Math.min((double) maxWidth / originalWidth, (double) maxHeight / originalHeight);
+		if (scale > 1d) {
+			scale = 1d;
+		}
+		int targetWidth = Math.max(1, (int) Math.round(originalWidth * scale));
+		int targetHeight = Math.max(1, (int) Math.round(originalHeight * scale));
+		Image scaled = source.getScaledInstance(targetWidth, targetHeight, Image.SCALE_SMOOTH);
+		BufferedImage output = new BufferedImage(targetWidth, targetHeight, BufferedImage.TYPE_INT_ARGB);
+		output.getGraphics().drawImage(scaled, 0, 0, null);
+		output.getGraphics().dispose();
+		return output;
+	}
+
+	private List<String> buildUsageList(DecalImage decal) {
+		if (decal == null) {
+			return Collections.emptyList();
+		}
+		List<String> usage = new ArrayList<>();
+		for (RocketComponent component : document.getRocket()) {
+			if (usesOutsideDecal(component, decal)) {
+				usage.add(formatComponentLabel(component, false));
+			}
+			if (usesInsideDecal(component, decal)) {
+				usage.add(formatComponentLabel(component, true));
+			}
+		}
+		return usage;
+	}
+
+	private boolean usesOutsideDecal(RocketComponent component, DecalImage decal) {
+		Appearance appearance = component.getAppearance();
+		if (appearance == null) {
+			return false;
+		}
+		Decal texture = appearance.getTexture();
+		return texture != null && decal.equals(texture.getImage());
+	}
+
+	private boolean usesInsideDecal(RocketComponent component, DecalImage decal) {
+		if (!(component instanceof InsideColorComponent)) {
+			return false;
+		}
+		Appearance appearance = ((InsideColorComponent) component).getInsideColorComponentHandler().getInsideAppearance();
+		if (appearance == null) {
+			return false;
+		}
+		Decal texture = appearance.getTexture();
+		return texture != null && decal.equals(texture.getImage());
+	}
+
+	private String formatComponentLabel(RocketComponent component, boolean inside) {
+		String name = component.getName();
+		if (name == null || name.isEmpty()) {
+			name = component.getComponentName();
+		}
+		if (inside) {
+			return trans.get("DecalModel.preview.componentInside", name);
+		}
+		return trans.get("DecalModel.preview.componentOutside", name);
+	}
+
+	public static class DecalPreviewData {
+		private final String displayName;
+		private final Icon previewIcon;
+		private final List<String> usage;
+		private final boolean placeholder;
+
+		private DecalPreviewData(String displayName, Icon previewIcon, List<String> usage) {
+			this.displayName = displayName;
+			this.previewIcon = previewIcon;
+			this.usage = usage == null ? Collections.emptyList() : Collections.unmodifiableList(usage);
+			this.placeholder = false;
+		}
+
+		private DecalPreviewData(String message) {
+			this.displayName = message;
+			this.previewIcon = null;
+			this.usage = Collections.emptyList();
+			this.placeholder = true;
+		}
+
+		public static DecalPreviewData placeholder(String message) {
+			return new DecalPreviewData(message);
+		}
+
+		public String getDisplayName() {
+			return displayName;
+		}
+
+		public Icon getPreviewIcon() {
+			return previewIcon;
+		}
+
+		public List<String> getUsage() {
+			return usage;
+		}
+
+		public boolean isPlaceholder() {
+			return placeholder;
+		}
 	}
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/adaptors/DecalModel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/adaptors/DecalModel.java
@@ -26,8 +26,6 @@ public class DecalModel extends AbstractListModel<DecalImage> implements ComboBo
 	
 	private static final ResourceDecalImage NONE_SELECTED = new ResourceDecalImage(trans.get("lbl.select"));
 	
-	private static final ResourceDecalImage SELECT_FILE = new ResourceDecalImage(trans.get("lbl.choose"));
-	
 	private final OpenRocketDocument document;
 	private final Component parent;
 	private final AppearanceBuilder ab;
@@ -45,16 +43,13 @@ public class DecalModel extends AbstractListModel<DecalImage> implements ComboBo
 	
 	@Override
 	public int getSize() {
-		return decals.length + 2;
+		return decals.length + 1;
 	}
 	
 	@Override
 	public DecalImage getElementAt(int index) {
 		if (index <= 0) {
 			return NONE_SELECTED;
-		}
-		if (index == getSize() - 1) {
-			return SELECT_FILE;
 		}
 		return decals[index - 1];
 	}
@@ -64,28 +59,30 @@ public class DecalModel extends AbstractListModel<DecalImage> implements ComboBo
 		
 		if (item == null || item.equals(NONE_SELECTED)) {
 			ab.setImage(null);
-		} else if (item.equals(SELECT_FILE)) {
-			SwingUtilities.invokeLater(new Runnable() {
-				@Override
-				public void run() {
-					File current = lastImageDir;
-					lastImageDir = current;
-					
-					JFileChooser fc = new JFileChooser(current);
-					fc.setFileFilter(FileHelper.getImageFileFilter());
-					fc.setCurrentDirectory(((SwingPreferences) Application.getPreferences()).getDefaultDirectory());
-					int action = fc.showOpenDialog(SwingUtilities.getWindowAncestor(parent));
-					if (action == JFileChooser.APPROVE_OPTION) {
-						((SwingPreferences) Application.getPreferences()).setDefaultDirectory(fc.getCurrentDirectory());
-						File file = fc.getSelectedFile();
-						Attachment a = (new FileSystemAttachmentFactory().getAttachment(file));
-						setSelectedItem(document.getDecalImage(a));
-					}
-				}
-			});
 		} else {
 			ab.setImage((DecalImage) item);
 		}
+	}
+
+	public void promptForFileSelection() {
+		SwingUtilities.invokeLater(new Runnable() {
+			@Override
+			public void run() {
+				File current = lastImageDir;
+
+				JFileChooser fc = new JFileChooser(current);
+				fc.setFileFilter(FileHelper.getImageFileFilter());
+				fc.setCurrentDirectory(((SwingPreferences) Application.getPreferences()).getDefaultDirectory());
+				int action = fc.showOpenDialog(SwingUtilities.getWindowAncestor(parent));
+				if (action == JFileChooser.APPROVE_OPTION) {
+					((SwingPreferences) Application.getPreferences()).setDefaultDirectory(fc.getCurrentDirectory());
+					File file = fc.getSelectedFile();
+					lastImageDir = file.getParentFile();
+					Attachment a = (new FileSystemAttachmentFactory().getAttachment(file));
+					setSelectedItem(document.getDecalImage(a));
+				}
+			}
+		});
 	}
 	
 	@Override

--- a/swing/src/main/java/info/openrocket/swing/gui/adaptors/DecalModel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/adaptors/DecalModel.java
@@ -142,6 +142,27 @@ public class DecalModel extends AbstractListModel<DecalImage> implements ComboBo
 		fireContentsChanged(this, 0, decals.length);
 	}
 
+	public DecalImage getActiveDecal() {
+		Object selected = getSelectedItem();
+		return (selected instanceof DecalImage && isDeletable((DecalImage) selected)) ? (DecalImage) selected : null;
+	}
+
+	public boolean isDeletable(DecalImage decal) {
+		return decal != null && !decal.equals(NONE_SELECTED);
+	}
+
+	public boolean deleteDecal(DecalImage decal) {
+		if (!isDeletable(decal)) {
+			return false;
+		}
+		boolean removed = document.removeDecal(decal);
+		if (removed) {
+			setSelectedItem(NONE_SELECTED);
+			refresh();
+		}
+		return removed;
+	}
+
 	public void dispose() {
 		document.removeDocumentChangeListener(documentChangeListener);
 		clearCaches();

--- a/swing/src/main/java/info/openrocket/swing/gui/components/DecalPreviewPopup.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/components/DecalPreviewPopup.java
@@ -1,0 +1,133 @@
+package info.openrocket.swing.gui.components;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.util.List;
+
+import javax.swing.BorderFactory;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.Popup;
+import javax.swing.PopupFactory;
+import javax.swing.JTextArea;
+import javax.swing.JComponent;
+import javax.swing.UIManager;
+
+import info.openrocket.core.l10n.Translator;
+import info.openrocket.core.startup.Application;
+import info.openrocket.swing.gui.adaptors.DecalModel.DecalPreviewData;
+
+/**
+ * Lightweight popup that displays a decal preview image and usage list while
+ * hovering over entries in the texture combo box.
+ */
+public class DecalPreviewPopup {
+	private static final Translator trans = Application.getTranslator();
+	private static final Dimension IMAGE_DIMENSION = new Dimension(150, 150);
+
+	private final JPanel content;
+	private final JLabel titleLabel;
+	private final JLabel imageLabel;
+	private final JPanel imageWrapper;
+	private final JLabel usageLabel;
+	private final JTextArea usageArea;
+	private Popup popup;
+
+	public DecalPreviewPopup() {
+		content = new JPanel(new BorderLayout(8, 8));
+		content.setBorder(BorderFactory.createCompoundBorder(
+				BorderFactory.createLineBorder(UIManager.getColor("ToolTip.foreground")),
+				BorderFactory.createEmptyBorder(8, 8, 8, 8)));
+		content.setBackground(UIManager.getColor("ToolTip.background"));
+
+		titleLabel = new JLabel();
+		titleLabel.setFont(titleLabel.getFont().deriveFont(titleLabel.getFont().getStyle() | java.awt.Font.BOLD));
+		content.add(titleLabel, BorderLayout.NORTH);
+
+		imageLabel = new JLabel();
+		imageLabel.setHorizontalAlignment(JLabel.CENTER);
+		imageLabel.setVerticalAlignment(JLabel.CENTER);
+		imageLabel.setPreferredSize(IMAGE_DIMENSION);
+		imageWrapper = new JPanel(new BorderLayout());
+		imageWrapper.setBackground(content.getBackground());
+		imageWrapper.add(imageLabel, BorderLayout.CENTER);
+		content.add(imageWrapper, BorderLayout.WEST);
+
+		JPanel usagePanel = new JPanel(new BorderLayout(4, 4));
+		usagePanel.setOpaque(false);
+		usageLabel = new JLabel(trans.get("DecalModel.preview.usedBy"));
+		usagePanel.add(usageLabel, BorderLayout.NORTH);
+
+		usageArea = new JTextArea();
+		usageArea.setEditable(false);
+		usageArea.setWrapStyleWord(true);
+		usageArea.setLineWrap(true);
+		usageArea.setOpaque(false);
+		usageArea.setBorder(BorderFactory.createEmptyBorder());
+		usageArea.setFocusable(false);
+		usageArea.setRows(6);
+		usagePanel.add(usageArea, BorderLayout.CENTER);
+		content.add(usagePanel, BorderLayout.CENTER);
+	}
+
+	public void show(JComponent invoker, Point screenLocation, DecalPreviewData data) {
+		if (invoker == null || screenLocation == null || data == null) {
+			hidePopup();
+			return;
+		}
+		updateContent(data);
+		hidePopup();
+		popup = PopupFactory.getSharedInstance().getPopup(invoker, content, screenLocation.x, screenLocation.y);
+		popup.show();
+	}
+
+	public void hidePopup() {
+		if (popup != null) {
+			popup.hide();
+			popup = null;
+		}
+	}
+
+	private void updateContent(DecalPreviewData data) {
+			titleLabel.setText(data.getDisplayName());
+			if (data.isPlaceholder()) {
+				usageLabel.setVisible(false);
+				imageLabel.setIcon(null);
+				imageLabel.setText("");
+				imageWrapper.setVisible(false);
+				usageArea.setVisible(false);
+				usageArea.setText("");
+				return;
+			}
+
+			imageWrapper.setVisible(true);
+			usageLabel.setVisible(true);
+			usageArea.setVisible(true);
+		if (data.getPreviewIcon() != null) {
+			imageLabel.setIcon(data.getPreviewIcon());
+			imageLabel.setText("");
+		} else {
+			imageLabel.setIcon(null);
+			imageLabel.setText(trans.get("DecalModel.preview.imageUnavailable"));
+		}
+
+		List<String> usage = data.getUsage();
+		if (usage.isEmpty()) {
+			usageArea.setText(trans.get("DecalModel.preview.none"));
+		} else {
+			usageArea.setText(formatUsageLines(usage));
+		}
+	}
+
+	private String formatUsageLines(List<String> usage) {
+		StringBuilder builder = new StringBuilder();
+		for (String entry : usage) {
+			if (builder.length() > 0) {
+				builder.append('\n');
+			}
+			builder.append("- ").append(entry);
+		}
+		return builder.toString();
+	}
+}

--- a/swing/src/main/java/info/openrocket/swing/gui/components/TextureComboBox.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/components/TextureComboBox.java
@@ -25,29 +25,54 @@ import info.openrocket.swing.gui.adaptors.DecalModel.DecalPreviewData;
 public class TextureComboBox extends JComboBox<DecalImage> {
 	private static final long serialVersionUID = 2493299948337060422L;
 
-	private final DecalModel decalModel;
-	private final DecalPreviewPopup previewPopup = new DecalPreviewPopup();
-	private DecalImage previousSelection;
-	private JList<?> popupList;
+    private final DecalModel decalModel;
+    private final DecalPreviewPopup previewPopup = new DecalPreviewPopup();
+    private DecalImage previousSelection;
+    private JList<?> popupList;
 
-	private final MouseAdapter hoverListener = new MouseAdapter() {
-		@Override
-		public void mouseMoved(MouseEvent e) {
-			handleListHover(e);
-		}
+    private final MouseAdapter hoverListener = new MouseAdapter() {
+        @Override
+        public void mouseMoved(MouseEvent e) {
+            handleListHover(e);
+        }
 
-		@Override
-		public void mouseExited(MouseEvent e) {
-			previewPopup.hidePopup();
-		}
-	};
+        @Override
+        public void mouseExited(MouseEvent e) {
+            previewPopup.hidePopup();
+        }
+    };
+
+    private final MouseAdapter comboHoverListener = new MouseAdapter() {
+        @Override
+        public void mouseMoved(MouseEvent e) {
+            if (!isPopupVisible()) {
+                showSelectedPreview();
+            }
+        }
+
+        @Override
+        public void mouseEntered(MouseEvent e) {
+            if (!isPopupVisible()) {
+                showSelectedPreview();
+            }
+        }
+
+        @Override
+        public void mouseExited(MouseEvent e) {
+            if (!isPopupVisible()) {
+                previewPopup.hidePopup();
+            }
+        }
+    };
 
 	public TextureComboBox(DecalModel decalModel) {
 		super(decalModel);
 		this.decalModel = decalModel;
-		setMaximumRowCount(20);
-		previousSelection = (DecalImage) decalModel.getSelectedItem();
-		addActionListener(this::handleSelectionChange);
+        setMaximumRowCount(20);
+        previousSelection = (DecalImage) decalModel.getSelectedItem();
+        addActionListener(this::handleSelectionChange);
+        addMouseMotionListener(comboHoverListener);
+        addMouseListener(comboHoverListener);
 		addPopupMenuListener(new PopupMenuListener() {
 			@Override
 			public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
@@ -123,10 +148,10 @@ public class TextureComboBox extends JComboBox<DecalImage> {
 		return null;
 	}
 
-	private void handleListHover(MouseEvent e) {
-		if (!(e.getSource() instanceof JList<?> list)) {
-			return;
-		}
+    private void handleListHover(MouseEvent e) {
+        if (!(e.getSource() instanceof JList<?> list)) {
+            return;
+        }
 		int index = list.locationToIndex(e.getPoint());
 		if (index < 0) {
 			previewPopup.hidePopup();
@@ -143,8 +168,15 @@ public class TextureComboBox extends JComboBox<DecalImage> {
 			return;
 		}
 		DecalPreviewData previewData = decalModel.getPreviewData((DecalImage) item);
-		Point popupLocation = new Point(bounds.x + bounds.width + 8, bounds.y);
-		SwingUtilities.convertPointToScreen(popupLocation, list);
-		previewPopup.show(list, popupLocation, previewData);
-	}
+        Point popupLocation = new Point(bounds.x + bounds.width + 8, bounds.y);
+        SwingUtilities.convertPointToScreen(popupLocation, list);
+        previewPopup.show(list, popupLocation, previewData);
+    }
+
+    private void showSelectedPreview() {
+        DecalPreviewData data = decalModel.getPreviewData((DecalImage) getSelectedItem());
+        Point location = new Point(getWidth() + 8, 0);
+        SwingUtilities.convertPointToScreen(location, this);
+        previewPopup.show(this, location, data);
+    }
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/components/TextureComboBox.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/components/TextureComboBox.java
@@ -1,36 +1,150 @@
 package info.openrocket.swing.gui.components;
 
+import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 
 import javax.swing.JComboBox;
+import javax.swing.JList;
+import javax.swing.SwingUtilities;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
+import javax.swing.plaf.ComboBoxUI;
+import javax.swing.plaf.basic.ComboPopup;
 
 import info.openrocket.core.appearance.DecalImage;
 import info.openrocket.swing.gui.adaptors.DecalModel;
+import info.openrocket.swing.gui.adaptors.DecalModel.DecalPreviewData;
 
 /**
- * Dedicated combo box for texture selection that encapsulates the required
- * DecalModel behaviour and keeps the UI wiring in one place.
+ * Combo box for selecting decals. Adds hover previews on top of the underlying
+ * DecalModel behaviour.
  */
 public class TextureComboBox extends JComboBox<DecalImage> {
 	private static final long serialVersionUID = 2493299948337060422L;
 
+	private final DecalModel decalModel;
+	private final DecalPreviewPopup previewPopup = new DecalPreviewPopup();
 	private DecalImage previousSelection;
+	private JList<?> popupList;
+
+	private final MouseAdapter hoverListener = new MouseAdapter() {
+		@Override
+		public void mouseMoved(MouseEvent e) {
+			handleListHover(e);
+		}
+
+		@Override
+		public void mouseExited(MouseEvent e) {
+			previewPopup.hidePopup();
+		}
+	};
 
 	public TextureComboBox(DecalModel decalModel) {
 		super(decalModel);
+		this.decalModel = decalModel;
 		setMaximumRowCount(20);
 		previousSelection = (DecalImage) decalModel.getSelectedItem();
 		addActionListener(this::handleSelectionChange);
+		addPopupMenuListener(new PopupMenuListener() {
+			@Override
+			public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
+				installPopupListeners(e.getSource());
+			}
+
+			@Override
+			public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
+				previewPopup.hidePopup();
+			}
+
+			@Override
+			public void popupMenuCanceled(PopupMenuEvent e) {
+				previewPopup.hidePopup();
+			}
+		});
+	}
+
+	@Override
+	public void removeNotify() {
+		previewPopup.hidePopup();
+		uninstallPopupListeners();
+		super.removeNotify();
 	}
 
 	private void handleSelectionChange(ActionEvent e) {
 		DecalModel model = (DecalModel) getModel();
 		DecalImage decal = (DecalImage) getSelectedItem();
 
-		// Trigger refreshes even if the same item is re-selected
 		if (decal == previousSelection) {
 			model.setSelectedItem(decal);
 		}
 		previousSelection = decal;
+	}
+
+	private void installPopupListeners(Object popupSource) {
+		JList<?> list = null;
+		if (popupSource instanceof ComboPopup) {
+			list = ((ComboPopup) popupSource).getList();
+		}
+		if (list == null) {
+			list = resolvePopupList();
+		}
+		if (list == null) {
+			return;
+		}
+		if (popupList == list) {
+			return;
+		}
+		uninstallPopupListeners();
+		popupList = list;
+		popupList.addMouseMotionListener(hoverListener);
+		popupList.addMouseListener(hoverListener);
+	}
+
+	private void uninstallPopupListeners() {
+		if (popupList != null) {
+			popupList.removeMouseMotionListener(hoverListener);
+			popupList.removeMouseListener(hoverListener);
+			popupList = null;
+		}
+	}
+
+	private JList<?> resolvePopupList() {
+		ComboBoxUI ui = getUI();
+		if (ui == null) {
+			return null;
+		}
+		Object popup = ui.getAccessibleChild(this, 0);
+		if (popup instanceof ComboPopup) {
+			return ((ComboPopup) popup).getList();
+		}
+		return null;
+	}
+
+	private void handleListHover(MouseEvent e) {
+		if (!(e.getSource() instanceof JList<?> list)) {
+			return;
+		}
+		int index = list.locationToIndex(e.getPoint());
+		if (index < 0) {
+			previewPopup.hidePopup();
+			return;
+		}
+		Rectangle bounds = list.getCellBounds(index, index);
+		if (bounds == null || !bounds.contains(e.getPoint())) {
+			previewPopup.hidePopup();
+			return;
+		}
+		Object item = list.getModel().getElementAt(index);
+		if (!(item instanceof DecalImage)) {
+			previewPopup.hidePopup();
+			return;
+		}
+		DecalPreviewData previewData = decalModel.getPreviewData((DecalImage) item);
+		Point popupLocation = new Point(bounds.x + bounds.width + 8, bounds.y);
+		SwingUtilities.convertPointToScreen(popupLocation, list);
+		previewPopup.show(list, popupLocation, previewData);
 	}
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/components/TextureComboBox.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/components/TextureComboBox.java
@@ -1,0 +1,36 @@
+package info.openrocket.swing.gui.components;
+
+import java.awt.event.ActionEvent;
+
+import javax.swing.JComboBox;
+
+import info.openrocket.core.appearance.DecalImage;
+import info.openrocket.swing.gui.adaptors.DecalModel;
+
+/**
+ * Dedicated combo box for texture selection that encapsulates the required
+ * DecalModel behaviour and keeps the UI wiring in one place.
+ */
+public class TextureComboBox extends JComboBox<DecalImage> {
+	private static final long serialVersionUID = 2493299948337060422L;
+
+	private DecalImage previousSelection;
+
+	public TextureComboBox(DecalModel decalModel) {
+		super(decalModel);
+		setMaximumRowCount(20);
+		previousSelection = (DecalImage) decalModel.getSelectedItem();
+		addActionListener(this::handleSelectionChange);
+	}
+
+	private void handleSelectionChange(ActionEvent e) {
+		DecalModel model = (DecalModel) getModel();
+		DecalImage decal = (DecalImage) getSelectedItem();
+
+		// Trigger refreshes even if the same item is re-selected
+		if (decal == previousSelection) {
+			model.setSelectedItem(decal);
+		}
+		previousSelection = decal;
+	}
+}

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/AppearancePanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/AppearancePanel.java
@@ -32,6 +32,7 @@ import javax.swing.event.ChangeListener;
 
 import info.openrocket.core.util.Invalidatable;
 import info.openrocket.swing.gui.components.ColorChooserButton;
+import info.openrocket.swing.gui.util.Icons;
 import info.openrocket.swing.gui.widgets.PlaceholderTextField;
 import net.miginfocom.swing.MigLayout;
 import info.openrocket.core.appearance.Appearance;
@@ -613,6 +614,7 @@ public class AppearancePanel extends JPanel implements Invalidatable, Invalidati
 
 		//// Select file button
 		JButton chooseTextureBtn = new JButton(trans.get("DecalModel.lbl.choose"));
+		chooseTextureBtn.setIcon(Icons.FILE_OPEN);
 		chooseTextureBtn.addActionListener(e -> decalModel.promptForFileSelection());
 		mDefault.addEnableComponent(chooseTextureBtn, false);
 		p.add(chooseTextureBtn, "top");
@@ -629,6 +631,7 @@ public class AppearancePanel extends JPanel implements Invalidatable, Invalidati
 		if ((SystemInfo.getPlatform() != Platform.UNIX) || !SystemInfo.isConfined()) {
 			JButton editBtn = new JButton(
 					trans.get("AppearanceCfg.but.edit"));
+			editBtn.setIcon(Icons.EDIT_EDIT);
 			// Enable the editBtn only when the appearance builder has an Image
 			// assigned to it.
 			editBtn.setEnabled(!materialDefault.isSelected() && builder.getImage() != null);
@@ -666,6 +669,7 @@ public class AppearancePanel extends JPanel implements Invalidatable, Invalidati
 
 		//// Delete button
 		JButton deleteTextureBtn = new JButton(trans.get("DecalModel.but.delete"));
+		deleteTextureBtn.setIcon(Icons.EDIT_DELETE);
 		Runnable refreshDeleteButtonState = () -> deleteTextureBtn.setEnabled(decalModel.getActiveDecal() != null);
 		deleteTextureBtn.addActionListener(e -> handleDeleteTexture(panel, decalModel, refreshDeleteButtonState));
 		textureDropDown.addActionListener(e -> refreshDeleteButtonState.run());

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/AppearancePanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/AppearancePanel.java
@@ -606,17 +606,24 @@ public class AppearancePanel extends JPanel implements Invalidatable, Invalidati
 		order.add(materialDefault);
 
 		// Texture File
-		panel.add(new JLabel(trans.get("AppearanceCfg.lbl.Texture")));
-		JPanel p = new JPanel(new MigLayout("fill, ins 0", "[grow][][]"));
+		panel.add(new JLabel(trans.get("AppearanceCfg.lbl.Texture")), "top");
+		JPanel p = new JPanel(new MigLayout("fill, ins 0", "[grow][][pref!]"));
 		mDefault.addEnableComponent(textureDropDown, false);
-		p.add(textureDropDown, "grow");
+		p.add(textureDropDown, "growx, top");
+
+		//// Select file button
 		JButton chooseTextureBtn = new JButton(trans.get("DecalModel.lbl.choose"));
 		chooseTextureBtn.addActionListener(e -> decalModel.promptForFileSelection());
 		mDefault.addEnableComponent(chooseTextureBtn, false);
-		p.add(chooseTextureBtn);
+		p.add(chooseTextureBtn, "top");
+
+		JPanel actionPanel = new JPanel(new MigLayout("fill, ins 0, gapy 4", "[fill]"));
+		p.add(actionPanel, "top");
 		panel.add(p, "spanx 3, growx, wrap");
 		order.add(textureDropDown);
 		order.add(chooseTextureBtn);
+
+		JPanel editDeletePanel = new JPanel(new MigLayout("fill, ins 0, gapy 4", "[fill]"));
 
 		//// Edit button
 		if ((SystemInfo.getPlatform() != Platform.UNIX) || !SystemInfo.isConfined()) {
@@ -653,8 +660,21 @@ public class AppearancePanel extends JPanel implements Invalidatable, Invalidati
 					}
 				}
 			});
-			p.add(editBtn);
+			editDeletePanel.add(editBtn, "growx, wrap");
+			order.add(editBtn);
 		}
+
+		//// Delete button
+		JButton deleteTextureBtn = new JButton(trans.get("DecalModel.but.delete"));
+		Runnable refreshDeleteButtonState = () -> deleteTextureBtn.setEnabled(decalModel.getActiveDecal() != null);
+		deleteTextureBtn.addActionListener(e -> handleDeleteTexture(panel, decalModel, refreshDeleteButtonState));
+		textureDropDown.addActionListener(e -> refreshDeleteButtonState.run());
+		refreshDeleteButtonState.run();
+		mDefault.addEnableComponent(deleteTextureBtn, false);
+		editDeletePanel.add(deleteTextureBtn, "growx");
+		order.add(deleteTextureBtn);
+
+		actionPanel.add(editDeletePanel, "growx");
 
 		// TODO: move the separate columns in two separate panels instead of adding them in a zig-zag way
 		// Color
@@ -811,6 +831,33 @@ public class AppearancePanel extends JPanel implements Invalidatable, Invalidati
 				decalModel.refresh();
 			}
 		});
+	}
+
+	private void handleDeleteTexture(Component parent, DecalModel decalModel, Runnable onUpdateState) {
+		DecalImage selected = decalModel.getActiveDecal();
+		if (selected == null) {
+			JOptionPane.showMessageDialog(parent,
+					trans.get("DecalModel.msg.noSelection"),
+					trans.get("DecalModel.msg.deleteTitle"),
+					JOptionPane.INFORMATION_MESSAGE);
+			return;
+		}
+		int decision = JOptionPane.showConfirmDialog(parent,
+				trans.get("DecalModel.msg.deleteConfirm", selected.getName()),
+				trans.get("DecalModel.msg.deleteTitle"),
+				JOptionPane.OK_CANCEL_OPTION,
+				JOptionPane.WARNING_MESSAGE);
+		if (decision == JOptionPane.OK_OPTION) {
+			boolean removed = decalModel.deleteDecal(selected);
+			if (!removed) {
+				JOptionPane.showMessageDialog(parent,
+						trans.get("DecalModel.msg.deleteFailed"),
+						trans.get("DecalModel.msg.deleteTitle"),
+						JOptionPane.ERROR_MESSAGE);
+			} else if (onUpdateState != null) {
+				onUpdateState.run();
+			}
+		}
 	}
 
 	@Override

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/AppearancePanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/AppearancePanel.java
@@ -537,6 +537,7 @@ public class AppearancePanel extends JPanel implements Invalidatable, Invalidati
 		register(mDefault);
 
 		DecalModel decalModel = new DecalModel(panel, document, builder);
+		cleanupTasks.add(decalModel::dispose);
 		TextureComboBox textureDropDown = new TextureComboBox(decalModel);
 
 		final ColorChooserButton colorButton = new ColorChooserButton(ColorConversion.toAwtColor(builder.getPaint()), paintColorChooser);

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/AppearancePanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/AppearancePanel.java
@@ -12,13 +12,13 @@ import java.util.ArrayList;
 import java.util.EventObject;
 import java.util.List;
 
+import javax.swing.JComboBox;
 import javax.swing.JPanel;
 import javax.swing.JColorChooser;
 import javax.swing.JDialog;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
-import javax.swing.JComboBox;
 import javax.swing.JSeparator;
 import javax.swing.JTextField;
 import javax.swing.SwingConstants;
@@ -66,6 +66,7 @@ import info.openrocket.swing.gui.components.ColorIcon;
 import info.openrocket.swing.gui.components.StyledLabel;
 import info.openrocket.swing.gui.components.StyledLabel.Style;
 import info.openrocket.swing.gui.components.UnitSelector;
+import info.openrocket.swing.gui.components.TextureComboBox;
 import info.openrocket.swing.gui.util.ColorConversion;
 import info.openrocket.swing.gui.util.EditDecalHelper;
 import info.openrocket.swing.gui.util.EditDecalHelper.EditDecalHelperException;
@@ -536,23 +537,7 @@ public class AppearancePanel extends JPanel implements Invalidatable, Invalidati
 		register(mDefault);
 
 		DecalModel decalModel = new DecalModel(panel, document, builder);
-		JComboBox<DecalImage> textureDropDown = new JComboBox<>(decalModel);
-		textureDropDown.setMaximumRowCount(20);
-
-		// We need to add this action listener that triggers a decalModel update when the same item is selected, because
-		// for multi-comp edits, the listeners' decals may not be updated otherwise
-		textureDropDown.addActionListener(new ActionListener() {
-			private DecalImage previousSelection = (DecalImage) decalModel.getSelectedItem();
-
-			@Override
-			public void actionPerformed(ActionEvent e) {
-				DecalImage decal = (DecalImage) textureDropDown.getSelectedItem();
-				if (decal == previousSelection) {
-					decalModel.setSelectedItem(decal);
-				}
-				previousSelection = decal;
-			}
-		});
+		TextureComboBox textureDropDown = new TextureComboBox(decalModel);
 
 		final ColorChooserButton colorButton = new ColorChooserButton(ColorConversion.toAwtColor(builder.getPaint()), paintColorChooser);
 		PlaceholderTextField colorHexField = new PlaceholderTextField(7);
@@ -621,11 +606,16 @@ public class AppearancePanel extends JPanel implements Invalidatable, Invalidati
 
 		// Texture File
 		panel.add(new JLabel(trans.get("AppearanceCfg.lbl.Texture")));
-		JPanel p = new JPanel(new MigLayout("fill, ins 0", "[grow][]"));
+		JPanel p = new JPanel(new MigLayout("fill, ins 0", "[grow][][]"));
 		mDefault.addEnableComponent(textureDropDown, false);
 		p.add(textureDropDown, "grow");
+		JButton chooseTextureBtn = new JButton(trans.get("DecalModel.lbl.choose"));
+		chooseTextureBtn.addActionListener(e -> decalModel.promptForFileSelection());
+		mDefault.addEnableComponent(chooseTextureBtn, false);
+		p.add(chooseTextureBtn);
 		panel.add(p, "spanx 3, growx, wrap");
 		order.add(textureDropDown);
+		order.add(chooseTextureBtn);
 
 		//// Edit button
 		if ((SystemInfo.getPlatform() != Platform.UNIX) || !SystemInfo.isConfined()) {


### PR DESCRIPTION
This PR fixes #2100. You can now delete the selected decal of a component. A drawback is that you do first have to select the decal before you can delete it. Maybe in the future, we can add delete buttons in the combobox items, or even better, add a decal manager tool where you can also swap decals from a new file (useful if you use the same decal for multiple components).

Additionally, I moved the "Select file" option from the combobox to a dedicated button, which should be more clear.

This PR also adds decal previews. When you hover over the texture combobox,, you get a preview of the currently selected decal and which components use it. If you open the combobox, you get the same preview window when hovering over the different items:

https://github.com/user-attachments/assets/c169ea38-4356-4fca-86a1-f926edf3d1f3

