### PR TITLE
[#3063] Disable texture creation button for unsupported components & Support inner tube/tube coupler texture creation

### DIFF
--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -1369,6 +1369,7 @@ AppearanceCfg.lbl.Appearance = Appearance
 AppearanceCfg.lbl.Usedefault = Use default
 AppearanceCfg.but.edit = Edit
 AppearanceCfg.but.createTexture = Create texture
+AppearanceCfg.but.createTexture.ttip.unsupported = Automatic texture creation is not supported for this component type
 AppearanceCfg.createTexture.dialog.title = Create texture
 AppearanceCfg.createTexture.lbl.dpi = Resolution (DPI):
 AppearanceCfg.createTexture.lbl.ttip.dpi = Dots per inch (DPI) of the generated texture

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/AppearancePanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/AppearancePanel.java
@@ -671,11 +671,16 @@ public class AppearancePanel extends JPanel implements Invalidatable, Invalidati
 
 		//// Create texture button
 		JButton createTextureBtn = new JButton(Icons.IMAGE_NEW);
-		createTextureBtn.setToolTipText(trans.get("AppearanceCfg.but.createTexture"));
 		createTextureBtn.setHorizontalAlignment(SwingConstants.LEFT);
 		createTextureBtn.addActionListener(e -> handleCreateTexture(panel, document, c, decalModel,
 				insideBuilder, builder));
-		mDefault.addEnableComponent(createTextureBtn, false);
+		if (TextureCreationService.isComponentSupported(c)) {
+			createTextureBtn.setToolTipText(trans.get("AppearanceCfg.but.createTexture"));
+			mDefault.addEnableComponent(createTextureBtn, false);
+		} else {
+			createTextureBtn.setToolTipText(trans.get("AppearanceCfg.but.createTexture.ttip.unsupported"));
+			createTextureBtn.setEnabled(false);
+		}
 		textureButtonsPanel.add(createTextureBtn);
 		order.add(createTextureBtn);
 

--- a/swing/src/main/java/info/openrocket/swing/gui/util/TextureCreationService.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/util/TextureCreationService.java
@@ -16,9 +16,11 @@ import java.util.List;
 import javax.imageio.ImageIO;
 
 import info.openrocket.core.rocketcomponent.FinSet;
-import info.openrocket.core.rocketcomponent.RingComponent;
+import info.openrocket.core.rocketcomponent.InnerTube;
 import info.openrocket.core.rocketcomponent.RocketComponent;
+import info.openrocket.core.rocketcomponent.ThicknessRingComponent;
 import info.openrocket.core.rocketcomponent.SymmetricComponent;
+import info.openrocket.core.rocketcomponent.TubeCoupler;
 import info.openrocket.core.util.CoordinateIF;
 
 /**
@@ -67,8 +69,8 @@ public class TextureCreationService {
 			return generateForSymmetric((SymmetricComponent) component, insideSurface, dpi);
 		}
 
-		if (component instanceof RingComponent) {
-			return generateForRingComponent((RingComponent) component, dpi);
+		if (component instanceof InnerTube || component instanceof TubeCoupler) {
+			return generateForRingComponent((ThicknessRingComponent) component, dpi);
 		}
 
 		throw new TextureGenerationException("Component type " + component.getClass().getSimpleName()
@@ -110,10 +112,11 @@ public class TextureCreationService {
 	public static boolean isComponentSupported(RocketComponent component) {
 		return component instanceof FinSet
 				|| component instanceof SymmetricComponent
-				|| component instanceof RingComponent;
+				|| component instanceof InnerTube
+				|| component instanceof TubeCoupler;
 	}
 
-	private TextureGenerationResult generateForRingComponent(RingComponent component, double dpi)
+	private TextureGenerationResult generateForRingComponent(ThicknessRingComponent component, double dpi)
 			throws TextureGenerationException {
 		double length = component.getLength();
 		if (length <= 0) {

--- a/swing/src/main/java/info/openrocket/swing/gui/util/TextureCreationService.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/util/TextureCreationService.java
@@ -99,6 +99,12 @@ public class TextureCreationService {
 		}
 
 		double widthMeters = 2 * Math.PI * maxRadius;
+	public static boolean isComponentSupported(RocketComponent component) {
+		return component instanceof FinSet
+				|| component instanceof SymmetricComponent
+				|| component instanceof RingComponent;
+	}
+
 		return renderBlankImage(widthMeters, length, dpi, null);
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/util/TextureCreationService.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/util/TextureCreationService.java
@@ -16,6 +16,7 @@ import java.util.List;
 import javax.imageio.ImageIO;
 
 import info.openrocket.core.rocketcomponent.FinSet;
+import info.openrocket.core.rocketcomponent.RingComponent;
 import info.openrocket.core.rocketcomponent.RocketComponent;
 import info.openrocket.core.rocketcomponent.SymmetricComponent;
 import info.openrocket.core.util.CoordinateIF;
@@ -66,6 +67,10 @@ public class TextureCreationService {
 			return generateForSymmetric((SymmetricComponent) component, insideSurface, dpi);
 		}
 
+		if (component instanceof RingComponent) {
+			return generateForRingComponent((RingComponent) component, dpi);
+		}
+
 		throw new TextureGenerationException("Component type " + component.getClass().getSimpleName()
 				+ " is not supported for automatic texture creation.");
 	}
@@ -99,12 +104,30 @@ public class TextureCreationService {
 		}
 
 		double widthMeters = 2 * Math.PI * maxRadius;
+		return renderBlankImage(widthMeters, length, dpi, null);
+	}
+
 	public static boolean isComponentSupported(RocketComponent component) {
 		return component instanceof FinSet
 				|| component instanceof SymmetricComponent
 				|| component instanceof RingComponent;
 	}
 
+	private TextureGenerationResult generateForRingComponent(RingComponent component, double dpi)
+			throws TextureGenerationException {
+		double length = component.getLength();
+		if (length <= 0) {
+			throw new TextureGenerationException(
+					"Component length must be greater than zero to create a texture.");
+		}
+
+		double outerRadius = component.getOuterRadius();
+		if (outerRadius <= 0) {
+			throw new TextureGenerationException(
+					"Component outer radius must be greater than zero to create a texture.");
+		}
+
+		double widthMeters = 2 * Math.PI * outerRadius;
 		return renderBlankImage(widthMeters, length, dpi, null);
 	}
 


### PR DESCRIPTION
Fixes #3063. Unsupported texture creation components have their "Create texture" button disabled. Inner tubes and tube couplers now support texture creation. Other ring components, like bulkheads, don't, since they are thin disks and require the top and bottom faces to be texture created instead of the side faces.