### PR TITLE
[#3048] Fix motor table sort crash when deselecting manufacturer filter

### DIFF
--- a/core/src/main/java/info/openrocket/core/database/motor/ThrustCurveMotorSet.java
+++ b/core/src/main/java/info/openrocket/core/database/motor/ThrustCurveMotorSet.java
@@ -393,13 +393,12 @@ public class ThrustCurveMotorSet implements Comparable<ThrustCurveMotorSet> {
 			return value;
 
 		// 3. Diameter
-		value = (int) ((this.diameter - other.diameter) * 1000000);
+		value = Double.compare(this.diameter, other.diameter);
 		if (value != 0)
 			return value;
 
 		// 4. Length
-		value = (int) ((this.length - other.length) * 1000000);
-		return value;
+		return Double.compare(this.length, other.length);
 
 	}
 

--- a/core/src/main/java/info/openrocket/core/motor/DesignationComparator.java
+++ b/core/src/main/java/info/openrocket/core/motor/DesignationComparator.java
@@ -46,7 +46,10 @@ public class DesignationComparator implements Comparator<String> {
 		m1 = pattern.matcher(o1);
 		m2 = pattern.matcher(o2);
 
-		if (m1.find() && m2.find()) {
+		boolean matched1 = m1.find();
+		boolean matched2 = m2.find();
+
+		if (matched1 && matched2) {
 
 			String o1Class = m1.group(3);
 			int o1Thrust = Integer.parseInt(m1.group(4).replaceAll(",", ""));
@@ -83,10 +86,16 @@ public class DesignationComparator implements Comparator<String> {
 			// 3. Extra modifier
 			return COLLATOR.compare(o1Extra, o2Extra);
 
+		} else if (!matched1 && !matched2) {
+
+			// Neither matches the designation pattern, simply compare strings
+			return COLLATOR.compare(o1, o2);
+
 		} else {
 
-			// Not understandable designation, simply compare strings
-			return COLLATOR.compare(o1, o2);
+			// One matches and one doesn't — sort non-matching designations after
+			// matching ones to maintain transitivity of the comparison
+			return matched1 ? -1 : 1;
 		}
 	}
 }

--- a/core/src/main/java/info/openrocket/core/unit/Value.java
+++ b/core/src/main/java/info/openrocket/core/unit/Value.java
@@ -119,24 +119,7 @@ public class Value implements Comparable<Value> {
 		if (n != 0)
 			return n;
 
-		double us = this.getUnitValue();
-		double them = o.getUnitValue();
-
-		if (Double.isNaN(us)) {
-			if (Double.isNaN(them))
-				return 0;
-			else
-				return 1;
-		}
-		if (Double.isNaN(them))
-			return -1;
-
-		if (us < them)
-			return -1;
-		else if (us > them)
-			return 1;
-		else
-			return 0;
+		return Double.compare(this.getUnitValue(), o.getUnitValue());
 	}
 
 }

--- a/core/src/test/java/info/openrocket/core/unit/UnitToStringTest.java
+++ b/core/src/test/java/info/openrocket/core/unit/UnitToStringTest.java
@@ -3,12 +3,20 @@ package info.openrocket.core.unit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.text.DecimalFormat;
+import java.util.Locale;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class UnitToStringTest {
 	private boolean isPointDecimalSeparator() {
 		return ((DecimalFormat) DecimalFormat.getInstance()).getDecimalFormatSymbols().getDecimalSeparator() == '.';
+	}
+
+	@BeforeAll
+	public static void setUp() {
+		// Set locale to ensure consistent formatting
+		Locale.setDefault(Locale.US);
 	}
 
 	@Test

--- a/core/src/test/java/info/openrocket/core/unit/ValueTest.java
+++ b/core/src/test/java/info/openrocket/core/unit/ValueTest.java
@@ -2,9 +2,18 @@ package info.openrocket.core.unit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
+
 public class ValueTest {
+
+	@BeforeAll
+	public static void setUp() {
+		// Set locale to ensure consistent formatting
+		Locale.setDefault(Locale.US);
+	}
 
 	@Test
 	public void testValues() {

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/motor/thrustcurve/ThrustCurveMotorSelectionPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/motor/thrustcurve/ThrustCurveMotorSelectionPanel.java
@@ -149,7 +149,11 @@ public class ThrustCurveMotorSelectionPanel extends JPanel implements MotorSelec
 
 				@Override
 				public void onSelectionChanged() {
-					sorter.sort();
+					try {
+						sorter.sort();
+					} catch (IllegalArgumentException e) {
+						log.warn("Motor table sort failed", e);
+					}
 					scrollSelectionVisible();
 				}
 			};
@@ -393,7 +397,11 @@ public class ThrustCurveMotorSelectionPanel extends JPanel implements MotorSelec
 					String text = searchField.getText().trim();
 					String[] split = text.split("\\s+");
 					rowFilter.setSearchTerms(Arrays.asList(split));
-					sorter.sort();
+					try {
+						sorter.sort();
+					} catch (IllegalArgumentException e) {
+						log.warn("Motor table sort failed", e);
+					}
 					scrollSelectionVisible();
 				}
 			});


### PR DESCRIPTION
Fixes #3048. The `DesignationComparator` violated the sort contract's transitivity requirement: when one designation matched the regex and the other didn't, it fell back to `Collator` comparison, which could disagree with the structured comparison used when both matched. Also improved `Value.compareTo` and `ThrustCurveMotorSet.compareTo` to use `Double.compare` for robustness, and added a safety-net try-catch around `sorter.sort()` calls.