### PR TITLE
 [#2956] Snap view rotation when holding shift key 

### DIFF
--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -85,7 +85,7 @@ RocketPanel.lbl.Stages = Stages:
 RocketPanel.btn.Stages.Toggle.ttip = Toggle this button to activate/deactivate the stage.
 RocketPanel.btn.Stages.LastActive.ttip = Cannot deactivate the only active stage.
 RocketPanel.btn.Stages.NoChildren.ttip = <html>This stage does not have child components and is therefore marked as inactive. <br>Add components to the stage to activate it.</html>
-RocketPanel.ttip.Rotation = Change the rocket's roll rotation (only affects the rocket view)
+RocketPanel.ttip.Rotation = <html>Adjust the view's roll rotation.<br>You can also drag empty space in the rocket view (view lock must be disabled).<br>Hold Shift for 30\u00B0 or 45\u00B0 increments.</html>
 
 RocketPanel.check.showWarnings = Show warnings
 RocketPanel.check.showWarnings.ttip = Show/hide geometry warnings in the rocket design view.

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
@@ -797,6 +797,12 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		double newRotation = originalRotation - rotationOffset;
 		// Ensure the rotation is within the range [0, 2*PI]
 		newRotation = (newRotation + 2 * Math.PI) % (2 * Math.PI);
+		
+		// Apply snapping if Shift key is pressed
+		if (event.isShiftDown()) {
+			newRotation = ViewRotationControl.snapRotation(newRotation);
+		}
+		
 		figure.setRotation(newRotation);
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/ViewRotationControl.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/ViewRotationControl.java
@@ -17,10 +17,15 @@ import javax.swing.JSlider;
 import javax.swing.JSpinner;
 import javax.swing.JToggleButton;
 import javax.swing.plaf.basic.BasicSpinnerUI;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionAdapter;
 
 /**
  * An enhanced version of the rotation control component for the RocketPanel.
@@ -37,6 +42,7 @@ public class ViewRotationControl extends JPanel {
 	private final BasicSlider rotationSlider;
 	private final JToggleButton lockButton;
 	private boolean dragRotationLocked = false;
+	private boolean shiftKeyPressed = false;
 
 	/**
 	 * Creates a new enhanced rotation control panel
@@ -100,11 +106,82 @@ public class ViewRotationControl extends JPanel {
 
 		rotationSlider = new BasicSlider(rotationModel.getSliderModel(0, 2 * Math.PI), JSlider.VERTICAL, true);
 		rotationSlider.setToolTipText(trans.get("RocketPanel.ttip.Rotation"));
+		
+		// Track Shift key state via mouse events
+		rotationSlider.addMouseListener(new MouseAdapter() {
+			@Override
+			public void mousePressed(MouseEvent e) {
+				shiftKeyPressed = e.isShiftDown();
+			}
+			
+			@Override
+			public void mouseReleased(MouseEvent e) {
+				shiftKeyPressed = false;
+			}
+		});
+		
+		// Track Shift key state during mouse motion (for when shift is pressed/released during drag)
+		rotationSlider.addMouseMotionListener(new MouseMotionAdapter() {
+			@Override
+			public void mouseDragged(MouseEvent e) {
+				shiftKeyPressed = e.isShiftDown();
+			}
+		});
+		
+		// Add change listener to apply snapping when Shift is pressed
+		rotationSlider.addChangeListener(new ChangeListener() {
+			@Override
+			public void stateChanged(ChangeEvent e) {
+				if (rotationSlider.getValueIsAdjusting() && shiftKeyPressed) {
+					double currentRotation = rotationModel.getValue();
+					double snappedRotation = snapRotation(currentRotation);
+					// Only update if the snapped value is different to avoid loops
+					if (Math.abs(currentRotation - snappedRotation) > 0.001) {
+						rotationModel.setValue(snappedRotation);
+					}
+				}
+			}
+		});
 
 		// Add components to this panel
 		add(controlsPanel, "growx, wrap");
 		add(rotationSlider, "ax 50%, growy, pushy, wrap");
 		add(lockButton, "ax 50%");
+	}
+	
+	/**
+	 * Snaps an angle (in radians) to the nearest multiple of 30 or 45 degrees.
+	 * Returns whichever snap point (30° or 45° multiple) is closer to the input angle.
+	 * 
+	 * @param angle the angle in radians to snap
+	 * @return the snapped angle in radians
+	 */
+	public static double snapRotation(double angle) {
+		// Convert to degrees for easier calculation
+		double angleDeg = Math.toDegrees(angle);
+		
+		// Calculate nearest multiples
+		double nearest30 = Math.round(angleDeg / 30.0) * 30.0;
+		double nearest45 = Math.round(angleDeg / 45.0) * 45.0;
+		
+		// Normalize to [0, 360)
+		nearest30 = ((nearest30 % 360) + 360) % 360;
+		nearest45 = ((nearest45 % 360) + 360) % 360;
+		
+		// Find which is closer
+		double dist30 = Math.min(Math.abs(angleDeg - nearest30), 
+		                         Math.min(Math.abs(angleDeg - (nearest30 - 360)), 
+		                                 Math.abs(angleDeg - (nearest30 + 360))));
+		double dist45 = Math.min(Math.abs(angleDeg - nearest45),
+		                         Math.min(Math.abs(angleDeg - (nearest45 - 360)),
+		                                 Math.abs(angleDeg - (nearest45 + 360))));
+		
+		// Return whichever is closer, converted back to radians
+		if (dist30 <= dist45) {
+			return Math.toRadians(nearest30);
+		} else {
+			return Math.toRadians(nearest45);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2956. You can snap the view to multiples of 30° or 45° by holding down the `Shift` key. The original issue proposed using the `Ctrl` key, but `Shift` is more standard in other software. The finpoint editor also uses `Shift` (and `Shift+Ctrl`).


https://github.com/user-attachments/assets/3e1f0ba7-86cc-4f18-9422-a4fbe53f55a9

