### PR TITLE
Improve clarity of warning/error icons

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/util/Icons.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/util/Icons.java
@@ -399,17 +399,17 @@ public class Icons {
 			"Favorite");
 
 	public static final Icon WARNING_LOW = loadIcon(
-			"pix/icons/lucide/info.svg",
+			"pix/icons/lucide/info-filled.svg",
 			"pix/icons/warning_low.png",
 			"Informational",
 			"OR.icons.warning.low");
 	public static final Icon WARNING_NORMAL = loadIcon(
-			"pix/icons/lucide/triangle-alert.svg",
+			"pix/icons/lucide/triangle-alert-filled.svg",
 			"pix/icons/warning_normal.png",
 			"Warning",
 			"OR.icons.warning.normal");
 	public static final Icon WARNING_HIGH = loadIcon(
-			"pix/icons/lucide/circle-alert.svg",
+			"pix/icons/lucide/circle-alert-filled.svg",
 			"pix/icons/warning_high.png",
 			"Critical",
 			"OR.icons.warning.high");

--- a/swing/src/main/resources/pix/icons/lucide/circle-alert-filled.svg
+++ b/swing/src/main/resources/pix/icons/lucide/circle-alert-filled.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <path d="M8,1.333C11.68,1.333 14.667,4.32 14.667,8C14.667,11.68 11.68,14.667 8,14.667C4.32,14.667 1.333,11.68 1.333,8C1.333,4.32 4.32,1.333 8,1.333ZM7.13,5.12L7.13,8.213C7.13,8.693 7.52,9.082 8,9.082C8.48,9.082 8.87,8.693 8.87,8.213L8.87,5.12C8.87,4.64 8.48,4.251 8,4.251C7.52,4.251 7.13,4.64 7.13,5.12ZM8.007,10.152C7.51,10.152 7.106,10.556 7.106,11.053C7.106,11.551 7.51,11.955 8.007,11.955C8.504,11.955 8.908,11.551 8.908,11.053C8.908,10.556 8.504,10.152 8.007,10.152Z"/>
+</svg>

--- a/swing/src/main/resources/pix/icons/lucide/info-filled.svg
+++ b/swing/src/main/resources/pix/icons/lucide/info-filled.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <path d="M8,1.333C11.68,1.333 14.667,4.32 14.667,8C14.667,11.68 11.68,14.667 8,14.667C4.32,14.667 1.333,11.68 1.333,8C1.333,4.32 4.32,1.333 8,1.333ZM8.941,11.007L8.941,7.66C8.941,7.141 8.519,6.719 8,6.719C7.481,6.719 7.059,7.141 7.059,7.66L7.059,11.007C7.059,11.526 7.481,11.948 8,11.948C8.519,11.948 8.941,11.526 8.941,11.007ZM8.007,3.857C7.5,3.857 7.089,4.268 7.089,4.775C7.089,5.282 7.5,5.693 8.007,5.693C8.514,5.693 8.925,5.282 8.925,4.775C8.925,4.268 8.514,3.857 8.007,3.857Z"/>
+</svg>

--- a/swing/src/main/resources/pix/icons/lucide/triangle-alert-filled.svg
+++ b/swing/src/main/resources/pix/icons/lucide/triangle-alert-filled.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <path d="M14.487,12C14.604,12.203 14.665,12.433 14.665,12.667C14.665,13.398 14.064,13.999 13.333,14L2.655,14C1.923,14 1.321,13.398 1.321,12.667C1.321,12.433 1.383,12.203 1.5,12L6.833,2.667C7.07,2.249 7.514,1.991 7.993,1.991C8.473,1.991 8.917,2.249 9.153,2.667L14.487,12ZM7.365,5.64L7.365,9.027C7.365,9.378 7.649,9.662 8,9.662C8.351,9.662 8.635,9.378 8.635,9.027L8.635,5.64C8.635,5.289 8.351,5.005 8,5.005C7.649,5.005 7.365,5.289 7.365,5.64ZM7.993,10.677C7.63,10.677 7.337,10.97 7.337,11.333C7.337,11.696 7.63,11.989 7.993,11.989C8.356,11.989 8.649,11.696 8.649,11.333C8.649,10.97 8.356,10.677 7.993,10.677Z"/>
+</svg>


### PR DESCRIPTION
This PR fixes #3008 by using filled icons for warnings and errors. The color contrast could still be better in light mode when the row is selected, but I think for now this'll do.
<img width="134" height="151" alt="image" src="https://github.com/user-attachments/assets/8cb6180e-e8c0-43ac-be91-d3f4bf9810a0" />
