### PR TITLE
[#1391] Add undo actions for simulations

### DIFF
--- a/core/src/main/java/info/openrocket/core/document/OpenRocketDocument.java
+++ b/core/src/main/java/info/openrocket/core/document/OpenRocketDocument.java
@@ -95,6 +95,7 @@ public class OpenRocketDocument implements ComponentChangeListener, StateChangeL
 	 */
 	private final LinkedList<Rocket> undoHistory = new LinkedList<>();
 	private final LinkedList<String> undoDescription = new LinkedList<>();
+	private final LinkedList<ArrayList<Simulation>> undoSimulationHistory = new LinkedList<>();
 	
 	/**
 	 * The position in the undoHistory we are currently at.  If modifications have been
@@ -482,6 +483,7 @@ public class OpenRocketDocument implements ComponentChangeListener, StateChangeL
 		if( !rocket.containsFlightConfigurationID( simId )){
 			rocket.createFlightConfiguration(simId);
 		}
+		simulationsChanged();
 		fireDocumentChangeEvent(new SimulationChangeEvent(simulation));
 	}
 	
@@ -491,6 +493,7 @@ public class OpenRocketDocument implements ComponentChangeListener, StateChangeL
 	 */
 	public void removeSimulation(Simulation simulation) {
 		simulations.remove(simulation);
+		simulationsChanged();
 		fireDocumentChangeEvent(new SimulationChangeEvent(simulation));
 	}
 	
@@ -502,8 +505,22 @@ public class OpenRocketDocument implements ComponentChangeListener, StateChangeL
 	 */
 	public Simulation removeSimulation(int n) {
 		Simulation simulation = simulations.remove(n);
+		simulationsChanged();
 		fireDocumentChangeEvent(new SimulationChangeEvent(simulation));
 		return simulation;
+	}
+
+	private void simulationsChanged() {
+		modID = new ModID();
+		if (undoPosition < undoHistory.size() - 1) {
+			log.info("Simulations changed while in undo history, removing redo information for " + this +
+					" undoPosition=" + undoPosition + " undoHistory.size=" + undoHistory.size() +
+					" isClean=" + isCleanState());
+		}
+
+		removeRedoInfo();
+		setLatestDescription();
+		fireUndoRedoChangeEvent();
 	}
 	
 	/**
@@ -593,6 +610,7 @@ public class OpenRocketDocument implements ComponentChangeListener, StateChangeL
 			for (int i = 0; i < UNDO_MARGIN; i++) {
 				undoHistory.removeFirst();
 				undoDescription.removeFirst();
+				undoSimulationHistory.removeFirst();
 				undoPosition--;
 			}
 		}
@@ -605,6 +623,7 @@ public class OpenRocketDocument implements ComponentChangeListener, StateChangeL
 		// Add the current state to the undo history
 		undoHistory.add(rocket.copyWithOriginalID());
 		undoDescription.add(null);
+		undoSimulationHistory.add(simulations.clone());
 		nextDescription = description;
 		undoPosition++;
 	}
@@ -691,9 +710,11 @@ public class OpenRocketDocument implements ComponentChangeListener, StateChangeL
 		//log.info("Clearing undo history of " + this);
 		undoHistory.clear();
 		undoDescription.clear();
+		undoSimulationHistory.clear();
 		
 		undoHistory.add(rocket.copyWithOriginalID());
 		undoDescription.add(null);
+		undoSimulationHistory.add(simulations.clone());
 		undoPosition = 0;
 		
 		fireUndoRedoChangeEvent();
@@ -737,6 +758,7 @@ public class OpenRocketDocument implements ComponentChangeListener, StateChangeL
 		while (undoPosition < undoHistory.size() - 1) {
 			undoHistory.removeLast();
 			undoDescription.removeLast();
+			undoSimulationHistory.removeLast();
 		}
 	}
 	
@@ -815,11 +837,13 @@ public class OpenRocketDocument implements ComponentChangeListener, StateChangeL
 			// Modifications have been made, save the state and restore previous state
 			undoHistory.add(rocket.copyWithOriginalID());
 			undoDescription.add(null);
+			undoSimulationHistory.add(simulations.clone());
 		}
 		
 		rocket.checkComponentStructure();
 		rocket.loadFrom(undoHistory.get(undoPosition));
 		rocket.checkComponentStructure();
+		loadSimulationsFrom(undoSimulationHistory.get(undoPosition));
 	}
 	
 	
@@ -841,11 +865,23 @@ public class OpenRocketDocument implements ComponentChangeListener, StateChangeL
 		undoPosition++;
 		
 		rocket.loadFrom(undoHistory.get(undoPosition).copyWithOriginalID());
+		loadSimulationsFrom(undoSimulationHistory.get(undoPosition));
 	}
 	
 	
 	private boolean isCleanState() {
-		return rocket.getModID() == undoHistory.get(undoPosition).getModID();
+		return rocket.getModID() == undoHistory.get(undoPosition).getModID() &&
+				simulations.equals(undoSimulationHistory.get(undoPosition));
+	}
+
+	private void loadSimulationsFrom(ArrayList<Simulation> simulationsSnapshot) {
+		if (simulationsSnapshot == null) {
+			return;
+		}
+
+		simulations.clear();
+		simulations.addAll(simulationsSnapshot);
+		fireDocumentChangeEvent(new SimulationChangeEvent(this));
 	}
 	
 	

--- a/core/src/main/java/info/openrocket/core/document/OpenRocketDocument.java
+++ b/core/src/main/java/info/openrocket/core/document/OpenRocketDocument.java
@@ -96,6 +96,7 @@ public class OpenRocketDocument implements ComponentChangeListener, StateChangeL
 	private final LinkedList<Rocket> undoHistory = new LinkedList<>();
 	private final LinkedList<String> undoDescription = new LinkedList<>();
 	private final LinkedList<ArrayList<Simulation>> undoSimulationHistory = new LinkedList<>();
+	private boolean inUndoRedo = false;
 	
 	/**
 	 * The position in the undoHistory we are currently at.  If modifications have been
@@ -623,7 +624,7 @@ public class OpenRocketDocument implements ComponentChangeListener, StateChangeL
 		// Add the current state to the undo history
 		undoHistory.add(rocket.copyWithOriginalID());
 		undoDescription.add(null);
-		undoSimulationHistory.add(simulations.clone());
+		undoSimulationHistory.add(copySimulationsForUndo());
 		nextDescription = description;
 		undoPosition++;
 	}
@@ -714,7 +715,7 @@ public class OpenRocketDocument implements ComponentChangeListener, StateChangeL
 		
 		undoHistory.add(rocket.copyWithOriginalID());
 		undoDescription.add(null);
-		undoSimulationHistory.add(simulations.clone());
+		undoSimulationHistory.add(copySimulationsForUndo());
 		undoPosition = 0;
 		
 		fireUndoRedoChangeEvent();
@@ -741,6 +742,29 @@ public class OpenRocketDocument implements ComponentChangeListener, StateChangeL
 	@Override
 	public void stateChanged(EventObject e) {
 		modID = new ModID();
+		if (!inUndoRedo && (e.getSource() instanceof Simulation)) {
+			boolean simulationsEqual = simulations.equals(undoSimulationHistory.get(undoPosition));
+			if (simulationsEqual && rocket.getModID() == undoHistory.get(undoPosition).getModID()) {
+				// Keep the "clean state" simulation snapshot in sync for non-undoable simulation changes
+				// (e.g. simulated data/status updates).
+					int index = getSimulationIndex((Simulation) e.getSource());
+					if (index >= 0 && index < undoSimulationHistory.get(undoPosition).size()) {
+						undoSimulationHistory.get(undoPosition).set(index,
+								((Simulation) e.getSource()).cloneForUndo());
+					} else {
+						undoSimulationHistory.set(undoPosition, copySimulationsForUndo());
+					}
+				} else if (!simulationsEqual) {
+				if (undoPosition < undoHistory.size() - 1) {
+					log.info("Simulation changed while in undo history, removing redo information for " + this +
+							" undoPosition=" + undoPosition + " undoHistory.size=" + undoHistory.size() +
+							" isClean=" + isCleanState());
+				}
+				removeRedoInfo();
+				setLatestDescription();
+				fireUndoRedoChangeEvent();
+			}
+		}
 		fireDocumentChangeEvent(new DocumentChangeEvent(e.getSource()));
 	}
 
@@ -837,13 +861,19 @@ public class OpenRocketDocument implements ComponentChangeListener, StateChangeL
 			// Modifications have been made, save the state and restore previous state
 			undoHistory.add(rocket.copyWithOriginalID());
 			undoDescription.add(null);
-			undoSimulationHistory.add(simulations.clone());
+			undoSimulationHistory.add(copySimulationsForUndo());
 		}
-		
-		rocket.checkComponentStructure();
-		rocket.loadFrom(undoHistory.get(undoPosition));
-		rocket.checkComponentStructure();
-		loadSimulationsFrom(undoSimulationHistory.get(undoPosition));
+
+		inUndoRedo = true;
+		try {
+			rocket.checkComponentStructure();
+			rocket.loadFrom(undoHistory.get(undoPosition));
+			rocket.checkComponentStructure();
+			loadSimulationsFrom(undoSimulationHistory.get(undoPosition));
+		} finally {
+			inUndoRedo = false;
+			fireUndoRedoChangeEvent();
+		}
 	}
 	
 	
@@ -863,9 +893,15 @@ public class OpenRocketDocument implements ComponentChangeListener, StateChangeL
 		}
 		
 		undoPosition++;
-		
-		rocket.loadFrom(undoHistory.get(undoPosition).copyWithOriginalID());
-		loadSimulationsFrom(undoSimulationHistory.get(undoPosition));
+
+		inUndoRedo = true;
+		try {
+			rocket.loadFrom(undoHistory.get(undoPosition).copyWithOriginalID());
+			loadSimulationsFrom(undoSimulationHistory.get(undoPosition));
+		} finally {
+			inUndoRedo = false;
+			fireUndoRedoChangeEvent();
+		}
 	}
 	
 	
@@ -874,13 +910,36 @@ public class OpenRocketDocument implements ComponentChangeListener, StateChangeL
 				simulations.equals(undoSimulationHistory.get(undoPosition));
 	}
 
+	private ArrayList<Simulation> copySimulationsForUndo() {
+		ArrayList<Simulation> copy = new ArrayList<>(simulations.size());
+		for (Simulation simulation : simulations) {
+			copy.add(simulation.cloneForUndo());
+		}
+		return copy;
+	}
+
 	private void loadSimulationsFrom(ArrayList<Simulation> simulationsSnapshot) {
 		if (simulationsSnapshot == null) {
 			return;
 		}
 
-		simulations.clear();
-		simulations.addAll(simulationsSnapshot);
+		if (simulations.size() == simulationsSnapshot.size()) {
+			for (int i = 0; i < simulations.size(); i++) {
+				simulations.get(i).loadFrom(simulationsSnapshot.get(i));
+			}
+			} else {
+				simulations.clear();
+				for (Simulation snapshot : simulationsSnapshot) {
+					Simulation simulation = snapshot.cloneForUndo();
+					FlightConfigurationId simId = simulation.getId();
+					if (!rocket.containsFlightConfigurationID(simId)) {
+						rocket.createFlightConfiguration(simId);
+					}
+					simulation.syncModID();
+					simulation.addChangeListener(this);
+					simulations.add(simulation);
+				}
+			}
 		fireDocumentChangeEvent(new SimulationChangeEvent(this));
 	}
 	

--- a/core/src/main/java/info/openrocket/core/document/Simulation.java
+++ b/core/src/main/java/info/openrocket/core/document/Simulation.java
@@ -4,6 +4,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.EventListener;
 import java.util.EventObject;
 import java.util.List;
+import java.util.Objects;
 
 import info.openrocket.core.simulation.FlightEvent;
 import org.slf4j.Logger;
@@ -33,6 +34,7 @@ import info.openrocket.core.startup.Application;
 import info.openrocket.core.util.ArrayList;
 import info.openrocket.core.util.BugException;
 import info.openrocket.core.util.ChangeSource;
+import info.openrocket.core.util.Config;
 import info.openrocket.core.util.ModID;
 import info.openrocket.core.util.SafetyMutex;
 import info.openrocket.core.util.StateChangeListener;
@@ -636,7 +638,56 @@ public class Simulation implements ChangeSource, Cloneable {
 	}
 
 	public Simulation clone() {
+		return clone(true);
+	}
+
+	public Simulation clone(boolean includeSimulatedDate) {
 		mutex.lock("clone");
+		try {
+			Simulation clone = (Simulation) super.clone();
+
+			clone.mutex = SafetyMutex.newInstance();
+			clone.name = this.name;
+			clone.configId = this.configId;
+			clone.simulatedConfigurationDescription = this.simulatedConfigurationDescription;
+			clone.simulatedConfigurationModID = this.simulatedConfigurationModID;
+			clone.options = this.options.clone();
+			clone.listeners = new ArrayList<>();
+			clone.options.addChangeListener(clone.new ConditionListener());
+			if (this.simulatedConditions != null) {
+				clone.simulatedConditions = this.simulatedConditions.clone();
+			} else {
+				clone.simulatedConditions = null;
+			}
+			clone.simulationExtensions = new ArrayList<>();
+			for (SimulationExtension c : this.simulationExtensions) {
+				clone.simulationExtensions.add(c.clone());
+			}
+			clone.status = this.status;
+			if (includeSimulatedDate) {
+				clone.simulatedData = this.simulatedData != null ? this.simulatedData.clone() : this.simulatedData;
+			} else {
+				clone.simulatedData = null;
+			}
+			clone.simulationStepperClass = this.simulationStepperClass;
+			clone.aerodynamicCalculatorClass = this.aerodynamicCalculatorClass;
+
+			return clone;
+		} catch (CloneNotSupportedException e) {
+			throw new BugException("Clone not supported, BUG", e);
+		} finally {
+			mutex.unlock("clone");
+		}
+	}
+
+	/**
+	 * Create a duplicate of this simulation suitable for use in document undo history.
+	 * <p>
+	 * The returned simulation has deep-copied settings but the simulated flight data is
+	 * copied by reference (i.e. it is not cloned).
+	 */
+	Simulation cloneForUndo() {
+		mutex.lock("cloneForUndo");
 		try {
 			Simulation clone = (Simulation) super.clone();
 
@@ -657,7 +708,7 @@ public class Simulation implements ChangeSource, Cloneable {
 				clone.simulationExtensions.add(c.clone());
 			}
 			clone.status = this.status;
-			clone.simulatedData = this.simulatedData != null ? this.simulatedData.clone() : this.simulatedData;
+			clone.simulatedData = this.simulatedData;
 			clone.simulationStepperClass = this.simulationStepperClass;
 			clone.aerodynamicCalculatorClass = this.aerodynamicCalculatorClass;
 
@@ -665,7 +716,7 @@ public class Simulation implements ChangeSource, Cloneable {
 		} catch (CloneNotSupportedException e) {
 			throw new BugException("Clone not supported, BUG", e);
 		} finally {
-			mutex.unlock("clone");
+			mutex.unlock("cloneForUndo");
 		}
 	}
 
@@ -683,12 +734,17 @@ public class Simulation implements ChangeSource, Cloneable {
 			this.options.copyConditionsFrom(simulation.options);
 			if (simulation.simulatedConditions == null) {
 				this.simulatedConditions = null;
+			} else if (this.simulatedConditions == null) {
+				this.simulatedConditions = simulation.simulatedConditions.clone();
 			} else {
 				this.simulatedConditions.copyConditionsFrom(simulation.simulatedConditions);
 			}
 			copyExtensionsFrom(simulation.getSimulationExtensions());
 			this.status = simulation.status;
 			this.simulatedData = simulation.simulatedData;
+			if (isStatusUpToDate(this.status) && !this.configId.hasError()) {
+				this.simulatedConfigurationModID = getActiveConfiguration().getModID();
+			}
 			this.simulationStepperClass = simulation.simulationStepperClass;
 			this.aerodynamicCalculatorClass = simulation.aerodynamicCalculatorClass;
 		} finally {
@@ -751,6 +807,81 @@ public class Simulation implements ChangeSource, Cloneable {
 				((StateChangeListener) l).stateChanged(e);
 			}
 		}
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof Simulation other)) {
+			return false;
+		}
+
+		mutex.verify();
+		other.mutex.verify();
+
+		return Objects.equals(this.name, other.name) &&
+				Objects.equals(this.configId, other.configId) &&
+				Objects.equals(this.options, other.options) &&
+				Objects.equals(this.simulationEngineClass, other.simulationEngineClass) &&
+				Objects.equals(this.simulationStepperClass, other.simulationStepperClass) &&
+				Objects.equals(this.aerodynamicCalculatorClass, other.aerodynamicCalculatorClass) &&
+				simulationExtensionsEqual(this.simulationExtensions, other.simulationExtensions);
+	}
+
+	@Override
+	public int hashCode() {
+		return 0;
+	}
+
+	private static boolean simulationExtensionsEqual(List<SimulationExtension> a, List<SimulationExtension> b) {
+		if (a == b) {
+			return true;
+		}
+		if (a == null || b == null) {
+			return false;
+		}
+		if (a.size() != b.size()) {
+			return false;
+		}
+
+		for (int i = 0; i < a.size(); i++) {
+			SimulationExtension extA = a.get(i);
+			SimulationExtension extB = b.get(i);
+			if (extA == extB) {
+				continue;
+			}
+			if (extA == null || extB == null) {
+				return false;
+			}
+			if (!Objects.equals(extA.getId(), extB.getId())) {
+				return false;
+			}
+			if (!configEqual(extA.getConfig(), extB.getConfig())) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private static boolean configEqual(Config a, Config b) {
+		if (a == b) {
+			return true;
+		}
+		if (a == null || b == null) {
+			return false;
+		}
+		if (!a.keySet().equals(b.keySet())) {
+			return false;
+		}
+		for (String key : a.keySet()) {
+			if (!Objects.equals(a.get(key, null), b.get(key, null))) {
+				return false;
+			}
+		}
+		return true;
 	}
 	
 	

--- a/core/src/main/java/info/openrocket/core/simulation/SimulationOptions.java
+++ b/core/src/main/java/info/openrocket/core/simulation/SimulationOptions.java
@@ -159,7 +159,7 @@ public class SimulationOptions implements ChangeSource, Cloneable, SimulationOpt
 			} else {
 				windDirection = multiLevelPinkNoiseWindModel.getWindDirection(0, launchAltitude);
 			}
-			this.setLaunchRodDirection(windDirection);
+			return MathUtil.reduce2Pi(windDirection);
 		}
 		return launchRodDirection;
 	}

--- a/core/src/test/java/info/openrocket/core/document/OpenRocketDocumentSimulationUndoRedoTest.java
+++ b/core/src/test/java/info/openrocket/core/document/OpenRocketDocumentSimulationUndoRedoTest.java
@@ -1,0 +1,216 @@
+package info.openrocket.core.document;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.simulation.FlightData;
+import info.openrocket.core.simulation.exception.SimulationException;
+import info.openrocket.core.util.BaseTestCase;
+import info.openrocket.core.util.TestRockets;
+import org.junit.jupiter.api.Test;
+
+public class OpenRocketDocumentSimulationUndoRedoTest extends BaseTestCase {
+	private static final double EPSILON = 1e-6;
+
+	private static Simulation createSimulation(OpenRocketDocument document, Rocket rocket, String name) {
+		Simulation simulation = new Simulation(document, rocket);
+		simulation.setFlightConfigurationId(TestRockets.TEST_FCID_0);
+		simulation.setName(name);
+		simulation.getOptions().setISAAtmosphere(true);
+		simulation.getOptions().setTimeStep(0.05);
+		return simulation;
+	}
+
+	@Test
+	public void undoRedoSimulationDeletion_restoresSimulationAndResults() throws SimulationException {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		OpenRocketDocument document = new OpenRocketDocument(rocket);
+
+		Simulation simulation = createSimulation(document, rocket, "Delete me");
+		document.addSimulation(simulation);
+
+		simulation.simulate();
+		FlightData dataBefore = simulation.getSimulatedData();
+		assertNotNull(dataBefore);
+		assertTrue(dataBefore.getMaxAltitude() > 0);
+
+		document.clearUndo();
+
+		document.addUndoPosition("Delete simulation");
+		document.removeSimulation(simulation);
+		assertEquals(0, document.getSimulationCount());
+
+		document.undo();
+		assertEquals(1, document.getSimulationCount());
+
+		Simulation restored = document.getSimulation(0);
+		assertEquals("Delete me", restored.getName());
+		assertEquals(TestRockets.TEST_FCID_0, restored.getFlightConfigurationId());
+
+		FlightData restoredData = restored.getSimulatedData();
+		assertNotNull(restoredData, "Undoing simulation deletion should restore results");
+		assertEquals(dataBefore.getMaxAltitude(), restoredData.getMaxAltitude(), 0.001);
+		assertEquals(Simulation.Status.UPTODATE, restored.getStatus());
+
+		assertTrue(document.isRedoAvailable());
+		document.redo();
+		assertEquals(0, document.getSimulationCount());
+		assertFalse(document.isRedoAvailable());
+	}
+
+	@Test
+	public void undoRedoSimulationSettingChanges_restoresSettingsAndKeepsResults() throws SimulationException {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		OpenRocketDocument document = new OpenRocketDocument(rocket);
+
+		Simulation simulation = createSimulation(document, rocket, "Original");
+		document.addSimulation(simulation);
+
+		simulation.simulate();
+		FlightData dataBefore = simulation.getSimulatedData();
+		assertNotNull(dataBefore);
+
+		double rodLengthBefore = simulation.getOptions().getLaunchRodLength();
+		double maxAltitudeBefore = dataBefore.getMaxAltitude();
+
+		document.clearUndo();
+
+		document.addUndoPosition("Edit simulation");
+		simulation.setName("Modified");
+		simulation.getOptions().setLaunchRodLength(rodLengthBefore + 0.5);
+		assertEquals(Simulation.Status.OUTDATED, simulation.getStatus());
+
+		document.undo();
+		assertEquals("Original", simulation.getName());
+		assertEquals(rodLengthBefore, simulation.getOptions().getLaunchRodLength(), EPSILON);
+		assertNotNull(simulation.getSimulatedData());
+		assertEquals(maxAltitudeBefore, simulation.getSimulatedData().getMaxAltitude(), 0.001);
+		assertEquals(Simulation.Status.UPTODATE, simulation.getStatus());
+
+		document.redo();
+		assertEquals("Modified", simulation.getName());
+		assertEquals(rodLengthBefore + 0.5, simulation.getOptions().getLaunchRodLength(), EPSILON);
+		assertNotNull(simulation.getSimulatedData());
+		assertEquals(maxAltitudeBefore, simulation.getSimulatedData().getMaxAltitude(), 0.001);
+		assertEquals(Simulation.Status.OUTDATED, simulation.getStatus());
+	}
+
+	@Test
+	public void redoNotClearedBySimulationRunWhileInUndoHistory() throws SimulationException {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		OpenRocketDocument document = new OpenRocketDocument(rocket);
+
+		Simulation simulation = createSimulation(document, rocket, "Original");
+		document.addSimulation(simulation);
+		document.clearUndo();
+
+		document.addUndoPosition("Rename simulation");
+		simulation.setName("Renamed");
+		document.undo();
+
+		assertEquals("Original", simulation.getName());
+		assertTrue(document.isRedoAvailable());
+
+		simulation.simulate();
+
+		assertTrue(document.isRedoAvailable(), "Running a simulation should not clear redo history");
+		document.redo();
+		assertEquals("Renamed", simulation.getName());
+	}
+
+	@Test
+	public void redoClearedByNewSimulationSettingChangeWhileInUndoHistory() {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		OpenRocketDocument document = new OpenRocketDocument(rocket);
+
+		Simulation simulation = createSimulation(document, rocket, "Original");
+		document.addSimulation(simulation);
+		document.clearUndo();
+
+		document.addUndoPosition("Rename simulation");
+		simulation.setName("Renamed");
+		document.undo();
+
+		assertTrue(document.isRedoAvailable());
+
+		simulation.setName("Different change");
+		assertFalse(document.isRedoAvailable(), "A new simulation edit should clear redo history");
+	}
+
+	@Test
+	public void getSimulationIndexAndRemoveSimulationUseIdentityNotEquals() {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		OpenRocketDocument document = new OpenRocketDocument(rocket);
+
+		Simulation first = createSimulation(document, rocket, "Same");
+		Simulation second = createSimulation(document, rocket, "Same");
+
+		document.addSimulation(first);
+		document.addSimulation(second);
+
+		assertEquals(0, document.getSimulationIndex(first));
+		assertEquals(1, document.getSimulationIndex(second));
+
+		document.removeSimulation(second);
+		assertEquals(1, document.getSimulationCount());
+		assertSame(first, document.getSimulation(0));
+		assertEquals(-1, document.getSimulationIndex(second));
+	}
+
+	@Test
+	public void undoRedoDeletionWithMultipleSimulations_restoresOrderAndResults() throws SimulationException {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		OpenRocketDocument document = new OpenRocketDocument(rocket);
+
+		Simulation first = createSimulation(document, rocket, "First");
+		Simulation second = createSimulation(document, rocket, "Second");
+		document.addSimulation(first);
+		document.addSimulation(second);
+
+		first.simulate();
+		second.simulate();
+		assertNotNull(first.getSimulatedData());
+		assertNotNull(second.getSimulatedData());
+
+		document.clearUndo();
+
+		document.addUndoPosition("Delete first simulation");
+		document.removeSimulation(first);
+		assertEquals(1, document.getSimulationCount());
+		assertEquals("Second", document.getSimulation(0).getName());
+
+		document.undo();
+		assertEquals(2, document.getSimulationCount());
+		assertEquals("First", document.getSimulation(0).getName());
+		assertEquals("Second", document.getSimulation(1).getName());
+		assertNotNull(document.getSimulation(0).getSimulatedData());
+		assertNotNull(document.getSimulation(1).getSimulatedData());
+
+		document.redo();
+		assertEquals(1, document.getSimulationCount());
+		assertEquals("Second", document.getSimulation(0).getName());
+	}
+
+	@Test
+	public void undoRedoSimulationSettingChange_onlyAffectsEditedSimulation() {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		OpenRocketDocument document = new OpenRocketDocument(rocket);
+
+		Simulation first = createSimulation(document, rocket, "First");
+		Simulation second = createSimulation(document, rocket, "Second");
+		document.addSimulation(first);
+		document.addSimulation(second);
+		document.clearUndo();
+
+		document.addUndoPosition("Edit second simulation");
+		second.setName("Second (edited)");
+
+		document.undo();
+		assertEquals("First", first.getName());
+		assertEquals("Second", second.getName());
+
+		document.redo();
+		assertEquals("First", first.getName());
+		assertEquals("Second (edited)", second.getName());
+	}
+}

--- a/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
@@ -504,6 +504,12 @@ private static final String APP_PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simu
 			return;
 		}
 
+		if (sims.length == 1) {
+			document.addUndoPosition("Delete " + sims[0].getName());
+		} else {
+			document.addUndoPosition("Delete simulations");
+		}
+
 		// Delete simulations
 		for (Simulation sim : sims) {
 			document.removeSimulation(sim);
@@ -535,8 +541,6 @@ private static final String APP_PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simu
 				new Object[] {
 				//// Delete the selected simulations?
 				trans.get("simpanel.dlg.lbl.DeleteSim1"),
-				//// <html><i>This operation cannot be undone.</i>
-				trans.get("simpanel.dlg.lbl.DeleteSim2"),
 				"",
 				panel },
 				//// Delete simulations
@@ -758,7 +762,6 @@ private static final String APP_PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simu
 	public void duplicateSimulation(Simulation[] sims, int index) {
 		if (sims == null || sims.length == 0) return;
 
-		// TODO: the undoing doesn't do anything...
 		if (sims.length == 1) {
 			document.addUndoPosition("Duplicate " + sims[0].getName());
 		} else {

--- a/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
@@ -462,6 +462,8 @@ private static final String APP_PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simu
 		Simulation sim = new Simulation(document, document.getRocket());
 		sim.setName(document.getNextSimulationName());
 
+		document.addUndoPosition("Add " + sim.getName());
+
 		int n = document.getSimulationCount();
 		document.addSimulation(sim);
 		simulationTableModel.fireTableDataChanged();

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConfigDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConfigDialog.java
@@ -61,7 +61,6 @@ public class SimulationConfigDialog extends JDialog {
 
 
 	private final WindowListener windowCloseCancelListener;
-	private final Simulation initialSim;		// A copy of the first selected simulation before it was modified
 	private final boolean initialIsSaved;		// Whether the document was saved before the dialog was opened
 	private boolean isModified = false;			// Whether the simulation has been modified
 	private final boolean isNewSimulation;		// Whether you are editing a new simulation, or an existing one
@@ -87,22 +86,28 @@ public class SimulationConfigDialog extends JDialog {
 		this.document = document;
 		this.parentWindow = parent;
 		this.simulationList = sims;
-		this.initialSim = simulationList[0].clone();
 		this.initialIsSaved = document.isSaved();
 		this.isNewSimulation = isNewSimulation;
 
-		if (simulationList.length == 1) {
-			document.addUndoPosition("Edit " + simulationList[0].getName());
-		} else {
-			document.addUndoPosition("Edit simulations");
+		// Creating new sim
+		if (isNewSimulation) {
+			document.addUndoPosition("Add " + simulationList[0].getName());
 		}
 
 		simulationList[0].addChangeListener(new StateChangeListener() {
 			@Override
 			public void stateChanged(EventObject e) {
+				if (!isNewSimulation) {
+					if (simulationList.length == 1) {
+						document.addUndoPosition("Edit " + simulationList[0].getName());
+					} else {
+						document.addUndoPosition("Edit simulations");
+					}
+				}
+
 				isModified = true;
 				setTitle("* " + getTitle());			// Add component changed indicator to the title
-				simulationList[0].removeChangeListener(this);
+				simulationList[0].removeChangeListener(this);	// Only do this once
 			}
 		});
 
@@ -521,21 +526,12 @@ public class SimulationConfigDialog extends JDialog {
 	}
 
 	private void discardChanges() {
-		if (isNewSimulation) {
-			document.removeSimulation(simulationList[0]);
-		} else {
-			undoSimulationChanges();
-		}
-		document.setSaved(this.initialIsSaved);			// Restore the saved state of the document
-		document.fireDocumentChangeEvent(new DocumentChangeEvent(this));
+			if (document.isUndoAvailable()) {
+				document.undo();
+			}
+			document.setSaved(this.initialIsSaved);			// Restore the saved state of the document
+			document.fireDocumentChangeEvent(new DocumentChangeEvent(this));
 
-		closeDialog();
-	}
-
-	private void undoSimulationChanges() {
-		if (simulationList == null || simulationList.length == 0) {
-			return;
+			closeDialog();
 		}
-		simulationList[0].loadFrom(initialSim);
 	}
-}

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConfigDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConfigDialog.java
@@ -91,6 +91,12 @@ public class SimulationConfigDialog extends JDialog {
 		this.initialIsSaved = document.isSaved();
 		this.isNewSimulation = isNewSimulation;
 
+		if (simulationList.length == 1) {
+			document.addUndoPosition("Edit " + simulationList[0].getName());
+		} else {
+			document.addUndoPosition("Edit simulations");
+		}
+
 		simulationList[0].addChangeListener(new StateChangeListener() {
 			@Override
 			public void stateChanged(EventObject e) {

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConfigDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConfigDialog.java
@@ -89,22 +89,15 @@ public class SimulationConfigDialog extends JDialog {
 		this.initialIsSaved = document.isSaved();
 		this.isNewSimulation = isNewSimulation;
 
-		// Creating new sim
-		if (isNewSimulation) {
-			document.addUndoPosition("Add " + simulationList[0].getName());
+		if (simulationList.length == 1) {
+			document.addUndoPosition("Edit " + simulationList[0].getName());
+		} else {
+			document.addUndoPosition("Edit simulations");
 		}
 
 		simulationList[0].addChangeListener(new StateChangeListener() {
 			@Override
 			public void stateChanged(EventObject e) {
-				if (!isNewSimulation) {
-					if (simulationList.length == 1) {
-						document.addUndoPosition("Edit " + simulationList[0].getName());
-					} else {
-						document.addUndoPosition("Edit simulations");
-					}
-				}
-
 				isModified = true;
 				setTitle("* " + getTitle());			// Add component changed indicator to the title
 				simulationList[0].removeChangeListener(this);	// Only do this once


### PR DESCRIPTION
This PR fixes #1391 by supporting undo operations on simulations, namely undoing deleting a sim, adding a new sim, duplicating a sim, and editing a sim.