### PR TITLE
Tests/add disable stage tests

### DIFF
--- a/core/src/test/java/info/openrocket/core/aerodynamics/BarrowmanCalculatorTest.java
+++ b/core/src/test/java/info/openrocket/core/aerodynamics/BarrowmanCalculatorTest.java
@@ -766,4 +766,46 @@ public class BarrowmanCalculatorTest {
 		}
 		assertEquals(11, boosterOnlyForceMap.size(), "Force map should contain 10 components");
 	}
+
+	@Test
+	public void testDisabledStageAerodynamics() {
+		Rocket rocket = TestRockets.makeFalcon9Heavy();
+		FlightConfigurationId fcid = new FlightConfigurationId(TestRockets.FALCON_9H_FCID_1);
+
+		Simulation simulation = new Simulation(rocket);
+		simulation.setFlightConfigurationId(fcid);
+		FlightConfiguration config = simulation.getActiveConfiguration();
+
+		BarrowmanCalculator calc = new BarrowmanCalculator();
+		FlightConditions conditions = new FlightConditions(config);
+		WarningSet warnings = new WarningSet();
+
+		// Baseline: all stages active
+		CoordinateIF cpAll = calc.getCP(config, conditions, warnings);
+		double cnAll = cpAll.getWeight();
+		double cpxAll = cpAll.getX();
+
+		// Disable core + booster stages
+		config._setStageActive(TestRockets.FALCON_9H_CORE_STAGE_NUMBER, false);
+		config._setStageActive(TestRockets.FALCON_9H_BOOSTER_STAGE_NUMBER, false);
+
+		warnings.clear();
+		CoordinateIF cpPayloadOnly = calc.getCP(config, conditions, warnings);
+
+		// CNa must decrease — booster fins are gone
+		assertTrue(cpPayloadOnly.getWeight() < cnAll,
+			"CNa should decrease when booster/core disabled");
+
+		// CP should shift forward — rear fins removed
+		assertTrue(cpPayloadOnly.getX() < cpxAll,
+			"CP should move forward when booster/core disabled");
+
+		// Re-enable all stages and verify full restoration
+		config.setAllStages();
+		warnings.clear();
+		CoordinateIF cpRestored = calc.getCP(config, conditions, warnings);
+
+		assertEquals(cnAll,  cpRestored.getWeight(), EPSILON, "CNa should be restored after re-enabling all stages");
+		assertEquals(cpxAll, cpRestored.getX(),      EPSILON, "CP should be restored after re-enabling all stages");
+	}
 }

--- a/core/src/test/java/info/openrocket/core/masscalc/MassCalculatorTest.java
+++ b/core/src/test/java/info/openrocket/core/masscalc/MassCalculatorTest.java
@@ -1466,5 +1466,4 @@ public class MassCalculatorTest extends BaseTestCase {
 		assertEquals(cmxAll, restored.getCM().getX(), EPSILON,
 				"CG should be fully restored after re-enabling all stages");
 	}
-
 }

--- a/core/src/test/java/info/openrocket/core/masscalc/MassCalculatorTest.java
+++ b/core/src/test/java/info/openrocket/core/masscalc/MassCalculatorTest.java
@@ -1420,4 +1420,51 @@ public class MassCalculatorTest extends BaseTestCase {
 		assertEquals(0.02, tubeFinSet.getMass(), EPSILON);
 	}
 
+	@Test
+	public void testDisabledStageMassAndCG() {
+		Rocket rocket = TestRockets.makeFalcon9Heavy();
+		FlightConfiguration config = rocket.getEmptyConfiguration();
+		config.setAllStages();
+
+		// Baseline: all stages active
+		RigidBody allActive = MassCalculator.calculateStructure(config);
+		double massAll = allActive.getMass();
+		double cmxAll = allActive.getCM().getX();
+
+		// Disable booster (also disable core since it is a child stage)
+		config._setStageActive(TestRockets.FALCON_9H_CORE_STAGE_NUMBER, false);
+		config._setStageActive(TestRockets.FALCON_9H_BOOSTER_STAGE_NUMBER, false);
+
+		RigidBody noBooster = MassCalculator.calculateStructure(config);
+		double expMassNoBooster = 0.11628853296935873; // payload only, known from testFalcon9HPayloadStructureCM
+		assertEquals(expMassNoBooster, noBooster.getMass(), EPSILON,
+				"Mass with core+booster disabled should equal payload mass only");
+
+		// CG must shift forward (toward nose) when heavy rear booster is removed
+		double expCMxNoBooster = 0.2780673116227175; // payload only, known from testFalcon9HPayloadStructureCM
+		assertEquals(expCMxNoBooster, noBooster.getCM().getX(), EPSILON,
+        "CG with core+booster disabled should match standalone payload CG");
+
+		// Disable core stage too (only payload remains)
+		config._setStageActive(TestRockets.FALCON_9H_CORE_STAGE_NUMBER, false);
+
+		RigidBody payloadOnly = MassCalculator.calculateStructure(config);
+		double expMassPayloadOnly = 0.11628853296935873; // known from testFalcon9HPayloadStructureCM
+		assertEquals(expMassPayloadOnly, payloadOnly.getMass(), EPSILON,
+				"Mass with core+booster disabled should equal payload mass only");
+
+		double expCMxPayloadOnly = 0.2780673116227175; // known from testFalcon9HPayloadStructureCM
+		assertEquals(expCMxPayloadOnly, payloadOnly.getCM().getX(), EPSILON,
+				"CG with core+booster disabled should match standalone payload CG");
+
+		// Re-enable all stages and verify full restoration
+		config.setAllStages();
+
+		RigidBody restored = MassCalculator.calculateStructure(config);
+		assertEquals(massAll, restored.getMass(), EPSILON,
+				"Mass should be fully restored after re-enabling all stages");
+		assertEquals(cmxAll, restored.getCM().getX(), EPSILON,
+				"CG should be fully restored after re-enabling all stages");
+	}
+
 }

--- a/core/src/test/java/info/openrocket/core/masscalc/MassCalculatorTest.java
+++ b/core/src/test/java/info/openrocket/core/masscalc/MassCalculatorTest.java
@@ -1435,13 +1435,14 @@ public class MassCalculatorTest extends BaseTestCase {
 		config._setStageActive(TestRockets.FALCON_9H_CORE_STAGE_NUMBER, false);
 		config._setStageActive(TestRockets.FALCON_9H_BOOSTER_STAGE_NUMBER, false);
 
+		// All hardcoded values are pulled from testFalcon9HPayloadStructureCM
 		RigidBody noBooster = MassCalculator.calculateStructure(config);
-		double expMassNoBooster = 0.11628853296935873; // payload only, known from testFalcon9HPayloadStructureCM
+		double expMassNoBooster = 0.11628853296935873; // payload only
 		assertEquals(expMassNoBooster, noBooster.getMass(), EPSILON,
 				"Mass with core+booster disabled should equal payload mass only");
 
-		// CG must shift forward (toward nose) when heavy rear booster is removed
-		double expCMxNoBooster = 0.2780673116227175; // payload only, known from testFalcon9HPayloadStructureCM
+		// CG must shift toward nose when heavy rear booster is removed
+		double expCMxNoBooster = 0.2780673116227175; // payload only
 		assertEquals(expCMxNoBooster, noBooster.getCM().getX(), EPSILON,
         "CG with core+booster disabled should match standalone payload CG");
 
@@ -1449,11 +1450,11 @@ public class MassCalculatorTest extends BaseTestCase {
 		config._setStageActive(TestRockets.FALCON_9H_CORE_STAGE_NUMBER, false);
 
 		RigidBody payloadOnly = MassCalculator.calculateStructure(config);
-		double expMassPayloadOnly = 0.11628853296935873; // known from testFalcon9HPayloadStructureCM
+		double expMassPayloadOnly = 0.11628853296935873;
 		assertEquals(expMassPayloadOnly, payloadOnly.getMass(), EPSILON,
 				"Mass with core+booster disabled should equal payload mass only");
 
-		double expCMxPayloadOnly = 0.2780673116227175; // known from testFalcon9HPayloadStructureCM
+		double expCMxPayloadOnly = 0.2780673116227175;
 		assertEquals(expCMxPayloadOnly, payloadOnly.getCM().getX(), EPSILON,
 				"CG with core+booster disabled should match standalone payload CG");
 


### PR DESCRIPTION
Closes #1693

### Description

This is my first open source contribution, and I chose this issue because I have a personal interest in rocketry and wanted to contribute to a project I find genuinely exciting.

This PR adds deterministic unit tests for the disable-stage functionality in `BarrowmanCalculatorTest.java` and `MassCalculatorTest.java`, as suggested in issue #1693.

The existing `DisableStageTest.java` verifies disable-stage behavior through full simulations, which can occasionally produce flaky failures due to simulation inaccuracies. The new tests avoid this by asserting on analytical outputs instead:

- **`BarrowmanCalculatorTest.testDisabledStageAerodynamics()`** — verifies that disabling the core and booster stages correctly reduces CNa, shifts the center of pressure forward, and that re-enabling all stages fully restores the original values
- **`MassCalculatorTest.testDisabledStageMassAndCG()`** — verifies that disabling the core and booster stages correctly reduces structural mass, produces the expected center of gravity, and that re-enabling all stages fully restores the original values

Both tests use the existing Falcon 9 Heavy test rocket and its established constants, so the expected values are cross-validated against the existing test suite.

### Testing

All existing tests in both `BarrowmanCalculatorTest` (20 tests) and `MassCalculatorTest` (33 tests) pass with the new additions included.