### PR TITLE
Fix RK6 stepper k-value accumulation bug

### DIFF
--- a/core/src/main/java/info/openrocket/core/simulation/RK6SimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/RK6SimulationStepper.java
@@ -269,23 +269,16 @@ public class RK6SimulationStepper extends AbstractSimulationStepper {
         double weightk3 = -1.0/12;
         status2 = status.clone();
         status2.setSimulationTime(status.getSimulationTime() + store.timeStep*1/3);
+        // Chain addScaled calls so all k-values are accumulated (not overwritten)
         status2.setRocketPosition(mutableCoordA.set(status.getRocketPosition())
                 .addScaled(k1.v, store.timeStep * weightk1)
-                .toImmutable());
-        status2.setRocketPosition(mutableCoordA.set(status.getRocketPosition())
                 .addScaled(k2.v, store.timeStep * weightk2)
-                .toImmutable());
-        status2.setRocketPosition(mutableCoordA.set(status.getRocketPosition())
                 .addScaled(k3.v, store.timeStep * weightk3)
                 .toImmutable());
 
         status2.setRocketVelocity(mutableCoordA.set(status.getRocketVelocity())
                 .addScaled(k1.a, store.timeStep * weightk1)
-                .toImmutable());
-        status2.setRocketVelocity(mutableCoordA.set(status.getRocketVelocity())
                 .addScaled(k2.a, store.timeStep * weightk2)
-                .toImmutable());
-        status2.setRocketVelocity(mutableCoordA.set(status.getRocketVelocity())
                 .addScaled(k3.a, store.timeStep * weightk3)
                 .toImmutable());
 
@@ -304,11 +297,7 @@ public class RK6SimulationStepper extends AbstractSimulationStepper {
 
         status2.setRocketRotationVelocity(mutableCoordA.set(status.getRocketRotationVelocity())
                 .addScaled(k1.ra, store.timeStep * weightk1)
-                .toImmutable());
-        status2.setRocketRotationVelocity(mutableCoordA.set(status.getRocketRotationVelocity())
                 .addScaled(k2.ra, store.timeStep * weightk2)
-                .toImmutable());
-        status2.setRocketRotationVelocity(mutableCoordA.set(status.getRocketRotationVelocity())
                 .addScaled(k3.ra, store.timeStep * weightk3)
                 .toImmutable());
 
@@ -325,27 +314,15 @@ public class RK6SimulationStepper extends AbstractSimulationStepper {
         status2.setSimulationTime(status.getSimulationTime() + store.timeStep*1/2);
         status2.setRocketPosition(mutableCoordA.set(status.getRocketPosition())
                 .addScaled(k1.v, store.timeStep * weightk1)
-                .toImmutable());
-        status2.setRocketPosition(mutableCoordA.set(status.getRocketPosition())
                 .addScaled(k2.v, store.timeStep * weightk2)
-                .toImmutable());
-        status2.setRocketPosition(mutableCoordA.set(status.getRocketPosition())
                 .addScaled(k3.v, store.timeStep * weightk3)
-                .toImmutable());
-        status2.setRocketPosition(mutableCoordA.set(status.getRocketPosition())
                 .addScaled(k4.v, store.timeStep * weightk4)
                 .toImmutable());
 
         status2.setRocketVelocity(mutableCoordA.set(status.getRocketVelocity())
                 .addScaled(k1.a, store.timeStep * weightk1)
-                .toImmutable());
-        status2.setRocketVelocity(mutableCoordA.set(status.getRocketVelocity())
                 .addScaled(k2.a, store.timeStep * weightk2)
-                .toImmutable());
-        status2.setRocketVelocity(mutableCoordA.set(status.getRocketVelocity())
                 .addScaled(k3.a, store.timeStep * weightk3)
-                .toImmutable());
-        status2.setRocketVelocity(mutableCoordA.set(status.getRocketVelocity())
                 .addScaled(k4.a, store.timeStep * weightk4)
                 .toImmutable());
 
@@ -368,14 +345,8 @@ public class RK6SimulationStepper extends AbstractSimulationStepper {
 
         status2.setRocketRotationVelocity(mutableCoordA.set(status.getRocketRotationVelocity())
                 .addScaled(k1.ra, store.timeStep * weightk1)
-                .toImmutable());
-        status2.setRocketRotationVelocity(mutableCoordA.set(status.getRocketRotationVelocity())
                 .addScaled(k2.ra, store.timeStep * weightk2)
-                .toImmutable());
-        status2.setRocketRotationVelocity(mutableCoordA.set(status.getRocketRotationVelocity())
                 .addScaled(k3.ra, store.timeStep * weightk3)
-                .toImmutable());
-        status2.setRocketRotationVelocity(mutableCoordA.set(status.getRocketRotationVelocity())
                 .addScaled(k4.ra, store.timeStep * weightk4)
                 .toImmutable());
 
@@ -393,27 +364,15 @@ public class RK6SimulationStepper extends AbstractSimulationStepper {
         status2.setSimulationTime(status.getSimulationTime() + store.timeStep*1/2);
         status2.setRocketPosition(mutableCoordA.set(status.getRocketPosition())
                 .addScaled(k2.v, store.timeStep * weightk2)
-                .toImmutable());
-        status2.setRocketPosition(mutableCoordA.set(status.getRocketPosition())
                 .addScaled(k3.v, store.timeStep * weightk3)
-                .toImmutable());
-        status2.setRocketPosition(mutableCoordA.set(status.getRocketPosition())
                 .addScaled(k4.v, store.timeStep * weightk4)
-                .toImmutable());
-        status2.setRocketPosition(mutableCoordA.set(status.getRocketPosition())
                 .addScaled(k5.v, store.timeStep * weightk5)
                 .toImmutable());
 
         status2.setRocketVelocity(mutableCoordA.set(status.getRocketVelocity())
                 .addScaled(k2.a, store.timeStep * weightk2)
-                .toImmutable());
-        status2.setRocketVelocity(mutableCoordA.set(status.getRocketVelocity())
                 .addScaled(k3.a, store.timeStep * weightk3)
-                .toImmutable());
-        status2.setRocketVelocity(mutableCoordA.set(status.getRocketVelocity())
                 .addScaled(k4.a, store.timeStep * weightk4)
-                .toImmutable());
-        status2.setRocketVelocity(mutableCoordA.set(status.getRocketVelocity())
                 .addScaled(k5.a, store.timeStep * weightk5)
                 .toImmutable());
 
@@ -436,14 +395,8 @@ public class RK6SimulationStepper extends AbstractSimulationStepper {
 
         status2.setRocketRotationVelocity(mutableCoordA.set(status.getRocketRotationVelocity())
                 .addScaled(k2.ra, store.timeStep * weightk2)
-                .toImmutable());
-        status2.setRocketRotationVelocity(mutableCoordA.set(status.getRocketRotationVelocity())
                 .addScaled(k3.ra, store.timeStep * weightk3)
-                .toImmutable());
-        status2.setRocketRotationVelocity(mutableCoordA.set(status.getRocketRotationVelocity())
                 .addScaled(k4.ra, store.timeStep * weightk4)
-                .toImmutable());
-        status2.setRocketRotationVelocity(mutableCoordA.set(status.getRocketRotationVelocity())
                 .addScaled(k5.ra, store.timeStep * weightk5)
                 .toImmutable());
 
@@ -461,33 +414,17 @@ public class RK6SimulationStepper extends AbstractSimulationStepper {
         status2.setSimulationTime(status.getSimulationTime() + store.timeStep);
         status2.setRocketPosition(mutableCoordA.set(status.getRocketPosition())
                 .addScaled(k1.v, store.timeStep * weightk1)
-                .toImmutable());
-        status2.setRocketPosition(mutableCoordA.set(status.getRocketPosition())
                 .addScaled(k2.v, store.timeStep * weightk2)
-                .toImmutable());
-        status2.setRocketPosition(mutableCoordA.set(status.getRocketPosition())
                 .addScaled(k3.v, store.timeStep * weightk3)
-                .toImmutable());
-        status2.setRocketPosition(mutableCoordA.set(status.getRocketPosition())
                 .addScaled(k4.v, store.timeStep * weightk4)
-                .toImmutable());
-        status2.setRocketPosition(mutableCoordA.set(status.getRocketPosition())
                 .addScaled(k6.v, store.timeStep * weightk6)
                 .toImmutable());
 
         status2.setRocketVelocity(mutableCoordA.set(status.getRocketVelocity())
                 .addScaled(k1.a, store.timeStep * weightk1)
-                .toImmutable());
-        status2.setRocketVelocity(mutableCoordA.set(status.getRocketVelocity())
                 .addScaled(k2.a, store.timeStep * weightk2)
-                .toImmutable());
-        status2.setRocketVelocity(mutableCoordA.set(status.getRocketVelocity())
                 .addScaled(k3.a, store.timeStep * weightk3)
-                .toImmutable());
-        status2.setRocketVelocity(mutableCoordA.set(status.getRocketVelocity())
                 .addScaled(k4.a, store.timeStep * weightk4)
-                .toImmutable());
-        status2.setRocketVelocity(mutableCoordA.set(status.getRocketVelocity())
                 .addScaled(k6.a, store.timeStep * weightk6)
                 .toImmutable());
 
@@ -514,17 +451,9 @@ public class RK6SimulationStepper extends AbstractSimulationStepper {
 
         status2.setRocketRotationVelocity(mutableCoordA.set(status.getRocketRotationVelocity())
                 .addScaled(k1.ra, store.timeStep * weightk1)
-                .toImmutable());
-        status2.setRocketRotationVelocity(mutableCoordA.set(status.getRocketRotationVelocity())
                 .addScaled(k2.ra, store.timeStep * weightk2)
-                .toImmutable());
-        status2.setRocketRotationVelocity(mutableCoordA.set(status.getRocketRotationVelocity())
                 .addScaled(k3.ra, store.timeStep * weightk3)
-                .toImmutable());
-        status2.setRocketRotationVelocity(mutableCoordA.set(status.getRocketRotationVelocity())
                 .addScaled(k4.ra, store.timeStep * weightk4)
-                .toImmutable());
-        status2.setRocketRotationVelocity(mutableCoordA.set(status.getRocketRotationVelocity())
                 .addScaled(k6.ra, store.timeStep * weightk6)
                 .toImmutable());
 

--- a/core/src/test/java/info/openrocket/core/simulation/RK6AccumulationBugTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/RK6AccumulationBugTest.java
@@ -1,0 +1,50 @@
+package info.openrocket.core.simulation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import info.openrocket.core.util.Coordinate;
+import info.openrocket.core.util.MutableCoordinate;
+import info.openrocket.core.util.BaseTestCase;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for RK6 weighted k-value accumulation.
+ *
+ * The RK6 algorithm requires combining multiple weighted k-values when computing
+ * intermediate positions (k4, k5, k6, k7). For example:
+ *   k4 = f(t + h/3, y + (1/12)*k1 + (1/3)*k2 + (-1/12)*k3)
+ *
+ * All terms must be accumulated together, not computed separately.
+ */
+public class RK6AccumulationBugTest extends BaseTestCase {
+
+    /**
+     * Verifies that chaining addScaled calls properly accumulates all terms.
+     */
+    @Test
+    public void testAccumulationPattern() {
+        Coordinate base = new Coordinate(0, 0, 0);
+        Coordinate k1 = new Coordinate(1, 0, 0);
+        Coordinate k2 = new Coordinate(2, 0, 0);
+        Coordinate k3 = new Coordinate(3, 0, 0);
+
+        double w1 = 0.5;
+        double w2 = 0.3;
+        double w3 = 0.2;
+
+        // Expected: base + k1*w1 + k2*w2 + k3*w3 = 0 + 0.5 + 0.6 + 0.6 = 1.7
+        double expectedX = base.getX() + k1.getX()*w1 + k2.getX()*w2 + k3.getX()*w3;
+
+        // Chained addScaled calls (correct pattern used in RK6SimulationStepper)
+        MutableCoordinate mutableCoord = new MutableCoordinate();
+        Coordinate result = mutableCoord.set(base)
+            .addScaled(k1, w1)
+            .addScaled(k2, w2)
+            .addScaled(k3, w3)
+            .toImmutable();
+
+        assertEquals(expectedX, result.getX(), 0.001,
+            "Chained addScaled should accumulate all weighted k-values");
+    }
+}


### PR DESCRIPTION
The RK6 algorithm requires accumulating multiple weighted k-values when computing intermediate positions. The previous code called setRocketPosition multiple times for k4, k5, k6, and k7 calculations, where each call overwrote the previous result instead of accumulating.

For example, computing k4 position requires:
  y + (1/12)*k1 + (1/3)*k2 + (-1/12)*k3

The fix chains the addScaled() calls together so all terms are accumulated in a single coordinate, matching the correct RK6 formulas.