### PR TITLE
[#1526] Restore parent selection after deleting a component

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/main/componenttree/ComponentTreeModel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/componenttree/ComponentTreeModel.java
@@ -2,9 +2,11 @@ package info.openrocket.swing.gui.main.componenttree;
 
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import javax.swing.JTree;
@@ -100,6 +102,7 @@ public class ComponentTreeModel implements TreeModel, ComponentChangeListener {
 	private void fireTreeStructureChanged(RocketComponent source) {
 		Object[] path = { root };
 		
+		List<List<UUID>> selectedPathIds = getSelectedPathIds();
 
 		// Get currently expanded path IDs
 		Enumeration<TreePath> enumer = tree.getExpandedDescendants(new TreePath(path));
@@ -116,10 +119,12 @@ public class ComponentTreeModel implements TreeModel, ComponentChangeListener {
 		Object[] l = listeners.toArray();
 		for (Object o : l) ((TreeModelListener) o).treeStructureChanged(e);
 		
+		restoreSelection(selectedPathIds);
+
 		// Re-expand the paths
 		for (UUID id : expanded) {
 			RocketComponent c = root.findComponent(id);
-			if (c == null)
+			if (c == RocketComponent.REMOVED)
 				continue;
 			tree.expandPath(makeTreePath(c));
 		}
@@ -128,6 +133,93 @@ public class ComponentTreeModel implements TreeModel, ComponentChangeListener {
 			tree.makeVisible(p);
 			tree.expandPath(p);
 		}
+	}
+
+	private List<List<UUID>> getSelectedPathIds() {
+		TreePath[] selectedPaths = tree.getSelectionPaths();
+		if (selectedPaths == null || selectedPaths.length == 0) {
+			return List.of();
+		}
+
+		List<List<UUID>> selectedPathIds = new ArrayList<>(selectedPaths.length);
+		for (TreePath path : selectedPaths) {
+			Object[] components = path.getPath();
+			List<UUID> ids = new ArrayList<>(components.length);
+			for (Object obj : components) {
+				if (obj instanceof RocketComponent) {
+					ids.add(((RocketComponent) obj).getID());
+				}
+			}
+			if (!ids.isEmpty()) {
+				selectedPathIds.add(ids);
+			}
+		}
+		return selectedPathIds;
+	}
+
+	private void restoreSelection(List<List<UUID>> selectedPathIds) {
+		if (selectedPathIds.isEmpty()) {
+			return;
+		}
+
+		// Restore selection; if a component was removed (e.g. undo add), select the nearest
+		// existing ancestor instead.
+		List<RocketComponent> desiredSelection = new ArrayList<>(selectedPathIds.size());
+		for (List<UUID> ids : selectedPathIds) {
+			RocketComponent component = findNearestExistingComponent(ids);
+			if (component != null) {
+				desiredSelection.add(component);
+			}
+		}
+
+		if (desiredSelection.isEmpty() || isCurrentSelection(desiredSelection)) {
+			return;
+		}
+
+		List<TreePath> restored = new ArrayList<>(desiredSelection.size());
+		for (RocketComponent component : desiredSelection) {
+			restored.add(makeTreePath(component));
+		}
+
+		tree.setSelectionPaths(restored.toArray(new TreePath[0]));
+	}
+
+	private boolean isCurrentSelection(List<RocketComponent> desiredSelection) {
+		TreePath[] current = tree.getSelectionPaths();
+		if (current == null || current.length == 0) {
+			return false;
+		}
+
+		// Compare by ID (not instance) because undo can replace component instances.
+		Set<UUID> desiredIds = new HashSet<>(desiredSelection.size());
+		for (RocketComponent c : desiredSelection) {
+			desiredIds.add(c.getID());
+		}
+
+		Set<UUID> currentIds = new HashSet<>(current.length);
+		for (TreePath path : current) {
+			Object last = path.getLastPathComponent();
+			if (!(last instanceof RocketComponent)) {
+				continue;
+			}
+			UUID id = ((RocketComponent) last).getID();
+			RocketComponent live = root.findComponent(id);
+			if (live != RocketComponent.REMOVED) {
+				currentIds.add(live.getID());
+			}
+		}
+
+		return currentIds.equals(desiredIds);
+	}
+
+	private RocketComponent findNearestExistingComponent(List<UUID> pathIds) {
+		for (int i = pathIds.size() - 1; i >= 0; i--) {
+			RocketComponent c = root.findComponent(pathIds.get(i));
+			if (c != RocketComponent.REMOVED) {
+				return c;
+			}
+		}
+		return null;
 	}
 	
 	@Override

--- a/swing/src/test/java/info/openrocket/swing/gui/main/UndoRedoSelectionTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/main/UndoRedoSelectionTest.java
@@ -1,0 +1,78 @@
+package info.openrocket.swing.gui.main;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.UUID;
+
+import javax.swing.JTree;
+import javax.swing.tree.DefaultTreeSelectionModel;
+
+import org.junit.jupiter.api.Test;
+
+import info.openrocket.core.document.OpenRocketDocument;
+import info.openrocket.core.document.OpenRocketDocumentFactory;
+import info.openrocket.core.rocketcomponent.AxialStage;
+import info.openrocket.core.rocketcomponent.BodyTube;
+import info.openrocket.core.rocketcomponent.InnerTube;
+import info.openrocket.swing.gui.main.componenttree.ComponentTreeModel;
+import info.openrocket.swing.util.BaseTestCase;
+
+public class UndoRedoSelectionTest extends BaseTestCase {
+
+	@Test
+	public void undoAddedComponentSelectsParent() {
+		OpenRocketDocument document = OpenRocketDocumentFactory.createNewRocket();
+
+		JTree tree = new JTree();
+		tree.setModel(new ComponentTreeModel(document.getRocket(), tree));
+
+		DocumentSelectionModel selectionModel = new DocumentSelectionModel(document);
+		tree.setSelectionModel(new DefaultTreeSelectionModel());
+		selectionModel.attachComponentTreeSelectionModel(tree.getSelectionModel());
+
+		AxialStage sustainer = (AxialStage) document.getRocket().getChild(0);
+		UUID sustainerId = sustainer.getID();
+
+		document.addUndoPosition("Add body tube");
+		BodyTube bodyTube = new BodyTube();
+		sustainer.addChild(bodyTube);
+
+		selectionModel.setSelectedComponent(bodyTube);
+
+		document.undo();
+
+		assertNotNull(selectionModel.getSelectedComponent());
+		assertEquals(sustainerId, selectionModel.getSelectedComponent().getID());
+	}
+
+	@Test
+	public void undoAddedChildComponentSelectsParent() {
+		OpenRocketDocument document = OpenRocketDocumentFactory.createNewRocket();
+
+		JTree tree = new JTree();
+		tree.setModel(new ComponentTreeModel(document.getRocket(), tree));
+
+		DocumentSelectionModel selectionModel = new DocumentSelectionModel(document);
+		tree.setSelectionModel(new DefaultTreeSelectionModel());
+		selectionModel.attachComponentTreeSelectionModel(tree.getSelectionModel());
+
+		AxialStage sustainer = (AxialStage) document.getRocket().getChild(0);
+
+		document.addUndoPosition("Add body tube");
+		BodyTube bodyTube = new BodyTube();
+		sustainer.addChild(bodyTube);
+		UUID bodyTubeId = bodyTube.getID();
+
+		document.addUndoPosition("Add inner tube");
+		InnerTube innerTube = new InnerTube();
+		bodyTube.addChild(innerTube);
+
+		selectionModel.setSelectedComponent(innerTube);
+
+		document.undo();
+
+		assertNotNull(selectionModel.getSelectedComponent());
+		assertEquals(bodyTubeId, selectionModel.getSelectedComponent().getID());
+	}
+}


### PR DESCRIPTION
Fixes #1526. When a component is deleted, or its addition has been undone, the parent component will be selected in the component tree.


https://github.com/user-attachments/assets/57917913-5e18-496a-9ad2-afbbfa1f8b2e

