### PR TITLE
Fix finset snap drag highlight color + add point context menu

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/FreeformFinSetConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/FreeformFinSetConfig.java
@@ -611,7 +611,13 @@ public class FreeformFinSetConfig extends FinSetConfig {
 					point = snapPoint(point, finset.getFinPoints()[lockIndex]);
 					int highlightIndex = getHighlightIndex(lockIndex);
 					figure.setHighlightIndex(highlightIndex);
+				} else {
+					// No valid lock index, reset highlight
+					figure.setHighlightIndex(-1);
 				}
+			} else {
+				// Shift not held down, reset highlight
+				figure.setHighlightIndex(-1);
 			}
 
 			try {

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/FreeformFinSetConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/FreeformFinSetConfig.java
@@ -85,6 +85,7 @@ public class FreeformFinSetConfig extends FinSetConfig {
 	private JTable table = null;
 	private FinPointTableModel tableModel = null;
 	private JPopupMenu pm;
+	private JPopupMenu figurePopupMenu;
 	
 	private int dragIndex = -1;
 	private Point dragPoint = null;
@@ -333,6 +334,10 @@ public class FreeformFinSetConfig extends FinSetConfig {
 		pm = new JPopupMenu();
 		pm.add(insertFinPointAction);
 		pm.add(deleteFinPointAction);
+		
+		// Context menu for figure
+		figurePopupMenu = new JPopupMenu();
+		figurePopupMenu.add(deleteFinPointAction);
 
 		table.getSelectionModel().addListSelectionListener(new ListSelectionListener() {
 			@Override
@@ -751,7 +756,19 @@ public class FreeformFinSetConfig extends FinSetConfig {
                     }
                     return;
                 }
-            }
+            } else if (event.getButton() == MouseEvent.BUTTON3) {
+				// Right-click: show context menu if clicking on a fin point
+				int clickIndex = getPoint(event);
+				if (clickIndex >= 0) {
+					// Select the point in the table so action state is correct
+					table.setRowSelectionInterval(clickIndex, clickIndex);
+					updateActionStates();
+					// Show context menu - convert coordinates to scroll pane coordinates
+					Point point = SwingUtilities.convertPoint(event.getComponent(), event.getX(), event.getY(), this);
+					figurePopupMenu.show(this, point.x, point.y);
+					return;
+				}
+			}
 			super.mouseClicked(event);
         }
 


### PR DESCRIPTION
This PR fixes an issue in the freeform finset point figure. The issue:
1. Go into snap-drag mode by holding the Shift key, or Shift-Ctrl key
2. Start dragging
3. Release the key modifier from step 1, while continuing to drag
4. The snap behavior stopped, but the line segment is still drawn in the snap highlight color

I also added the ability to right-click a point in the fin editor to show a context menu to delete the current point. I intuitively always right-click a point in the editor, only to be disappointed that nothing happens...

Demo showing old behavior first and then the new behavior:

https://github.com/user-attachments/assets/290d5498-f206-458f-bf8e-f6664ad7edfc

