### PR TITLE
[#2165] Fix menu items staying disabled after save/export dialog chains

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/main/BasicFrame.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/BasicFrame.java
@@ -1657,6 +1657,20 @@ private static final Translator trans = Application.getTranslator();
 
 
 	/**
+	 * Restore focus to this frame after a dialog chain completes.
+	 * On some platforms (notably macOS), when a chain of modal dialogs opens and closes
+	 * (e.g. file chooser followed by overwrite confirmation), the parent frame may not
+	 * automatically regain focus, leaving the application menu bar disabled.
+	 * Using invokeLater ensures the focus request happens after all dialog-related events are processed.
+	 */
+	private void restoreFocus() {
+		SwingUtilities.invokeLater(() -> {
+			toFront();
+			requestFocus();
+		});
+	}
+
+	/**
 	 * "Save" action.  If the design is new, then this is identical to "Save As", with a default file filter for .ork.
 	 * If the rocket being edited previously was opened from a .ork file, then it will be saved immediately to the same
 	 * file.  But clicking on 'Save' for an existing design file with a RockSim or RASAero file will bring up a confirmation
@@ -1666,15 +1680,19 @@ private static final Translator trans = Application.getTranslator();
 	 * @return true if the file was saved, false otherwise
 	 */
 	private boolean saveAction() {
-		document.fireDocumentSavingEvent(new DocumentChangeEvent(this));
-		File file = document.getFile();
-		if (file == null || document.getDefaultStorageOptions().getFileType().equals(FileType.ROCKSIM)
-				|| document.getDefaultStorageOptions().getFileType().equals(FileType.RASAERO)) {
-			log.info("Document does not contain file, opening save as dialog instead");
-			return saveAsAction();
+		try {
+			document.fireDocumentSavingEvent(new DocumentChangeEvent(this));
+			File file = document.getFile();
+			if (file == null || document.getDefaultStorageOptions().getFileType().equals(FileType.ROCKSIM)
+					|| document.getDefaultStorageOptions().getFileType().equals(FileType.RASAERO)) {
+				log.info("Document does not contain file, opening save as dialog instead");
+				return saveAsAction();
+			}
+			log.info("Saving document to " + file);
+			return saveAsOpenRocket(file);
+		} finally {
+			restoreFocus();
 		}
-		log.info("Saving document to " + file);
-		return saveAsOpenRocket(file);
 	}
 
 	/**
@@ -1726,20 +1744,24 @@ private static final Translator trans = Application.getTranslator();
 
 
 	public boolean exportRASAeroAction() {
-		File file = openFileSaveAsDialog(FileType.RASAERO);
-		if (file == null) {
-			return false;
-		}
-
-		file = FileHelper.forceExtension(file, RASAeroCommonConstants.FILE_EXTENSION);
-		if (FileHelper.confirmWrite(file, BasicFrame.this)) {
-			boolean result = saveAsRASAero(file);
-			if (!result) {
-				file.delete();
+		try {
+			File file = openFileSaveAsDialog(FileType.RASAERO);
+			if (file == null) {
+				return false;
 			}
-			return result;
+
+			file = FileHelper.forceExtension(file, RASAeroCommonConstants.FILE_EXTENSION);
+			if (FileHelper.confirmWrite(file, BasicFrame.this)) {
+				boolean result = saveAsRASAero(file);
+				if (!result) {
+					file.delete();
+				}
+				return result;
+			}
+			return false;
+		} finally {
+			restoreFocus();
 		}
-		return false;
 	}
 
 	/**
@@ -1837,16 +1859,20 @@ private static final Translator trans = Application.getTranslator();
 	* @return true if the file was saved, false otherwise
 	*/
 	public boolean exportRockSimAction() {
-		File file = openFileSaveAsDialog(FileType.ROCKSIM);
-		if (file == null) {
-			return false;
-		}
+		try {
+			File file = openFileSaveAsDialog(FileType.ROCKSIM);
+			if (file == null) {
+				return false;
+			}
 
-		file = FileHelper.forceExtension(file, "rkt");
-		if (FileHelper.confirmWrite(file, BasicFrame.this) ) {
-			return saveAsRockSim(file);
+			file = FileHelper.forceExtension(file, "rkt");
+			if (FileHelper.confirmWrite(file, BasicFrame.this)) {
+				return saveAsRockSim(file);
+			}
+			return false;
+		} finally {
+			restoreFocus();
 		}
-		return false;
 	}
 
 	/**
@@ -1922,18 +1948,22 @@ private static final Translator trans = Application.getTranslator();
 	 * @return true if the file was saved, false otherwise
 	 */
 	public boolean exportWavefrontOBJAction() {
-		File file = openFileSaveAsDialog(FileType.WAVEFRONT_OBJ, getSelectedComponents());
-		if (file == null) {
-			return false;
-		}
+		try {
+			File file = openFileSaveAsDialog(FileType.WAVEFRONT_OBJ, getSelectedComponents());
+			if (file == null) {
+				return false;
+			}
 
-		file = FileHelper.forceExtension(file, "obj");
-		OBJExportOptions options = document.getDefaultOBJOptions();
-		boolean isExportAsSeparateFiles = options.isExportAsSeparateFiles();
-		if (isExportAsSeparateFiles || FileHelper.confirmWrite(file, BasicFrame.this)) {		// No overwrite warning for separate files
-			return saveAsWavefrontOBJ(file);
+			file = FileHelper.forceExtension(file, "obj");
+			OBJExportOptions options = document.getDefaultOBJOptions();
+			boolean isExportAsSeparateFiles = options.isExportAsSeparateFiles();
+			if (isExportAsSeparateFiles || FileHelper.confirmWrite(file, BasicFrame.this)) {		// No overwrite warning for separate files
+				return saveAsWavefrontOBJ(file);
+			}
+			return false;
+		} finally {
+			restoreFocus();
 		}
-		return false;
 	}
 
 	private boolean saveAsWavefrontOBJ(File file) {
@@ -1973,119 +2003,123 @@ private static final Translator trans = Application.getTranslator();
 	 * @param components Components to export, or null to export all from document
 	 */
 	private void exportSvgProfilesAction(List<RocketComponent> components) {
-		// Get currently selected components from design (if components parameter is null)
-		List<RocketComponent> initiallySelected = components;
-		if (initiallySelected == null) {
-			initiallySelected = getSelectedComponents();
+		try {
+			// Get currently selected components from design (if components parameter is null)
+			List<RocketComponent> initiallySelected = components;
 			if (initiallySelected == null) {
-				initiallySelected = new ArrayList<>();
+				initiallySelected = getSelectedComponents();
+				if (initiallySelected == null) {
+					initiallySelected = new ArrayList<>();
+				}
 			}
-		}
-		
-		// Show SVG options dialog first
-		SvgOptionsDialog optionsDialog = new SvgOptionsDialog(BasicFrame.this, document, initiallySelected);
-		optionsDialog.setFromPreferences(prefs);
-		if (!optionsDialog.showDialog()) {
-			return; // User cancelled
-		}
 
-		// Get the selected tab to determine export type
-		int selectedTab = optionsDialog.getSelectedTab();
-		
-		// Get options from dialog (includes spacing)
-		SVGExportOptions options = optionsDialog.getExportOptions();
+			// Show SVG options dialog first
+			SvgOptionsDialog optionsDialog = new SvgOptionsDialog(BasicFrame.this, document, initiallySelected);
+			optionsDialog.setFromPreferences(prefs);
+			if (!optionsDialog.showDialog()) {
+				return; // User cancelled
+			}
 
-		// Now show file chooser
-		JFileChooser chooser = new JFileChooser();
-		chooser.setFileFilter(FileHelper.SVG_FILTER);
+			// Get the selected tab to determine export type
+			int selectedTab = optionsDialog.getSelectedTab();
 
-		SwingPreferences swingPrefs = (SwingPreferences) Application.getPreferences();
-		File defaultDir = swingPrefs.getDefaultDirectory();
-		if (defaultDir != null) {
-			chooser.setCurrentDirectory(defaultDir);
-		}
+			// Get options from dialog (includes spacing)
+			SVGExportOptions options = optionsDialog.getExportOptions();
 
-		// Determine default filename based on selected tab
-		String defaultName;
-		String fileSuffix;
-		if (selectedTab == SvgOptionsDialog.COMPONENTS_TAB) {
-			// Components tab
-			if (components != null && !components.isEmpty()) {
-				if (components.size() == 1) {
-					defaultName = components.get(0).getName();
-					if (defaultName == null || defaultName.isBlank()) {
-						defaultName = components.get(0).getComponentName();
+			// Now show file chooser
+			JFileChooser chooser = new JFileChooser();
+			chooser.setFileFilter(FileHelper.SVG_FILTER);
+
+			SwingPreferences swingPrefs = (SwingPreferences) Application.getPreferences();
+			File defaultDir = swingPrefs.getDefaultDirectory();
+			if (defaultDir != null) {
+				chooser.setCurrentDirectory(defaultDir);
+			}
+
+			// Determine default filename based on selected tab
+			String defaultName;
+			String fileSuffix;
+			if (selectedTab == SvgOptionsDialog.COMPONENTS_TAB) {
+				// Components tab
+				if (components != null && !components.isEmpty()) {
+					if (components.size() == 1) {
+						defaultName = components.get(0).getName();
+						if (defaultName == null || defaultName.isBlank()) {
+							defaultName = components.get(0).getComponentName();
+						}
+					} else {
+						defaultName = "components";
 					}
 				} else {
-					defaultName = "components";
+					defaultName = document.getRocket().getName();
+					if (defaultName == null || defaultName.isBlank()) {
+						defaultName = "rocket";
+					}
 				}
+				fileSuffix = "-profile.svg";
 			} else {
+				// Fin Guides tab
 				defaultName = document.getRocket().getName();
 				if (defaultName == null || defaultName.isBlank()) {
 					defaultName = "rocket";
 				}
+				fileSuffix = "-finguides.svg";
 			}
-			fileSuffix = "-profile.svg";
-		} else {
-			// Fin Guides tab
-			defaultName = document.getRocket().getName();
-			if (defaultName == null || defaultName.isBlank()) {
-				defaultName = "rocket";
+			File parentDir = defaultDir != null ? defaultDir : new File(System.getProperty("user.home", "."));
+			chooser.setSelectedFile(new File(parentDir, defaultName + fileSuffix));
+
+			if (chooser.showSaveDialog(BasicFrame.this) != JFileChooser.APPROVE_OPTION) {
+				return;
 			}
-			fileSuffix = "-finguides.svg";
-		}
-		File parentDir = defaultDir != null ? defaultDir : new File(System.getProperty("user.home", "."));
-		chooser.setSelectedFile(new File(parentDir, defaultName + fileSuffix));
 
-		if (chooser.showSaveDialog(BasicFrame.this) != JFileChooser.APPROVE_OPTION) {
-			return;
-		}
+			File target = FileHelper.forceExtension(chooser.getSelectedFile(), "svg");
+			if (!FileHelper.confirmWrite(target, BasicFrame.this)) {
+				return;
+			}
 
-		File target = FileHelper.forceExtension(chooser.getSelectedFile(), "svg");
-		if (!FileHelper.confirmWrite(target, BasicFrame.this)) {
-			return;
-		}
+			swingPrefs.setDefaultDirectory(chooser.getCurrentDirectory());
 
-		swingPrefs.setDefaultDirectory(chooser.getCurrentDirectory());
+			// Save SVG preferences
+			prefs.setSVGStrokeColor(optionsDialog.getStrokeColor());
+			prefs.setSVGStrokeWidth(optionsDialog.getStrokeWidth());
+			prefs.setSVGDrawCrosshair(optionsDialog.isDrawCrosshair());
+			prefs.setSVGCrosshairColor(optionsDialog.getCrosshairColor());
+			prefs.setSVGCrosshairSize(optionsDialog.getCrosshairSize());
+			prefs.setSVGShowLabels(optionsDialog.isShowLabels());
+			prefs.setSVGLabelColor(optionsDialog.getLabelColor());
 
-		// Save SVG preferences
-		prefs.setSVGStrokeColor(optionsDialog.getStrokeColor());
-		prefs.setSVGStrokeWidth(optionsDialog.getStrokeWidth());
-		prefs.setSVGDrawCrosshair(optionsDialog.isDrawCrosshair());
-		prefs.setSVGCrosshairColor(optionsDialog.getCrosshairColor());
-		prefs.setSVGCrosshairSize(optionsDialog.getCrosshairSize());
-		prefs.setSVGShowLabels(optionsDialog.isShowLabels());
-		prefs.setSVGLabelColor(optionsDialog.getLabelColor());
-
-		try {
-			if (selectedTab == SvgOptionsDialog.COMPONENTS_TAB) {
-				// Export components
-				List<RocketComponent> selectedComponents = optionsDialog.getSelectedComponents();
-				if (!selectedComponents.isEmpty()) {
-					new SVGRocketPartsExporter().export(selectedComponents, target, options);
-				} else {
-					new SVGRocketPartsExporter().export(document, target, options);
+			try {
+				if (selectedTab == SvgOptionsDialog.COMPONENTS_TAB) {
+					// Export components
+					List<RocketComponent> selectedComponents = optionsDialog.getSelectedComponents();
+					if (!selectedComponents.isEmpty()) {
+						new SVGRocketPartsExporter().export(selectedComponents, target, options);
+					} else {
+						new SVGRocketPartsExporter().export(document, target, options);
+					}
+					log.info(Markers.USER_MARKER, "Exported SVG profiles to {}", target.getAbsolutePath());
 				}
-				log.info(Markers.USER_MARKER, "Exported SVG profiles to {}", target.getAbsolutePath());
+				// TODO: other tabs here (e.g. fin guides)
+			} catch (UnsupportedOperationException ex) {
+				log.warn("Fin guide export not implemented", ex);
+				JOptionPane.showMessageDialog(BasicFrame.this,
+						trans.get("SVGOptionPanel.finGuides.notImplemented"),
+						trans.get("SVGOptionPanel.finGuides.notImplemented.title"),
+						JOptionPane.INFORMATION_MESSAGE);
+			} catch (IllegalStateException noParts) {
+				JOptionPane.showMessageDialog(BasicFrame.this,
+						trans.get("main.menu.file.exportAs.SVGProfiles.empty"),
+						trans.get("main.menu.file.exportAs.SVGProfiles.title"),
+						JOptionPane.INFORMATION_MESSAGE);
+			} catch (Exception ex) {
+				log.warn("Failed to export SVG", ex);
+				JOptionPane.showMessageDialog(BasicFrame.this,
+						String.format(trans.get("main.menu.file.exportAs.SVGProfiles.error"), ex.getMessage()),
+						trans.get("main.menu.file.exportAs.SVGProfiles.title"),
+						JOptionPane.ERROR_MESSAGE);
 			}
-			// TODO: other tabs here (e.g. fin guides)
-		} catch (UnsupportedOperationException ex) {
-			log.warn("Fin guide export not implemented", ex);
-			JOptionPane.showMessageDialog(BasicFrame.this,
-					trans.get("SVGOptionPanel.finGuides.notImplemented"),
-					trans.get("SVGOptionPanel.finGuides.notImplemented.title"),
-					JOptionPane.INFORMATION_MESSAGE);
-		} catch (IllegalStateException noParts) {
-			JOptionPane.showMessageDialog(BasicFrame.this,
-					trans.get("main.menu.file.exportAs.SVGProfiles.empty"),
-					trans.get("main.menu.file.exportAs.SVGProfiles.title"),
-					JOptionPane.INFORMATION_MESSAGE);
-		} catch (Exception ex) {
-			log.warn("Failed to export SVG", ex);
-			JOptionPane.showMessageDialog(BasicFrame.this,
-					String.format(trans.get("main.menu.file.exportAs.SVGProfiles.error"), ex.getMessage()),
-					trans.get("main.menu.file.exportAs.SVGProfiles.title"),
-					JOptionPane.ERROR_MESSAGE);
+		} finally {
+			restoreFocus();
 		}
 	}
 
@@ -2114,21 +2148,25 @@ private static final Translator trans = Application.getTranslator();
 	 * @return true if the file was saved, false otherwise
 	 */
 	private boolean saveAsAction() {
-		// Open dialog for saving rocket info
-		showSaveRocketInfoDialog();
+		try {
+			// Open dialog for saving rocket info
+			showSaveRocketInfoDialog();
 
-		File file = openFileSaveAsDialog(FileType.OPENROCKET);
-		if (file == null) {
-			return false;
-		}
+			File file = openFileSaveAsDialog(FileType.OPENROCKET);
+			if (file == null) {
+				return false;
+			}
 
-		file = FileHelper.forceExtension(file, "ork");
-		boolean result = FileHelper.confirmWrite(file, BasicFrame.this) && saveAsOpenRocket(file);
-		if (result) {
-			MRUDesignFile opts = MRUDesignFile.getInstance();
-			opts.addFile(file.getAbsolutePath());
+			file = FileHelper.forceExtension(file, "ork");
+			boolean result = FileHelper.confirmWrite(file, BasicFrame.this) && saveAsOpenRocket(file);
+			if (result) {
+				MRUDesignFile opts = MRUDesignFile.getInstance();
+				opts.addFile(file.getAbsolutePath());
+			}
+			return result;
+		} finally {
+			restoreFocus();
 		}
-		return result;
 	}
 
 	private void showSaveRocketInfoDialog() {


### PR DESCRIPTION
Fixes #2165. When a secondary dialog (e.g. overwrite confirmation) appeared after a file chooser during save/export, BasicFrame did not regain focus, leaving all application menu items disabled. This PR restores focus after each save/export action completes.