### PR TITLE
Allow finset config subclass to expand and shrink

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/EllipticalFinSetConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/EllipticalFinSetConfig.java
@@ -35,11 +35,11 @@ public class EllipticalFinSetConfig extends FinSetConfig {
 		DoubleModel m;
 		JSpinner spin;
 		
-		JPanel mainPanel = new JPanel(new MigLayout());
+		JPanel mainPanel = new JPanel(new MigLayout("fillx, ins n n 0 n"));
 		
 		// Left side
-		JPanel panel = new JPanel(new MigLayout("gap rel unrel, ins 0", "[][65lp::][30lp::]", ""));
-		
+		JPanel panel = new JPanel(new MigLayout("fillx, gap rel unrel, ins 0", "[][65lp::][30lp::]", ""));
+
 		////  Number of fins
 		panel.add(new JLabel(trans.get("EllipticalFinSetCfg.Nbroffins")));
 		
@@ -126,10 +126,10 @@ public class EllipticalFinSetConfig extends FinSetConfig {
 			panel.add(new BasicSlider(m.getSliderModel(0, 0.01)), "w 100lp, wrap 30lp");
 		}
 
-		mainPanel.add(panel, "aligny 0, gapright 40lp");
+		mainPanel.add(panel, "grow, aligny 0, gapright 40lp");
 
 		// Right side panel
-		panel = new JPanel(new MigLayout("gap rel unrel, ins 0", "[][65lp::][30lp::]", ""));
+		panel = new JPanel(new MigLayout("fillx, gap rel unrel, ins 0", "[][65lp::][30lp::]", ""));
 
 		{// ------ Placement ------
 			//// Position relative to:
@@ -165,7 +165,7 @@ public class EllipticalFinSetConfig extends FinSetConfig {
 			panel.add(filletMaterialPanel(), "span, grow, wrap");
 		}
 		
-		mainPanel.add(panel, "aligny 0");
+		mainPanel.add(panel, "grow, aligny 0");
 		
 		addFinSetButtons();
 		

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/FreeformFinSetConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/FreeformFinSetConfig.java
@@ -118,9 +118,9 @@ public class FreeformFinSetConfig extends FinSetConfig {
 	
 	
 	private JPanel generalPane() {
-		JPanel mainPanel = new JPanel(new MigLayout());
+		JPanel mainPanel = new JPanel(new MigLayout("fillx, ins n n 0 n"));
 		
-		JPanel panel = new JPanel(new MigLayout("gap rel unrel, ins 0", "[][65lp::][30lp::]", ""));
+		JPanel panel = new JPanel(new MigLayout("fillx, gap rel unrel, ins 0", "[150][65lp::][30lp::]", ""));
 
 		{ ////  Number of fins:
 			panel.add(new JLabel(trans.get("FreeformFinSetCfg.lbl.Numberoffins")));
@@ -177,10 +177,10 @@ public class FreeformFinSetConfig extends FinSetConfig {
 			panel.add(new BasicSlider(m.getSliderModel(0, 0.01)), "w 100lp, wrap 30lp");
 		}
 
-		mainPanel.add(panel, "aligny 0, gapright 40lp");
+		mainPanel.add(panel, "aligny 0, gapright 40lp, grow");
 
 		// Right side panel
-		panel = new JPanel(new MigLayout("gap rel unrel, ins 0", "[][65lp::][30lp::]", ""));
+		panel = new JPanel(new MigLayout("fillx, gap rel unrel, ins 0", "[][65lp::][30lp::]", ""));
 
 		{//// -------- Placement ------
 			//// Position relative to:
@@ -216,7 +216,7 @@ public class FreeformFinSetConfig extends FinSetConfig {
 			panel.add(filletMaterialPanel(), "span, grow, wrap");
 		}
 		
-		mainPanel.add(panel, "aligny 0");
+		mainPanel.add(panel, "aligny 0, grow");
 
 		return mainPanel;
 	}

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/RocketComponentConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/RocketComponentConfig.java
@@ -196,12 +196,12 @@ public class RocketComponentConfig extends JPanel implements Invalidatable, Inva
 		tabbedPane.addTab(trans.get("RocketCompCfg.tab.Comment"), null, commentTab(),
 				trans.get("RocketCompCfg.tab.Comment.ttip"));
 
-    JScrollPane scrollPane = new JScrollPane(tabbedPane);
-    scrollPane.setBorder(null);
-    scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
-    scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+        JScrollPane scrollPane = new JScrollPane(tabbedPane);
+        scrollPane.setBorder(null);
+        scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+        scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
 
-    this.add(scrollPane, "newline, grow, push, wrap");
+        this.add(scrollPane, "newline, grow, push, wrap");
 
 		addButtons();
 

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/TrapezoidFinSetConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/TrapezoidFinSetConfig.java
@@ -34,10 +34,10 @@ public class TrapezoidFinSetConfig extends FinSetConfig {
 	public TrapezoidFinSetConfig(OpenRocketDocument d, final RocketComponent component, JDialog parent) {
 		super(d, component, parent);
 
-		JPanel mainPanel = new JPanel(new MigLayout());
+		JPanel mainPanel = new JPanel(new MigLayout("fillx, ins n n 0 n"));
 
 		// Left side
-		JPanel panel = new JPanel(new MigLayout("gap rel unrel, ins 0", "[][65lp::][30lp::]", ""));
+		JPanel panel = new JPanel(new MigLayout("fillx, gap rel unrel, ins 0", "[][65lp::][30lp::]", ""));
 
 		////  Number of fins:
 		JLabel label = new JLabel(trans.get("TrapezoidFinSetCfg.lbl.Nbroffins"));
@@ -182,10 +182,10 @@ public class TrapezoidFinSetConfig extends FinSetConfig {
 			panel.add(new BasicSlider(thicknessModel.getSliderModel(0, 0.01)), "w 100lp, wrap para");
 		}
 
-		mainPanel.add(panel, "aligny 0, gapright 40lp");
+		mainPanel.add(panel, "grow, aligny 0, gapright 40lp");
 
 		// Right side panel
-		panel = new JPanel(new MigLayout("gap rel unrel, ins 0", "[][65lp::][30lp::]", ""));
+        panel = new JPanel(new MigLayout("fillx, gap rel unrel, ins 0", "[][65lp::][30lp::]", ""));
 
 		{//// -------- Placement -------
 			// Position relative to:
@@ -222,7 +222,7 @@ public class TrapezoidFinSetConfig extends FinSetConfig {
 			panel.add(filletMaterialPanel(), "span, grow, wrap");
 		}
 
-		mainPanel.add(panel, "aligny 0");
+		mainPanel.add(panel, "grow, aligny 0");
 
 		//// General and General properties
 		tabbedPane.insertTab(trans.get("TrapezoidFinSetCfg.tab.General"), null, mainPanel,


### PR DESCRIPTION
This is similar to my previous pull request, with one minor issue: when the dialog is resized smaller to the point where the button panel layout can no longer shrink, it forces the scroll pane’s vertical bar to stop at the minimum width of the button panel. This causes part of the dialog content to be cut off a part of dialog.


https://github.com/user-attachments/assets/55d4f2bb-945e-48bf-90c4-3be9e80a05d0

