### PR TITLE
Import and export component 2D and 3D appearance for RockSim (no texture)

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/rocksim/RockSimCommonConstants.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/RockSimCommonConstants.java
@@ -90,6 +90,12 @@ public class RockSimCommonConstants {
     public static final String TEXTURE = "Texture";
     public static final String TUBE_COUNT = "TubeCount";
     public static final String MAX_TUBES_ALLOWED = "MaxTubesAllowed";
+    public static final String COLOR = "Color";
+    public static final String DIFFUSE_COLOR = "DiffuseColor";
+    public static final String AMBIENT_COLOR = "AbientColor";       // This is not a typo! This is how RockSim spells it.
+    public static final String SPECULAR_COLOR = "SpecularColor";
+    public static final String USE_SINGLE_COLOR = "UseSingleColor";
+    public static final String OPACITY = "Opacity";
 
     /**
      * Length conversion. RockSim is in millimeters, OpenRocket in meters.

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/BasePartDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/BasePartDTO.java
@@ -5,18 +5,32 @@ import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 
+import info.openrocket.core.appearance.Appearance;
 import info.openrocket.core.file.rocksim.RockSimCommonConstants;
 import info.openrocket.core.file.rocksim.RockSimDensityType;
 import info.openrocket.core.file.rocksim.RockSimFinishCode;
 import info.openrocket.core.file.rocksim.RockSimLocationMode;
 import info.openrocket.core.file.rocksim.importt.BaseHandler;
+import info.openrocket.core.rocketcomponent.BodyComponent;
 import info.openrocket.core.rocketcomponent.ExternalComponent;
 import info.openrocket.core.rocketcomponent.FinSet;
+import info.openrocket.core.rocketcomponent.InternalComponent;
+import info.openrocket.core.rocketcomponent.LaunchLug;
+import info.openrocket.core.rocketcomponent.MassObject;
+import info.openrocket.core.rocketcomponent.PodSet;
+import info.openrocket.core.rocketcomponent.ParallelStage;
+import info.openrocket.core.rocketcomponent.RailButton;
 import info.openrocket.core.rocketcomponent.RecoveryDevice;
 import info.openrocket.core.rocketcomponent.RingComponent;
 import info.openrocket.core.rocketcomponent.RocketComponent;
 import info.openrocket.core.rocketcomponent.StructuralComponent;
+import info.openrocket.core.rocketcomponent.TubeFinSet;
 import info.openrocket.core.rocketcomponent.position.AxialMethod;
+import info.openrocket.core.util.ORColor;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * The base class for all OpenRocket to RockSim conversions.
@@ -57,6 +71,14 @@ public abstract class BasePartDTO {
     private double radialLoc = 0;
     @XmlElement(name = RockSimCommonConstants.RADIAL_ANGLE)
     private double radialAngle = 0;
+    @XmlElement(name = RockSimCommonConstants.OPACITY)
+    private double opacity = 1;
+    @XmlElement(name = RockSimCommonConstants.DIFFUSE_COLOR)
+    private String diffuseColor;
+    @XmlElement(name = RockSimCommonConstants.AMBIENT_COLOR)
+    private String ambientColor;
+    @XmlElement(name = RockSimCommonConstants.USE_SINGLE_COLOR)
+    private int useSingleColor = 1;
     @XmlElement(name = RockSimCommonConstants.LOCATION_MODE)
     private int locationMode = 0;
     @XmlElement(name = RockSimCommonConstants.LEN, required = false, nillable = false)
@@ -65,6 +87,23 @@ public abstract class BasePartDTO {
     private int finishCode = 0;
     @XmlElement(name = RockSimCommonConstants.SERIAL_NUMBER)
     private int serialNumber = -1;
+    @XmlElement(name = RockSimCommonConstants.COLOR)
+    private String color;
+
+    private static final Map<Class<? extends RocketComponent>, ORColor> DEFAULT_FIGURE_COLORS = new LinkedHashMap<>();
+
+    static {
+        DEFAULT_FIGURE_COLORS.put(BodyComponent.class, parseDefaultColor("0,0,240"));
+        DEFAULT_FIGURE_COLORS.put(TubeFinSet.class, parseDefaultColor("0,0,200"));
+        DEFAULT_FIGURE_COLORS.put(FinSet.class, parseDefaultColor("0,0,200"));
+        DEFAULT_FIGURE_COLORS.put(LaunchLug.class, parseDefaultColor("0,0,180"));
+        DEFAULT_FIGURE_COLORS.put(RailButton.class, parseDefaultColor("0,0,180"));
+        DEFAULT_FIGURE_COLORS.put(InternalComponent.class, parseDefaultColor("170,0,100"));
+        DEFAULT_FIGURE_COLORS.put(MassObject.class, parseDefaultColor("0,0,0"));
+        DEFAULT_FIGURE_COLORS.put(RecoveryDevice.class, parseDefaultColor("255,0,0"));
+        DEFAULT_FIGURE_COLORS.put(PodSet.class, parseDefaultColor("160,160,215"));
+        DEFAULT_FIGURE_COLORS.put(ParallelStage.class, parseDefaultColor("198,163,184"));
+    }
 
     /**
      * Default constructor.
@@ -147,6 +186,30 @@ public abstract class BasePartDTO {
             RingComponent rc = (RingComponent) ec;
             setRadialAngle(rc.getRadialDirection());
             setRadialLoc(rc.getRadialPosition() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
+        }
+
+        ORColor figureColor = ec.getColor();
+        if (figureColor == null) {
+            figureColor = getDefaultFigureColor(ec);
+        }
+        if (figureColor != null) {
+            setColor(formatRgb(figureColor));
+        }
+
+        Appearance appearance = ec.getAppearance();
+        ORColor appearanceColor = null;
+        if (appearance != null) {
+            appearanceColor = appearance.getPaint();
+        }
+        if (appearanceColor != null) {
+            setDiffuseColor(formatRgb(appearanceColor));
+            setAmbientColor(formatRgb(appearanceColor));
+            setOpacity(appearanceColor.getAlpha() / 255.0);
+        } else if (figureColor != null) {
+            setDiffuseColor(formatRgb(figureColor));
+            setOpacity(figureColor.getAlpha() / 255.0);
+        } else {
+            setOpacity(1.0);
         }
     }
 
@@ -254,6 +317,38 @@ public abstract class BasePartDTO {
         locationMode = theLocationMode;
     }
 
+    public double getOpacity() {
+        return opacity;
+    }
+
+    public void setOpacity(double theOpacity) {
+        opacity = theOpacity;
+    }
+
+    public String getDiffuseColor() {
+        return diffuseColor;
+    }
+
+    public void setDiffuseColor(String theDiffuseColor) {
+        diffuseColor = theDiffuseColor;
+    }
+
+    public String getAmbientColor() {
+        return ambientColor;
+    }
+
+    public void setAmbientColor(String theAmbientColor) {
+        ambientColor = theAmbientColor;
+    }
+
+    public int getUseSingleColor() {
+        return useSingleColor;
+    }
+
+    public void setUseSingleColor(int theUseSingleColor) {
+        useSingleColor = theUseSingleColor;
+    }
+
     public double getLen() {
         return len;
     }
@@ -270,6 +365,14 @@ public abstract class BasePartDTO {
         finishCode = theFinishCode;
     }
 
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(String theColor) {
+        color = theColor;
+    }
+
     public static int getCurrentSerialNumber() {
         return currentSerialNumber - 1;
     }
@@ -279,5 +382,23 @@ public abstract class BasePartDTO {
      */
     public static void resetCurrentSerialNumber() {
         currentSerialNumber = 0;
+    }
+
+    private static String formatRgb(ORColor color) {
+        return String.format(Locale.US, "rgb(%d,%d,%d)", color.getRed(), color.getGreen(), color.getBlue());
+    }
+
+    private static ORColor getDefaultFigureColor(RocketComponent component) {
+        for (Map.Entry<Class<? extends RocketComponent>, ORColor> entry : DEFAULT_FIGURE_COLORS.entrySet()) {
+            if (entry.getKey().isInstance(component)) {
+                return entry.getValue();
+            }
+        }
+        return ORColor.BLACK;
+    }
+
+    private static ORColor parseDefaultColor(String rgb) {
+        String[] parts = rgb.split(",");
+        return new ORColor(Integer.parseInt(parts[0]), Integer.parseInt(parts[1]), Integer.parseInt(parts[2]));
     }
 }

--- a/core/src/main/java/info/openrocket/core/file/rocksim/importt/BaseHandler.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/importt/BaseHandler.java
@@ -99,6 +99,12 @@ public abstract class BaseHandler<C extends RocketComponent> extends AbstractEle
 			if (RockSimCommonConstants.DENSITY_TYPE.equals(element)) {
 				densityType = RockSimDensityType.fromCode(Integer.parseInt(content));
 			}
+			if (RockSimCommonConstants.COLOR.equals(element)) {
+				String trimmed = content.trim();
+				if (!trimmed.isEmpty()) {
+					component.setColor(RockSimAppearanceBuilder.parseColor(trimmed));
+				}
+			}
 
 			appearanceBuilder.processElement(element, content, warnings);
 		} catch (NumberFormatException nfe) {

--- a/core/src/main/java/info/openrocket/core/file/rocksim/importt/RockSimAppearanceBuilder.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/importt/RockSimAppearanceBuilder.java
@@ -16,7 +16,7 @@ public class RockSimAppearanceBuilder extends AppearanceBuilder {
 	
 	boolean preventSeam = false;
 	boolean repeat = false;
-	
+
 	private final DocumentLoadingContext context;
 	
 	public RockSimAppearanceBuilder(DocumentLoadingContext context) {
@@ -33,10 +33,13 @@ public class RockSimAppearanceBuilder extends AppearanceBuilder {
 				//ignored
 			} else if ("Specular".equals(element)) {
 				//ignored
+			} else if ("Opacity".equals(element)) {
+				double opacity = Double.parseDouble(content);
+				setOpacity(opacity);
 			} else if ("AbientColor".equals(element)) {
-				setPaint(parseColor(content));
-			} else if ("DiffuseColor".equals(element)) {
 				//ignored
+			} else if ("DiffuseColor".equals(element)) {
+				setPaint(parseColor(content));
 			} else if ("SpecularColor".equals(element)) {
 				//Ignored
 			} else if ("UseSingleColor".equals(element) || "SimpleColorModel".equals(element)) {

--- a/core/src/main/java/info/openrocket/core/preferences/ApplicationPreferences.java
+++ b/core/src/main/java/info/openrocket/core/preferences/ApplicationPreferences.java
@@ -199,6 +199,10 @@ public abstract class ApplicationPreferences implements ChangeSource, ORPreferen
 
 	private PinkNoiseWindModel averageWindModel = null;
 
+	// Default component colors. This is filled by SwingPreferences, but defined here so it can be used by code
+	// in the core module.
+	protected final HashMap<Class<?>, String> DEFAULT_COLORS = new HashMap<>();
+
 
 	/*
 	 * ******************************************************************************************
@@ -1845,6 +1849,19 @@ public abstract class ApplicationPreferences implements ChangeSource, ORPreferen
 		static {
 			DEFAULT_LINE_STYLES.put(RocketComponent.class, LineStyle.SOLID.name());
 			DEFAULT_LINE_STYLES.put(MassObject.class, LineStyle.DASHED.name());
+		}
+	}
+
+	public ORColor getDefaultColor(Class<? extends RocketComponent> c) {
+		String color = get("componentColors", c, DEFAULT_COLORS);
+		if (color == null)
+			return ORColor.fromAWTColor(Color.BLACK);
+
+		ORColor clr = parseColor(color);
+		if (clr != null) {
+			return clr;
+		} else {
+			return ORColor.fromAWTColor(Color.BLACK);
 		}
 	}
 	

--- a/swing/src/main/java/info/openrocket/swing/gui/theme/UITheme.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/theme/UITheme.java
@@ -242,6 +242,7 @@ public class UITheme {
 
         // Static method to notify all listeners
         static void notifyUIThemeChangeListeners() {
+            ((SwingPreferences) Application.getPreferences()).updateColors();
             Iterator<WeakReference<Runnable>> it = themeChangeListeners.iterator();
             while (it.hasNext()) {
                 WeakReference<Runnable> ref = it.next();

--- a/swing/src/main/java/info/openrocket/swing/gui/util/SwingPreferences.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/util/SwingPreferences.java
@@ -123,6 +123,7 @@ public class SwingPreferences extends ApplicationPreferences {
 		}
 		PREFNODE = root.node(NODENAME);
 		fillDefaultComponentColors();
+		UITheme.Theme.addUIThemeChangeListener(this::updateColors);
 	}
 
 	private void fillDefaultComponentColors() {
@@ -513,8 +514,6 @@ public class SwingPreferences extends ApplicationPreferences {
 	}
 
 	public ORColor getDefaultColor(Class<? extends RocketComponent> c) {
-		// Refresh defaults to pick up the current theme each time
-		fillDefaultComponentColors();
 		String color = get("componentColors", c, DEFAULT_COLORS);
 		if (color == null)
 			return ORColor.fromAWTColor(UITheme.getColor(UITheme.Keys.TEXT, Color.BLACK));

--- a/swing/src/main/java/info/openrocket/swing/gui/util/SwingPreferences.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/util/SwingPreferences.java
@@ -7,12 +7,10 @@ import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
 import java.awt.Point;
 import java.awt.Rectangle;
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -84,8 +82,6 @@ public class SwingPreferences extends ApplicationPreferences {
 		list.add(new Locale("uk", "UA"));
 		SUPPORTED_LOCALES = Collections.unmodifiableList(list);
 	}
-
-	private final HashMap<Class<?>, String> DEFAULT_COLORS = new HashMap<>();
 	
 	
 	/**
@@ -513,18 +509,7 @@ public class SwingPreferences extends ApplicationPreferences {
 		putBoolean(UPDATE_ROCKET_WHILE_DRAGGING_POINT, update);
 	}
 
-	public ORColor getDefaultColor(Class<? extends RocketComponent> c) {
-		String color = get("componentColors", c, DEFAULT_COLORS);
-		if (color == null)
-			return ORColor.fromAWTColor(UITheme.getColor(UITheme.Keys.TEXT, Color.BLACK));
-
-		ORColor clr = parseColor(color);
-		if (clr != null) {
-			return clr;
-		} else {
-			return ORColor.fromAWTColor(UITheme.getColor(UITheme.Keys.TEXT, Color.BLACK));
-		}
-	}
+	// getDefaultColor is in ApplicationPreferences
 
 	public final void setDefaultColor(Class<? extends RocketComponent> c, ORColor color) {
 		if (color == null)


### PR DESCRIPTION
This PR supports exporting and importing 2D and 3D colors to and from RockSim. Texture importing and exporting is not yet supported.