### PR TITLE
 [#1624] Implement undo/redo for fin shape editor 

### DIFF
--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -1569,6 +1569,8 @@ FreeformFinSetConfig.lbl.insertPoint = Insert point
 FreeformFinSetConfig.lbl.pointActions = Point Actions\u2026
 FreeformFinSetConfig.lbl.updateRocketWhileDraggingPoint = Live update the rocket
 FreeformFinSetConfig.lbl.updateRocketWhileDraggingPoint.ttip = <html>If enabled, the rocket figure will update in real-time while dragging points.<br>Disabling this improves performance but updates only occur when dragging is finished.</html>
+FreeformFinSetConfig.btn.undo.ttip = Undo last point edit
+FreeformFinSetConfig.btn.redo.ttip = Redo last point edit
 
 !TubeFinSetConfig
 TubeFinSetCfg.lbl.Nbroffins = Number of fins:

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/FreeformFinSetConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/FreeformFinSetConfig.java
@@ -3,10 +3,13 @@ package info.openrocket.swing.gui.configdialog;
 import java.awt.Component;
 import java.awt.Point;
 import java.awt.Rectangle;
+import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.geom.Point2D;
@@ -22,8 +25,10 @@ import java.util.List;
 
 import javax.swing.AbstractAction;
 import javax.swing.DefaultCellEditor;
+import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
+import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JFileChooser;
 import javax.swing.JLabel;
@@ -35,6 +40,7 @@ import javax.swing.JSpinner;
 import javax.swing.JSplitPane;
 import javax.swing.JTable;
 import javax.swing.JTextField;
+import javax.swing.KeyStroke;
 import javax.swing.ListSelectionModel;
 import javax.swing.SwingUtilities;
 import javax.swing.event.ListSelectionEvent;
@@ -98,6 +104,8 @@ public class FreeformFinSetConfig extends FinSetConfig {
 
 	private FinPointAction insertFinPointAction;
 	private FinPointAction deleteFinPointAction;
+	private JButton finPointUndoButton = null;
+	private JButton finPointRedoButton = null;
 	
 	public FreeformFinSetConfig(OpenRocketDocument d, RocketComponent component, JDialog parent) {
 		super(d, component, parent);
@@ -309,9 +317,14 @@ public class FreeformFinSetConfig extends FinSetConfig {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				log.info(Markers.USER_MARKER, "Scaling free-form fin");
-				ScaleDialog dialog = new ScaleDialog(document, new ArrayList<>(List.of(finset)), SwingUtilities.getWindowAncestor(FreeformFinSetConfig.this), true);
-				dialog.setVisible(true);
-				dialog.dispose();
+				beginFinPointEdit();
+				try {
+					ScaleDialog dialog = new ScaleDialog(document, new ArrayList<>(List.of(finset)), SwingUtilities.getWindowAncestor(FreeformFinSetConfig.this), true);
+					dialog.setVisible(true);
+					dialog.dispose();
+				} finally {
+					commitFinPointEdit();
+				}
 			}
 		});
 		
@@ -410,7 +423,25 @@ public class FreeformFinSetConfig extends FinSetConfig {
         panel.add(new StyledLabel(trans.get("FreeformFinSetConfig.lbl.ctrlShiftClickDrag"), -2), "spanx 2, wrap");
         
         // row of controls at the bottom of the tab:
-        panel.add(selector.getAsPanel(), "aligny bottom, gap unrel");
+		finPointUndoButton = new JButton(Icons.EDIT_UNDO);
+		finPointUndoButton.setToolTipText(trans.get("FreeformFinSetConfig.btn.undo.ttip"));
+		finPointUndoButton.setFocusable(false);
+		finPointUndoButton.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				performFinPointUndo();
+			}
+		});
+
+		finPointRedoButton = new JButton(Icons.EDIT_REDO);
+		finPointRedoButton.setToolTipText(trans.get("FreeformFinSetConfig.btn.redo.ttip"));
+		finPointRedoButton.setFocusable(false);
+		finPointRedoButton.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				performFinPointRedo();
+			}
+		});
         
         // Checkbox to control whether rocket updates during dragging
         JCheckBox liveUpdateCheckbox = new JCheckBox(trans.get("FreeformFinSetConfig.lbl.updateRocketWhileDraggingPoint"));
@@ -422,7 +453,16 @@ public class FreeformFinSetConfig extends FinSetConfig {
 				prefs.setUpdateRocketWhileDraggingPoint(liveUpdateCheckbox.isSelected());
 			}
 		});
-        panel.add(liveUpdateCheckbox, "aligny bottom, gap unrel");
+
+		JPanel bottomControlsPanel = new JPanel(new MigLayout("ins 0, gap 5!, align left", "[]", ""));
+		bottomControlsPanel.add(selector.getAsPanel());
+		bottomControlsPanel.add(finPointUndoButton, "gapleft para");
+		bottomControlsPanel.add(finPointRedoButton);
+		bottomControlsPanel.add(liveUpdateCheckbox, "gapleft para");
+		panel.add(bottomControlsPanel, "spanx, alignx left");
+
+		installFinPointUndoRedoKeyBindings(panel);
+		updateFinPointUndoRedoControls();
 		
 		//		panel.add(new CustomFinBmpImporter(finset), "spany 2, bottom");
 		
@@ -476,17 +516,26 @@ public class FreeformFinSetConfig extends FinSetConfig {
 		int option = chooser.showOpenDialog(this);
 		
 		if (option == JFileChooser.APPROVE_OPTION) {
+			boolean startedUndo = false;
+			beginFinPointEdit();
 			try {
 				CustomFinImporter importer = new CustomFinImporter();
 				ArrayList<CoordinateIF> points = importer.getPoints(chooser.getSelectedFile());
 				document.startUndo(trans.get("CustomFinImport.undo"));
+				startedUndo = true;
 				finset.setPoints( points);
 			} catch (IOException e) {
 				log.warn("Error loading file", e);
 				JOptionPane.showMessageDialog(this, e.getLocalizedMessage(),
 						trans.get("CustomFinImport.error.title"), JOptionPane.ERROR_MESSAGE);
 			} finally {
-				document.stopUndo();
+				try {
+					if (startedUndo) {
+						document.stopUndo();
+					}
+				} finally {
+					commitFinPointEdit();
+				}
 				Application.getPreferences().setDefaultDirectory(chooser.getCurrentDirectory());
 			}
 		}	
@@ -520,6 +569,8 @@ public class FreeformFinSetConfig extends FinSetConfig {
 		if (figurePane != null) {
 			figurePane.revalidate();
 		}
+
+		updateFinPointUndoRedoControls();
 	}
 
 	/**
@@ -535,7 +586,12 @@ public class FreeformFinSetConfig extends FinSetConfig {
 		CoordinateIF currentPoint = finSet.getFinPoints()[currentPointIdx];
 		CoordinateIF nextPoint = finSet.getFinPoints()[currentPointIdx + 1];
 		Point2D.Double toAdd = new Point2D.Double((currentPoint.getX() + nextPoint.getX()) / 2, (currentPoint.getY() + nextPoint.getY()) / 2);
-		finSet.addPoint(currentPointIdx + 1, toAdd);
+		beginFinPointEdit();
+		try {
+			finSet.addPoint(currentPointIdx + 1, toAdd);
+		} finally {
+			commitFinPointEdit();
+		}
 	}
 
 	/**
@@ -555,9 +611,12 @@ public class FreeformFinSetConfig extends FinSetConfig {
 		
 		final FreeformFinSet finSet = (FreeformFinSet) component;
 		try {
+			beginFinPointEdit();
 			finSet.removePoint(currentPointIdx);
 		} catch (IllegalFinPointException ex) {
 			throw new RuntimeException(ex);
+		} finally {
+			commitFinPointEdit();
 		}
 	}
 
@@ -590,6 +649,7 @@ public class FreeformFinSetConfig extends FinSetConfig {
 
 			final int pressIndex = getPoint(event);
 			if (pressIndex >= 0) {
+				beginFinPointEdit();
 				dragIndex = pressIndex;
 				dragPoint = event.getPoint();
 				
@@ -604,6 +664,7 @@ public class FreeformFinSetConfig extends FinSetConfig {
 
 			final int segmentIndex = getSegment(event);
 			if (segmentIndex >= 0) {
+				beginFinPointEdit();
 				Point2D.Double point = getCoordinates(event);
 				try {
 					finset.addPoint(segmentIndex, point);
@@ -786,6 +847,7 @@ public class FreeformFinSetConfig extends FinSetConfig {
 				dragPoint = null;
 				figure.setHighlightIndex(-1);
 				figure.updateFigure();
+				commitFinPointEdit();
 				
 				super.mouseReleased(event);
 			}
@@ -800,7 +862,12 @@ public class FreeformFinSetConfig extends FinSetConfig {
                     // if ctrl+click, delete point
                     try {
                         final FreeformFinSet finset = (FreeformFinSet)component;
-                        finset.removePoint(clickIndex);
+						beginFinPointEdit();
+						try {
+							finset.removePoint(clickIndex);
+						} finally {
+							commitFinPointEdit();
+						}
                     } catch (IllegalFinPointException ignore) {
                         log.error("Ignoring IllegalFinPointException while dragging, dragIndex=" + dragIndex + ".  This is likely an internal error.");
                     }
@@ -942,7 +1009,12 @@ public class FreeformFinSetConfig extends FinSetConfig {
 					c = c.setY(value);
 				}
 
-				finset.setPoint(rowIndex, c.getX(), c.getY());
+				beginFinPointEdit();
+				try {
+					finset.setPoint(rowIndex, c.getX(), c.getY());
+				} finally {
+					commitFinPointEdit();
+				}
 				
 				updateFields();
 			} catch (NumberFormatException ignore) {
@@ -951,6 +1023,96 @@ public class FreeformFinSetConfig extends FinSetConfig {
 				throw new RuntimeException(e);
 			}
 		}
+	}
+
+	/**
+	 * Call before beginning an undoable edit of fin points.
+	 */
+	private void beginFinPointEdit() {
+		if (figure != null) {
+			figure.beginUndoableEdit();
+		}
+		updateFinPointUndoRedoControls();
+	}
+
+	/**
+	 * Call after completing an undoable edit of fin points.
+	 */
+	private void commitFinPointEdit() {
+		if (figure != null) {
+			figure.commitUndoableEdit();
+		}
+		updateFinPointUndoRedoControls();
+	}
+
+	/**
+	 * Perform an undo of the last fin point edit.
+	 */
+	private void performFinPointUndo() {
+		if (figure == null) {
+			return;
+		}
+		if (dragIndex >= 0 || figure.isUndoableEditInProgress()) {
+			return;
+		}
+		figure.undo();
+		updateFinPointUndoRedoControls();
+	}
+
+	/**
+	 * Perform a redo of the last undone fin point edit.
+	 */
+	private void performFinPointRedo() {
+		if (figure == null) {
+			return;
+		}
+		if (dragIndex >= 0 || figure.isUndoableEditInProgress()) {
+			return;
+		}
+		figure.redo();
+		updateFinPointUndoRedoControls();
+	}
+
+	/**
+	 * Update the enabled state of the fin point undo/redo buttons.
+	 */
+	private void updateFinPointUndoRedoControls() {
+		if (figure == null) {
+			return;
+		}
+
+		final boolean busy = dragIndex >= 0 || figure.isUndoableEditInProgress();
+		if (finPointUndoButton != null) {
+			finPointUndoButton.setEnabled(!busy && figure.canUndo());
+		}
+		if (finPointRedoButton != null) {
+			finPointRedoButton.setEnabled(!busy && figure.canRedo());
+		}
+	}
+
+	/**
+	 * Install undo/redo key bindings for fin point editing on the given component.
+	 * @param component The component to install the key bindings on
+	 */
+	private void installFinPointUndoRedoKeyBindings(JComponent component) {
+		// Always consume the keystroke while editing fin points so global (document-level) undo/redo isn't triggered.
+		component.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(
+				KeyStroke.getKeyStroke(KeyEvent.VK_Z, InputEvent.META_DOWN_MASK), "finPointUndo");
+		component.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(
+				KeyStroke.getKeyStroke(KeyEvent.VK_Y, InputEvent.META_DOWN_MASK), "finPointRedo");
+
+		component.getActionMap().put("finPointUndo", new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				performFinPointUndo();
+			}
+		});
+		component.getActionMap().put("finPointRedo", new AbstractAction() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				performFinPointRedo();
+			}
+		});
 	}
 
 	private abstract static class FinPointAction extends AbstractAction {

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/FreeformFinSetConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/FreeformFinSetConfig.java
@@ -573,6 +573,17 @@ public class FreeformFinSetConfig extends FinSetConfig {
 		updateFinPointUndoRedoControls();
 	}
 
+	@Override
+	public void removeNotify() {
+		try {
+			if (figure != null) {
+				figure.dispose();
+			}
+		} finally {
+			super.removeNotify();
+		}
+	}
+
 	/**
 	 * Insert a new fin point between the currently selected point and the next point.
 	 * The coordinates of the new point will be the average of the two points.

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/FinPointFigure.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/FinPointFigure.java
@@ -12,12 +12,13 @@ import java.awt.geom.NoninvertibleTransformException;
 import java.awt.geom.Path2D;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
+import info.openrocket.core.document.OpenRocketDocument;
 import info.openrocket.core.util.CoordinateIF;
 import info.openrocket.core.util.Coordinate;
-import info.openrocket.swing.gui.util.GUIUtil;
 import info.openrocket.swing.gui.theme.UITheme;
 import info.openrocket.core.rocketcomponent.FreeformFinSet;
 import info.openrocket.core.rocketcomponent.RocketComponent;
@@ -52,6 +53,7 @@ public class FinPointFigure extends AbstractScaleFigure {
 
 	private final FreeformFinSet finset;
 	private ModID modID = ModID.INVALID;
+	private final FinPointEditHistory editHistory;
 
 	protected BoundingBox finBounds_m = null;
 	// Fin parent bounds
@@ -78,6 +80,7 @@ public class FinPointFigure extends AbstractScaleFigure {
 	
 	public FinPointFigure(FreeformFinSet finset) {
 		this.finset = finset;
+		this.editHistory = new FinPointEditHistory(finset, OpenRocketDocument.UNDO_LEVELS);
 
 		setBackground(backgroundColor);
 		setOpaque(true);
@@ -480,12 +483,286 @@ public class FinPointFigure extends AbstractScaleFigure {
 		this.selectedIndex = -1;
 	}
 
+	/**
+	 * Sets the index of the currently selected fin point.
+	 * @param newIndex The index of the selected fin point.
+	 */
 	public void setSelectedIndex(final int newIndex) {
 		this.selectedIndex = newIndex;
 	}
 
+	/**
+	 * Sets the index of the segment to highlight when snapping to a fin point.
+	 * @param newIndex The index of the starting point of the segment to highlight.
+	 */
 	public void setHighlightIndex(final int newIndex) {
 		this.highlightIndex = newIndex;
+	}
+
+	/**
+	 * Must be called before starting an undoable edit.
+	 */
+	public void beginUndoableEdit() {
+		editHistory.beginEdit();
+	}
+
+	/**
+	 * Must be called to commit the current undoable edit (after you performed the fin point edit).
+	 */
+	public void commitUndoableEdit() {
+		editHistory.commitEdit();
+	}
+
+	/**
+	 * Returns whether an undoable edit is currently in progress.
+	 * @return true if an edit is in progress, false otherwise.
+	 */
+	public boolean isUndoableEditInProgress() {
+		return editHistory.isEditInProgress();
+	}
+
+	/**
+	 * Returns whether an undo is possible.
+	 * @return true if an undo can be performed, false otherwise.
+	 */
+	public boolean canUndo() {
+		return editHistory.canUndo();
+	}
+
+	/**
+	 * Returns whether a redo is possible.
+	 * @return true if a redo can be performed, false otherwise.
+	 */
+	public boolean canRedo() {
+		return editHistory.canRedo();
+	}
+
+	/**
+	 * Undoes the last fin point edit.
+	 */
+	public void undo() {
+		editHistory.undo();
+	}
+
+	/**
+	 * Redoes the last undone fin point edit.
+	 */
+	public void redo() {
+		editHistory.redo();
+	}
+
+	/**
+	 * Class to manage the undo/redo history of fin point edits.
+	 */
+	private static final class FinPointEditHistory {
+		private final FreeformFinSet finset;
+		private final int maxSize;
+
+		private final ArrayList<CoordinateIF[]> history = new ArrayList<>();
+		private int position = -1;
+
+		private CoordinateIF[] pendingBefore = null;
+		private boolean editInProgress = false;
+		private boolean applying = false;
+
+		private FinPointEditHistory(FreeformFinSet finset, int maxSize) {
+			this.finset = finset;
+			this.maxSize = Math.max(1, maxSize);
+			reset();
+		}
+
+		/**
+		 * Resets the history to contain only the current fin points.
+		 */
+		private void reset() {
+			history.clear();
+			history.add(snapshotCurrent());
+			position = 0;
+		}
+
+		/**
+		 * Returns whether an undo is possible.
+		 * @return true if an undo can be performed, false otherwise.
+		 */
+		private boolean canUndo() {
+			return position > 0;
+		}
+
+		/**
+		 * Returns whether a redo is possible.
+		 * @return true if a redo can be performed, false otherwise.
+		 */
+		private boolean canRedo() {
+			return position >= 0 && position < history.size() - 1;
+		}
+
+		/**
+		 * Returns whether an edit is currently in progress.
+		 * @return true if an edit is in progress, false otherwise.
+		 */
+		private boolean isEditInProgress() {
+			return editInProgress || applying;
+		}
+
+		/**
+		 * Begins an edit, storing the current fin points as the "before" state.
+		 */
+		private void beginEdit() {
+			if (applying || editInProgress) {
+				return;
+			}
+			pendingBefore = snapshotCurrent();
+			editInProgress = true;
+		}
+
+		/**
+		 * Commits the current edit, pushing it to the history if there was a change.
+		 */
+		private void commitEdit() {
+			if (applying || !editInProgress) {
+				return;
+			}
+
+			final CoordinateIF[] before = pendingBefore;
+			pendingBefore = null;
+			editInProgress = false;
+
+			final CoordinateIF[] after = snapshotCurrent();
+			if (before != null && !snapshotsEqual(before, after)) {
+				push(after);
+			}
+		}
+
+		/**
+		 * Undoes the last edit.
+		 */
+		private void undo() {
+			if (isEditInProgress() || !canUndo()) {
+				return;
+			}
+			position--;
+			applyFromHistory();
+		}
+
+		/**
+		 * Redoes the last undone edit.
+		 */
+		private void redo() {
+			if (isEditInProgress() || !canRedo()) {
+				return;
+			}
+			position++;
+			applyFromHistory();
+		}
+
+		/**
+		 * Applies the fin points at the current position in history to the finset.
+		 */
+		private void applyFromHistory() {
+			if (position < 0 || position >= history.size()) {
+				return;
+			}
+
+			applying = true;
+			try {
+				finset.setPoints(deepCopy(history.get(position)));
+			} finally {
+				applying = false;
+			}
+		}
+
+		/**
+		 * Pushes a new snapshot onto the history, discarding any redo states.
+		 * @param snapshot The snapshot to push.
+		 */
+		private void push(CoordinateIF[] snapshot) {
+			// Discard redo states
+			if (position < history.size() - 1) {
+				history.subList(position + 1, history.size()).clear();
+			}
+
+			// Don't add duplicates
+			if (!history.isEmpty() && snapshotsEqual(history.get(position), snapshot)) {
+				return;
+			}
+
+			history.add(deepCopy(snapshot));
+			position = history.size() - 1;
+
+			// Limit size
+			while (history.size() > maxSize) {
+				history.remove(0);
+				position = Math.max(0, position - 1);
+			}
+		}
+
+		/**
+		 * Takes a snapshot of the current fin points.
+		 * @return A deep copy of the current fin points.
+		 */
+		private CoordinateIF[] snapshotCurrent() {
+			return deepCopy(finset.getFinPoints());
+		}
+
+		/**
+		 * Creates a deep copy of the given array of CoordinateIF.
+		 * @param points The array to copy.
+		 * @return A deep copy of the array.
+		 */
+		private static CoordinateIF[] deepCopy(CoordinateIF[] points) {
+			if (points == null) {
+				return new CoordinateIF[0];
+			}
+			CoordinateIF[] copy = new CoordinateIF[points.length];
+			for (int i = 0; i < points.length; i++) {
+				CoordinateIF p = points[i];
+				copy[i] = (p == null) ? Coordinate.NaN : new Coordinate(p.getX(), p.getY(), p.getZ(), p.getWeight());
+			}
+			return copy;
+		}
+
+		/**
+		 * Compares two snapshots of CoordinateIF arrays for equality.
+		 * @param a The first snapshot.
+		 * @param b The second snapshot.
+		 * @return true if the snapshots are equal, false otherwise.
+		 */
+		private static boolean snapshotsEqual(CoordinateIF[] a, CoordinateIF[] b) {
+			if (a == b) {
+				return true;
+			}
+			if (a == null || b == null) {
+				return false;
+			}
+			if (a.length != b.length) {
+				return false;
+			}
+
+			for (int i = 0; i < a.length; i++) {
+				CoordinateIF p1 = a[i];
+				CoordinateIF p2 = b[i];
+				if (p1 == p2) {
+					continue;
+				}
+				if (p1 == null || p2 == null) {
+					return false;
+				}
+				if (!MathUtil.equals(p1.getX(), p2.getX())) {
+					return false;
+				}
+				if (!MathUtil.equals(p1.getY(), p2.getY())) {
+					return false;
+				}
+				if (!MathUtil.equals(p1.getZ(), p2.getZ())) {
+					return false;
+				}
+				if (!MathUtil.equals(p1.getWeight(), p2.getWeight())) {
+					return false;
+				}
+			}
+
+			return true;
+		}
 	}
 
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/FinPointFigure.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/FinPointFigure.java
@@ -552,6 +552,14 @@ public class FinPointFigure extends AbstractScaleFigure {
 	}
 
 	/**
+	 * Clears undo/redo history snapshots so any deep-copied point arrays can be garbage-collected.
+	 * This is intended to be called when the owning dialog/figure is disposed.
+	 */
+	public void dispose() {
+		editHistory.clear();
+	}
+
+	/**
 	 * Class to manage the undo/redo history of fin point edits.
 	 */
 	private static final class FinPointEditHistory {
@@ -631,6 +639,14 @@ public class FinPointFigure extends AbstractScaleFigure {
 			if (before != null && !snapshotsEqual(before, after)) {
 				push(after);
 			}
+		}
+
+		private void clear() {
+			history.clear();
+			position = -1;
+			pendingBefore = null;
+			editInProgress = false;
+			applying = false;
 		}
 
 		/**


### PR DESCRIPTION
Fixes #1624. You can now undo/redo changes made in the fin set shape editor by either using Ctrl/Cmd+z and Ctrl/Cmd+y (it overrides the default OpenRocket undo/redo shortcut) or by clicking the undo/redo buttons next to the scale selector.


https://github.com/user-attachments/assets/bcdcb2f2-0ac6-405c-a743-c3dc3891e4c5

