### PR TITLE
Add in-plane shear modulus to material

### DIFF
--- a/core/src/main/java/info/openrocket/core/database/Databases.java
+++ b/core/src/main/java/info/openrocket/core/database/Databases.java
@@ -41,38 +41,57 @@ public class Databases {
 	static {
 		
 		// Add default materials
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Acrylic", 1190, MaterialGroup.PLASTICS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Aluminum", 2700, MaterialGroup.METALS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Balsa", 170, MaterialGroup.WOODS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Basswood", 500, MaterialGroup.WOODS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Birch", 670, MaterialGroup.WOODS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Brass", 8600, MaterialGroup.METALS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Cardboard", 680, MaterialGroup.PAPER));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Carbon fiber", 1780, MaterialGroup.COMPOSITES));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Cork", 240, MaterialGroup.WOODS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Delrin", 1420, MaterialGroup.PLASTICS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Depron (XPS)", 40, MaterialGroup.FOAMS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Fiberglass", 1850, MaterialGroup.COMPOSITES));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Kraft phenolic", 950, MaterialGroup.COMPOSITES));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Maple", 755, MaterialGroup.WOODS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Nylon", 1150, MaterialGroup.FIBERS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Paper (office)", 820, MaterialGroup.PAPER));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Pine", 530, MaterialGroup.WOODS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Plywood (birch)", 630, MaterialGroup.WOODS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Polycarbonate (Lexan)", 1200, MaterialGroup.PLASTICS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Polystyrene", 1050, MaterialGroup.PLASTICS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "PVC", 1390, MaterialGroup.PLASTICS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Spruce", 450, MaterialGroup.WOODS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Steel", 7850, MaterialGroup.METALS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Styrofoam (generic EPS)", 20, MaterialGroup.FOAMS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Styrofoam \"Blue foam\" (XPS)", 32, MaterialGroup.FOAMS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Titanium", 4500, MaterialGroup.METALS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Quantum tubing", 1050, MaterialGroup.PLASTICS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "Blue tube", 1300, MaterialGroup.COMPOSITES));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "PLA - 100% infill", 1250, MaterialGroup.PLASTICS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "PETG - 100% infill", 1250, MaterialGroup.PLASTICS));
-		BULK_MATERIAL.add(newMaterial(Type.BULK, "ABS - 100% infill", 1050, MaterialGroup.PLASTICS));
+		// Note: Shear Modulus (G) values added based on standard engineering data (MatWeb, USDA Wood Handbook, lookpolymers).
+		// Values are in Pascals.
+		// Note: if the Shear modulus is not given, but the Young's modulus and Poisson's ratio are known, G can be calculated as:
+		// G = E / (2*(1+v))
 
+		// Plastics
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Acrylic", 1190, 1.7e9, MaterialGroup.PLASTICS));		// https://www.matweb.com/search/DataSheet.aspx?MatGUID=a5e93a1f1fff43bcbac5b6ca51b8981f&ckck=1
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Delrin", 1420, 0.946e9, MaterialGroup.PLASTICS));		// https://www.matweb.com/search/datasheet_print.aspx?matguid=0c568e14e05c4dba9dc2944331a042cd
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Nylon", 1150, 1.15e9, MaterialGroup.FIBERS)); // Nylon 6/6
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Polycarbonate (Lexan)", 1200, 0.786e9, MaterialGroup.PLASTICS));	// www.matweb.com/search/DataSheet.aspx?MatGUID=37807ef5e0134a0b80ca0a862bee2314 &
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Polystyrene", 1050, 1.23e9, MaterialGroup.PLASTICS));				// https://www.matweb.com/search/DataSheet.aspx?MatGUID=df6b1ef50ce84e7995bdd1f6fd1b04c9
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "PVC", 1390, 2.28e9, MaterialGroup.PLASTICS));			// https://www.matweb.com/search/DataSheet.aspx?MatGUID=bb6e739c553d4a34b199f0185e92f6f7 & https://www.lookpolymers.com/polymer_Overview-of-materials-for-PVC-Rigid-Grade.php?utm_source=chatgpt.com
+
+		// 3D Printing Plastics (Assumed 100% infill isotropic approximation)
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "PLA - 100% infill", 1250, 2.4e9, MaterialGroup.PLASTICS));
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "PETG - 100% infill", 1250, 0.8e9, MaterialGroup.PLASTICS));
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "ABS - 100% infill", 1050, 0.875e9, MaterialGroup.PLASTICS));		// https://designerdata.nl/materials/plastics/thermo-plastics/acrylonitril-butadieen-styreen-general-purpose
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "ASA - 100% infill", 1050, 0.8e9, MaterialGroup.PLASTICS));		// https://designerdata.nl/materials/plastics/thermo-plastics/acrylonitrile---styrene---acrylester
+
+		// Metals
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Aluminum", 2700, 26.0e9, MaterialGroup.METALS)); 	// 6061-T6, https://www.matweb.com/search/DataSheet.aspx?MatGUID=b8d536e0b9b54bd7b69e4124d8f1d20a
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Brass", 8600, 38.9e9, MaterialGroup.METALS));		// https://www.matweb.com/search/DataSheet.aspx?MatGUID=d3bd4617903543ada92f4c101c2a20e5
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Steel", 7850, 79.7e9, MaterialGroup.METALS));		// https://www.matweb.com/search/DataSheet.aspx?MatGUID=210fcd12132049d0a3e0cabe7d091eef
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Titanium", 4500, 43.0e9, MaterialGroup.METALS)); 	// https://www.matweb.com/search/DataSheet.aspx?MatGUID=66a15d609a3f4c829cb6ad08f0dafc01
+
+		// Woods (Values are approximate G_LT / In-plane shear)
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Balsa", 170, 0.23e9, MaterialGroup.WOODS));		// Peak of Flight issue 615
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Basswood", 500, 0.331e9, MaterialGroup.WOODS));	// GLT/EL = 0.046, EL = 7.2 GPa
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Birch", 670, 0.70e9, MaterialGroup.WOODS));		// GLT/EL = 0.068, EL = 10.3 GPa
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Cork", 240, 0.01e9, MaterialGroup.WOODS)); 	// https://www.makeitfrom.com/material-properties/Cork
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Maple", 755, 0.71e9, MaterialGroup.WOODS));	// GLT/EL = 0.074, EL = 9.6 GPa
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Pine", 530, 0.71e9, MaterialGroup.WOODS));	// GLT/EL = 0.081, EL = 8.8 GPa
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Plywood (birch)", 630, 0.613e9, MaterialGroup.WOODS));	// https://www.matweb.com/search/datasheet_print.aspx?matguid=bd6620450973496ea2578c283e9fb807 & Peak of Flight issue 615
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Spruce", 450, 1.1e9, MaterialGroup.WOODS));	// GLT/EL = 0.12, EL = 9.2 GPa
+
+		// Composites
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Carbon fiber", 1780, 4.14e9, MaterialGroup.COMPOSITES)); // Quasi-isotropic, Peak of Flight issue 615
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Fiberglass", 1850, 4.14e9, MaterialGroup.COMPOSITES)); // https://www.matweb.com/search/DataSheet.aspx?MatGUID=7bfc3c023dab4b288a29a29052734788 & Peak of Flight issue 615
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Kraft phenolic", 950, 1.78e9, MaterialGroup.COMPOSITES)); // Paper phenolic
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Blue tube", 1300, 0, MaterialGroup.COMPOSITES));
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Quantum tubing", 1050, 0, MaterialGroup.PLASTICS));
+
+		// Paper/Foams (Low shear modulus, often negligible, but non-zero values provided where applicable)
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Cardboard", 680, 0.4e9, MaterialGroup.PAPER)); // Solid paperboard
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Paper (office)", 820, 0.0, MaterialGroup.PAPER));
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Depron (XPS)", 40, 0.0027e9, MaterialGroup.FOAMS));
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Styrofoam (generic EPS)", 20, 0.002e9, MaterialGroup.FOAMS));
+		BULK_MATERIAL.add(newMaterial(Type.BULK, "Styrofoam \"Blue foam\" (XPS)", 32, 0.0028e9, MaterialGroup.FOAMS));
+
+
+		// Surface Materials (Films/Fabrics - Shear Modulus generally not applicable for thin flexible membranes in this model)
 		SURFACE_MATERIAL.add(newMaterial(Type.SURFACE, "Ripstop nylon", 0.067, MaterialGroup.FABRICS));
 		SURFACE_MATERIAL.add(newMaterial(Type.SURFACE, "Mylar", 0.021, MaterialGroup.PLASTICS));
 		SURFACE_MATERIAL.add(newMaterial(Type.SURFACE, "Polyethylene (thin)", 0.015, MaterialGroup.PLASTICS));
@@ -81,7 +100,8 @@ public class Databases {
 		SURFACE_MATERIAL.add(newMaterial(Type.SURFACE, "Paper (office)", 0.080, MaterialGroup.PAPER));
 		SURFACE_MATERIAL.add(newMaterial(Type.SURFACE, "Cellophane", 0.018, MaterialGroup.PLASTICS));
 		SURFACE_MATERIAL.add(newMaterial(Type.SURFACE, "Cr\u00eape paper", 0.025, MaterialGroup.PAPER));
-		
+
+		// Line Materials (1D tension members - Shear Modulus N/A)
 		LINE_MATERIAL.add(newMaterial(Type.LINE, "Thread (heavy-duty)", 0.0003, MaterialGroup.OTHER));
 		LINE_MATERIAL.add(newMaterial(Type.LINE, "Elastic cord (round 2 mm, 1/16 in)", 0.0018, MaterialGroup.ELASTICS));
 		LINE_MATERIAL.add(newMaterial(Type.LINE, "Elastic cord (flat 6 mm, 1/4 in)", 0.0043, MaterialGroup.ELASTICS));
@@ -124,59 +144,101 @@ public class Databases {
 		LINE_MATERIAL.add(newMaterial(Type.LINE, "Elastic braided cord (round 2.5 mm, 3/32 in)", 0.0038, MaterialGroup.ELASTICS));
 		LINE_MATERIAL.add(newMaterial(Type.LINE, "Elastic braided cord (flat 10 mm, 3/8 in)", 0.00381, MaterialGroup.ELASTICS));
 		LINE_MATERIAL.add(newMaterial(Type.LINE, "Elastic braided cord (flat 13 mm, 1/2 in)", 0.00551172, MaterialGroup.ELASTICS));
-		
-		
+
+
 		// Add user-defined materials
 		for (Material m : Application.getPreferences().getUserMaterials()) {
 			switch (m.getType()) {
-			case LINE:
-				LINE_MATERIAL.add(m);
-				break;
-			
-			case SURFACE:
-				SURFACE_MATERIAL.add(m);
-				break;
-			
-			case BULK:
-				BULK_MATERIAL.add(m);
-				break;
-			
-			default:
-				log.warn("ERROR: Unknown material type " + m);
+				case LINE:
+					LINE_MATERIAL.add(m);
+					break;
+
+				case SURFACE:
+					SURFACE_MATERIAL.add(m);
+					break;
+
+				case BULK:
+					BULK_MATERIAL.add(m);
+					break;
+
+				default:
+					log.warn("ERROR: Unknown material type " + m);
 			}
 		}
-		
+
 		// Add database storage listener
 		MaterialStorage listener = new MaterialStorage();
 		LINE_MATERIAL.addDatabaseListener(listener);
 		SURFACE_MATERIAL.addDatabaseListener(listener);
 		BULK_MATERIAL.addDatabaseListener(listener);
 	}
-	
+
+	/**
+	 * builds a new material based on the parameters given
+	 * @param type		The type of material
+	 * @param baseName	the name of material
+	 * @param density	density (in kg/m3)
+	 * @param inPlaneShearModulus	the in-plane shear modulus G (in Pa)
+	 * @param group		the material group
+	 * @return	a new object with the material data
+	 */
+	private static Material newMaterial(Type type, String baseName, double density, double inPlaneShearModulus, MaterialGroup group) {
+		String name = trans.get("material", baseName);
+		return Material.newMaterial(type, name, density, inPlaneShearModulus, group, false);
+	}
+
 	/**
 	 * builds a new material based on the parameters given
 	 * @param type		The type of material
 	 * @param baseName	the name of material
 	 * @param density	density
+	 * @param group		the material group
 	 * @return	a new object with the material data
 	 */
 	private static Material newMaterial(Type type, String baseName, double density, MaterialGroup group) {
-		String name = trans.get("material", baseName);
-		return Material.newMaterial(type, name, density, group, false);
+		return newMaterial(type, baseName, density, 0.0, group);
 	}
 
 	private static Material newMaterial(Type type, String baseName, double density) {
 		return newMaterial(type, baseName, density, null);
 	}
-	
-	
-	
-	
+
+
+
+
 	/*
 	 * Used just for ensuring initialization of the class.
 	 */
 	public static void fakeMethod() {
-		
+
+	}
+
+	/**
+	 * Find a material from the database or return a new user defined material if the specified
+	 * material with the specified density and in-plane shear modulus is not found.
+	 * <p>
+	 * This method will attempt to localize the material name to the current locale, or use
+	 * the provided name if unable to do so.
+	 *
+	 * @param type				the material type.
+	 * @param baseName			the base name of the material.
+	 * @param density			the density of the material.
+	 * @param inPlaneShearModulus	the in-plane shear modulus G (in Pa).
+	 * @param group				the material group.
+	 * @return					the material object from the database or a new material.
+	 */
+	public static Material findMaterial(Material.Type type, String baseName, double density, double inPlaneShearModulus, MaterialGroup group) {
+		Database<Material> db = getDatabase(type);
+		String name = trans.get("material", baseName);
+
+		for (Material m : db) {
+			// Material group comparison is omitted to keep compatibility with files pre OR 24.12
+			if (m.getName().equalsIgnoreCase(name) && MathUtil.equals(m.getDensity(), density) 
+					&& MathUtil.equals(m.getInPlaneShearModulus(), inPlaneShearModulus)) {
+				return m;
+			}
+		}
+		return Material.newMaterial(type, name, density, inPlaneShearModulus, group, true, true);
 	}
 
 	/**
@@ -197,12 +259,12 @@ public class Databases {
 		String name = trans.get("material", baseName);
 
 		for (Material m : db) {
-			// Material group comparison is omitted to keep compatibility with files pre OR 24.12
+			// Backward-compatible lookup: match by name and density only.
 			if (m.getName().equalsIgnoreCase(name) && MathUtil.equals(m.getDensity(), density)) {
 				return m;
 			}
 		}
-		return Material.newMaterial(type, name, density, group, true, true);
+		return Material.newMaterial(type, name, density, 0.0, group, true, true);
 	}
 
 	/**

--- a/core/src/main/java/info/openrocket/core/file/openrocket/importt/MaterialSetter.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/importt/MaterialSetter.java
@@ -3,7 +3,6 @@ package info.openrocket.core.file.openrocket.importt;
 import java.util.HashMap;
 import java.util.Locale;
 
-import info.openrocket.core.document.OpenRocketDocument;
 import info.openrocket.core.logging.Warning;
 import info.openrocket.core.logging.WarningSet;
 import info.openrocket.core.database.Databases;
@@ -50,6 +49,18 @@ class MaterialSetter implements Setter {
 			return;
 		}
 
+		// Parse shear modulus (optional; only use when explicitly provided)
+		Double shearModulus = null;
+		str = attributes.remove("shearModulus");
+		if (str != null) {
+			try {
+				shearModulus = Double.parseDouble(str);
+			} catch (NumberFormatException e) {
+				warnings.add(Warning.fromString("Illegal shear modulus value, using 0.0."));
+				shearModulus = 0.0;
+			}
+		}
+
 		// Parse thickness
 		// double thickness = 0;
 		// str = attributes.remove("thickness");
@@ -80,7 +91,11 @@ class MaterialSetter implements Setter {
 			}
 		}
 
-		mat = Databases.findMaterial(type, name, density, group);
+		if (shearModulus == null) {
+			mat = Databases.findMaterial(type, name, density, group);
+		} else {
+			mat = Databases.findMaterial(type, name, density, shearModulus, group);
+		}
 
 		setMethod.invoke(c, mat);
 	}

--- a/core/src/main/java/info/openrocket/core/file/openrocket/savers/RocketComponentSaver.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/savers/RocketComponentSaver.java
@@ -214,8 +214,17 @@ public class RocketComponentSaver {
 		
 		String baseName = trans.getBaseText("material", mat.getName());
 		
-		return str + " density=\"" + mat.getDensity() + "\" group=\"" + mat.getGroup().getDatabaseString() + "\">" +
+		String result = str + " density=\"" + mat.getDensity() + "\"";
+		
+		// Add shear modulus when defined or explicitly set for a user-defined material.
+		double shearModulus = mat.getInPlaneShearModulus();
+		if (shearModulus != 0.0 || mat.isUserDefined()) {
+			result += " shearModulus=\"" + shearModulus + "\"";
+		}
+		
+		result += " group=\"" + mat.getGroup().getDatabaseString() + "\">" +
 				TextUtil.escapeXML(baseName) + "</" + tag + ">";
+		return result;
 	}
 	
 	

--- a/core/src/main/java/info/openrocket/core/material/Material.java
+++ b/core/src/main/java/info/openrocket/core/material/Material.java
@@ -51,16 +51,24 @@ public abstract class Material implements Comparable<Material>, Groupable<Materi
 	/////  Definitions of different material types  /////
 	
 	public static class Line extends Material {
+		Line(String name, double density, double inPlaneShearModulus, MaterialGroup group, boolean userDefined, boolean documentMaterial) {
+			super(name, density, inPlaneShearModulus, group, userDefined, documentMaterial);
+		}
+
+		Line(String name, double density, double inPlaneShearModulus, MaterialGroup group, boolean userDefined) {
+			super(name, density, inPlaneShearModulus, group, userDefined, false);
+		}
+
 		Line(String name, double density, MaterialGroup group, boolean userDefined, boolean documentMaterial) {
-			super(name, density, group, userDefined, documentMaterial);
+			super(name, density, 0.0, group, userDefined, documentMaterial);
 		}
 
 		Line(String name, double density, MaterialGroup group, boolean userDefined) {
-			super(name, density, group, userDefined);
+			super(name, density, 0.0, group, userDefined);
 		}
 
 		Line(String name, double density, boolean userDefined) {
-			super(name, density, userDefined);
+			super(name, density, 0.0, userDefined);
 		}
 		
 		@Override
@@ -70,16 +78,24 @@ public abstract class Material implements Comparable<Material>, Groupable<Materi
 	}
 	
 	public static class Surface extends Material {
+		Surface(String name, double density, double inPlaneShearModulus, MaterialGroup group, boolean userDefined, boolean documentMaterial) {
+			super(name, density, inPlaneShearModulus, group, userDefined, documentMaterial);
+		}
+
+		Surface(String name, double density, double inPlaneShearModulus, MaterialGroup group, boolean userDefined) {
+			super(name, density, inPlaneShearModulus, group, userDefined, false);
+		}
+
 		Surface(String name, double density, MaterialGroup group, boolean userDefined, boolean documentMaterial) {
-			super(name, density, group, userDefined, documentMaterial);
+			super(name, density, 0.0, group, userDefined, documentMaterial);
 		}
 
 		Surface(String name, double density, MaterialGroup group, boolean userDefined) {
-			super(name, density, group, userDefined);
+			super(name, density, 0.0, group, userDefined);
 		}
 
 		Surface(String name, double density, boolean userDefined) {
-			super(name, density, userDefined);
+			super(name, density, 0.0, userDefined);
 		}
 		
 		@Override
@@ -94,16 +110,24 @@ public abstract class Material implements Comparable<Material>, Groupable<Materi
 	}
 	
 	public static class Bulk extends Material {
+		Bulk(String name, double density, double inPlaneShearModulus, MaterialGroup group, boolean userDefined, boolean documentMaterial) {
+			super(name, density, inPlaneShearModulus, group, userDefined, documentMaterial);
+		}
+
+		Bulk(String name, double density, double inPlaneShearModulus, MaterialGroup group, boolean userDefined) {
+			super(name, density, inPlaneShearModulus, group, userDefined, false);
+		}
+
 		Bulk(String name, double density, MaterialGroup group, boolean userDefined, boolean documentMaterial) {
-			super(name, density, group, userDefined, documentMaterial);
+			super(name, density, 0.0, group, userDefined, documentMaterial);
 		}
 
 		Bulk(String name, double density, MaterialGroup group, boolean userDefined) {
-			super(name, density, group, userDefined);
+			super(name, density, 0.0, group, userDefined);
 		}
 
 		Bulk(String name, double density, boolean userDefined) {
-			super(name, density, userDefined);
+			super(name, density, 0.0, userDefined);
 		}
 		
 		@Override
@@ -114,16 +138,24 @@ public abstract class Material implements Comparable<Material>, Groupable<Materi
 	
 
 	public static class Custom extends Material {
+		Custom(String name, double density, double inPlaneShearModulus, MaterialGroup group, boolean userDefined, boolean documentMaterial) {
+			super(name, density, inPlaneShearModulus, group, userDefined, documentMaterial);
+		}
+
+		Custom(String name, double density, double inPlaneShearModulus, MaterialGroup group, boolean userDefined) {
+			super(name, density, inPlaneShearModulus, group, userDefined, false);
+		}
+
 		Custom(String name, double density, MaterialGroup group, boolean userDefined, boolean documentMaterial) {
-			super(name, density, group, userDefined, documentMaterial);
+			super(name, density, 0.0, group, userDefined, documentMaterial);
 		}
 
 		Custom(String name, double density, MaterialGroup group, boolean userDefined) {
-			super(name, density, group, userDefined);
+			super(name, density, 0.0, group, userDefined);
 		}
 
 		Custom(String name, double density, boolean userDefined) {
-			super(name, density, userDefined);
+			super(name, density, 0.0, userDefined);
 		}
 		
 		@Override
@@ -136,6 +168,7 @@ public abstract class Material implements Comparable<Material>, Groupable<Materi
 	
 	private String name;
 	private double density;
+	private double inPlaneShearModulus;
 	private boolean userDefined;
 	private boolean documentMaterial;
 	private MaterialGroup group;
@@ -146,28 +179,51 @@ public abstract class Material implements Comparable<Material>, Groupable<Materi
 	 * 
 	 * @param name ignored when defining system materials.
 	 * @param density: the density of the material.
+	 * @param inPlaneShearModulus: the in-plane shear modulus G of the material (in Pa).
 	 * @param group the material group.
 	 * @param userDefined true if this is a user defined material, false if it is a system material.
 	 * @param documentMaterial true if this material is stored in the document preferences.
 	 */
-	private Material(String name, double density, MaterialGroup group, boolean userDefined, boolean documentMaterial) {
+	private Material(String name, double density, double inPlaneShearModulus, MaterialGroup group, boolean userDefined, boolean documentMaterial) {
 		this.name = name;
 		this.density = density;
+		this.inPlaneShearModulus = inPlaneShearModulus;
 		this.userDefined = userDefined;
 		this.documentMaterial = documentMaterial;
 		this.group = getEquivalentGroup(group, userDefined);
 	}
 
+	private Material(String name, double density, double inPlaneShearModulus, MaterialGroup group, boolean userDefined) {
+		this(name, density, inPlaneShearModulus, group, userDefined, false);
+	}
+
+	private Material(String name, double density, double inPlaneShearModulus, boolean userDefined) {
+		this(name, density, inPlaneShearModulus, null, userDefined);
+	}
+
+	private Material(String name, double density, MaterialGroup group, boolean userDefined, boolean documentMaterial) {
+		this(name, density, 0.0, group, userDefined, documentMaterial);
+	}
+
 	private Material(String name, double density, MaterialGroup group, boolean userDefined) {
-		this(name, density, group, userDefined, false);
+		this(name, density, 0.0, group, userDefined, false);
 	}
 
 	private Material(String name, double density, boolean userDefined) {
-		this(name, density, null, userDefined);
+		this(name, density, 0.0, null, userDefined);
 	}
 	
 	public double getDensity() {
 		return density;
+	}
+
+	/**
+	 * Get the in-plane shear modulus G of the material.
+	 * 
+	 * @return the in-plane shear modulus in Pascals (Pa)
+	 */
+	public double getInPlaneShearModulus() {
+		return inPlaneShearModulus;
 	}
 	
 	public String getName() {
@@ -230,7 +286,7 @@ public abstract class Material implements Comparable<Material>, Groupable<Materi
 	
 	/**
 	 * Compares this object to another object.  Material objects are equal if and only if
-	 * their types, names and densities are identical.
+	 * their types, names, densities, and in-plane shear moduli are identical.
 	 */
 	@Override
 	public boolean equals(Object o) {
@@ -239,7 +295,8 @@ public abstract class Material implements Comparable<Material>, Groupable<Materi
 		if (this.getClass() != o.getClass())
 			return false;
 		Material m = (Material) o;
-		return ((m.name.equals(this.name)) && MathUtil.equals(m.density, this.density)) && groupsEqual(m);
+		return ((m.name.equals(this.name)) && MathUtil.equals(m.density, this.density) 
+				&& MathUtil.equals(m.inPlaneShearModulus, this.inPlaneShearModulus)) && groupsEqual(m);
 	}
 
 	private boolean groupsEqual(Material m) {
@@ -255,7 +312,7 @@ public abstract class Material implements Comparable<Material>, Groupable<Materi
 	 */
 	@Override
 	public int hashCode() {
-		return name.hashCode() + (int) (density * 1000);
+		return name.hashCode() + (int) (density * 1000) + (int) (inPlaneShearModulus * 1e-9);
 	}
 	
 	
@@ -279,32 +336,47 @@ public abstract class Material implements Comparable<Material>, Groupable<Materi
 	 * @param type			the material type
 	 * @param name			the material name
 	 * @param density		the material density
+	 * @param inPlaneShearModulus	the in-plane shear modulus G (in Pa)
 	 * @param group			the material group
 	 * @param userDefined	whether the material is user-defined or not
 	 * @param documentMaterial	whether the material is stored in the document preferences
 	 * @return				the new material
 	 */
-	public static Material newMaterial(Type type, String name, double density, MaterialGroup group, boolean userDefined,
+	public static Material newMaterial(Type type, String name, double density, double inPlaneShearModulus, MaterialGroup group, boolean userDefined,
 									   boolean documentMaterial) {
 		return switch (type) {
-			case LINE -> new Line(name, density, group, userDefined, documentMaterial);
-			case SURFACE -> new Surface(name, density, group, userDefined, documentMaterial);
-			case BULK -> new Bulk(name, density, group, userDefined, documentMaterial);
-			case CUSTOM -> new Custom(name, density, group, userDefined, documentMaterial);
+			case LINE -> new Line(name, density, inPlaneShearModulus, group, userDefined, documentMaterial);
+			case SURFACE -> new Surface(name, density, inPlaneShearModulus, group, userDefined, documentMaterial);
+			case BULK -> new Bulk(name, density, inPlaneShearModulus, group, userDefined, documentMaterial);
+			case CUSTOM -> new Custom(name, density, inPlaneShearModulus, group, userDefined, documentMaterial);
 		};
 	}
 
+	public static Material newMaterial(Type type, String name, double density, MaterialGroup group, boolean userDefined,
+									   boolean documentMaterial) {
+		return newMaterial(type, name, density, 0.0, group, userDefined, documentMaterial);
+	}
+
 	public static Material newMaterial(Type type, String name, double density, MaterialGroup group, boolean userDefined) {
-		return newMaterial(type, name, density, group, userDefined, false);
+		return newMaterial(type, name, density, 0.0, group, userDefined, false);
+	}
+
+	public static Material newMaterial(Type type, String name, double density, double inPlaneShearModulus, MaterialGroup group, boolean userDefined) {
+		return newMaterial(type, name, density, inPlaneShearModulus, group, userDefined, false);
+	}
+
+	public static Material newMaterial(Type type, String name, double density, double inPlaneShearModulus, boolean userDefined,
+									   boolean documentMaterial) {
+		return newMaterial(type, name, density, inPlaneShearModulus, null, userDefined, documentMaterial);
 	}
 
 	public static Material newMaterial(Type type, String name, double density, boolean userDefined,
 									   boolean documentMaterial) {
-		return newMaterial(type, name, density, null, userDefined, documentMaterial);
+		return newMaterial(type, name, density, 0.0, null, userDefined, documentMaterial);
 	}
 
 	public static Material newMaterial(Type type, String name, double density, boolean userDefined) {
-		return newMaterial(type, name, density, null, userDefined);
+		return newMaterial(type, name, density, 0.0, null, userDefined, false);
 	}
 
 	public void loadFrom(Material m) {
@@ -314,20 +386,22 @@ public abstract class Material implements Comparable<Material>, Groupable<Materi
 			throw new IllegalArgumentException("Material type mismatch");
 		name = m.name;
 		density = m.density;
+		inPlaneShearModulus = m.inPlaneShearModulus;
 		group = m.group;
 		userDefined = m.userDefined;
 		documentMaterial = m.documentMaterial;
 	}
 	
 	public String toStorableString() {
-		return getType().name() + "|" + name.replace('|', ' ') + '|' + density + '|' + group.getDatabaseString();
+		return getType().name() + "|" + name.replace('|', ' ') + '|' + density + '|' + inPlaneShearModulus + '|' + group.getDatabaseString();
 	}
 
 	
 	/**
 	 * Return a material defined by the provided string.
 	 * 
-	 * @param str			the material storage string, formatted as "{type}|{name}|{density}|{group}".
+	 * @param str			the material storage string, formatted as "{type}|{name}|{density}|{inPlaneShearModulus}|{group}".
+	 * 						For backward compatibility, the format "{type}|{name}|{density}|{group}" is also supported.
 	 * @param userDefined	whether the created material is user-defined.
 	 * @return				a new <code>Material</code> object.
 	 * @throws IllegalArgumentException		if <code>str</code> is invalid or null.
@@ -336,13 +410,14 @@ public abstract class Material implements Comparable<Material>, Groupable<Materi
 		if (str == null)
 			throw new IllegalArgumentException("Material string is null");
 		
-		String[] split = str.split("\\|", 4);
+		String[] split = str.split("\\|", 5);
 		if (split.length < 3)
 			throw new IllegalArgumentException("Illegal material string: " + str);
 		
 		Type type;
 		String name;
 		double density;
+		double inPlaneShearModulus = 0.0;
 		MaterialGroup group = null;
 		
 		try {
@@ -359,18 +434,34 @@ public abstract class Material implements Comparable<Material>, Groupable<Materi
 			throw new IllegalArgumentException("Illegal material string: " + str, e);
 		}
 
-		if (split.length == 4) {
+		// Handle backward compatibility: old format has 4 fields (type|name|density|group)
+		// new format has 5 fields (type|name|density|inPlaneShearModulus|group)
+		if (split.length >= 4) {
 			try {
-				group = MaterialGroup.loadFromDatabaseStringWithBackwardCompatibility(split[3], type, name, density);
-			} catch (IllegalArgumentException e) {
-				log.debug(e.toString());
+				// Try to parse the 4th field as a double (shear modulus)
+				inPlaneShearModulus = Double.parseDouble(split[3]);
+				// If successful and there's a 5th field, it's the group
+				if (split.length == 5) {
+					try {
+						group = MaterialGroup.loadFromDatabaseStringWithBackwardCompatibility(split[4], type, name, density);
+					} catch (IllegalArgumentException e) {
+						log.debug(e.toString());
+					}
+				}
+			} catch (NumberFormatException e) {
+				// 4th field is not a number, so it must be the group (old format)
+				try {
+					group = MaterialGroup.loadFromDatabaseStringWithBackwardCompatibility(split[3], type, name, density);
+				} catch (IllegalArgumentException ex) {
+					log.debug(ex.toString());
+				}
 			}
 		}
 
 		return switch (type) {
-			case BULK -> new Bulk(name, density, group, userDefined);
-			case SURFACE -> new Surface(name, density, group, userDefined);
-			case LINE -> new Line(name, density, group, userDefined);
+			case BULK -> new Bulk(name, density, inPlaneShearModulus, group, userDefined);
+			case SURFACE -> new Surface(name, density, inPlaneShearModulus, group, userDefined);
+			case LINE -> new Line(name, density, inPlaneShearModulus, group, userDefined);
 			default -> throw new IllegalArgumentException("Illegal material string: " + str);
 		};
 	}

--- a/core/src/main/java/info/openrocket/core/preset/ComponentPreset.java
+++ b/core/src/main/java/info/openrocket/core/preset/ComponentPreset.java
@@ -481,6 +481,7 @@ public class ComponentPreset implements Comparable<ComponentPreset>, Serializabl
 		String type;
 		boolean userDefined;
 		Double density;
+		Double inPlaneShearModulus;
 		String group;
 	}
 
@@ -499,6 +500,7 @@ public class ComponentPreset implements Comparable<ComponentPreset>, Serializabl
 				m.name = material.getName();
 				m.type = material.getType().name();
 				m.density = material.getDensity();
+				m.inPlaneShearModulus = material.getInPlaneShearModulus();
 				m.userDefined = material.isUserDefined();
 				m.group = material.getGroup().getDatabaseString();
 				value = m;
@@ -527,8 +529,9 @@ public class ComponentPreset implements Comparable<ComponentPreset>, Serializabl
 				MaterialSerializationProxy m = (MaterialSerializationProxy) value;
 				MaterialGroup group = MaterialGroup.loadFromDatabaseStringWithBackwardCompatibility(
 						m.group, Material.Type.valueOf(m.type), m.name, m.density);
+				double shearModulus = m.inPlaneShearModulus != null ? m.inPlaneShearModulus : 0.0;
 				value = Material.newMaterial(Material.Type.valueOf(m.type), m.name, m.density,
-						group, m.userDefined, true);
+						shearModulus, group, m.userDefined, true);
 			}
 			if (TYPE.getName().equals(keyName)) {
 				this.properties.put(TYPE, (ComponentPreset.Type) value);

--- a/core/src/main/java/info/openrocket/core/preset/xml/MaterialDTO.java
+++ b/core/src/main/java/info/openrocket/core/preset/xml/MaterialDTO.java
@@ -28,6 +28,8 @@ public class MaterialDTO {
 	private MaterialTypeDTO type;
 	@XmlAttribute(name = "UnitsOfMeasure")
 	private String uom;
+	@XmlElement(name = "ShearModulus")
+	private Double inPlaneShearModulus;
 	@XmlElement(name = "Group")
 	private MaterialGroupDTO group;
 
@@ -38,15 +40,22 @@ public class MaterialDTO {
 	}
 
 	public MaterialDTO(final Material theMaterial) {
-		this(theMaterial.getName(), theMaterial.getDensity(), MaterialTypeDTO.asDTO(theMaterial.getType()),
+		this(theMaterial.getName(), theMaterial.getDensity(), theMaterial.getInPlaneShearModulus(),
+				MaterialTypeDTO.asDTO(theMaterial.getType()),
 				theMaterial.getType().getUnitGroup().getDefaultUnit().toString(),
 				MaterialGroupDTO.asDTO(theMaterial.getGroup()));
 	}
 
 	public MaterialDTO(final String theName, final double theDensity, final MaterialTypeDTO theType,
 			final String theUom, final MaterialGroupDTO theGroup) {
+		this(theName, theDensity, null, theType, theUom, theGroup);
+	}
+
+	public MaterialDTO(final String theName, final double theDensity, final Double theInPlaneShearModulus,
+			final MaterialTypeDTO theType, final String theUom, final MaterialGroupDTO theGroup) {
 		name = theName;
 		density = theDensity;
+		inPlaneShearModulus = theInPlaneShearModulus;
 		type = theType;
 		uom = theUom;
 		group = theGroup;
@@ -87,6 +96,14 @@ public class MaterialDTO {
 		uom = theUom;
 	}
 
+	public Double getInPlaneShearModulus() {
+		return inPlaneShearModulus;
+	}
+
+	public void setInPlaneShearModulus(final Double theInPlaneShearModulus) {
+		inPlaneShearModulus = theInPlaneShearModulus;
+	}
+
 	public MaterialGroupDTO getGroup() {
 		return group;
 	}
@@ -99,7 +116,11 @@ public class MaterialDTO {
 		if (group == null) {
 			group = MaterialGroupDTO.OTHER;
 		}
-		return Databases.findMaterial(type.getORMaterialType(), name, density, group.getORMaterialGroup());
+		if (inPlaneShearModulus == null) {
+			return Databases.findMaterial(type.getORMaterialType(), name, density, group.getORMaterialGroup());
+		}
+		return Databases.findMaterial(type.getORMaterialType(), name, density, inPlaneShearModulus,
+				group.getORMaterialGroup());
 	}
 
 	/**

--- a/core/src/main/java/info/openrocket/core/unit/UnitGroup.java
+++ b/core/src/main/java/info/openrocket/core/unit/UnitGroup.java
@@ -74,6 +74,7 @@ public class UnitGroup {
 	public static final UnitGroup UNITS_ROLL;
 	public static final UnitGroup UNITS_TEMPERATURE;
 	public static final UnitGroup UNITS_PRESSURE;
+	public static final UnitGroup UNITS_SHEAR_MODULUS;
 	public static final UnitGroup UNITS_RELATIVE;
 	public static final UnitGroup UNITS_ROUGHNESS;
 
@@ -294,6 +295,11 @@ public class UnitGroup {
 		UNITS_PRESSURE.addUnit(new FixedPrecisionUnit("psi", 0.01, 6894.75729));
 		UNITS_PRESSURE.addUnit(new GeneralUnit(1, "Pa"));
 
+		UNITS_SHEAR_MODULUS = new UnitGroup();
+		UNITS_SHEAR_MODULUS.addUnit(new GeneralUnit(1, "Pa"));
+		UNITS_SHEAR_MODULUS.addUnit(new GeneralUnit(1.0e9, "GPa"));
+		UNITS_SHEAR_MODULUS.addUnit(new GeneralUnit(6.89475729e6, "ksi"));
+
 		UNITS_RELATIVE = new UnitGroup();
 		UNITS_RELATIVE.addUnit(new FixedPrecisionUnit("" + ZWSP, 0.01, 1.0));
 		UNITS_RELATIVE.addUnit(new GeneralUnit(0.01, "%"));
@@ -350,6 +356,7 @@ public class UnitGroup {
 		map.put("ROLL", UNITS_ROLL);
 		map.put("TEMPERATURE", UNITS_TEMPERATURE);
 		map.put("PRESSURE", UNITS_PRESSURE);
+		map.put("SHEAR_MODULUS", UNITS_SHEAR_MODULUS);
 		map.put("RELATIVE", UNITS_RELATIVE);
 		map.put("ROUGHNESS", UNITS_ROUGHNESS);
 		map.put("COEFFICIENT", UNITS_COEFFICIENT);
@@ -415,6 +422,7 @@ public class UnitGroup {
 		UNITS_LATITUDE.setDefaultUnit(DEGREE + " " + trans.get("CompassRose.lbl.north"));
 		UNITS_LONGITUDE.setDefaultUnit(DEGREE + " " + trans.get("CompassRose.lbl.east"));
 		UNITS_PRESSURE.setDefaultUnit("mbar");
+		UNITS_SHEAR_MODULUS.setDefaultUnit("GPa");
 		UNITS_RELATIVE.setDefaultUnit("%");
 		UNITS_ROUGHNESS.setDefaultUnit(MICRO + "m");
 		UNITS_STROKE_WIDTH.setDefaultUnit("mm");
@@ -445,6 +453,7 @@ public class UnitGroup {
 		UNITS_LATITUDE.setDefaultUnit(DEGREE + " " + trans.get("CompassRose.lbl.north"));
 		UNITS_LONGITUDE.setDefaultUnit(DEGREE + " " + trans.get("CompassRose.lbl.east"));
 		UNITS_PRESSURE.setDefaultUnit("mbar");
+		UNITS_SHEAR_MODULUS.setDefaultUnit("ksi");
 		UNITS_RELATIVE.setDefaultUnit("%");
 		UNITS_ROUGHNESS.setDefaultUnit("mil");
 		UNITS_STROKE_WIDTH.setDefaultUnit("mil");
@@ -484,6 +493,7 @@ public class UnitGroup {
 		UNITS_ROLL.setDefaultUnit(1);
 		UNITS_TEMPERATURE.setDefaultUnit(1);
 		UNITS_PRESSURE.setDefaultUnit(0);
+		UNITS_SHEAR_MODULUS.setDefaultUnit(1);
 		UNITS_RELATIVE.setDefaultUnit(1);
 		UNITS_ROUGHNESS.setDefaultUnit(0);
 		UNITS_COEFFICIENT.setDefaultUnit(0);

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -289,6 +289,7 @@ matedtpan.but.revertall = Revert all
 matedtpan.col.Material = Material
 matedtpan.col.Type = Type
 matedtpan.col.Density = Density
+matedtpan.col.ShearModulus = Shear Modulus (G)
 matedtpan.col.Group = Group
 matedtpan.col.Scope = Scope
 matedtpan.col.Scope.Application = Application
@@ -1233,6 +1234,7 @@ custmatdlg.title.Custommaterial = Custom material
 custmatdlg.lbl.Materialname = Material name:
 custmatdlg.lbl.Materialtype = Material type:
 custmatdlg.lbl.Materialdensity = Material density:
+custmatdlg.lbl.ShearModulus = In-Plane Shear Modulus (G):
 custmatdlg.lbl.MaterialGroup = Material group:
 custmatdlg.checkbox.Addmaterial = Add material to application database
 

--- a/core/src/test/java/info/openrocket/core/material/MaterialTest.java
+++ b/core/src/test/java/info/openrocket/core/material/MaterialTest.java
@@ -75,7 +75,7 @@ public class MaterialTest extends BaseTestCase {
 
 		// Test storable string
 		String storable = m.toStorableString();
-		assertEquals("BULK|Test Material|1.0|Woods", storable);
+		assertEquals("BULK|Test Material|1.0|0.0|Woods", storable);
 	}
 
 	@Test

--- a/docs/source/dev_guide/file_specification.rst
+++ b/docs/source/dev_guide/file_specification.rst
@@ -257,6 +257,7 @@ Most components share these common attributes:
    * ``type``: (bulk, surface, line)
    * ``density``: Material density
    * ``group``: Material category
+   * ``shearModulus``: In-plane shear modulus in Pa (optional)
 
 Position and Offset Attributes:
 
@@ -1035,10 +1036,15 @@ The ``<docprefs>`` section contains document-wide settings, including material d
 
     <docprefs>
         <docmaterials>
-            <material>BULK|My Custom Material 1|680.0|Custom</material>
-            <material>BULK|My Custom Metal|0.0018|Metals</material>
+            <material>BULK|My Custom Material 1|680.0|1.2E9|Custom</material>
+            <material>BULK|My Custom Metal|0.0018|7.5E10|Metals</material>
         </docmaterials>
     </docprefs>
+
+Material string format:
+
+- ``{type}|{name}|{density}|{inPlaneShearModulus}|{group}``
+- Older files may omit ``inPlaneShearModulus`` and store ``{type}|{name}|{density}|{group}``
 
 ----
 
@@ -1107,6 +1113,7 @@ The ``<Materials>`` section defines materials used within the component database
        <Material UnitsOfMeasure="g/cm3">
            <Name>Material Name</Name>
            <Density>0.0</Density>
+           <ShearModulus>0.0</ShearModulus>
            <Type>BULK</Type>
            <Group>MaterialGroup</Group>
        </Material>
@@ -1121,6 +1128,7 @@ Material properties:
 
 - ``Type``: Material type (`BULK`, `SURFACE`, or `LINE`)
 - ``Group``: Material group for categorization (optional)
+- ``ShearModulus``: In-plane shear modulus in Pa (optional, defaults to 0.0 when omitted)
 
 Components
 ----------

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/CustomMaterialDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/CustomMaterialDialog.java
@@ -22,6 +22,8 @@ import info.openrocket.core.l10n.Translator;
 import info.openrocket.core.material.Material;
 import info.openrocket.core.material.MaterialGroup;
 import info.openrocket.core.startup.Application;
+import info.openrocket.core.unit.Unit;
+import info.openrocket.core.unit.UnitGroup;
 
 import net.miginfocom.swing.MigLayout;
 import info.openrocket.swing.gui.SpinnerEditor;
@@ -43,6 +45,9 @@ public class CustomMaterialDialog extends JDialog {
 	private DoubleModel density;
 	private final JSpinner densitySpinner;
 	private final UnitSelector densityUnit;
+	private DoubleModel shearModulus;
+	private final JSpinner shearModulusSpinner;
+	private final UnitSelector shearModulusUnit;
 	private JComboBox<MaterialGroup> groupBox;
 	private JCheckBox addBox;
 
@@ -112,6 +117,7 @@ public class CustomMaterialDialog extends JDialog {
 				@Override
 				public void actionPerformed(ActionEvent e) {
 					updateDensityModel();
+					updateShearModulusModel();
 				}
 			});
 			panel.add(typeBox, "span, growx, wrap");
@@ -128,6 +134,16 @@ public class CustomMaterialDialog extends JDialog {
 		panel.add(densityUnit, "w 30lp");
 		panel.add(new JPanel(), "growx, wrap");
 		updateDensityModel();
+
+
+		// In-Plane Shear Modulus (only for BULK materials):
+		panel.add(new JLabel(trans.get("custmatdlg.lbl.ShearModulus")));
+		shearModulusSpinner = new JSpinner();
+		panel.add(shearModulusSpinner, "w 70lp");
+		shearModulusUnit = new UnitSelector((DoubleModel) null);
+		panel.add(shearModulusUnit, "w 30lp");
+		panel.add(new JPanel(), "growx, wrap");
+		updateShearModulusModel();
 
 
 		// Material group
@@ -198,6 +214,7 @@ public class CustomMaterialDialog extends JDialog {
 		Material.Type type;
 		String name;
 		double materialDensity;
+		double materialShearModulus;
 		MaterialGroup group;
 		
 		if (typeBox != null) {
@@ -208,9 +225,10 @@ public class CustomMaterialDialog extends JDialog {
 		
 		name = nameField.getText().trim();
 		materialDensity = this.density.getValue();
+		materialShearModulus = this.shearModulus != null ? this.shearModulus.getValue() : 0.0;
 		group = (MaterialGroup) groupBox.getSelectedItem();
 		
-		return Databases.findMaterial(type, name, materialDensity, group);
+		return Databases.findMaterial(type, name, materialDensity, materialShearModulus, group);
 	}
 	
 	
@@ -230,6 +248,35 @@ public class CustomMaterialDialog extends JDialog {
 			densitySpinner.setModel(density.getSpinnerModel());
 			densitySpinner.setEditor(new SpinnerEditor(densitySpinner));
 			densityUnit.setModel(density);
+		}
+	}
+
+	private void updateShearModulusModel() {
+		// Find GPa unit index for shear modulus (default to GPa for input)
+		int gpaUnitIndex = 0;
+		try {
+			Unit gpaUnit = UnitGroup.UNITS_SHEAR_MODULUS.getUnit("GPa");
+			gpaUnitIndex = UnitGroup.UNITS_SHEAR_MODULUS.getUnitIndex(gpaUnit);
+		} catch (IllegalArgumentException e) {
+			// GPa unit not found, use default index 0 (Pa)
+		}
+		
+		if (originalMaterial != null) {
+			if (shearModulus == null) {
+				double shearModulusValue = onlyCopyTypeFromMaterial ? 0 : originalMaterial.getInPlaneShearModulus();
+				// Use the shear modulus unit group with GPa as the default for input
+				shearModulus = new DoubleModel(shearModulusValue,
+						UnitGroup.UNITS_SHEAR_MODULUS, gpaUnitIndex);
+				shearModulusSpinner.setModel(shearModulus.getSpinnerModel());
+				shearModulusSpinner.setEditor(new SpinnerEditor(shearModulusSpinner));
+				shearModulusUnit.setModel(shearModulus);
+			}
+		} else {
+			// Use the shear modulus unit group with GPa as the default for input
+			shearModulus = new DoubleModel(0, UnitGroup.UNITS_SHEAR_MODULUS, gpaUnitIndex);
+			shearModulusSpinner.setModel(shearModulus.getSpinnerModel());
+			shearModulusSpinner.setEditor(new SpinnerEditor(shearModulusSpinner));
+			shearModulusUnit.setModel(shearModulus);
 		}
 	}
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/MaterialEditPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/MaterialEditPanel.java
@@ -34,6 +34,7 @@ import info.openrocket.core.database.Databases;
 import info.openrocket.core.l10n.Translator;
 import info.openrocket.core.material.Material;
 import info.openrocket.core.startup.Application;
+import info.openrocket.core.unit.Unit;
 import info.openrocket.core.unit.UnitGroup;
 import info.openrocket.core.unit.Value;
 
@@ -106,6 +107,36 @@ public class MaterialEditPanel extends JPanel {
 					@Override
 					public Class<?> getColumnClass() {
 						return Value.class;
+					}
+				},
+				//// Shear Modulus
+				new Column(trans.get("matedtpan.col.ShearModulus")) {
+					@Override
+					public Object getValueAt(int row) {
+						Material m = getMaterial(row);
+						double g = m.getInPlaneShearModulus();
+						// Only show shear modulus for bulk materials
+						if (m.getType() == Material.Type.BULK && g > 0) {
+							// Use GPa for display in the table
+							try {
+								Unit gpaUnit = UnitGroup.UNITS_SHEAR_MODULUS.getUnit("GPa");
+								return gpaUnit.toValue(g);
+							} catch (IllegalArgumentException e) {
+								// Fallback to default unit if GPa is not found
+								return UnitGroup.UNITS_SHEAR_MODULUS.toValue(g);
+							}
+						}
+						return "";
+					}
+					
+					@Override
+					public int getDefaultWidth() {
+						return 15;
+					}
+					
+					@Override
+					public Class<?> getColumnClass() {
+						return Object.class;
 					}
 				},
 				//// Group


### PR DESCRIPTION
This is a preparation for #2709 - calculating the fin flutter velocity. It adds an (in-plane) shear modulus material property to the materials, and fills in default values for the materials in the database.

<img width="834" height="769" alt="image" src="https://github.com/user-attachments/assets/379bf4f9-52da-4622-b6e1-c372c3c66f00" />
