### PR TITLE
[#2731] Fix geopotential-geometric altitude conversion in ISA model

### DIFF
--- a/core/src/main/java/info/openrocket/core/models/atmosphere/ExtendedISAModel.java
+++ b/core/src/main/java/info/openrocket/core/models/atmosphere/ExtendedISAModel.java
@@ -8,14 +8,15 @@ import info.openrocket.core.util.ModID;
  * An atmospheric model based on the International Standard Atmosphere (ISA)
  * with extensions for custom launch site conditions. This model divides the
  * atmosphere into distinct layers based on the ISA standard, each with its
- * own temperature and pressure characteristics.
- *
+ * own temperature and pressure characteristics. It is based on geopotential
+ * altitudes.
+ * <p>
  * Key Features:
  * 1. Implements standard ISA model by default
  * 2. Supports custom launch site conditions
  * 3. Maintains ISA behavior above launch site
  * 4. Uses interpolation for efficient computation
- *
+ * <p>
  * Layer Structure:
  * - 0-11km (Troposphere): Temperature decreases linearly (288.15K -> 216.65K, -6.5 degC/km)
  * - 11-20km (Tropopause): Temperature constant (216.65K)
@@ -25,12 +26,12 @@ import info.openrocket.core.util.ModID;
  * - 51-71km (Mesosphere 1): Temperature decreases linearly (270.65K -> 214.65K, -2.8 degC/km)
  * - 71-84.852km (Mesosphere 2): Temperature decreases linearly (214.65K -> 186.95K, -2.0 degC/km)
  * - > 84.852km (Mesopause): Temperature constant (186.95K)
- *
+ * <p>
  * Usage:
  * 1. Standard ISA: new ExtendedISAModel()
  * 2. Custom sea level: new ExtendedISAModel(temperature, pressure)
  * 3. Custom altitude: new ExtendedISAModel(altitude, temperature, pressure)
- *
+ * <p>
  *
  * TODO: LOW: Values at altitudes over 32km differ from standard results by ~5%.
  *
@@ -49,9 +50,12 @@ public class ExtendedISAModel extends InterpolatingAtmosphericModel {
 	/** Gravitational acceleration in m/s2 */
 	private static final double G = 9.80665;
 
+	/** ISA reference Earth radius in meters for geopotential altitude conversion */
+	private static final double ISA_EARTH_RADIUS = 6356766.0;
+
 	/**
 	 * ISA atmospheric layers.
-	 * Each element represents the altitude in meters where a new layer begins.
+	 * Each element represents the geopotential altitude in meters where a new layer begins.
 	 */
 	private static final double[] STANDARD_LAYERS = { 0, 11000, 20000, 32000, 47000, 51000, 71000, 84852 };
 	/**
@@ -102,19 +106,20 @@ public class ExtendedISAModel extends InterpolatingAtmosphericModel {
 
 	/**
 	 * Construct an extended model with the given temperature and pressure at the
-	 * specified altitude. Conditions below the given altitude cannot be calculated,
+	 * specified geometric altitude. Conditions below the given altitude cannot be calculated,
 	 * and the values at the specified altitude will be returned instead. The
 	 * altitude
 	 * must be lower than the altitude of the next ISA standard layer (below 11km).
 	 * 
-	 * @param altitude    the altitude of the measurements.
+	 * @param altitude    the geometric altitude of the measurements.
 	 * @param temperature the temperature.
 	 * @param pressure    the pressure.
-	 * @param relativeHumidity    the relative humdity.
+	 * @param relativeHumidity    the relative humidity.
 	 * @throws IllegalArgumentException if the altitude exceeds the second layer boundary of the ISA model (over 11km).
 	 */
 	public ExtendedISAModel(double altitude, double temperature, double pressure, double relativeHumidity) {
-		if (altitude >= STANDARD_LAYERS[1]) {
+		double geopotentialAltitude = geometricToGeopotential(altitude);
+		if (geopotentialAltitude >= STANDARD_LAYERS[1]) {
 			throw new IllegalArgumentException("Too high first altitude: " + altitude);
 		}
 		if (temperature <= 0) {
@@ -141,19 +146,19 @@ public class ExtendedISAModel extends InterpolatingAtmosphericModel {
 			double layer1Temp = STANDARD_TEMPERATURES[1];
 
 			// Calculate temperature lapse rate between altitude and 11km
-			double tempRate = (layer1Temp - temperature) / (layer1Alt - altitude);
+			double tempRate = (layer1Temp - temperature) / (layer1Alt - geopotentialAltitude);
 
 			// Back-calculate sea level temperature using the same lapse rate
-			double seaLevelTemp = temperature - tempRate * altitude;
+			double seaLevelTemp = temperature - tempRate * geopotentialAltitude;
 
 			// Set up the layers
 			layer[0] = 0;                  // Sea level
-			layer[1] = altitude;           // Custom altitude
+			layer[1] = geopotentialAltitude;           // Custom altitude
 			baseTemperature[0] = seaLevelTemp;
 			baseTemperature[1] = temperature;
-			basePressure[0] = calculatePressure(0, seaLevelTemp, altitude, temperature, pressure);
+			basePressure[0] = calculatePressure(0, seaLevelTemp, geopotentialAltitude, temperature, pressure);
 			basePressure[1] = pressure;
-			baseRelativeHumidity[0] = calculateRelativeHumidity(altitude, 0, relativeHumidity);
+			baseRelativeHumidity[0] = calculateRelativeHumidity(geopotentialAltitude, 0, relativeHumidity);
 			baseRelativeHumidity[1] = relativeHumidity;
 
 			// Copy remaining standard layers
@@ -174,31 +179,33 @@ public class ExtendedISAModel extends InterpolatingAtmosphericModel {
 
 		// Calculate pressures and relative relativeHumidity for all remaining layers
 		for (int i = (altitude > 0 ? 2 : 1); i < basePressure.length; i++) {
-			basePressure[i] = getExactConditions(layer[i] - 1).getPressure();
-			baseRelativeHumidity[i] = getExactConditions(layer[i] - 1).getRelativeHumidity();
+			double sampleAltitude = geopotentialToGeometric(layer[i] - 1);
+			basePressure[i] = getExactConditions(sampleAltitude).getPressure();
+			baseRelativeHumidity[i] = getExactConditions(sampleAltitude).getRelativeHumidity();
 		}
 	}
 
 	/**
-	 * Calculates exact atmospheric conditions at the specified altitude by interpolating between ISA layers.
+	 * Calculates exact atmospheric conditions at the specified geometric altitude by interpolating between ISA layers.
 	 * The pressure is calculated using the barometric formula, and the temperature is interpolated linearly.
-	 * @param altitude The altitude in meters
+	 * @param altitude The geometric altitude in meters
 	 * @return Atmospheric conditions at the specified altitude
 	 */
 	@Override
 	protected AtmosphericConditions getExactConditions(double altitude) {
+		double geopotentialAltitude = geometricToGeopotential(altitude);
 		// Clamp altitude to be within defined layers
-		altitude = MathUtil.clamp(altitude, layer[0], layer[layer.length - 1]);
+		geopotentialAltitude = MathUtil.clamp(geopotentialAltitude, layer[0], layer[layer.length - 1]);
 
 		// Find the correct layer
 		int startLayer;
 		for (startLayer = 0; startLayer < layer.length - 1; startLayer++) {
-			if (layer[startLayer + 1] > altitude) {
+			if (layer[startLayer + 1] > geopotentialAltitude) {
 				break;
 			}
 		}
 
-		double altDiff = altitude - layer[startLayer];
+		double altDiff = geopotentialAltitude - layer[startLayer];
 
 		double startTemp = baseTemperature[startLayer];
 		// Temperature lapse rate
@@ -206,15 +213,15 @@ public class ExtendedISAModel extends InterpolatingAtmosphericModel {
 
 		double temp = startTemp + altDiff * tempRate;
 		double startPress = basePressure[startLayer];
-		double press = calculatePressure(altitude, temp, layer[startLayer], startTemp, startPress);
+		double press = calculatePressure(geopotentialAltitude, temp, layer[startLayer], startTemp, startPress);
 		double startHumid = baseRelativeHumidity[startLayer];
-		double humid = calculateRelativeHumidity(altitude, layer[startLayer], startHumid);
+		double humid = calculateRelativeHumidity(geopotentialAltitude, layer[startLayer], startHumid);
 
 		return new AtmosphericConditions(temp, press, humid);
 	}
 
 	/**
-	 * Calculate pressure at sea level given conditions at altitude.
+	 * Calculate pressure at sea level given conditions at geopotential altitude.
 	 * Uses the barometric formula (<a href="https://en.wikipedia.org/wiki/Barometric_formula">source</a>).
 	 */
 	private double calculatePressure(double alt1, double temp1, double alt2, double temp2, double press2) {
@@ -229,11 +236,11 @@ public class ExtendedISAModel extends InterpolatingAtmosphericModel {
 	}
 
 	/**
-	 * Calculate relative humidity at a different altitude.
-	 * @param altSource Source altitude
-	 * @param altTarget Target altitude
+	 * Calculate relative humidity at a different geopotential altitude.
+	 * @param altSource Source geopotential altitude
+	 * @param altTarget Target geopotential altitude
 	 * @param relativeHumiditySource Relative humidity at the source altitude
-	 * @return the relative humidity at the target altitude
+	 * @return the relative humidity at the target geopotential altitude
 	 */
 	private double calculateRelativeHumidity(double altSource, double altTarget, double relativeHumiditySource) {
         // TODO: Implement changing humidity based on altitude.
@@ -242,15 +249,23 @@ public class ExtendedISAModel extends InterpolatingAtmosphericModel {
 
 	@Override
 	protected double getMaxAltitude() {
-		return layer[layer.length - 1];
+		return geopotentialToGeometric(layer[layer.length - 1]);
 	}
 
 	/**
 	 * Get the maximum allowed launch site altitude where the model is valid.
-	 * @return The maximum altitude in meters
+	 * @return The maximum geometric altitude in meters
 	 */
 	public static double getMaximumAllowedAltitude() {
-		return STANDARD_LAYERS[1] - 1;
+		return geopotentialToGeometric(STANDARD_LAYERS[1] - 1);
+	}
+
+	private static double geometricToGeopotential(double geometricAltitude) {
+		return ISA_EARTH_RADIUS * geometricAltitude / (ISA_EARTH_RADIUS + geometricAltitude);
+	}
+
+	private static double geopotentialToGeometric(double geopotentialAltitude) {
+		return ISA_EARTH_RADIUS * geopotentialAltitude / (ISA_EARTH_RADIUS - geopotentialAltitude);
 	}
 
 	public static void main(String[] foo) {

--- a/core/src/test/java/info/openrocket/core/models/atmosphere/ExtendedISAModelTest.java
+++ b/core/src/test/java/info/openrocket/core/models/atmosphere/ExtendedISAModelTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 
 public class ExtendedISAModelTest {
+	private static final double ISA_GRAVITY = 9.80665;
 	private ExtendedISAModel standardModel;
 	private ExtendedISAModel customModel;
 	private ExtendedISAModel altitudeModel;
@@ -115,11 +116,24 @@ public class ExtendedISAModelTest {
 		AtmosphericConditions conditions500 = altitudeModel.getConditions(500.0);
 		AtmosphericConditions conditions0 = altitudeModel.getConditions(0.0);
 
+		double launchTemperature = 281.15;
+		double launchPressure = 89876.0;
+		double geopotentialLaunch = 999.8427120469674;
+		double layer1Alt = 11000.0;
+		double layer1Temp = 216.65;
+		double tempRate = (layer1Temp - launchTemperature) / (layer1Alt - geopotentialLaunch);
+		double seaLevelTemp = launchTemperature - tempRate * geopotentialLaunch;
+		double seaLevelPressure = calculatePressure(0, seaLevelTemp, geopotentialLaunch, launchTemperature, launchPressure);
+
+		double geopotential500 = 499.9606749190611;
+		double expectedTemp500 = seaLevelTemp + tempRate * geopotential500;
+		double expectedPressure500 = calculatePressure(geopotential500, expectedTemp500, 0, seaLevelTemp, seaLevelPressure);
+
 		// Should return launch site conditions for any altitude below launch site
-		assertEquals(284.375, conditions500.getTemperature(), 0.01);
-		assertEquals(95472.8, conditions500.getPressure(), 0.01);
-		assertEquals(287.6, conditions0.getTemperature(), 0.01);
-		assertEquals(101349.04, conditions0.getPressure(), 0.01);
+		assertEquals(expectedTemp500, conditions500.getTemperature(), 0.01);
+		assertEquals(expectedPressure500, conditions500.getPressure(), 0.01);
+		assertEquals(seaLevelTemp, conditions0.getTemperature(), 0.01);
+		assertEquals(seaLevelPressure, conditions0.getPressure(), 0.01);
 	}
 
 	@Test
@@ -303,5 +317,56 @@ public class ExtendedISAModelTest {
 		assertEquals(0.0, model.getConditions(0).getRelativeHumidity(), 1e-12);
 		assertEquals(0.25, model.getConditions(250).getRelativeHumidity(), 1e-12);
 		assertEquals(0.5, model.getConditions(500).getRelativeHumidity(), 1e-12);
+	}
+
+	@Test
+	@DisplayName("Geometric altitude should be converted to geopotential for ISA temperature")
+	void testGeopotentialConversionForTemperature() {
+		double geometricAltitude = 32000.0;
+		double geopotentialAltitude = 31839.71865615363;
+		double expectedTemp = expectedISATemperature(geopotentialAltitude);
+
+		AtmosphericConditions conditions = standardModel.getConditions(geometricAltitude);
+		assertEquals(expectedTemp, conditions.getTemperature(), 0.03);
+	}
+
+	@Test
+	@DisplayName("Maximum allowed altitude should be based on geometric altitude")
+	void testMaximumAllowedAltitudeUsesGeometric() {
+		double expected = 11018.064362274883;
+		assertEquals(expected, ExtendedISAModel.getMaximumAllowedAltitude(), 1e-6);
+	}
+
+	private static double expectedISATemperature(double geopotentialAltitude) {
+		if (geopotentialAltitude <= 11000.0) {
+			return 288.15 - 0.0065 * geopotentialAltitude;
+		}
+		if (geopotentialAltitude <= 20000.0) {
+			return 216.65;
+		}
+		if (geopotentialAltitude <= 32000.0) {
+			return 216.65 + 0.001 * (geopotentialAltitude - 20000.0);
+		}
+		if (geopotentialAltitude <= 47000.0) {
+			return 228.65 + 0.0028 * (geopotentialAltitude - 32000.0);
+		}
+		if (geopotentialAltitude <= 51000.0) {
+			return 270.65;
+		}
+		if (geopotentialAltitude <= 71000.0) {
+			return 270.65 - 0.0028 * (geopotentialAltitude - 51000.0);
+		}
+		if (geopotentialAltitude <= 84852.0) {
+			return 214.65 - 0.0020 * (geopotentialAltitude - 71000.0);
+		}
+		return 186.95;
+	}
+
+	private static double calculatePressure(double alt1, double temp1, double alt2, double temp2, double press2) {
+		double tempRate = (temp2 - temp1) / (alt2 - alt1);
+		if (Math.abs(tempRate) > 0.000001) {
+			return press2 / Math.pow(1 + (alt2 - alt1) * tempRate / temp1, -ISA_GRAVITY / (tempRate * AtmosphericConditions.R));
+		}
+		return press2 / Math.exp(-(alt2 - alt1) * ISA_GRAVITY / (AtmosphericConditions.R * temp1));
 	}
 }


### PR DESCRIPTION
Fixes #2731. The ISA model now correctly converts the geometric altitude parameters to geopotential altitudes for its internal calculations.