### PR TITLE
Refine open airframe

### DIFF
--- a/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanStabilityCalculator.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanStabilityCalculator.java
@@ -153,7 +153,15 @@ public class BarrowmanStabilityCalculator implements StabilityCalculator {
 					SymmetricComponent sym = (SymmetricComponent) comp;
 					if (prevComp == null) {
 						if (sym.getForeRadius() - sym.getThickness() > MathUtil.EPSILON) {
-							actualWarnings.add(Warning.OPEN_AIRFRAME_FORWARD, sym);
+
+							// only recorde open airframe warning if it's the sustainer is active or if
+							// the booster has a recovery device
+							boolean sustainer = configuration.isStageActive(0);
+							boolean hasRecoveryDevice = configuration.getBottomStage().hasRecoveryDevice();
+
+							if (sustainer || hasRecoveryDevice) {
+								actualWarnings.add(Warning.OPEN_AIRFRAME_FORWARD, sym);
+							}
 						}
 					} else {
 						if (!UnitGroup.UNITS_LENGTH.getDefaultUnit().toStringUnit(2.0 * sym.getForeRadius())

--- a/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanStabilityCalculator.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanStabilityCalculator.java
@@ -68,7 +68,6 @@ public class BarrowmanStabilityCalculator implements StabilityCalculator {
 		ensureCalcMap(configuration);
 
 		WarningSet actualWarnings = (warnings != null) ? warnings : ignoreWarningSet;
-		checkGeometry(configuration, configuration.getRocket(), actualWarnings);
 
 		InstanceMap imap = configuration.getActiveInstances();
 		AerodynamicForces assemblyForces = new AerodynamicForces().zero();

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/AxialStage.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/AxialStage.java
@@ -1,5 +1,7 @@
 package info.openrocket.core.rocketcomponent;
 
+import java.util.Iterator;
+
 import info.openrocket.core.l10n.Translator;
 import info.openrocket.core.rocketcomponent.position.AxialMethod;
 import info.openrocket.core.startup.Application;
@@ -137,6 +139,21 @@ public class AxialStage extends ComponentAssembly implements FlightConfigurableC
 	 */
 	public boolean isLaunchStage(FlightConfiguration config) {
 		return (getRocket().getBottomCoreStage(config).equals(this));
+	}
+ 
+	/**
+	 * Return true if this stage has a recovery device
+	 */
+	public boolean hasRecoveryDevice() {
+		Iterator<RocketComponent> iterator = this.iterator();
+		while (iterator.hasNext()) {
+			RocketComponent child = iterator.next();
+			if ((child.getStage() == this) &&
+				(child instanceof RecoveryDevice)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/FlightConfiguration.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/FlightConfiguration.java
@@ -706,14 +706,22 @@ public class FlightConfiguration implements FlightConfigurableParameter<FlightCo
 	}
 
 	/**
-	 * Return true if rocket has a RecoveryDevice
+	 * Return true if rocket has a RecoveryDevice in an
+	 * active stage
 	 */
 	public boolean hasRecoveryDevice() {
 		if (fcid.hasError()) {
 			return false;
 		}
 
-		return this.getRocket().hasRecoveryDevice();
+		for (AxialStage stage : getRocket().getStageList()) {
+			if (this.isStageActive(stage.getStageNumber()) &&
+				stage.hasRecoveryDevice()) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/////////////// Helper methods ///////////////

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
@@ -11,6 +11,9 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import info.openrocket.core.aerodynamics.AerodynamicCalculator;
 import info.openrocket.core.aerodynamics.AerodynamicForces;
 import info.openrocket.core.aerodynamics.BarrowmanCalculator;
@@ -26,8 +29,6 @@ import info.openrocket.core.util.CoordinateIF;
 import info.openrocket.core.util.ModID;
 import info.openrocket.core.util.ORColor;
 import info.openrocket.core.util.Transformation;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import info.openrocket.core.appearance.Appearance;
 import info.openrocket.core.appearance.Decal;
@@ -473,20 +474,6 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 		clone.configListeners = new LinkedList<>();
 		clone.bypassComponentChangeEvent = false;
 		return clone;
-	}
-	
-	/**
-	 * Return true if any of this component's children are a RecoveryDevice
-	 */
-	public boolean hasRecoveryDevice() {
-		Iterator<RocketComponent> iterator = this.iterator();
-		while (iterator.hasNext()) {
-			RocketComponent child = iterator.next();
-			if (child instanceof RecoveryDevice) {
-				return true;
-			}
-		}
-		return false;
 	}
 	
 	//////////////  Methods that may not be overridden  ////////////

--- a/core/src/main/java/info/openrocket/core/simulation/BasicEventSimulationEngine.java
+++ b/core/src/main/java/info/openrocket/core/simulation/BasicEventSimulationEngine.java
@@ -729,14 +729,16 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 	// stages in a simulation branch when the branch starts executing, and
 	// whenever a stage separation occurs
 	private void checkGeometry(SimulationStatus currentStatus) throws SimulationException {
+
+		FlightConfiguration configuration = currentStatus.getConfiguration();
 		
 		// Active stages have total length of 0.
-		if (currentStatus.getConfiguration().getLengthAerodynamic() < MathUtil.EPSILON) {
+		if (configuration.getLengthAerodynamic() < MathUtil.EPSILON) {
 			currentStatus.abortSimulation(SimulationAbort.Cause.ACTIVE_LENGTH_ZERO);
 		}
 
 		// test -- force an exception if we aren't the sustainer
-		// if (currentStatus.getConfiguration().isStageActive(0)) {
+		// if (configuration.isStageActive(0)) {
 		//    throw new SimulationCalculationException("test", currentStatus.getFlightDataBranch());
 		// }
 
@@ -744,15 +746,18 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 		// we'll just transition to tumbling (if it's a booster and under thrust code elsewhere
 		// will abort).
 		if (currentStatus.getSimulationConditions().getAerodynamicCalculator()
-			.getCP(currentStatus.getConfiguration(),
-				   new FlightConditions(currentStatus.getConfiguration()),
+			.getCP(configuration,
+				   new FlightConditions(configuration),
 				   new WarningSet()).getWeight() < MathUtil.EPSILON) {
-			if (currentStatus.getConfiguration().isStageActive(0)) {
+			if (configuration.isStageActive(0)) {
 				currentStatus.abortSimulation(SimulationAbort.Cause.NO_CP);
 			} else {
 				currentStatus.addEvent(new FlightEvent(FlightEvent.Type.TUMBLE, currentStatus.getSimulationTime()));
 			}
 		}
+
+		// see what the aero calculators have to say
+		currentStatus.getSimulationConditions().getAerodynamicCalculator().checkGeometry(configuration, configuration.getRocket(), currentStatus.getWarnings());
 	}
 	
 	private void checkNaN() throws SimulationException {

--- a/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
@@ -510,10 +510,7 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 		// Calculate aerodynamic forces
 		store.forces = status.getSimulationConditions().getAerodynamicCalculator()
 				.getAerodynamicForces(status.getConfiguration(), store.flightConditions, warnings);
-
-		if (null != warnings) {
-			status.addWarnings(warnings);
-		}
+		status.addWarnings(warnings);
 
 		// Add very small randomization to yaw & pitch moments to prevent over-perfect flight
 		// TODO: HIGH: This should rather be performed as a listener

--- a/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/RK4SimulationStepper.java
@@ -512,22 +512,6 @@ public class RK4SimulationStepper extends AbstractSimulationStepper {
 				.getAerodynamicForces(status.getConfiguration(), store.flightConditions, warnings);
 
 		if (null != warnings) {
-			// If this doesn't include the sustainer and either isn't stable or is about
-			// to deploy a recovery device, don't store open airframe warnings
-			boolean sustainer = status.getConfiguration().isStageActive(0);
-			boolean stable = store.rocketMass.getCM().getX() < store.forces.getCP().getX();
-			boolean recoverySoon = false;
-			for (FlightEvent e : status.getEventQueue()) {
-				if ((e.getType() == FlightEvent.Type.RECOVERY_DEVICE_DEPLOYMENT) &&
-					(e.getTime() < status.getSimulationTime() + 0.5)) {
-					recoverySoon = true;
-				}
-			}
-			
-			if (!sustainer && (!stable || recoverySoon)) {
-				warnings.filterOut(Warning.OPEN_AIRFRAME_FORWARD);
-			}
-				
 			status.addWarnings(warnings);
 		}
 

--- a/core/src/main/java/info/openrocket/core/simulation/RK6SimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/RK6SimulationStepper.java
@@ -794,22 +794,6 @@ public class RK6SimulationStepper extends AbstractSimulationStepper {
                 .getAerodynamicForces(status.getConfiguration(), store.flightConditions, warnings);
 
         if (null != warnings) {
-            // If this doesn't include the sustainer and either isn't stable or is about
-            // to deploy a recovery device, don't store open airframe warnings
-            boolean sustainer = status.getConfiguration().isStageActive(0);
-            boolean stable = store.rocketMass.getCM().getX() < store.forces.getCP().getX();
-            boolean recoverySoon = false;
-            for (FlightEvent e : status.getEventQueue()) {
-                if ((e.getType() == FlightEvent.Type.RECOVERY_DEVICE_DEPLOYMENT) &&
-                        (e.getTime() < status.getSimulationTime() + 0.5)) {
-                    recoverySoon = true;
-                }
-            }
-
-            if (!sustainer && (!stable || recoverySoon)) {
-                warnings.filterOut(Warning.OPEN_AIRFRAME_FORWARD);
-            }
-
             status.addWarnings(warnings);
         }
 

--- a/core/src/main/java/info/openrocket/core/simulation/RK6SimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/RK6SimulationStepper.java
@@ -792,10 +792,7 @@ public class RK6SimulationStepper extends AbstractSimulationStepper {
         // Calculate aerodynamic forces
         store.forces = status.getSimulationConditions().getAerodynamicCalculator()
                 .getAerodynamicForces(status.getConfiguration(), store.flightConditions, warnings);
-
-        if (null != warnings) {
-            status.addWarnings(warnings);
-        }
+		status.addWarnings(warnings);
 
         // Add very small randomization to yaw & pitch moments to prevent over-perfect flight
         // TODO: HIGH: This should rather be performed as a listener

--- a/core/src/main/java/info/openrocket/core/simulation/SimulationStatus.java
+++ b/core/src/main/java/info/openrocket/core/simulation/SimulationStatus.java
@@ -464,8 +464,10 @@ public class SimulationStatus implements Cloneable, Monitorable {
 	}
 
 	public void addWarnings(WarningSet warnings) {
-		for (Warning warning : warnings) {
-			addWarning(warning);
+		if (null != warnings) {
+			for (Warning warning : warnings) {
+				addWarning(warning);
+			}
 		}
 	}
 

--- a/core/src/test/java/info/openrocket/core/aerodynamics/BarrowmanCalculatorTest.java
+++ b/core/src/test/java/info/openrocket/core/aerodynamics/BarrowmanCalculatorTest.java
@@ -518,19 +518,19 @@ public class BarrowmanCalculatorTest {
 
 		// move the pod back.
 		pod.setAxialOffset(pod.getAxialOffset() + 0.1);
-		testCP = testCalc.getCP(testConfig, testConditions, warnings).getX();
+		testCalc.checkGeometry(testConfig, testRocket, warnings);
 		assertEquals(1, warnings.size(), "should be warning from gap in airframe");
 
 		// move the pod forward.
 		warnings.clear();
 		pod.setAxialOffset(pod.getAxialOffset() - 0.3);
-		testCP = testCalc.getCP(testConfig, testConditions, warnings).getX();
+		testCalc.checkGeometry(testConfig, testRocket, warnings);
 		assertEquals(1, warnings.size(), "should be warning from airframe overlap");
 
 		// move the pod back.
 		warnings.clear();
 		pod.setAxialOffset(pod.getAxialOffset() + 0.1);
-		testCP = testCalc.getCP(testConfig, testConditions, warnings).getX();
+		testCalc.checkGeometry(testConfig, testRocket, warnings);
 		assertEquals(1, warnings.size(), "should be warning from podset airframe overlap");
 	}
 


### PR DESCRIPTION
Another iteration of trying to only give the open airframe warning when the user is going to be interested in it.  Rather than looking at the stability of the booster, this iteration only checks to see if it contains a recovery device. If it does we register the open airframe Warning; if not we assume the user is not interested in whether the post-separation booster sim is accurate, so we don't register the Warning.

This also lets us decide in checkGeometry() whether to register the Warning, instead of always registering it and then checking in RK4SimulationStepper and RK6SimulationStepper to see if we should filter it out. Another advantage here is it reduced duplicated code between those steppers.

It also lets us only check the geometry when a new simulation branch starts, instead of on every simulation step.

Finally, spotted a little bug in the check for a rocket with no recovery device at all; it now puts up that warning based on the configuration (so if the recovery device is in an inactive stage then that warning does get set).