### PR TITLE
[#2998] Set pressure drag of tangent ogive nose cone to 0

### DIFF
--- a/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/SymmetricComponentCalc.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/SymmetricComponentCalc.java
@@ -86,7 +86,11 @@ public class SymmetricComponentCalc extends RocketComponentCalc {
 			frontalArea = Math.abs(Math.PI * (foreRadius * foreRadius - aftRadius * aftRadius));
 
 			double r = component.getRadius(0.99 * length);
-			sinphi = (aftRadius - r) / MathUtil.hypot(aftRadius - r, 0.01 * length);
+			if (shape.equals(Transition.Shape.OGIVE) && param == 1.0) {
+				sinphi = 0; // special case: tangent ogive
+			} else {
+				sinphi = (aftRadius - r) / MathUtil.hypot(aftRadius - r, 0.01 * length);
+			}
 		} else {
 			throw new UnsupportedOperationException("Unknown component type " +
 					component.getComponentName());
@@ -223,16 +227,15 @@ public class SymmetricComponentCalc extends RocketComponentCalc {
 
 	/*
 	 * Experimental values of pressure drag for different nose cone shapes with a
-	 * fineness
-	 * ratio of 3. The data is taken from 'Collection of Zero-Lift Drag Data on
-	 * Bodies
-	 * of Revolution from Free-Flight Investigations', NASA TR-R-100, NTRS
+	 * fineness ratio of 3. The data is taken from 'Collection of Zero-Lift Drag Data on
+	 * Bodies of Revolution from Free-Flight Investigations', NASA TR-R-100, NTRS
 	 * 19630004995,
 	 * page 16.
 	 * 
 	 * This data is extrapolated for other fineness ratios.
 	 */
 
+	// Format: array of {Mach numbers}, array of {Cd values}
 	private static final LinearInterpolator ellipsoidInterpolator = new LinearInterpolator(
 			new double[] { 1.2, 1.25, 1.3, 1.4, 1.6, 2.0, 2.4 },
 			new double[] { 0.110, 0.128, 0.140, 0.148, 0.152, 0.159, 0.162 /* constant */ });
@@ -294,11 +297,9 @@ public class SymmetricComponentCalc extends RocketComponentCalc {
 
 		/*
 		 * Take into account nose cone shape. Conical and ogive generate the
-		 * interpolator
-		 * directly. Others store a interpolator for fineness ratio 3 into int1, or
-		 * for parameterized shapes store the bounding fineness ratio 3 interpolators
-		 * into
-		 * int1 and int2 and set 0 <= p <= 1 according to the bounds.
+		 * interpolator directly. Others store a interpolator for fineness ratio 3 into int1,
+		 * or for parameterized shapes store the bounding fineness ratio 3 interpolators
+		 * into int1 and int2 and set 0 <= p <= 1 according to the bounds.
 		 */
 		switch (shape) {
 			case CONICAL:
@@ -416,8 +417,7 @@ public class SymmetricComponentCalc extends RocketComponentCalc {
 	private static final PolyInterpolator conicalPolyInterpolator = new PolyInterpolator(new double[] { 1.0, 1.3 },
 			new double[] { 1.0, 1.3 });
 
-	private static LinearInterpolator calculateOgiveNoseInterpolator(double param,
-			double sinphi) {
+	private static LinearInterpolator calculateOgiveNoseInterpolator(double param, double sinphi) {
 		LinearInterpolator interpolator = new LinearInterpolator();
 
 		// In the range M = 1 ... 1.3 use polynomial approximation


### PR DESCRIPTION
Fixes #2998. For tangent ogive nose cones (param = 1), the pressure drag is now set to 0, instead of a very small value caused by the calculation of the joint angle (more information [here](https://github.com/openrocket/openrocket/issues/2998#issuecomment-3708280872)).