### PR TITLE
Prevent creating simulation without motor and configuration

### DIFF
--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -2966,7 +2966,7 @@ MotorConfigurationPanel.btn.deleteMotor = Delete motor
 MotorConfigurationPanel.btn.selectMotor = Select motor
 MotorConfigurationPanel.btn.selectIgnition = Select ignition
 MotorConfigurationPanel.btn.resetIgnition = Reset ignition
-MotorConfigurationPanel.lbl.nomotors = No motor mounts defined. Select one or more tubes from the list on the left as motor mounts.
+MotorConfigurationPanel.lbl.nomotors = <html>No motor mounts defined.<br>Add a tube in the '%s' tab and select it from the list on the left.</html>
 
 MotorConfigurationTableModel.table.ignition.default = Default ({0})
 RecoveryConfigurationPanel.table.deployment.default = Default ({0})

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -889,6 +889,7 @@ simpanel.ttip.InformationalWarnings = Informational(s):
 simpanel.msg.invalidCopySelection = Invalid copy selection
 simpanel.btn.SaveAsDefault = Save as default
 simpanel.btn.SaveAsDefault.ttip = Save the selected visibility settings for all new designs
+simpanel.lbl.noConfiguration = No configuration defined. Please select a configuration from the Motors & Configuration tab.
 
 ! SimulationRunDialog
 SimuRunDlg.title.RunSim = Running simulations\u2026

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -889,7 +889,7 @@ simpanel.ttip.InformationalWarnings = Informational(s):
 simpanel.msg.invalidCopySelection = Invalid copy selection
 simpanel.btn.SaveAsDefault = Save as default
 simpanel.btn.SaveAsDefault.ttip = Save the selected visibility settings for all new designs
-simpanel.lbl.noConfiguration = No configuration defined. Please select a configuration from the Motors & Configuration tab.
+simpanel.lbl.noConfiguration = <html>No configuration with motors defined.<br>Please create a valid configuration in the '%s' tab.</html>
 
 ! SimulationRunDialog
 SimuRunDlg.title.RunSim = Running simulations\u2026

--- a/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
@@ -54,8 +54,6 @@ import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
-import javax.swing.event.TableModelEvent;
-import javax.swing.event.TableModelListener;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
@@ -67,15 +65,11 @@ import info.openrocket.core.logging.WarningSet;
 import info.openrocket.core.document.OpenRocketDocument;
 import info.openrocket.core.document.Simulation;
 import info.openrocket.core.document.Simulation.Status;
-import info.openrocket.core.document.events.DocumentChangeEvent;
-import info.openrocket.core.document.events.DocumentChangeListener;
 import info.openrocket.core.document.events.SimulationChangeEvent;
 import info.openrocket.core.formatting.RocketDescriptor;
 import info.openrocket.core.l10n.Translator;
 import info.openrocket.core.preferences.ApplicationPreferences;
 import info.openrocket.core.preferences.DocumentPreferences;
-import info.openrocket.core.rocketcomponent.ComponentChangeEvent;
-import info.openrocket.core.rocketcomponent.ComponentChangeListener;
 import info.openrocket.core.rocketcomponent.FlightConfigurationId;
 import info.openrocket.core.rocketcomponent.Rocket;
 import info.openrocket.core.simulation.FlightData;
@@ -90,7 +84,6 @@ import info.openrocket.swing.gui.simulation.SimulationConfigDialog;
 import info.openrocket.swing.gui.util.ColorConversion;
 import info.openrocket.swing.gui.util.FileHelper;
 import info.openrocket.swing.gui.util.GUIUtil;
-import info.openrocket.swing.gui.util.SwingPreferences;
 import info.openrocket.swing.gui.theme.UITheme;
 import info.openrocket.swing.gui.widgets.SaveFileChooser;
 import org.slf4j.Logger;
@@ -131,6 +124,7 @@ public class SimulationPanel extends JPanel {
 	private final JPopupMenu pm;
 	private final ColumnVisibilityController columnVisibilityController;
 
+	private final SimulationAction newSimulationAction;
 	private final SimulationAction editSimulationAction;
 	private final SimulationAction cutSimulationAction;
 	private final SimulationAction copySimulationAction;
@@ -186,7 +180,10 @@ public class SimulationPanel extends JPanel {
 	private static Color errorColor;
 	private static Color informationColor;
 
-	private boolean hasMotors;
+	private boolean hasValidConfig;
+
+	private final JPanel cardPanel;
+	private final CardLayout cardLayout;
 
 	static {
 		initColors();
@@ -199,7 +196,7 @@ public class SimulationPanel extends JPanel {
 
 
 		// Simulation actions
-		SimulationAction newSimulationAction = new NewSimulationAction();
+		newSimulationAction = new NewSimulationAction();
 		editSimulationAction = new EditSimulationAction();
 		cutSimulationAction = new CutSimulationAction();
 		copySimulationAction = new CopySimulationAction();
@@ -375,7 +372,8 @@ public class SimulationPanel extends JPanel {
 			}
 		});
 
-		JPanel cardPanel = new JPanel(new CardLayout());
+		cardPanel = new JPanel(new CardLayout());
+		cardLayout = (CardLayout) cardPanel.getLayout();
 
 		JLabel label = new JLabel(String.format(trans.get("simpanel.lbl.noConfiguration"), trans.get("BasicFrame.tab.Flightconfig")), SwingConstants.CENTER);
 		cardPanel.add(label, CARD_HELP);
@@ -384,47 +382,20 @@ public class SimulationPanel extends JPanel {
 		tablePanel.add(new JScrollPane(simulationTable), BorderLayout.CENTER);
 		cardPanel.add(tablePanel, CARD_TABLE);
 
-		CardLayout cardLayout = (CardLayout) (cardPanel.getLayout());
+		updateMotorState();
 
-		Runnable updateMotorState = () -> {
-			Rocket rocket = document.getRocket();
-
-			hasMotors = rocket != null &&
-					!rocket.getSelectedConfiguration()
-							.getAllMotors()
-							.isEmpty();
-
-			newSimulationAction.setEnabled(hasMotors);
-			cardLayout.show(cardPanel, hasMotors ? CARD_TABLE : CARD_HELP);
-		};
-
-		updateMotorState.run();
-
-		simulationTableModel.addTableModelListener(new TableModelListener() {
-			@Override
-			public void tableChanged(TableModelEvent e) {
-				updateMotorState.run();
-			}
+		document.addDocumentChangeListener(event -> {
+			if (!(event instanceof SimulationChangeEvent))
+				return;
+			fireMaintainSelection();
 		});
 
-		document.addDocumentChangeListener(new DocumentChangeListener() {
-			@Override
-			public void documentChanged(DocumentChangeEvent event) {
-				if (!(event instanceof SimulationChangeEvent))
-					return;
-				fireMaintainSelection();
+		// Fire table change event when the rocket changes, and update motor state when relevant
+		document.getRocket().addComponentChangeListener(e -> {
+			if (e.isMotorChange() || e.isTreeChange()) {
+				updateMotorState();
 			}
-		});
-
-
-
-
-		// Fire table change event when the rocket changes
-		document.getRocket().addComponentChangeListener(new ComponentChangeListener() {
-			@Override
-			public void componentChanged(ComponentChangeEvent e) {
-				fireMaintainSelection();
-			}
+			fireMaintainSelection();
 		});
 
 		this.add(cardPanel, "spanx, grow, pushy, wrap rel");
@@ -442,6 +413,19 @@ public class SimulationPanel extends JPanel {
 		warningColor = UITheme.getColor(UITheme.Keys.WARNING);
 		errorColor = UITheme.getColor(UITheme.Keys.ERROR);
 		informationColor = UITheme.getColor(UITheme.Keys.INFO);
+	}
+
+	private void updateMotorState() {
+		Rocket rocket = document.getRocket();
+		boolean newHasValidConfig = rocket != null &&
+				rocket.getIds().stream().anyMatch(rocket::hasMotors);
+
+		if (newHasValidConfig == hasValidConfig) {
+			return;
+		}
+
+		hasValidConfig = newHasValidConfig;
+		cardLayout.show(cardPanel, hasValidConfig ? CARD_TABLE : CARD_HELP);
 	}
 
 	/**
@@ -1046,7 +1030,7 @@ public class SimulationPanel extends JPanel {
 
 		@Override
 		public void updateEnabledState() {
-			setEnabled(hasMotors);
+			setEnabled(hasValidConfig);
 		}
 	}
 
@@ -1066,7 +1050,7 @@ public class SimulationPanel extends JPanel {
 
 		@Override
 		public void updateEnabledState() {
-			this.setEnabled(simulationTable.getSelectedRowCount() > 0 && hasMotors);
+			this.setEnabled(simulationTable.getSelectedRowCount() > 0 && hasValidConfig);
 		}
 	}
 
@@ -1173,7 +1157,7 @@ public class SimulationPanel extends JPanel {
 
 		@Override
 		public void updateEnabledState() {
-			this.setEnabled(simulationTable.getSelectedRowCount() > 0 && hasMotors);
+			this.setEnabled(simulationTable.getSelectedRowCount() > 0 && hasValidConfig);
 		}
 	}
 
@@ -1192,7 +1176,7 @@ public class SimulationPanel extends JPanel {
 
 		@Override
 		public void updateEnabledState() {
-			this.setEnabled(simulationTable.getSelectedRowCount() > 0 && hasMotors);
+			this.setEnabled(simulationTable.getSelectedRowCount() > 0 && hasValidConfig);
 		}
 	}
 
@@ -1210,7 +1194,7 @@ public class SimulationPanel extends JPanel {
 
 		@Override
 		public void updateEnabledState() {
-			this.setEnabled(simulationTable.getSelectedRowCount() == 1 && hasMotors);
+			this.setEnabled(simulationTable.getSelectedRowCount() == 1 && hasValidConfig);
 		}
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
@@ -144,8 +144,8 @@ public class SimulationPanel extends JPanel {
 
 	private int[] previousSelection = null;
 
-private static final String PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simulation.table.hiddenColumns";
-private static final String APP_PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simulation.table.hiddenColumns.default";
+    private static final String PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simulation.table.hiddenColumns";
+    private static final String APP_PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simulation.table.hiddenColumns.default";
 	private static final String COLUMN_ID_STATUS = "status";
 	private static final String COLUMN_ID_WARNINGS = "warnings";
 	private static final String COLUMN_ID_NAME = "name";
@@ -185,6 +185,8 @@ private static final String APP_PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simu
 	private static Color warningColor;
 	private static Color errorColor;
 	private static Color informationColor;
+
+	private boolean hasMotors;
 
 	static {
 		initColors();
@@ -372,6 +374,7 @@ private static final String APP_PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simu
 				}
 			}
 		});
+
 		JPanel cardPanel = new JPanel(new CardLayout());
 
 		JLabel label = new JLabel(trans.get("simpanel.lbl.noConfiguration"), SwingConstants.CENTER);
@@ -382,21 +385,25 @@ private static final String APP_PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simu
 		cardPanel.add(tablePanel, CARD_TABLE);
 
 		CardLayout cardLayout = (CardLayout) (cardPanel.getLayout());
-		if (!document.getRocket().getSelectedConfiguration().getAllMotors().isEmpty()) {
-			cardLayout.show(cardPanel, "table");
-		}
+
+		Runnable updateMotorState = () -> {
+			Rocket rocket = document.getRocket();
+
+			hasMotors = rocket != null &&
+					!rocket.getSelectedConfiguration()
+							.getAllMotors()
+							.isEmpty();
+
+			newSimulationAction.setEnabled(hasMotors);
+			cardLayout.show(cardPanel, hasMotors ? CARD_TABLE : CARD_HELP);
+		};
+
+		updateMotorState.run();
 
 		simulationTableModel.addTableModelListener(new TableModelListener() {
 			@Override
 			public void tableChanged(TableModelEvent e) {
-				Rocket rocket = document.getRocket();
-				boolean hasMotors = (rocket != null &&
-						!rocket.getSelectedConfiguration()
-								.getAllMotors()
-								.isEmpty());
-
-				newSimulationAction.setEnabled(hasMotors);
-				cardLayout.show(cardPanel, hasMotors ? CARD_TABLE : CARD_HELP);
+				updateMotorState.run();
 			}
 		});
 
@@ -1039,7 +1046,7 @@ private static final String APP_PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simu
 
 		@Override
 		public void updateEnabledState() {
-			setEnabled(true);
+			setEnabled(hasMotors);
 		}
 	}
 
@@ -1059,7 +1066,7 @@ private static final String APP_PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simu
 
 		@Override
 		public void updateEnabledState() {
-			this.setEnabled(simulationTable.getSelectedRowCount() > 0);
+			this.setEnabled(simulationTable.getSelectedRowCount() > 0 && hasMotors);
 		}
 	}
 
@@ -1166,7 +1173,7 @@ private static final String APP_PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simu
 
 		@Override
 		public void updateEnabledState() {
-			this.setEnabled(simulationTable.getSelectedRowCount() > 0);
+			this.setEnabled(simulationTable.getSelectedRowCount() > 0 && hasMotors);
 		}
 	}
 
@@ -1185,7 +1192,7 @@ private static final String APP_PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simu
 
 		@Override
 		public void updateEnabledState() {
-			this.setEnabled(simulationTable.getSelectedRowCount() > 0);
+			this.setEnabled(simulationTable.getSelectedRowCount() > 0 && hasMotors);
 		}
 	}
 
@@ -1203,7 +1210,7 @@ private static final String APP_PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simu
 
 		@Override
 		public void updateEnabledState() {
-			this.setEnabled(simulationTable.getSelectedRowCount() == 1);
+			this.setEnabled(simulationTable.getSelectedRowCount() == 1 && hasMotors);
 		}
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
@@ -1,13 +1,7 @@
 package info.openrocket.swing.gui.main;
 
 
-import java.awt.BorderLayout;
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Container;
-import java.awt.Dimension;
-import java.awt.Toolkit;
-import java.awt.Window;
+import java.awt.*;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
@@ -30,28 +24,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.swing.AbstractAction;
-import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.InputMap;
-import javax.swing.JButton;
-import javax.swing.JCheckBox;
-import javax.swing.JCheckBoxMenuItem;
-import javax.swing.JMenuItem;
-import javax.swing.JComponent;
-import javax.swing.JFileChooser;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.KeyStroke;
-import javax.swing.ListSelectionModel;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
+import javax.swing.event.TableModelEvent;
+import javax.swing.event.TableModelListener;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
@@ -173,6 +150,10 @@ private static final String APP_PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simu
 		COLUMN_ID_GROUND_HIT_VELOCITY
 	};
 
+	private static final String CARD_HELP = "help";
+	private static final String CARD_TABLE = "table";
+
+
 	private static Color dimTextColor;
 	private static Color warningColor;
 	private static Color errorColor;
@@ -235,7 +216,6 @@ private static final String APP_PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simu
 		//// Run then Dump simulations
 		simTableExportButton = new IconButton();
 		RocketActions.tieActionToButton(simTableExportButton, simTableExportAction, trans.get("simpanel.but.runsimulations"));
-
 
 		////////  The simulation table
 		simulationTableModel = new SimulationTableModel();
@@ -365,6 +345,33 @@ private static final String APP_PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simu
 				}
 			}
 		});
+		JPanel cardPanel = new JPanel(new CardLayout());
+
+		JLabel label = new JLabel(trans.get("simpanel.lbl.noConfiguration"), SwingConstants.CENTER);
+		cardPanel.add(label, CARD_HELP);
+
+		JPanel tablePanel = new JPanel(new BorderLayout());
+		tablePanel.add(new JScrollPane(simulationTable), BorderLayout.CENTER);
+		cardPanel.add(tablePanel, CARD_TABLE);
+
+		CardLayout cardLayout = (CardLayout) (cardPanel.getLayout());
+		if (!document.getRocket().getSelectedConfiguration().getAllMotors().isEmpty()) {
+			cardLayout.show(cardPanel, "table");
+		}
+
+		simulationTableModel.addTableModelListener(new TableModelListener() {
+			@Override
+			public void tableChanged(TableModelEvent e) {
+				Rocket rocket = document.getRocket();
+				boolean hasMotors = (rocket != null &&
+						!rocket.getSelectedConfiguration()
+								.getAllMotors()
+								.isEmpty());
+
+				newSimulationAction.setEnabled(hasMotors);
+				cardLayout.show(cardPanel, hasMotors ? CARD_TABLE : CARD_HELP);
+			}
+		});
 
 		document.addDocumentChangeListener(new DocumentChangeListener() {
 			@Override
@@ -386,9 +393,7 @@ private static final String APP_PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simu
 			}
 		});
 
-
-		JScrollPane scrollpane = new JScrollPane(simulationTable);
-		this.add(scrollpane, "spanx, grow, wrap rel");
+		this.add(cardPanel, "spanx, grow, pushy, wrap rel");
 
 		updateActions();
 	}
@@ -996,6 +1001,8 @@ private static final String APP_PREF_KEY_SIMULATION_TABLE_HIDDEN_COLUMNS = "simu
 			putValue(NAME, trans.get("simpanel.but.newsimulation"));
 			this.putValue(MNEMONIC_KEY, KeyEvent.VK_N);
 			this.putValue(SMALL_ICON, Icons.FILE_NEW);
+
+			setEnabled(false);
 		}
 
 		@Override

--- a/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
@@ -377,7 +377,7 @@ public class SimulationPanel extends JPanel {
 
 		JPanel cardPanel = new JPanel(new CardLayout());
 
-		JLabel label = new JLabel(trans.get("simpanel.lbl.noConfiguration"), SwingConstants.CENTER);
+		JLabel label = new JLabel(String.format(trans.get("simpanel.lbl.noConfiguration"), trans.get("BasicFrame.tab.Flightconfig")), SwingConstants.CENTER);
 		cardPanel.add(label, CARD_HELP);
 
 		JPanel tablePanel = new JPanel(new BorderLayout());

--- a/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
@@ -1,7 +1,14 @@
 package info.openrocket.swing.gui.main;
 
 
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.CardLayout;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Toolkit;
+import java.awt.Window;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
@@ -24,7 +31,27 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.swing.*;
+import javax.swing.AbstractAction;
+import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.InputMap;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JMenuItem;
+import javax.swing.JComponent;
+import javax.swing.JFileChooser;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.KeyStroke;
+import javax.swing.ListSelectionModel;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.event.TableModelEvent;

--- a/swing/src/main/java/info/openrocket/swing/gui/main/flightconfigpanel/MotorConfigurationPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/flightconfigpanel/MotorConfigurationPanel.java
@@ -106,7 +106,13 @@ public class MotorConfigurationPanel extends FlightConfigurablePanel<MotorMount>
 		popupMenuFull.add(deleteConfigAction);
 		popupMenuFull.add(duplicateConfigAction);
 
-		JLabel helpText = new JLabel(trans.get("MotorConfigurationPanel.lbl.nomotors"));
+		String txt = trans.get("MotorConfigurationPanel.lbl.nomotors");
+		final JLabel helpText;
+		if (txt.contains("%s")) {
+			helpText = new JLabel(String.format(txt, trans.get("BasicFrame.tab.Rocketdesign")));
+		} else {
+			helpText = new JLabel(txt);
+		}
 		cards.add(helpText, HELP_LABEL );
 
 		JPanel configurationPanel = new JPanel(new MigLayout("fill, insets n n 5px n"));


### PR DESCRIPTION
## Description
Fixes part of #2757: Prevent users from creating a simulation without selecting a configuration, avoiding invalid simulations.

## Video
### Simple tube

https://github.com/user-attachments/assets/3985872b-6ddf-4956-809d-fbc0f8d45b8e

### with example

https://github.com/user-attachments/assets/4bdcb829-0213-40f1-85f5-5e45424ab320