### PR TITLE
 [#1838] Embed thrust curve points in .ork 

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/openrocket/importt/MotorHandler.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/importt/MotorHandler.java
@@ -54,22 +54,35 @@ class MotorHandler extends AbstractElementHandler {
 	 * <p>
 	 * Preference order:
 	 * <ol>
-	 *   <li>Embedded thrust curve data (one or more {@code <thrustcurvepoint>} elements), if present.</li>
 	 *   <li>Lookup via {@link DocumentLoadingContext#getMotorFinder()} (typically the motor database).</li>
+	 *   <li>Embedded thrust curve data (one or more {@code <thrustcurvepoint>} elements), if present.</li>
 	 * </ol>
 	 *
 	 * @param warnings warnings sink
 	 * @return the resolved motor, or {@code null} if not found/invalid
 	 */
 	public Motor getMotor(WarningSet warnings) {
+		// First try to locate an equivalent motor in the motor database.
+		// If that fails, fall back to the embedded thrust curve data (if present).
+		WarningSet databaseWarnings = new WarningSet();
+		Motor databaseMotor = context.getMotorFinder().findMotor(type, manufacturer, designation, Double.NaN, Double.NaN, digest,
+				databaseWarnings);
+		if (databaseMotor != null) {
+			warnings.addAll(databaseWarnings);
+			return databaseMotor;
+		}
+
 		if (!thrustCurveTime.isEmpty()) {
 			Motor embedded = buildEmbeddedThrustCurveMotor(warnings);
 			if (embedded != null) {
+				// Deliberately discard databaseWarnings here: the motor isn't missing since we loaded it from the file.
 				return embedded;
 			}
 		}
-		return context.getMotorFinder().findMotor(type, manufacturer, designation, Double.NaN, Double.NaN, digest,
-				warnings);
+
+		// Nothing worked: surface any database lookup warnings (e.g. missing motor).
+		warnings.addAll(databaseWarnings);
+		return null;
 	}
 
 	/**

--- a/core/src/main/java/info/openrocket/core/file/openrocket/importt/MotorHandler.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/importt/MotorHandler.java
@@ -1,7 +1,9 @@
 package info.openrocket.core.file.openrocket.importt;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.List;
 
 import info.openrocket.core.logging.Warning;
 import info.openrocket.core.logging.WarningSet;
@@ -9,7 +11,12 @@ import info.openrocket.core.file.DocumentLoadingContext;
 import info.openrocket.core.file.simplesax.AbstractElementHandler;
 import info.openrocket.core.file.simplesax.ElementHandler;
 import info.openrocket.core.file.simplesax.PlainTextHandler;
+import info.openrocket.core.motor.Manufacturer;
 import info.openrocket.core.motor.Motor;
+import info.openrocket.core.motor.MotorDigest;
+import info.openrocket.core.motor.ThrustCurveMotor;
+import info.openrocket.core.util.Coordinate;
+import info.openrocket.core.util.CoordinateIF;
 
 import org.xml.sax.SAXException;
 
@@ -26,6 +33,12 @@ class MotorHandler extends AbstractElementHandler {
 	private double length = Double.NaN;
 	private double delay = Double.NaN;
 
+	private final List<Double> standardDelays = new ArrayList<>();
+	private final List<Double> thrustCurveTime = new ArrayList<>();
+	private final List<Double> thrustCurveThrust = new ArrayList<>();
+	private final List<Double> thrustCurveCGx = new ArrayList<>();
+	private final List<Double> thrustCurveMass = new ArrayList<>();
+
 	public MotorHandler(DocumentLoadingContext context) {
 		this.context = context;
 	}
@@ -37,11 +50,115 @@ class MotorHandler extends AbstractElementHandler {
 	}
 
 	/**
-	 * Return the motor to use, or null.
+	 * Resolve the {@link Motor} for this {@code <motor>} element.
+	 * <p>
+	 * Preference order:
+	 * <ol>
+	 *   <li>Embedded thrust curve data (one or more {@code <thrustcurvepoint>} elements), if present.</li>
+	 *   <li>Lookup via {@link DocumentLoadingContext#getMotorFinder()} (typically the motor database).</li>
+	 * </ol>
+	 *
+	 * @param warnings warnings sink
+	 * @return the resolved motor, or {@code null} if not found/invalid
 	 */
 	public Motor getMotor(WarningSet warnings) {
+		if (!thrustCurveTime.isEmpty()) {
+			Motor embedded = buildEmbeddedThrustCurveMotor(warnings);
+			if (embedded != null) {
+				return embedded;
+			}
+		}
 		return context.getMotorFinder().findMotor(type, manufacturer, designation, Double.NaN, Double.NaN, digest,
 				warnings);
+	}
+
+	/**
+	 * Build a {@link ThrustCurveMotor} from motor data embedded in the .ork file.
+	 * <p>
+	 * The embedded file format stores:
+	 * <ul>
+	 *   <li>{@code <standarddelays>} as a comma-separated list of delays in seconds; {@code none} represents
+	 *       {@link Motor#PLUGGED_DELAY}.</li>
+	 *   <li>One or more {@code <thrustcurvepoint>} elements, each containing {@code time,thrust,cg_x,mass} with units
+	 *       seconds, Newtons, meters and kilograms.</li>
+	 * </ul>
+	 *
+	 * @param warnings warnings sink
+	 * @return the reconstructed motor, or {@code null} if embedded data is incomplete/invalid
+	 */
+	private Motor buildEmbeddedThrustCurveMotor(WarningSet warnings) {
+		// Validate that we have a complete set of point arrays.
+		int count = thrustCurveTime.size();
+		if (count < 2) {
+			warnings.add(Warning.fromString("Embedded motor thrust curve is too short, ignoring."));
+			return null;
+		}
+		if (count != thrustCurveThrust.size() ||
+				count != thrustCurveCGx.size() ||
+				count != thrustCurveMass.size()) {
+			warnings.add(Warning.fromString("Embedded motor thrust curve point data is inconsistent, ignoring."));
+			return null;
+		}
+
+		String manufacturerName = (manufacturer == null || manufacturer.isBlank()) ? "Unknown" : manufacturer.trim();
+		String motorDesignation = (designation == null || designation.isBlank()) ? null : designation.trim();
+		if (motorDesignation == null) {
+			warnings.add(Warning.fromString("Embedded motor is missing designation, ignoring."));
+			return null;
+		}
+
+		Motor.Type motorType = (type == null) ? Motor.Type.UNKNOWN : type;
+
+		// Convert list data into primitive arrays expected by ThrustCurveMotor and build CG points.
+		double[] timeArray = new double[count];
+		double[] thrustArray = new double[count];
+		double[] cgxArray = new double[count];
+		double[] massArray = new double[count];
+		CoordinateIF[] cgArray = new CoordinateIF[count];
+		for (int i = 0; i < count; i++) {
+			timeArray[i] = thrustCurveTime.get(i);
+			thrustArray[i] = thrustCurveThrust.get(i);
+			cgxArray[i] = thrustCurveCGx.get(i);
+			massArray[i] = thrustCurveMass.get(i);
+			cgArray[i] = new Coordinate(cgxArray[i], 0, 0, massArray[i]);
+		}
+
+		double[] delaysArray = new double[standardDelays.size()];
+		for (int i = 0; i < standardDelays.size(); i++) {
+			delaysArray[i] = standardDelays.get(i);
+		}
+
+		// Prefer the digest stored in the file; if it's missing (e.g. old file versions), compute one from the embedded
+		// thrust curve data to preserve identity across load/save.
+		String motorDigest = (digest == null || digest.isBlank()) ? null : digest.trim();
+		if (motorDigest == null) {
+			MotorDigest md = new MotorDigest();
+			md.update(MotorDigest.DataType.TIME_ARRAY, timeArray);
+			md.update(MotorDigest.DataType.MASS_PER_TIME, massArray);
+			md.update(MotorDigest.DataType.CG_PER_TIME, cgxArray);
+			md.update(MotorDigest.DataType.FORCE_PER_TIME, thrustArray);
+			motorDigest = md.getDigest();
+		}
+
+		try {
+			Manufacturer m = Manufacturer.getManufacturer(manufacturerName);
+			ThrustCurveMotor.Builder builder = new ThrustCurveMotor.Builder()
+					.setManufacturer(m)
+					.setDesignation(motorDesignation)
+					.setMotorType(motorType)
+					.setStandardDelays(delaysArray)
+					.setDiameter(diameter)
+					.setLength(length)
+					.setTimePoints(timeArray)
+					.setThrustPoints(thrustArray)
+					.setCGPoints(cgArray)
+					.setDigest(motorDigest);
+			return builder.build();
+		} catch (IllegalArgumentException e) {
+			warnings.add(Warning.fromString(
+					"Invalid embedded thrust curve data for motor '" + motorDesignation + "', ignoring."));
+			return null;
+		}
 	}
 
 	/**
@@ -134,6 +251,49 @@ class MotorHandler extends AbstractElementHandler {
 					warnings.add(Warning.fromString("Illegal motor delay specified, ignoring."));
 				}
 
+			}
+
+		} else if (element.equals("standarddelays")) {
+			// Parse a comma-separated list of delays; accept "none"/"p"/"plugged" as a plugged motor delay.
+			standardDelays.clear();
+			if (content.isEmpty()) {
+				return;
+			}
+			for (String s : content.split(",")) {
+				String token = s.trim();
+				if (token.isEmpty()) {
+					continue;
+				}
+				if (token.equalsIgnoreCase("none") || token.equalsIgnoreCase("p") ||
+						token.equalsIgnoreCase("plugged")) {
+					standardDelays.add(Motor.PLUGGED_DELAY);
+					continue;
+				}
+				try {
+					standardDelays.add(Double.parseDouble(token));
+				} catch (NumberFormatException ignore) {
+					warnings.add(Warning.fromString("Illegal motor standard delay specified, ignoring."));
+				}
+			}
+
+		} else if (element.equals("thrustcurvepoint")) {
+			// Parse "time,thrust,cg_x,mass" (s, N, m, kg) into lists.
+			if (content.isEmpty()) {
+				return;
+			}
+			String[] parts = content.split("\\s*,\\s*");
+			if (parts.length != 4) {
+				warnings.add(Warning.fromString("Illegal motor thrust curve point specified, ignoring."));
+				return;
+			}
+
+			try {
+				thrustCurveTime.add(Double.parseDouble(parts[0]));
+				thrustCurveThrust.add(Double.parseDouble(parts[1]));
+				thrustCurveCGx.add(Double.parseDouble(parts[2]));
+				thrustCurveMass.add(Double.parseDouble(parts[3]));
+			} catch (NumberFormatException e) {
+				warnings.add(Warning.fromString("Illegal motor thrust curve point specified, ignoring."));
 			}
 
 		} else {

--- a/core/src/main/java/info/openrocket/core/file/openrocket/savers/RocketComponentSaver.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/savers/RocketComponentSaver.java
@@ -219,6 +219,15 @@ public class RocketComponentSaver {
 	}
 	
 	
+	/**
+	 * Serialize motor mount configuration for a component acting as a motor mount.
+	 * <p>
+	 * For {@link info.openrocket.core.motor.ThrustCurveMotor} instances this also embeds the thrust curve data so the
+	 * resulting .ork file can be shared and re-opened without requiring the receiver to have the same motor database.
+	 *
+	 * @param mount motor mount component
+	 * @return XML element lines (empty if not a motor mount)
+	 */
 	protected final List<String> motorMountParams(MotorMount mount) {
 		if (!mount.isMotorMount())
 			return Collections.emptyList();
@@ -258,6 +267,39 @@ public class RocketComponentSaver {
 				elements.add("    <manufacturer>" + TextUtil.escapeXML(m.getManufacturer().getSimpleName()) +
 						"</manufacturer>");
 				elements.add("    <digest>" + m.getDigest() + "</digest>");
+
+				// Embed thrust curve data
+				// Standard delays are a comma-separated list; "none" represents a plugged/no-ejection-charge delay.
+				double[] standardDelays = m.getStandardDelays();
+				if (standardDelays != null && standardDelays.length > 0) {
+					StringBuilder delayString = new StringBuilder();
+					for (int i = 0; i < standardDelays.length; i++) {
+						if (i > 0) {
+							delayString.append(',');
+						}
+						// Use "none" for Motor.PLUGGED_DELAY so it round-trips via <delay>none</delay>.
+						delayString.append(ThrustCurveMotor.getDelayString(standardDelays[i], "none"));
+					}
+					elements.add("    <standarddelays>" + delayString + "</standarddelays>");
+				}
+
+				// Thrust curve points are stored as "time,thrust,cg_x,mass" with units:
+				//   time: seconds, thrust: N, cg_x: m, mass: kg
+				double[] timePoints = m.getTimePoints();
+				double[] thrustPoints = m.getThrustPoints();
+				CoordinateIF[] cgPoints = m.getCGPoints();
+				int pointCount = Math.min(timePoints.length, Math.min(thrustPoints.length, cgPoints.length));
+				for (int i = 0; i < pointCount; i++) {
+					CoordinateIF cgPoint = cgPoints[i];
+					if (cgPoint == null) {
+						continue;
+					}
+					String point = TextUtil.doubleToString(timePoints[i]) + "," +
+							TextUtil.doubleToString(thrustPoints[i]) + "," +
+							TextUtil.doubleToString(cgPoint.getX()) + "," +
+							TextUtil.doubleToString(cgPoint.getWeight());
+					elements.add("    <thrustcurvepoint>" + point + "</thrustcurvepoint>");
+				}
 			}
 			elements.add("    <designation>" + TextUtil.escapeXML(motor.getDesignation()) + "</designation>");
 			elements.add("    <diameter>" + motor.getDiameter() + "</diameter>");

--- a/core/src/test/java/info/openrocket/core/file/openrocket/OpenRocketSaverTest.java
+++ b/core/src/test/java/info/openrocket/core/file/openrocket/OpenRocketSaverTest.java
@@ -33,10 +33,15 @@ import info.openrocket.core.logging.ErrorSet;
 import info.openrocket.core.logging.WarningSet;
 import info.openrocket.core.motor.Manufacturer;
 import info.openrocket.core.motor.Motor;
+import info.openrocket.core.motor.MotorConfiguration;
 import info.openrocket.core.motor.ThrustCurveMotor;
 import info.openrocket.core.plugin.PluginModule;
+import info.openrocket.core.rocketcomponent.AxialStage;
 import info.openrocket.core.rocketcomponent.BodyTube;
 import info.openrocket.core.rocketcomponent.FlightConfiguration;
+import info.openrocket.core.rocketcomponent.FlightConfigurationId;
+import info.openrocket.core.rocketcomponent.InnerTube;
+import info.openrocket.core.rocketcomponent.MotorMount;
 import info.openrocket.core.rocketcomponent.Rocket;
 import info.openrocket.core.simulation.extension.impl.ScriptingExtension;
 import info.openrocket.core.simulation.extension.impl.ScriptingUtil;
@@ -336,6 +341,74 @@ public class OpenRocketSaverTest {
 	public void testFileVersion111_withSimulationExtension() {
 		OpenRocketDocument rocketDoc = TestRockets.makeTestRocket_v110_withSimulationExtension(SIMULATION_EXTENSION_SCRIPT);
 		assertEquals(111, getCalculatedFileVersion(rocketDoc));
+	}
+
+	@Test
+	public void testCustomMotorThrustCurveEmbeddedInOrk() {
+		Rocket rocket = new Rocket();
+		rocket.setName("embedded_motor_test");
+
+		AxialStage stage = new AxialStage();
+		stage.setName("Stage1");
+		rocket.addChild(stage);
+
+		BodyTube bodyTube = new BodyTube(12, 1, 0.05);
+		stage.addChild(bodyTube);
+
+		InnerTube innerTube = new InnerTube();
+		bodyTube.addChild(innerTube);
+
+		FlightConfigurationId fcid = new FlightConfigurationId();
+		rocket.createFlightConfiguration(fcid);
+		rocket.setSelectedConfiguration(fcid);
+
+		ThrustCurveMotor motor = new ThrustCurveMotor.Builder()
+				.setManufacturer(Manufacturer.getManufacturer("Custom"))
+				.setDesignation("F12X")
+				.setDescription("Desc")
+				.setCaseInfo("info")
+				.setMotorType(Motor.Type.UNKNOWN)
+				.setStandardDelays(new double[] { 0, 3, 5, Motor.PLUGGED_DELAY })
+				.setDiameter(0.024)
+				.setLength(0.07)
+				.setTimePoints(new double[] { 0, 1, 2 })
+				.setThrustPoints(new double[] { 0, 1, 0 })
+				.setCGPoints(new CoordinateIF[] { Coordinate.NUL, Coordinate.NUL, Coordinate.NUL })
+				.setDigest("digestA")
+				.build();
+
+		MotorConfiguration motorConfig = new MotorConfiguration(innerTube, fcid);
+		motorConfig.setMotor(motor);
+		motorConfig.setEjectionDelay(5);
+		innerTube.setMotorConfig(motorConfig, fcid);
+
+		rocket.enableEvents();
+		OpenRocketDocument rocketDoc = OpenRocketDocumentFactory.createDocumentFromRocket(rocket);
+		StorageOptions options = new StorageOptions();
+		options.setSaveSimulationData(false);
+
+		File file = saveRocket(rocketDoc, options);
+		OpenRocketDocument rocketDocLoaded = loadRocket(file.getPath());
+
+		Rocket loadedRocket = rocketDocLoaded.getRocket();
+		FlightConfigurationId loadedFcid = loadedRocket.getSelectedConfiguration().getFlightConfigurationID();
+
+		MotorMount motorMount = null;
+		for (java.util.Iterator<info.openrocket.core.rocketcomponent.RocketComponent> it = loadedRocket.iterator(true); it.hasNext();) {
+			info.openrocket.core.rocketcomponent.RocketComponent c = it.next();
+			if (c instanceof MotorMount mount && mount.isMotorMount()) {
+				motorMount = mount;
+				break;
+			}
+		}
+		assertNotNull(motorMount, "Expected a motor mount in the loaded rocket");
+
+		MotorConfiguration loadedMotorConfig = motorMount.getMotorConfig(loadedFcid);
+		assertNotNull(loadedMotorConfig);
+		Motor loadedMotor = loadedMotorConfig.getMotor();
+		assertNotNull(loadedMotor, "Expected motor to be loaded from embedded thrust curve data");
+		assertTrue(loadedMotor instanceof ThrustCurveMotor);
+		assertEquals("digestA", loadedMotor.getDigest());
 	}
 	
 

--- a/docs/source/dev_guide/file_specification.rst
+++ b/docs/source/dev_guide/file_specification.rst
@@ -140,6 +140,7 @@ of our repository).
      - * Added ``<simulationsteppermethod>`` to simulation conditions
        * Added simulation table column visibility preferences
        * Include file preview image (``preview.png``) in .ork zip file
+       * Embedded thrust curve motor data (``<standarddelays>``, ``<thrustcurvepoint>``) into ``<motor>`` elements so designs are self-contained when sharing custom motors
 
 ----
 
@@ -151,7 +152,7 @@ The following shows the root XML structure of an OpenRocket design file:
 .. code-block:: xml
 
    <?xml version='1.0' encoding='utf-8'?>
-   <openrocket version="1.11" creator="OpenRocket 25.xx">
+   <openrocket version="1.12" creator="OpenRocket 25.xx">
       <rocket>
          <!-- Rocket definition -->
       </rocket>
@@ -537,6 +538,10 @@ be present in the XML component block:
             <type>single</type>
             <manufacturer>Estes</manufacturer>
             <digest>22aec01287ea1e3b8c6f66b26fe5fea6</digest>
+            <standarddelays>0,3,5,none</standarddelays>
+            <thrustcurvepoint>0,0,0.035,0.0164</thrustcurvepoint>
+            <thrustcurvepoint>1,9,0.035,0.0145</thrustcurvepoint>
+            <thrustcurvepoint>2,0,0.035,0.0131</thrustcurvepoint>
             <designation>A8</designation>
             <diameter>0.018</diameter>
             <length>0.07</length>
@@ -548,6 +553,15 @@ be present in the XML component block:
          </ignitionconfiguration>
       </motormount>
    </bodytube>
+
+As of file format version ``1.11``, OpenRocket embeds the full thrust curve motor data directly inside ``<motor>``
+elements. This is primarily intended to make designs self-contained when sharing custom motors.
+
+* ``standarddelays``: Comma-separated list of standard motor delays in seconds; use ``none`` for plugged/no ejection charge.
+* ``thrustcurvepoint``: Repeated element containing ``time,thrust,cg_x,mass`` values (seconds, Newtons, meters, kg).
+
+When one or more ``thrustcurvepoint`` elements are present, OpenRocket will reconstruct the motor from the embedded data
+instead of looking it up in the motor database.
 
 ----
 
@@ -1320,4 +1334,3 @@ Important Notes
 2. When a component is first created in a .ork file, the material definition is copied from the .orc file. Subsequent changes to the material definition in the .orc file will not automatically update existing components in .ork files.
 3. To update a component's material properties, you must manually reselect the component preset from the database.
 4. The XML schema for .orc files is not formally defined in an XSD file.
-

--- a/fileformat.txt
+++ b/fileformat.txt
@@ -76,7 +76,7 @@ The following file format versions exist:
       Added <designtype> and  <kitname> to <rocket> element.
 
 1.11: Introduced with OpenRocket 25.XX.
-      Added <simulationsteppermethod> to <simulation> element.
+      Added <simulationsteppermethod> to <simulation >element.
       Added simulation.table.hiddenColumns document preference for simulation table column visibility.
       Include a file preview image of the 2D side view in the .ork zip file ('preview.png').
       Added gravity model settings (<gravity model="{wgs or constant}">) to simulation conditions.
@@ -91,3 +91,5 @@ The following file format versions exist:
               </draglookupcsv>
       When loading, embedded row data is preferred over the file path. If no rows
       are embedded, the file path is used to load from disk (backward compatible).
+      Embedded thrust curve motor data (<thrustcurvepoint> and <standarddelays>)
+      into <motor> elements so designs are self-contained when sharing custom motors.


### PR DESCRIPTION
This PR fixes #1838 by embedding thrust curve points and standard motor delays of a motor in the .ork file:

Example:
```xml
<motor configid="05896b5a-71a7-48ac-b7ae-eadeb267975b">
  <type>single</type>
  <manufacturer>Estes</manufacturer>
  <digest>c15b9b96bf06e0ab896394787da3c47e</digest>
  <standarddelays>2,4</standarddelays>
  <thrustcurvepoint>0,0,0.035,0.019</thrustcurvepoint>
  <thrustcurvepoint>0.02,0.418,0.035,0.019</thrustcurvepoint>
  <thrustcurvepoint>0.04,1.673,0.035,0.019</thrustcurvepoint>
  <thrustcurvepoint>0.065,4.076,0.035,0.019</thrustcurvepoint>
  <thrustcurvepoint>0.085,6.69,0.035,0.019</thrustcurvepoint>
  <thrustcurvepoint>0.105,9.304,0.035,0.018</thrustcurvepoint>
  <thrustcurvepoint>0.119,11.496,0.035,0.018</thrustcurvepoint>
  <thrustcurvepoint>0.136,12.75,0.035,0.018</thrustcurvepoint>
  <thrustcurvepoint>0.153,11.916,0.035,0.018</thrustcurvepoint>
  <thrustcurvepoint>0.173,10.666,0.035,0.017</thrustcurvepoint>
  <thrustcurvepoint>0.187,9.304,0.035,0.017</thrustcurvepoint>
  <thrustcurvepoint>0.198,7.214,0.035,0.017</thrustcurvepoint>
  <thrustcurvepoint>0.207,5.645,0.035,0.017</thrustcurvepoint>
  <thrustcurvepoint>0.226,4.809,0.035,0.017</thrustcurvepoint>
  <thrustcurvepoint>0.258,4.182,0.035,0.017</thrustcurvepoint>
  <thrustcurvepoint>0.326,3.763,0.035,0.016</thrustcurvepoint>
  <thrustcurvepoint>0.422,3.554,0.035,0.016</thrustcurvepoint>
  <thrustcurvepoint>0.549,3.345,0.035,0.015</thrustcurvepoint>
  <thrustcurvepoint>0.665,3.345,0.035,0.015</thrustcurvepoint>
  <thrustcurvepoint>0.776,3.345,0.035,0.014</thrustcurvepoint>
  <thrustcurvepoint>0.863,3.345,0.035,0.014</thrustcurvepoint>
  <thrustcurvepoint>0.94,3.449,0.035,0.013</thrustcurvepoint>
  <thrustcurvepoint>0.991,3.449,0.035,0.013</thrustcurvepoint>
  <thrustcurvepoint>1.002,2.404,0.035,0.013</thrustcurvepoint>
  <thrustcurvepoint>1.01,1.254,0.035,0.013</thrustcurvepoint>
  <thrustcurvepoint>1.03,0,0.035,0.013</thrustcurvepoint>
  <designation>B4</designation>
  <diameter>0.018</diameter>
  <length>0.07</length>
  <delay>4.0</delay>
</motor>
```

When loading a .ork file, the following sequence is followed:
1. First, try to load the motor from the database
2. If the motor was not found in the database, load it from the embedded motor data

This ensures that when the motor database is updated, this is reflected when opening your file (instead of first trying to load the motor data from the .ork file).