### PR TITLE
Add a RemovedComponent subclass of RocketComponent

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/openrocket/OpenRocketSaver.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/OpenRocketSaver.java
@@ -456,10 +456,13 @@ public class OpenRocketSaver extends RocketSaver {
 				writeElement("description", w.getMessageDescription());
 				writeElement("priority", w.getPriority());
 
-				if (null != w.getSources()) {
-					for (RocketComponent c : w.getSources()) {
-						// Save component ID if it's still in the tree, else nil UUID
-						writeElement("source", null != simulation.getRocket().findComponent(c.getID()) ? c.getID() : new UUID(0, 0));
+				RocketComponent[] sources = w.getSources();
+				if (null != sources) {
+					for (RocketComponent c : sources) {
+						if (c != null) {
+							// Save component ID if it's still in the tree, else RemovedComponent UUID
+							writeElement("source", simulation.getRocket().findComponent(c.getID()).getID());
+						}
 					}
 				}
 

--- a/core/src/main/java/info/openrocket/core/logging/Message.java
+++ b/core/src/main/java/info/openrocket/core/logging/Message.java
@@ -49,10 +49,7 @@ public abstract class Message implements Cloneable {
 		if (sources != null && sources.length > 0) {
 			String[] sourceNames = new String[sources.length];
 			for (int i = 0; i < sources.length; i++) {
-				sourceNames[i] =
-					(null != sources[i]) ?
-					("\"" + sources[i].getName() + "\"") :
-					(trans.get("Message.SOURCE_REMOVED"));
+				sourceNames[i] = "\"" + sources[i].getName() + "\"";
 			}
 			return text + ":  " + String.join(", ", sourceNames);
 		}

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
@@ -15,6 +15,7 @@ import info.openrocket.core.aerodynamics.AerodynamicCalculator;
 import info.openrocket.core.aerodynamics.AerodynamicForces;
 import info.openrocket.core.aerodynamics.BarrowmanCalculator;
 import info.openrocket.core.aerodynamics.FlightConditions;
+import info.openrocket.core.l10n.Translator;
 import info.openrocket.core.logging.WarningSet;
 import info.openrocket.core.material.Material;
 import info.openrocket.core.rocketcomponent.position.AnglePositionable;
@@ -53,6 +54,8 @@ import info.openrocket.core.util.StateChangeListener;
 public abstract class RocketComponent implements ChangeSource, Cloneable, Iterable<RocketComponent> {
 	@SuppressWarnings("unused")
 	private static final Logger log = LoggerFactory.getLogger(RocketComponent.class);
+
+	public static RemovedComponent REMOVED = new RemovedComponent();
 	
 	// Because of changes to Java 1.7.0-45's mechanism to construct DataFlavor objects (used in Drag and Drop)
 	// We cannot access static members of the Application object in this class.  Instead of holding
@@ -2448,7 +2451,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 	/**
 	 * Find a component with the given ID.  The component tree is searched from this component
 	 * down (including this component) for the ID and the corresponding component is returned,
-	 * or null if not found.
+	 * or the RemovedCompoment if not found.
 	 *
 	 * @param idToFind  ID to search for.
 	 * @return    The component with the ID, or null if not found.
@@ -2465,7 +2468,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 			}
 		}
 		mutex.unlock("findComponent");
-		return null;
+		return REMOVED;
 	}
 
 	public final RocketComponent getNextComponent() {
@@ -3229,4 +3232,55 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 	public void setDisplayOrder_back(int displayOrder_back) {
 		this.displayOrder_back = displayOrder_back;
 	}
+
+	// A null component. Attempting to get a component from a null UUID returns this component
+	private static class RemovedComponent extends RocketComponent {
+		
+		private static final Translator trans = Application.getTranslator();
+		
+		private RemovedComponent() {
+			super(AxialMethod.TOP);
+		}
+		
+		public String getComponentName() {
+			return trans.get("NullComponent.COMPONENT_REMOVED");
+		}
+		
+		public double getComponentMass() {
+			return 0;
+		}
+		
+		public CoordinateIF getComponentCG() {
+			return Coordinate.ZERO;
+		}
+		
+		public double getLongitudinalUnitInertia() {
+			return 0;
+		}
+		
+		public double getRotationalUnitInertia() {
+			return 0;
+		}
+		
+		public boolean allowsChildren() {
+			return false;
+		}
+		
+		public boolean isCompatible(Class<? extends RocketComponent> type) {
+			return false;
+		}
+		
+		public ArrayList<CoordinateIF> getComponentBounds() {
+			return new ArrayList<CoordinateIF>();
+		}
+		
+		public boolean isAerodynamic() {
+			return false;
+		}
+		
+		public boolean isMassive() {
+			return false;
+		}
+	}
+
 }

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
@@ -3243,7 +3243,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 		}
 		
 		public String getComponentName() {
-			return trans.get("NullComponent.COMPONENT_REMOVED");
+			return trans.get("RemovedComponent.COMPONENT_REMOVED");
 		}
 		
 		public double getComponentMass() {

--- a/core/src/main/java/info/openrocket/core/simulation/FlightEvent.java
+++ b/core/src/main/java/info/openrocket/core/simulation/FlightEvent.java
@@ -222,10 +222,10 @@ public class FlightEvent implements Comparable<FlightEvent> {
 		}
 		switch( this.type ){
 		case BURNOUT:
-			if( null != this.source){
+			if( (null != this.source) && (RocketComponent.REMOVED != this.source)){
 				if( ! ( this.source instanceof MotorMount)){
 					throw new IllegalStateException(type.name()+" events should have "
-							+MotorMount.class.getSimpleName()+" type data payloads, instead of"
+							+MotorMount.class.getSimpleName()+" type data payloads, instead of "
 							+this.getSource().getClass().getSimpleName());
 				}
 			}
@@ -237,10 +237,10 @@ public class FlightEvent implements Comparable<FlightEvent> {
 			}
 			break;
 		case IGNITION:
-			if( null != this.source){
+			if((null != this.source) && (RocketComponent.REMOVED != this.source)){
 				if( ! ( this.getSource() instanceof MotorMount)){
 					throw new IllegalStateException(type.name()+" events should have "
-							+MotorMount.class.getSimpleName()+" type data payloads, instead of"
+							+MotorMount.class.getSimpleName()+" type data payloads, instead of "
 							+this.getSource().getClass().getSimpleName());
 				}
 			}
@@ -252,10 +252,10 @@ public class FlightEvent implements Comparable<FlightEvent> {
 			}
 			break;
 		case EJECTION_CHARGE:
-			if( null != this.source){
+			if((null != this.source) && (RocketComponent.REMOVED != this.source)) {
 				if( ! ( this.getSource() instanceof AxialStage)){
 					throw new IllegalStateException(type.name()+" events should have "
-							+AxialStage.class.getSimpleName()+" type data payloads, instead of"
+							+AxialStage.class.getSimpleName()+" type data payloads, instead of "
 							+this.getSource().getClass().getSimpleName());
 				}
 			}

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -2232,6 +2232,8 @@ FlightConfiguration.noMotors = No motors
 
 MotorConfiguration.empty = None
 
+!Null Component
+NullComponent.COMPONENT_REMOVED <i>Component Removed From Rocket</i>
 
 !ComponentIcons
 ComponentIcons.Stage = Axial Stage

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -2233,7 +2233,7 @@ FlightConfiguration.noMotors = No motors
 MotorConfiguration.empty = None
 
 !Null Component
-NullComponent.COMPONENT_REMOVED <i>Component Removed From Rocket</i>
+RemovedComponent.COMPONENT_REMOVED <i>Component Removed From Rocket</i>
 
 !ComponentIcons
 ComponentIcons.Stage = Axial Stage
@@ -2469,8 +2469,6 @@ Warning.EMPTY_BRANCH = Simulation branch contains no data
 Warning.SEPARATION_ORDER = Stages separated in an unreasonable order
 Warning.EARLY_SEPARATION = Stages separated before clearing launch rod/rail
 Warning.OBJ_ZERO_THICKNESS = Zero-thickness component can cause issues for 3D printing
-
-Message.SOURCE_REMOVED = <i>&lt;component deleted&gt;</i>
 
 ! Scale dialog
 ScaleDialog.lbl.scaleRocket = Entire rocket

--- a/core/src/test/java/info/openrocket/core/rocketcomponent/UUIDSearchTest.java
+++ b/core/src/test/java/info/openrocket/core/rocketcomponent/UUIDSearchTest.java
@@ -1,0 +1,59 @@
+package info.openrocket.core.rocketcomponent;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import info.openrocket.core.rocketcomponent.AxialStage;
+import info.openrocket.core.rocketcomponent.NoseCone;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.rocketcomponent.RocketComponent;
+import info.openrocket.core.util.BaseTestCase;
+import info.openrocket.core.util.TestRockets;
+
+public class UUIDSearchTest extends BaseTestCase {
+
+	/**
+	 * find the first child component of the given type
+	 */
+	RocketComponent findComponent(RocketComponent parent, Class componentClass) {
+		RocketComponent ret = null;
+		for (RocketComponent child : parent.getChildren()) {
+			if (child.getClass() == componentClass) {
+				ret = child;
+			}
+		}
+		return ret;
+	}
+	
+	/**
+	 * Test search for rocket component using UUID
+	 */
+	@Test
+	public void testUUIDSearch() {
+		final Rocket rocket = TestRockets.makeEstesAlphaIII();
+
+		// Get the fin set
+		RocketComponent stage = findComponent(rocket, AxialStage.class);
+		assertNotNull(stage, "Failed to find stage");
+		
+		RocketComponent noseCone = findComponent(stage, NoseCone.class);
+		assertNotNull(noseCone, "Failed to find NoseCone");
+
+		// If I search for the NoseCone using its UUID I should get it back
+		UUID noseConeID = noseCone.getID();
+		assertEquals(noseCone, rocket.findComponent(noseConeID), "UUID search didn't find NoseCone");
+
+		// If I remove the NoseCone from the rocket and search for it by UUID, I should get a RemovedComponent back
+		assertTrue(stage.removeChild(noseCone, false), "failed to remove NoseCone");
+		assertEquals(rocket.findComponent(noseConeID), RocketComponent.REMOVED, "Search for NoseCone failed to find REMOVED");
+
+		// If I explicitly search for the null UUID I should get the RemovedComponent
+		assertEquals(rocket.findComponent(new UUID(0, 0)), RocketComponent.REMOVED, "Failed to find REMOVED");
+	}
+}
+
+	


### PR DESCRIPTION
At present, when a search is made through the rocket component tree for a component that has been removed from the tree, a null pointer is returned. This ends up requiring special case handling of the null component when doing things like writing a .ork file, and makes it impossible to tell whether a null refers to a removed component or if it's a bug.

This PR adds a new subclass of RocketComponent called RemovedComponent. The RemovedComponent provides minimal implementations of the required abstract classes from RocketComponent, and has a UUID of 0. There is exactly one RemovedComponent instance, RocketComponent.REMOVED.

Searching for a removed component in the component tree now returns RemovedComponent. A search for a UUID  of 0 also ends up returning the RemovedComponent, though no special case is required to make it happen.

Fixes #2873 