### PR TITLE
Store "show warnings" in document preferences

### DIFF
--- a/core/src/main/java/info/openrocket/core/preferences/DocumentPreferences.java
+++ b/core/src/main/java/info/openrocket/core/preferences/DocumentPreferences.java
@@ -30,6 +30,8 @@ public class DocumentPreferences implements ChangeSource, ORPreferences {
 	 */
 	private final Database<Material> LINE_MATERIAL = new Database<>();
 
+	public static final String PREF_SHOW_WARNINGS = "RocketPanel.showWarnings";
+
 
 	@Override
 	public void addChangeListener(StateChangeListener listener) {

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
@@ -100,6 +100,8 @@ import java.util.stream.Collectors;
 import javax.imageio.ImageIO;
 import info.openrocket.swing.gui.theme.UITheme;
 
+import static info.openrocket.core.preferences.DocumentPreferences.PREF_SHOW_WARNINGS;
+
 
 /**
  * A JPanel that contains a RocketFigure and buttons to manipulate the figure.
@@ -520,12 +522,13 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 
 		//// Show warnings
 		this.showWarnings = new JCheckBox(trans.get("RocketPanel.check.showWarnings"));
-		showWarnings.setSelected(true);
+		showWarnings.setSelected(document.getDocumentPreferences().getBoolean(PREF_SHOW_WARNINGS, true));
 		showWarnings.setToolTipText(trans.get("RocketPanel.check.showWarnings.ttip"));
 		bottomRow.add(showWarnings, "pushx, right");
 		showWarnings.addItemListener(new ItemListener() {
 			@Override
 			public void itemStateChanged(ItemEvent e) {
+				document.getDocumentPreferences().putBoolean(PREF_SHOW_WARNINGS, showWarnings.isSelected());
 				updateExtras();
 				updateFigures();
 			}


### PR DESCRIPTION
This PR stores the "show warnings" checkbox setting from the rocket figure in a document preference. This means that the checkbox's state is stored on a per-document basis (if you have unchecked "show warnings" in 'test.ork' and then re-open that file, the checkbox state will be correctly loaded).