### PR TITLE
Set AoA to 0 until the launch rod is cleared

### DIFF
--- a/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
@@ -84,7 +84,7 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 
 		double velocity = airSpeed.length();
 		store.flightConditions.setVelocity(velocity);
-		if (velocity > 0.01) {
+		if (status.isLaunchRodCleared() && velocity > 0.01) {
 			// aoa must be calculated from the monotonous cosine
 			// sine can be calculated by a simple division
 			store.flightConditions.setAOA(Math.acos(airSpeed.getZ() / velocity), len / velocity);

--- a/core/src/test/java/info/openrocket/core/simulation/AngleOfAttackTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/AngleOfAttackTest.java
@@ -1,0 +1,50 @@
+package info.openrocket.core.simulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import info.openrocket.core.document.Simulation;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.simulation.exception.SimulationException;
+import info.openrocket.core.util.BaseTestCase;
+import info.openrocket.core.util.TestRockets;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class AngleOfAttackTest extends BaseTestCase {
+
+	/**
+	 * Check that the initial angle of attack is zero while the rocket remains on the launch rod.
+	 */
+	@ParameterizedTest
+	@EnumSource(SimulationStepperMethod.class)
+	public void testAngleOfAttackIsZeroOnLaunchRodAtT0(SimulationStepperMethod stepperMethod)
+			throws SimulationException {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		Simulation simulation = new Simulation(rocket);
+		simulation.setFlightConfigurationId(TestRockets.TEST_FCID_0);
+		simulation.getOptions().setISAAtmosphere(true);
+		simulation.getOptions().setTimeStep(0.05);
+		simulation.getOptions().setRandomSeed(0xC0FFEE);
+		simulation.getOptions().setSimulationStepperMethodChoice(stepperMethod);
+
+		simulation.simulate();
+
+		FlightDataBranch branch = simulation.getSimulatedData().getBranch(0);
+		assertNotNull(branch);
+
+		List<Double> time = branch.get(FlightDataType.TYPE_TIME);
+		List<Double> aoa = branch.get(FlightDataType.TYPE_AOA);
+
+		assertNotNull(time);
+		assertNotNull(aoa);
+		assertFalse(aoa.isEmpty());
+		assertEquals(time.size(), aoa.size());
+
+		// At t=0 the rocket has not cleared the launch rod, so angle of attack is zero.
+		assertEquals(0.0, aoa.get(0), "Expected zero AoA at t=0 while on launch rod");
+	}
+}


### PR DESCRIPTION
When the rocket has not yet cleared the launch rod, the angle of attack is 90° (because `airspeed.getZ() = 0`, causing `Math.acos(airspeed.getZ() / velocity)` to be 90°). This doesn't make sense because while the rocket is on the launch rod, the rocket centerline and velocity vector are parallel.

This PR sets the AoA to 0 if the launch rod has not yet been cleared.

Before:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/e3e804ce-e4db-4ee4-9062-6bcfcdd711e9" />

After:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/8bd52be4-334d-4c9d-a66e-3a8f1d99fcd9" />
