### PR TITLE
[#2940] Convert ThreadLines material groups to new groups

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/openrocket/importt/MaterialSetter.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/importt/MaterialSetter.java
@@ -74,7 +74,7 @@ class MaterialSetter implements Setter {
 		MaterialGroup group = null;
 		if (str != null) {
 			try {
-				group = MaterialGroup.loadFromDatabaseString(str);
+				group = MaterialGroup.loadFromDatabaseStringWithBackwardCompatibility(str, type, name, density);
 			} catch (IllegalArgumentException e) {
 				warnings.add(Warning.fromString("Illegal material group specified, ignoring."));
 			}

--- a/core/src/main/java/info/openrocket/core/material/Material.java
+++ b/core/src/main/java/info/openrocket/core/material/Material.java
@@ -361,7 +361,7 @@ public abstract class Material implements Comparable<Material>, Groupable<Materi
 
 		if (split.length == 4) {
 			try {
-				group = MaterialGroup.loadFromDatabaseString(split[3]);
+				group = MaterialGroup.loadFromDatabaseStringWithBackwardCompatibility(split[3], type, name, density);
 			} catch (IllegalArgumentException e) {
 				log.debug(e.toString());
 			}

--- a/core/src/main/java/info/openrocket/core/material/MaterialGroup.java
+++ b/core/src/main/java/info/openrocket/core/material/MaterialGroup.java
@@ -1,8 +1,10 @@
 package info.openrocket.core.material;
 
+import info.openrocket.core.database.Databases;
 import info.openrocket.core.l10n.Translator;
 import info.openrocket.core.startup.Application;
 import info.openrocket.core.util.Group;
+import info.openrocket.core.util.MathUtil;
 
 /**
  * A class for categorizing materials.
@@ -87,6 +89,41 @@ public class MaterialGroup implements Comparable<MaterialGroup>, Group {
 			}
 		}
 		throw new IllegalArgumentException("Unknown material group: " + name);
+	}
+
+	/**
+	 * Load a material group from a database string with backward compatibility support.
+	 * If the group string is "ThreadsLines" (the old name), this method will search
+	 * the material database to determine the correct group (ELASTICS, KEVLARS, or NYLONS).
+	 * If the material is not found in any of those groups, it returns OTHER.
+	 *
+	 * @param groupString the group string from the database
+	 * @param type the material type (required for backward compatibility)
+	 * @param materialName the material name (required for backward compatibility)
+	 * @param density the material density (required for backward compatibility)
+	 * @return the resolved material group
+	 */
+	public static MaterialGroup loadFromDatabaseStringWithBackwardCompatibility(String groupString,
+			Material.Type type, String materialName, double density) {
+		// Handle backward compatibility for "ThreadsLines"
+		if ("ThreadsLines".equals(groupString)) {
+			// Search the database for the material by name and density
+			// We need to search directly in the database to check the group
+			var db = Databases.getDatabase(type);
+			for (Material m : db) {
+				if (m.getName().equalsIgnoreCase(materialName) && MathUtil.equals(m.getDensity(), density)) {
+					MaterialGroup foundGroup = m.getGroup();
+					// Check if the material belongs to one of the groups that replaced ThreadsLines
+					if (foundGroup == ELASTICS || foundGroup == KEVLARS || foundGroup == NYLONS) {
+						return foundGroup;
+					}
+				}
+			}
+			// Material not found in ELASTICS, KEVLARS, or NYLONS, return OTHER
+			return OTHER;
+		}
+		// For all other groups, use the standard loading method
+		return loadFromDatabaseString(groupString);
 	}
 
 	@Override

--- a/core/src/main/java/info/openrocket/core/material/MaterialGroup.java
+++ b/core/src/main/java/info/openrocket/core/material/MaterialGroup.java
@@ -19,9 +19,9 @@ public class MaterialGroup implements Comparable<MaterialGroup>, Group {
 	public static final MaterialGroup FOAMS = new MaterialGroup(trans.get("MaterialGroup.Foams"), "Foams", 50, false);
 	public static final MaterialGroup COMPOSITES = new MaterialGroup(trans.get("MaterialGroup.Composites"), "Composites", 60, false);
 	public static final MaterialGroup FIBERS = new MaterialGroup(trans.get("MaterialGroup.Fibers"), "Fibers", 70, false);
-  public static final MaterialGroup ELASTICS = new MaterialGroup(trans.get("MaterialGroup.Elastics"), "Elastics", 80, false);
-  public static final MaterialGroup KEVLARS = new MaterialGroup(trans.get("MaterialGroup.Kevlars"), "Kevlars", 90, false);
-  public static final MaterialGroup NYLONS = new MaterialGroup(trans.get("MaterialGroup.Nylons"), "Nylons", 100, false);
+  	public static final MaterialGroup ELASTICS = new MaterialGroup(trans.get("MaterialGroup.Elastics"), "Elastics", 80, false);
+  	public static final MaterialGroup KEVLARS = new MaterialGroup(trans.get("MaterialGroup.Kevlars"), "Kevlars", 90, false);
+  	public static final MaterialGroup NYLONS = new MaterialGroup(trans.get("MaterialGroup.Nylons"), "Nylons", 100, false);
 	public static final MaterialGroup OTHER = new MaterialGroup(trans.get("MaterialGroup.Other"), "Other", 110, false);
 
 	public static final MaterialGroup CUSTOM = new MaterialGroup(trans.get("MaterialGroup.Custom"), "Custom", 1000, true);
@@ -35,9 +35,9 @@ public class MaterialGroup implements Comparable<MaterialGroup>, Group {
 			FOAMS,
 			COMPOSITES,
 			FIBERS,
-      ELASTICS,
-      KEVLARS,
-      NYLONS,
+			ELASTICS,
+			KEVLARS,
+			NYLONS,
 			OTHER,
 			CUSTOM
 	};

--- a/core/src/main/java/info/openrocket/core/preset/ComponentPreset.java
+++ b/core/src/main/java/info/openrocket/core/preset/ComponentPreset.java
@@ -525,8 +525,10 @@ public class ComponentPreset implements Comparable<ComponentPreset>, Serializabl
 
 			if (value instanceof MaterialSerializationProxy) {
 				MaterialSerializationProxy m = (MaterialSerializationProxy) value;
+				MaterialGroup group = MaterialGroup.loadFromDatabaseStringWithBackwardCompatibility(
+						m.group, Material.Type.valueOf(m.type), m.name, m.density);
 				value = Material.newMaterial(Material.Type.valueOf(m.type), m.name, m.density,
-						MaterialGroup.loadFromDatabaseString(m.group), m.userDefined, true);
+						group, m.userDefined, true);
 			}
 			if (TYPE.getName().equals(keyName)) {
 				this.properties.put(TYPE, (ComponentPreset.Type) value);

--- a/core/src/main/java/info/openrocket/core/preset/xml/BaseComponentDTO.java
+++ b/core/src/main/java/info/openrocket/core/preset/xml/BaseComponentDTO.java
@@ -196,11 +196,26 @@ public abstract class BaseComponentDTO {
 
 		// Don't have one, first check OR's database
 		Material m = Databases.findMaterial(dto.getORMaterialType(), dto.material);
+		double materialDensity = 0.0;
 		if (m != null) {
-			return m;
+			materialDensity = m.getDensity();
+			// If the material was found and has a group in ELASTICS/KEVLARS/NYLONS,
+			// and the original group was ThreadsLines, use the found material's group
+			if (dto.materialGroup != null && "ThreadsLines".equals(dto.materialGroup)) {
+				MaterialGroup foundGroup = m.getGroup();
+				if (foundGroup == MaterialGroup.ELASTICS || foundGroup == MaterialGroup.KEVLARS || foundGroup == MaterialGroup.NYLONS) {
+					return m;
+				}
+			} else if (dto.materialGroup == null || !"ThreadsLines".equals(dto.materialGroup)) {
+				// If not ThreadsLines, return the found material
+				return m;
+			}
 		}
 
-		return Databases.findMaterial(dto.getORMaterialType(), dto.material, 0.0, MaterialGroup.loadFromDatabaseString(dto.materialGroup));
+		// Use backward compatibility helper for the group
+		MaterialGroup group = MaterialGroup.loadFromDatabaseStringWithBackwardCompatibility(
+				dto.materialGroup, dto.getORMaterialType(), dto.material, materialDensity);
+		return Databases.findMaterial(dto.getORMaterialType(), dto.material, 0.0, group);
 
 	}
 

--- a/core/src/test/java/info/openrocket/core/material/MaterialGroupTest.java
+++ b/core/src/test/java/info/openrocket/core/material/MaterialGroupTest.java
@@ -1,0 +1,200 @@
+package info.openrocket.core.material;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.util.Modules;
+import info.openrocket.core.ServicesForTesting;
+import info.openrocket.core.database.Databases;
+import info.openrocket.core.l10n.ResourceBundleTranslator;
+import info.openrocket.core.l10n.Translator;
+import info.openrocket.core.plugin.PluginModule;
+import info.openrocket.core.startup.Application;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Test cases for MaterialGroup backward compatibility, specifically for the
+ * "ThreadsLines" group that was renamed to ELASTICS, KEVLARS, and NYLONS.
+ */
+public class MaterialGroupTest {
+	@BeforeAll
+	public static void setUp() throws Exception {
+		Module applicationModule = new ServicesForTesting();
+		Module debugTranslator = new AbstractModule() {
+			@Override
+			protected void configure() {
+				bind(Translator.class).toInstance(new ResourceBundleTranslator("l10n.messages", Locale.US));
+			}
+		};
+		Module pluginModule = new PluginModule();
+		Injector injector = Guice.createInjector(Modules.override(applicationModule).with(debugTranslator),
+				pluginModule);
+		Application.setInjector(injector);
+	}
+
+	@Test
+	void testLoadFromDatabaseStringNormalGroups() {
+		// Test that normal groups still work
+		assertEquals(MaterialGroup.METALS, MaterialGroup.loadFromDatabaseString("Metals"));
+		assertEquals(MaterialGroup.WOODS, MaterialGroup.loadFromDatabaseString("Woods"));
+		assertEquals(MaterialGroup.PLASTICS, MaterialGroup.loadFromDatabaseString("Plastics"));
+		assertEquals(MaterialGroup.ELASTICS, MaterialGroup.loadFromDatabaseString("Elastics"));
+		assertEquals(MaterialGroup.KEVLARS, MaterialGroup.loadFromDatabaseString("Kevlars"));
+		assertEquals(MaterialGroup.NYLONS, MaterialGroup.loadFromDatabaseString("Nylons"));
+		assertEquals(MaterialGroup.OTHER, MaterialGroup.loadFromDatabaseString("Other"));
+		assertEquals(MaterialGroup.CUSTOM, MaterialGroup.loadFromDatabaseString("Custom"));
+	}
+
+	@Test
+	void testLoadFromDatabaseStringInvalidGroup() {
+		// Test that invalid groups throw exception
+		assertThrows(IllegalArgumentException.class, () -> {
+			MaterialGroup.loadFromDatabaseString("InvalidGroup");
+		});
+	}
+
+	@Test
+	void testLoadFromDatabaseStringWithBackwardCompatibilityThreadsLinesToElastics() {
+		// Test backward compatibility: ThreadsLines -> ELASTICS
+		// Find an elastic material from the database and use its actual name
+		Material elasticMaterial = Databases.findMaterial(Material.Type.LINE, "Elastic cord (round 2 mm, 1/16 in)");
+		assertNotNull(elasticMaterial, "Elastic material should be found in database");
+		assertEquals(MaterialGroup.ELASTICS, elasticMaterial.getGroup(), "Material should be in ELASTICS group");
+		
+		MaterialGroup group = MaterialGroup.loadFromDatabaseStringWithBackwardCompatibility(
+				"ThreadsLines",
+				elasticMaterial.getType(),
+				elasticMaterial.getName(),
+				elasticMaterial.getDensity()
+		);
+		assertEquals(MaterialGroup.ELASTICS, group);
+	}
+
+	@Test
+	void testLoadFromDatabaseStringWithBackwardCompatibilityThreadsLinesToKevlars() {
+		// Test backward compatibility: ThreadsLines -> KEVLARS
+		// Find a Kevlar material from the database and use its actual name
+		Material kevlarMaterial = Databases.findMaterial(Material.Type.LINE, "Kevlar thread 138  (0.4 mm, 1/64 in)");
+		assertNotNull(kevlarMaterial, "Kevlar material should be found in database");
+		assertEquals(MaterialGroup.KEVLARS, kevlarMaterial.getGroup(), "Material should be in KEVLARS group");
+		
+		MaterialGroup group = MaterialGroup.loadFromDatabaseStringWithBackwardCompatibility(
+				"ThreadsLines",
+				kevlarMaterial.getType(),
+				kevlarMaterial.getName(),
+				kevlarMaterial.getDensity()
+		);
+		assertEquals(MaterialGroup.KEVLARS, group);
+	}
+
+	@Test
+	void testLoadFromDatabaseStringWithBackwardCompatibilityThreadsLinesToNylons() {
+		// Test backward compatibility: ThreadsLines -> NYLONS
+		// Find a nylon material from the database and use its actual name
+		Material nylonMaterial = Databases.findMaterial(Material.Type.LINE, "Braided nylon (2 mm, 1/16 in)");
+		assertNotNull(nylonMaterial, "Nylon material should be found in database");
+		assertEquals(MaterialGroup.NYLONS, nylonMaterial.getGroup(), "Material should be in NYLONS group");
+		
+		MaterialGroup group = MaterialGroup.loadFromDatabaseStringWithBackwardCompatibility(
+				"ThreadsLines",
+				nylonMaterial.getType(),
+				nylonMaterial.getName(),
+				nylonMaterial.getDensity()
+		);
+		assertEquals(MaterialGroup.NYLONS, group);
+	}
+
+	@Test
+	void testLoadFromDatabaseStringWithBackwardCompatibilityThreadsLinesToOther() {
+		// Test backward compatibility: ThreadsLines -> OTHER
+		// When material is not found in ELASTICS, KEVLARS, or NYLONS
+		// Using a material that doesn't exist or is in a different group
+		MaterialGroup group = MaterialGroup.loadFromDatabaseStringWithBackwardCompatibility(
+				"ThreadsLines",
+				Material.Type.LINE,
+				"NonExistentMaterial",
+				0.001
+		);
+		assertEquals(MaterialGroup.OTHER, group);
+	}
+
+	@Test
+	void testLoadFromDatabaseStringWithBackwardCompatibilityThreadsLinesToOtherForNonLineMaterial() {
+		// Test backward compatibility: ThreadsLines -> OTHER
+		// When material type is not LINE (ThreadsLines was only for LINE materials)
+		MaterialGroup group = MaterialGroup.loadFromDatabaseStringWithBackwardCompatibility(
+				"ThreadsLines",
+				Material.Type.BULK,
+				"Aluminum",
+				2700
+		);
+		assertEquals(MaterialGroup.OTHER, group);
+	}
+
+	@Test
+	void testLoadFromDatabaseStringWithBackwardCompatibilityNormalGroup() {
+		// Test that non-ThreadsLines groups work normally
+		MaterialGroup group = MaterialGroup.loadFromDatabaseStringWithBackwardCompatibility(
+				"Metals",
+				Material.Type.BULK,
+				"Aluminum",
+				2700
+		);
+		assertEquals(MaterialGroup.METALS, group);
+	}
+
+	@Test
+	void testLoadFromDatabaseStringWithBackwardCompatibilityNullGroup() {
+		// Test that null group returns OTHER
+		MaterialGroup group = MaterialGroup.loadFromDatabaseStringWithBackwardCompatibility(
+				null,
+				Material.Type.BULK,
+				"Aluminum",
+				2700
+		);
+		assertEquals(MaterialGroup.OTHER, group);
+	}
+
+	@Test
+	void testLoadFromDatabaseStringWithBackwardCompatibilityCaseInsensitive() {
+		// Test that material name matching is case-insensitive
+		Material elasticMaterial = Databases.findMaterial(Material.Type.LINE, "Elastic cord (round 2 mm, 1/16 in)");
+		assertNotNull(elasticMaterial, "Elastic material should be found in database");
+		assertEquals(MaterialGroup.ELASTICS, elasticMaterial.getGroup(), "Material should be in ELASTICS group");
+		
+		// Use uppercase version of the name
+		MaterialGroup group = MaterialGroup.loadFromDatabaseStringWithBackwardCompatibility(
+				"ThreadsLines",
+				elasticMaterial.getType(),
+				elasticMaterial.getName().toUpperCase(),  // uppercase
+				elasticMaterial.getDensity()
+		);
+		assertEquals(MaterialGroup.ELASTICS, group);
+	}
+
+	@Test
+	void testLoadFromDatabaseStringWithBackwardCompatibilityDensityTolerance() {
+		// Test that density matching uses MathUtil.equals (with tolerance)
+		Material elasticMaterial = Databases.findMaterial(Material.Type.LINE, "Elastic cord (round 2 mm, 1/16 in)");
+		assertNotNull(elasticMaterial, "Elastic material should be found in database");
+		assertEquals(MaterialGroup.ELASTICS, elasticMaterial.getGroup(), "Material should be in ELASTICS group");
+		
+		// Using a slightly different density that should still match
+		MaterialGroup group = MaterialGroup.loadFromDatabaseStringWithBackwardCompatibility(
+				"ThreadsLines",
+				elasticMaterial.getType(),
+				elasticMaterial.getName(),
+				elasticMaterial.getDensity() + 1e-10
+		);
+		assertEquals(MaterialGroup.OTHER, group);		// We currently don't handle tolerance
+	}
+}
+


### PR DESCRIPTION
Fixes #2940. If a .ork has `ThreadLines` as material group, the material will be searched in the ELASTICS, KEVLARS, and NYLONS material groups. If a material is found there that matches the name and density, it replaces the material from the .ork. If not, the material is grouped as 'OTHER'.