### PR TITLE
[Fixes #2592] Make plot legend sensitive and embolden plot lines

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/plot/Plot.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/Plot.java
@@ -398,7 +398,7 @@ public abstract class Plot<T extends DataType, B extends DataBranch<T>, C extend
 			for (String s : lineLabels) {
 				String label = s;
 				String description = s;
-				String toolTipText = null;
+				String toolTipText = s;
 				String urlText = null;
 				boolean shapeIsVisible = false;
 				Shape shape = pointShapes.get(i);

--- a/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationChart.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationChart.java
@@ -184,8 +184,9 @@ public class SimulationChart extends ChartPanel {
 	}
 
     /**
-     * <p>Called whenever the mouse moves.</p>
-     * <p>Gets an entity at the location of the mouse, if this entity is a LegendItemEntity, calls updateHighlightingSet.</p>
+     * Called whenever the mouse moves.
+     *
+     * Gets an entity at the location of the mouse, if this entity is a LegendItemEntity, calls updateHighlightingSet.
      */
     @Override
     public void mouseMoved(MouseEvent e) {
@@ -204,7 +205,7 @@ public class SimulationChart extends ChartPanel {
     }
 
     /**
-     * <p>Responsible for adding and removing labels from the selectedLegendLabels set before calling updateHighlightingSet.</p>
+     * Responsible for adding and removing labels from the selectedLegendLabels set before calling updateHighlightingSet.
      */
     @Override
     public void mouseClicked(MouseEvent e) {

--- a/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationChart.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationChart.java
@@ -1,8 +1,6 @@
 package info.openrocket.swing.gui.plot;
 
-import java.awt.Color;
-import java.awt.Cursor;
-import java.awt.Point;
+import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
@@ -32,12 +30,7 @@ import org.jfree.chart.entity.EntityCollection;
 import org.jfree.chart.entity.LegendItemEntity;
 import org.jfree.chart.plot.XYPlot;
 import org.jfree.chart.renderer.xy.XYItemRenderer;
-import org.jfree.chart.renderer.xy.XYLineAndShapeRenderer;
-import org.jfree.data.xy.XYDataset;
-import org.jfree.data.xy.XYSeries;
 import org.jfree.data.xy.XYSeriesCollection;
-
-import info.openrocket.swing.gui.plot.Plot.MetadataXYSeries;
 
 import com.jogamp.newt.event.InputEvent;
 
@@ -217,11 +210,53 @@ public class SimulationChart extends ChartPanel {
             String label = entity.getToolTipText();
             if (selectedLegendLabels.contains(label)) {
                 selectedLegendLabels.remove(label);
-                if (hoveredLegendLabel.equals(label)) hoveredLegendLabel = null;
             }
             else selectedLegendLabels.add(label);
             updateHighlightingSet();
         }
+    }
+    /**
+     * Draw a border around swatches of legend items that are currently highlighted.
+     */
+    @Override
+    public void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        Set<String> labelsToHighlight = new HashSet<>(selectedLegendLabels);
+        EntityCollection entities = getChartRenderingInfo().getEntityCollection();
+        Graphics2D g2 = (Graphics2D) g.create();
+        try {
+            g2.setColor(Color.black);
+            g2.setStroke(new BasicStroke(4.0f));
+            for (int i = 0; i < entities.getEntityCount(); i++) {
+                ChartEntity entity = entities.getEntity(i);
+                if (entity instanceof LegendItemEntity) {
+                    String label = entity.getToolTipText();
+                    if (label != null && labelsToHighlight.contains(label)) {
+                        Rectangle2D swatchBorder = getRectangle2D(entity);
+                        g2.draw(swatchBorder);
+                    }
+                }
+            }
+        } finally {
+            g2.dispose();
+        }
+    }
+
+    private static Rectangle2D getRectangle2D(ChartEntity entity) {
+        Rectangle2D area = entity.getArea().getBounds2D();
+        double h = area.getHeight();
+
+        double swatchSize = 0.6 * h;
+        double swatch_centerX = area.getX() + 0.5 * h; //center of the swatch
+        double swatchX = swatch_centerX - 0.75 * swatchSize; // X coordinate for the top left corner of the swatch
+        double swatchY = area.getY() + 0.5 * (h - swatchSize);// Y coordinate for the top left corner of the swatch
+
+        return new Rectangle2D.Double(
+                swatchX,
+                swatchY,
+                swatchSize,
+                swatchSize
+        );
     }
 
     private void updateHighlightingSet() {
@@ -358,7 +393,5 @@ public class SimulationChart extends ChartPanel {
 			}
 			plot.setNotify(notifyState); // this generates the change event too
 		}
-		
 	}
-	
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationChart.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationChart.java
@@ -249,7 +249,7 @@ public class SimulationChart extends ChartPanel {
 
                 BasicStroke stroke = base;
                 if (hasHighlight && labelsToHighlight.contains(dataset.getSeries(s).getDescription())) {
-                    stroke = new BasicStroke(base.getLineWidth() * 2.0f, base.getEndCap(), base.getLineJoin(), base.getMiterLimit(), base.getDashArray(), base.getDashPhase());
+                    stroke = new BasicStroke(base.getLineWidth() * 3.0f, base.getEndCap(), base.getLineJoin(), base.getMiterLimit(), base.getDashArray(), base.getDashPhase());
                 }
 
                 renderer.setSeriesStroke(s, stroke);

--- a/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationChart.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationChart.java
@@ -1,6 +1,10 @@
 package info.openrocket.swing.gui.plot;
 
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Cursor;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Point;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;

--- a/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationChart.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationChart.java
@@ -8,7 +8,14 @@ import java.awt.event.MouseWheelEvent;
 import java.awt.event.MouseWheelListener;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
+import java.awt.BasicStroke;
+import java.awt.Stroke;
 import java.io.Serializable;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import javax.swing.BorderFactory;
 
@@ -20,6 +27,17 @@ import org.jfree.chart.plot.Plot;
 import org.jfree.chart.plot.PlotOrientation;
 import org.jfree.chart.plot.PlotRenderingInfo;
 import org.jfree.chart.plot.Zoomable;
+import org.jfree.chart.entity.ChartEntity;
+import org.jfree.chart.entity.EntityCollection;
+import org.jfree.chart.entity.LegendItemEntity;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.chart.renderer.xy.XYItemRenderer;
+import org.jfree.chart.renderer.xy.XYLineAndShapeRenderer;
+import org.jfree.data.xy.XYDataset;
+import org.jfree.data.xy.XYSeries;
+import org.jfree.data.xy.XYSeriesCollection;
+
+import info.openrocket.swing.gui.plot.Plot.MetadataXYSeries;
 
 import com.jogamp.newt.event.InputEvent;
 
@@ -47,6 +65,12 @@ public class SimulationChart extends ChartPanel {
 	private Interaction interaction = null;
 	
 	private MouseWheelHandler mouseWheelHandler = null;
+
+    private String hoveredLegendLabel = null;
+
+    private final Set<String> selectedLegendLabels = new HashSet<>();
+
+    private final Map<String, Stroke> baseStrokes = new HashMap<>();
 	
 	public SimulationChart(JFreeChart chart) {
 		super(chart,
@@ -158,9 +182,80 @@ public class SimulationChart extends ChartPanel {
 		}
 		interaction = null;
 	}
-	
-	
-	/**
+
+    /**
+     * <p>Called whenever the mouse moves.</p>
+     * <p>Gets an entity at the location of the mouse, if this entity is a LegendItemEntity, calls updateHighlightingSet.</p>
+     */
+    @Override
+    public void mouseMoved(MouseEvent e) {
+        super.mouseMoved(e);
+        String legendLabel = null;
+        ChartEntity entity = getChartRenderingInfo().getEntityCollection().getEntity(e.getX(), e.getY());
+
+        if (entity instanceof LegendItemEntity) {
+            legendLabel = entity.getToolTipText();
+        }
+
+        if ((legendLabel == null && hoveredLegendLabel != null)||(legendLabel != null && !legendLabel.equals(hoveredLegendLabel))) {
+            hoveredLegendLabel = legendLabel;
+            updateHighlightingSet();
+        }
+    }
+
+    /**
+     * <p>Responsible for adding and removing labels from the selectedLegendLabels set before calling updateHighlightingSet.</p>
+     */
+    @Override
+    public void mouseClicked(MouseEvent e) {
+        super.mouseClicked(e);
+        if (e.getButton() != MouseEvent.BUTTON1) return;
+        ChartEntity entity = getChartRenderingInfo().getEntityCollection().getEntity(e.getX(), e.getY());
+
+        if (entity instanceof LegendItemEntity) {
+            String label = entity.getToolTipText();
+            if (selectedLegendLabels.contains(label)) {
+                selectedLegendLabels.remove(label);
+                if (hoveredLegendLabel.equals(label)) hoveredLegendLabel = null;
+            }
+            else selectedLegendLabels.add(label);
+            updateHighlightingSet();
+        }
+    }
+
+    private void updateHighlightingSet() {
+        Set<String> labelsToHighlight = new HashSet<>(selectedLegendLabels);
+        if (hoveredLegendLabel != null) {
+            labelsToHighlight.add(hoveredLegendLabel);
+        }
+        applyLegendHighlight(labelsToHighlight);
+    }
+
+    private void applyLegendHighlight(Set<String> labelsToHighlight) {
+        XYPlot plot = getChart().getXYPlot();
+        boolean hasHighlight = labelsToHighlight != null;
+
+        for (int r = 0; r < plot.getRendererCount(); r++) {
+            XYItemRenderer renderer = plot.getRenderer(r);
+            XYSeriesCollection dataset = (XYSeriesCollection) plot.getDataset(r);
+
+            for (int s = 0; s < dataset.getSeriesCount(); s++) {
+                String key = r + ":" + s;
+                int finalS = s;
+
+                //Stores the original stroke in the baseStrokes set so it can be recovered later to remove highlighting.
+                BasicStroke base = (BasicStroke) baseStrokes.computeIfAbsent(key, k -> renderer.getSeriesStroke(finalS));
+
+                BasicStroke stroke = base;
+                if (hasHighlight && labelsToHighlight.contains(dataset.getSeries(s).getDescription())) {
+                    stroke = new BasicStroke(base.getLineWidth() * 2.0f, base.getEndCap(), base.getLineJoin(), base.getMiterLimit(), base.getDashArray(), base.getDashPhase());
+                }
+
+                renderer.setSeriesStroke(s, stroke);
+            }
+        }
+    }
+    /**
 	 * 
 	 * Hacked up copy of MouseWheelHandler from JFreechart.  This version
 	 * has the special ability to only zoom on the domain if the alt key is pressed.


### PR DESCRIPTION
This PR fixes [#2592](https://github.com/openrocket/openrocket/issues/2592), in which the user requested for lines in the plot window to be highlighted upon being hovered on by the mouse, while remaining highlighted upon a mouse click.

The proposed solution: I decided to implement a set that would highlight plot lines by replacing the plotted line with another one with double de width. The original plot line is stored in the baseStrokes map along with a string to identify it so it can later be recovered to remove the highlighting.

Additionally, I implemented the mouseMoved and mouseClicked methods to retrieve entities in order to properly manipulate them.

Finally, the current implementation only removes highlighting from plot lines if the user clicks on the same line to unhighlight it, which allows the user to highlight all of the lines on the plot if they want. 