### PR TITLE
[#2875] Added PhotoSettings to the change listener check in DoubleModel.java.…

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/adaptors/DoubleModel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/adaptors/DoubleModel.java
@@ -18,6 +18,7 @@ import javax.swing.SpinnerModel;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
+import info.openrocket.swing.gui.figure3d.photo.PhotoSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -727,11 +728,13 @@ public class DoubleModel implements StateChangeListener, ChangeSource, Invalidat
 		} else {
 			this.maxValue = Double.POSITIVE_INFINITY;
 		}
-		
-		if (RocketComponent.class.isAssignableFrom(source.getClass())) {
-		    ((RocketComponent)source).addChangeListener(this);
-		}
-		
+
+        if (source instanceof RocketComponent rc) {
+            rc.addChangeListener(this);
+        } else if (source instanceof PhotoSettings ps) {
+            ps.addChangeListener(this);
+        }
+
 		try {
 			getMethod = source.getClass().getMethod("get" + valueName);
 		} catch (NoSuchMethodException e) {


### PR DESCRIPTION
Addresses #2875. 

Apologies for the delay on this one. It ended up being **extremely easier** than I would of imagined. 

Turns out all the way back in 2018 there was a check added to have backwards listening of changes from a source, but only if it was a `RocketComponent.java` instance. 

I have not put the `ChangeSource.java` as the instance to check (as I am not sure how many change sources would have unintended behavior induced if I just recklessly added all change sources to this check).

Once again, apologies for the delay. I had convinced myself this bug would require a whole MVVM-style rewrite of this system, and it turned out to be embarrassingly easy of a fix. 