### PR TITLE
Set a non-zero minimum pressure

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/openrocket/importt/AtmosphereHandler.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/importt/AtmosphereHandler.java
@@ -48,7 +48,7 @@ class AtmosphereHandler extends AbstractElementHandler {
 			if (Double.isNaN(d)) {
 				warnings.add("Illegal base pressure specified, ignoring.");
 			}
-			pressure = d;
+			pressure = Math.max(d, 0.001); // Prevent zero or negative pressures.
 		} else {
 			super.closeElement(element, attributes, content, warnings);
 		}

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConditionsPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationConditionsPanel.java
@@ -164,7 +164,7 @@ public class SimulationConditionsPanel extends JPanel {
 		isa.addEnableComponent(label, false);
 		sub.add(label);
 
-		pressureModel = new DoubleModel(target, "LaunchPressure", UnitGroup.UNITS_PRESSURE, 0);
+		pressureModel = new DoubleModel(target, "LaunchPressure", UnitGroup.UNITS_PRESSURE, 0.001);
 
 		spin = new JSpinner(pressureModel.getSpinnerModel());
 		spin.setEditor(new SpinnerEditor(spin));


### PR DESCRIPTION
I recently had a user contact me that one of his simulations threw this exception:

```
 Caused by: java.lang.IllegalArgumentException: Pressure must be positive (Pascals)
at info.openrocket.core.models.atmosphere.ExtendedISAModel.<init>(ExtendedISAModel.java:106)
at info.openrocket.core.simulation.SimulationOptions.getAtmosphericModel(SimulationOptions.java:334)
at info.openrocket.core.simulation.SimulationOptions.toSimulationConditions(SimulationOptions.java:577)
at info.openrocket.core.document.Simulation.simulate(Simulation.java:490).
```

It turned out that he set his launch pressure to 0 mbar. PR #2970 already ensures that the user is notified of this issue in the UI, but this PR ensures that OR doesn't throw an exception when this happens. Instead, it forces a minimum pressure of 0.001 Pa instead of 0.