### PR TITLE
[#2862] Fix launch preferences panel issues

### DIFF
--- a/core/src/main/java/info/openrocket/core/preferences/ApplicationPreferences.java
+++ b/core/src/main/java/info/openrocket/core/preferences/ApplicationPreferences.java
@@ -428,10 +428,13 @@ public abstract class ApplicationPreferences implements ChangeSource, ORPreferen
 	
 	
 	public double getLaunchRodDirection() {
-		if (this.getBoolean(LAUNCH_INTO_WIND, true)) {
-			this.setLaunchRodDirection(this.getDouble(WIND_DIRECTION, Math.PI / 2));
+		if (this.getBoolean(LAUNCH_INTO_WIND, false)) {
+			// When launching into wind, sync the launch rod direction with wind direction
+			double windDirection = this.getDouble(WIND_DIRECTION, Math.PI / 2);
+			this.setLaunchRodDirection(windDirection);
+			return windDirection;
 		}
-		return this.getDouble(WIND_DIRECTION, Math.PI / 2);
+		return this.getDouble(LAUNCH_ROD_DIRECTION, Math.PI / 2);
 	}
 	
 	public void setLaunchRodDirection(double launchRodDirection) {

--- a/core/src/test/java/info/openrocket/core/preferences/ApplicationPreferencesTest.java
+++ b/core/src/test/java/info/openrocket/core/preferences/ApplicationPreferencesTest.java
@@ -1,0 +1,112 @@
+package info.openrocket.core.preferences;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.util.Modules;
+import info.openrocket.core.ServicesForTesting;
+import info.openrocket.core.formatting.RocketDescriptor;
+import info.openrocket.core.formatting.RocketDescriptorImpl;
+import info.openrocket.core.l10n.DebugTranslator;
+import info.openrocket.core.l10n.Translator;
+import info.openrocket.core.plugin.PluginModule;
+import info.openrocket.core.startup.Application;
+import info.openrocket.core.startup.MockPreferences;
+import info.openrocket.core.util.MathUtil;
+
+public class ApplicationPreferencesTest {
+    private static final double EPSILON = MathUtil.EPSILON;
+    private MockPreferences prefs;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        Module applicationModule = new PreferencesModule();
+        Module debugTranslator = new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(Translator.class).toInstance(new DebugTranslator(null));
+            }
+        };
+        Module pluginModule = new PluginModule();
+        Injector injector = Guice.createInjector(Modules.override(applicationModule).with(debugTranslator),
+                pluginModule);
+        Application.setInjector(injector);
+    }
+
+    @BeforeEach
+    public void setUpTest() {
+        prefs = new MockPreferences();
+    }
+
+    @Test
+    @DisplayName("getLaunchRodDirection returns LAUNCH_ROD_DIRECTION when LAUNCH_INTO_WIND is false")
+    public void testGetLaunchRodDirectionWhenNotIntoWind() {
+        // Set launch into wind to false
+        prefs.setLaunchIntoWind(false);
+        
+        // Set a specific launch rod direction
+        double expectedDirection = Math.PI / 4; // 45 degrees
+        prefs.setLaunchRodDirection(expectedDirection);
+        
+        // Set a different wind direction to ensure it's not used
+        prefs.getAverageWindModel().setDirection(Math.PI); // 180 degrees
+        
+        // Verify getLaunchRodDirection returns the launch rod direction, not wind direction
+        double actualDirection = prefs.getLaunchRodDirection();
+        assertEquals(expectedDirection, actualDirection, EPSILON,
+                "getLaunchRodDirection should return LAUNCH_ROD_DIRECTION when LAUNCH_INTO_WIND is false");
+    }
+
+    @Test
+    @DisplayName("getLaunchRodDirection returns WIND_DIRECTION and syncs when LAUNCH_INTO_WIND is true")
+    public void testGetLaunchRodDirectionWhenIntoWind() {
+        // Set launch into wind to true
+        prefs.setLaunchIntoWind(true);
+        
+        // Set a specific wind direction
+        double expectedWindDirection = Math.PI / 3; // 60 degrees
+        prefs.getAverageWindModel().setDirection(expectedWindDirection);
+        
+        // Set a different launch rod direction initially
+        prefs.setLaunchRodDirection(Math.PI / 4); // 45 degrees
+        
+        // Verify getLaunchRodDirection returns the wind direction and syncs
+        double actualDirection = prefs.getLaunchRodDirection();
+        assertEquals(expectedWindDirection, actualDirection, EPSILON,
+                "getLaunchRodDirection should return WIND_DIRECTION when LAUNCH_INTO_WIND is true");
+        
+        // Verify that the launch rod direction was synced
+        double syncedDirection = prefs.getDouble(ApplicationPreferences.LAUNCH_ROD_DIRECTION, 0);
+        assertEquals(expectedWindDirection, syncedDirection, EPSILON,
+                "LAUNCH_ROD_DIRECTION should be synced with WIND_DIRECTION when LAUNCH_INTO_WIND is true");
+    }
+
+    @Test
+    @DisplayName("getLaunchRodDirection uses default value when preferences are not set")
+    public void testGetLaunchRodDirectionDefaultValue() {
+        // Don't set any preferences
+        // When LAUNCH_INTO_WIND is false, should return default LAUNCH_ROD_DIRECTION
+        prefs.setLaunchIntoWind(false);
+        double defaultDirection = prefs.getLaunchRodDirection();
+        assertEquals(Math.PI / 2, defaultDirection, EPSILON,
+                "getLaunchRodDirection should return default Math.PI/2 when not set");
+    }
+
+    private static class PreferencesModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            bind(ApplicationPreferences.class).to(MockPreferences.class);
+            bind(Translator.class).toProvider(ServicesForTesting.TranslatorProviderForTesting.class);
+            bind(RocketDescriptor.class).to(RocketDescriptorImpl.class);
+        }
+    }
+}
+

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/LaunchPreferencesPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/LaunchPreferencesPanel.java
@@ -9,6 +9,9 @@ import info.openrocket.swing.gui.components.StyledLabel;
 import info.openrocket.swing.gui.simulation.SimulationConditionsPanel;
 import info.openrocket.swing.gui.util.GUIUtil;
 import info.openrocket.swing.gui.theme.UITheme;
+import info.openrocket.core.simulation.DefaultSimulationOptionFactory;
+import info.openrocket.core.simulation.SimulationOptions;
+import info.openrocket.core.startup.Application;
 
 public class LaunchPreferencesPanel extends PreferencesPanel {
 	private static Color darkErrorColor;
@@ -44,6 +47,38 @@ public class LaunchPreferencesPanel extends PreferencesPanel {
 
 	public static void updateColors() {
 		darkErrorColor = GUIUtil.getUITheme().getDarkErrorColor();
+	}
+
+	/**
+	 * Saves the current launch preferences to DefaultSimulationOptionFactory
+	 * so that new simulations will use these values.
+	 */
+	public void saveLaunchPreferencesToDefaults() {
+		// Create a SimulationOptions from the current preferences
+		// Since preferences implements SimulationOptionsInterface, we can create
+		// a SimulationOptions and copy the values
+		SimulationOptions options = new SimulationOptions();
+		
+		// Copy values from preferences (which implements SimulationOptionsInterface)
+		options.setLaunchLatitude(preferences.getLaunchLatitude());
+		options.setLaunchLongitude(preferences.getLaunchLongitude());
+		options.setLaunchAltitude(preferences.getLaunchAltitude());
+		options.setISAAtmosphere(preferences.isISAAtmosphere());
+		options.setLaunchTemperature(preferences.getLaunchTemperature());
+		options.setLaunchPressure(preferences.getLaunchPressure());
+		options.setLaunchIntoWind(preferences.getLaunchIntoWind());
+		options.setLaunchRodLength(preferences.getLaunchRodLength());
+		options.setLaunchRodAngle(preferences.getLaunchRodAngle());
+		options.setLaunchRodDirection(preferences.getLaunchRodDirection());
+		
+		// Copy wind model settings
+		options.getAverageWindModel().setAverage(preferences.getAverageWindModel().getAverage());
+		options.getAverageWindModel().setStandardDeviation(preferences.getAverageWindModel().getStandardDeviation());
+		options.getAverageWindModel().setTurbulenceIntensity(preferences.getAverageWindModel().getTurbulenceIntensity());
+		
+		// Save to DefaultSimulationOptionFactory
+		DefaultSimulationOptionFactory factory = Application.getInjector().getInstance(DefaultSimulationOptionFactory.class);
+		factory.saveDefault(options);
 	}
 
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/PreferencesDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/PreferencesDialog.java
@@ -46,6 +46,7 @@ public class PreferencesDialog extends JDialog {
 
 	private boolean storePreferences = true;
 	private File initPrefsFile = null;
+	private LaunchPreferencesPanel launchPanel = null;
 
 	public final static int TAB_GENERAL = 0;
 	public final static int TAB_UI = 1;
@@ -88,8 +89,9 @@ public class PreferencesDialog extends JDialog {
 				new SimulationPreferencesPanel(),
 				trans.get("pref.dlg.tab.Simulation"), TAB_SIMULATION);
 		// Launch options
+		this.launchPanel = new LaunchPreferencesPanel();
 		tabbedPane.insertTab(trans.get("pref.dlg.tab.Launch"), null,
-				new LaunchPreferencesPanel(), trans.get("pref.dlg.tab.Launch"), TAB_LAUNCH);
+				this.launchPanel, trans.get("pref.dlg.tab.Launch"), TAB_LAUNCH);
 		// Units and Default units
 		tabbedPane.insertTab(trans.get("pref.dlg.tab.Units"), null,
 				new UnitsPreferencesPanel(this),
@@ -159,6 +161,10 @@ public class PreferencesDialog extends JDialog {
 				// Either store changed preferences (if OK) or reload initial preferences (if Cancel)
 				if (storePreferences) {
 					preferences.storeDefaultUnits();
+					// Save launch preferences to DefaultSimulationOptionFactory
+					if (launchPanel != null) {
+						launchPanel.saveLaunchPreferencesToDefaults();
+					}
 				} else {
 					loadInitPreferences();
 				}

--- a/swing/src/test/java/info/openrocket/swing/gui/dialogs/preferences/LaunchPreferencesPanelTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/dialogs/preferences/LaunchPreferencesPanelTest.java
@@ -1,0 +1,138 @@
+package info.openrocket.swing.gui.dialogs.preferences;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.util.Modules;
+import info.openrocket.core.formatting.RocketDescriptor;
+import info.openrocket.core.formatting.RocketDescriptorImpl;
+import info.openrocket.core.l10n.DebugTranslator;
+import info.openrocket.core.l10n.Translator;
+import info.openrocket.core.plugin.PluginModule;
+import info.openrocket.core.preferences.ApplicationPreferences;
+import info.openrocket.core.simulation.DefaultSimulationOptionFactory;
+import info.openrocket.core.simulation.SimulationOptions;
+import info.openrocket.core.startup.Application;
+import info.openrocket.core.util.MathUtil;
+import info.openrocket.swing.ServicesForTesting;
+import info.openrocket.swing.gui.util.SwingPreferences;
+
+public class LaunchPreferencesPanelTest {
+    private static final double EPSILON = MathUtil.EPSILON;
+    private SwingPreferences prefs;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        Module applicationModule = new PreferencesModule();
+        Module debugTranslator = new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(Translator.class).toInstance(new DebugTranslator(null));
+            }
+        };
+        Module pluginModule = new PluginModule();
+        Injector injector = Guice.createInjector(Modules.override(applicationModule).with(debugTranslator),
+                pluginModule);
+        Application.setInjector(injector);
+    }
+
+    @BeforeEach
+    public void setUpTest() {
+        prefs = (SwingPreferences) Application.getPreferences();
+    }
+
+    @Test
+    @DisplayName("saveLaunchPreferencesToDefaults saves all launch preferences correctly")
+    public void testSaveLaunchPreferencesToDefaults() {
+        // Set up test preferences
+        double testLatitude = 50.8791; // Leuven
+        double testLongitude = 4.7025;
+        double testAltitude = 10.0;
+        boolean testISAAtmosphere = false;
+        double testTemperature = 293.15; // 20°C
+        double testPressure = 101000.0;
+        boolean testLaunchIntoWind = false;
+        double testRodLength = 1.5;
+        double testRodAngle = 0.1;
+        double testRodDirection = Math.PI / 4; // 45 degrees
+        double testWindAverage = 3.0;
+        double testWindTurbulence = 0.15;
+        // Standard deviation is calculated from turbulence intensity: stdDev = turbulence * average
+        double testWindStdDev = testWindTurbulence * testWindAverage; // 0.15 * 3.0 = 0.45
+
+        // Set preferences
+        prefs.setLaunchLatitude(testLatitude);
+        prefs.setLaunchLongitude(testLongitude);
+        prefs.setLaunchAltitude(testAltitude);
+        prefs.setISAAtmosphere(testISAAtmosphere);
+        prefs.setLaunchTemperature(testTemperature);
+        prefs.setLaunchPressure(testPressure);
+        prefs.setLaunchIntoWind(testLaunchIntoWind);
+        prefs.setLaunchRodLength(testRodLength);
+        prefs.setLaunchRodAngle(testRodAngle);
+        prefs.setLaunchRodDirection(testRodDirection);
+        // Set wind model values - note that standard deviation is calculated from turbulence intensity
+        prefs.getAverageWindModel().setAverage(testWindAverage);
+        prefs.getAverageWindModel().setTurbulenceIntensity(testWindTurbulence);
+        // The standard deviation will be calculated as turbulence * average = 0.15 * 3.0 = 0.45
+        testWindStdDev = prefs.getAverageWindModel().getStandardDeviation();
+
+        // Create panel and save preferences
+        LaunchPreferencesPanel panel = new LaunchPreferencesPanel();
+        panel.saveLaunchPreferencesToDefaults();
+
+        // Verify that DefaultSimulationOptionFactory has the saved values
+        DefaultSimulationOptionFactory factory = Application.getInjector()
+                .getInstance(DefaultSimulationOptionFactory.class);
+        assertNotNull(factory, "Factory should not be null");
+
+        SimulationOptions savedOptions = factory.getDefault();
+        assertNotNull(savedOptions, "Saved options should not be null");
+
+        assertEquals(testLatitude, savedOptions.getLaunchLatitude(), EPSILON,
+                "Launch latitude should be saved correctly");
+        assertEquals(testLongitude, savedOptions.getLaunchLongitude(), EPSILON,
+                "Launch longitude should be saved correctly");
+        assertEquals(testAltitude, savedOptions.getLaunchAltitude(), EPSILON,
+                "Launch altitude should be saved correctly");
+        assertEquals(testISAAtmosphere, savedOptions.isISAAtmosphere(),
+                "ISA atmosphere flag should be saved correctly");
+        assertEquals(testTemperature, savedOptions.getLaunchTemperature(), EPSILON,
+                "Launch temperature should be saved correctly");
+        assertEquals(testPressure, savedOptions.getLaunchPressure(), EPSILON,
+                "Launch pressure should be saved correctly");
+        assertEquals(testLaunchIntoWind, savedOptions.getLaunchIntoWind(),
+                "Launch into wind flag should be saved correctly");
+        assertEquals(testRodLength, savedOptions.getLaunchRodLength(), EPSILON,
+                "Launch rod length should be saved correctly");
+        assertEquals(testRodAngle, savedOptions.getLaunchRodAngle(), EPSILON,
+                "Launch rod angle should be saved correctly");
+        assertEquals(testRodDirection, savedOptions.getLaunchRodDirection(), EPSILON,
+                "Launch rod direction should be saved correctly");
+        assertEquals(testWindAverage, savedOptions.getAverageWindModel().getAverage(), EPSILON,
+                "Wind average should be saved correctly");
+        assertEquals(testWindStdDev, savedOptions.getAverageWindModel().getStandardDeviation(), EPSILON,
+                "Wind standard deviation should be saved correctly");
+        assertEquals(testWindTurbulence, savedOptions.getAverageWindModel().getTurbulenceIntensity(), EPSILON,
+                "Wind turbulence intensity should be saved correctly");
+    }
+
+    private static class PreferencesModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            bind(ApplicationPreferences.class).to(ServicesForTesting.PreferencesForTesting.class);
+            bind(Translator.class).toProvider(ServicesForTesting.TranslatorProviderForTesting.class);
+            bind(RocketDescriptor.class).to(RocketDescriptorImpl.class);
+        }
+    }
+}
+


### PR DESCRIPTION
Fixes #2862:

1. Fixed getLaunchRodDirection() bug that returned WIND_DIRECTION instead of LAUNCH_ROD_DIRECTION. The method now correctly returns the stored launch rod direction when "Launch into wind" is unchecked, and syncs with wind direction when checked. This fixes the direction spinner and slider not being editable.

2. Added automatic saving of launch preferences to DefaultSimulationOptionFactory when the preferences dialog closes. This ensures that launch site and launch rod settings changed in the preferences panel are properly applied to new simulations.