### PR TITLE
Add docs on new translation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ You can view the full list of contributors [here](https://github.com/openrocket/
 - Mohamed Amin Elkebsi
 - Oleksandr Hladin
 
+Want to help us translate OpenRocket into your language? Join our [Crowdin project](https://crowdin.com/project/openrocket) and contribute!
+
 ## 📜 License
 
 OpenRocket is proudly open-source under the [GNU GPL](https://www.gnu.org/licenses/gpl-3.0.en.html) license. Feel free to use, study, and extend.

--- a/docs/source/dev_guide/contributing_to_translations.rst
+++ b/docs/source/dev_guide/contributing_to_translations.rst
@@ -25,9 +25,9 @@ in the appropriate language file and returning the translated text.
 
 The language files are located in the :file:`core/src/main/resources/l10n` directory. The base file for all translations is
 ``messages.properties``, which contains the English text. Each language has its own file, named ``messages_xx.properties``,
-where ``xx`` is the language code (e.g. ``messages_nl.properties`` for Dutch). The l10n files are a simple key-value pair
-where the key is the text to be translated and the value is the translated text. For example, this is a snippet from the
-``messages.properties`` file:
+where ``xx`` is the two-letter ISO 639-1 language code (e.g. ``messages_nl.properties`` for Dutch, ``messages_zh.properties``
+for Chinese). The l10n files are a simple key-value pair where the key is the text to be translated and the value is the
+translated text. For example, this is a snippet from the ``messages.properties`` file:
 
 .. code-block:: properties
 
@@ -64,14 +64,52 @@ When the GUI is displayed, the Translator object will look up the key ``RocketPa
 file and return the translated text. If the key is not found in the language file, the Translator object will return the English.
 This way, the GUI can be easily translated into different languages by simply adding a new language file with the translated text.
 
+.. note::
+   Java's ``ResourceBundle`` uses a fallback chain when looking up translation files. For example, a user with locale
+   ``zh_CN`` (Chinese Simplified) will automatically use ``messages_zh.properties`` if no ``messages_zh_CN.properties``
+   exists. This means all languages, including regional ones, use a simple two-letter filename.
+
+----
+
+Crowdin Workflow
+================
+
+Translations are managed via `Crowdin <https://crowdin.com/project/openrocket>`__, which is integrated with the GitHub
+repository. This automates the translation sync process:
+
+**Source strings → Crowdin (automatic)**
+   When changes to :file:`messages.properties` are pushed to the ``unstable`` branch, Crowdin automatically detects the new
+   or modified strings and makes them available for translators on the Crowdin platform.
+
+**Translations → GitHub (automatic)**
+   Once translators have updated strings in Crowdin, Crowdin periodically opens a pull request to the repository with the
+   updated ``.properties`` files. Maintainers review and merge this PR.
+
+The configuration for this integration lives in :file:`crowdin.yml` at the root of the repository.
+
+Translating via Crowdin
+-----------------------
+
+The recommended way to contribute translations is through the Crowdin web interface:
+
+1. Go to `<https://crowdin.com/project/openrocket>`__ and sign in (or create a free account).
+2. Select your language.
+3. Translate the strings shown in the editor. Crowdin highlights untranslated and outdated strings.
+4. Your changes are saved automatically and will be included in the next sync PR to GitHub.
+
+You do not need to clone the repository or edit any files manually to contribute translations this way.
+
 ----
 
 Modifying an Existing Translation
 =================================
 
-Open the l10n file for the language you want to modify in the :file:`core/src/main/resources/l10n` directory. For example, to modify
-the French translation, open the :file:`messages_fr.properties` file, since ``fr`` corresponds to the language code of French.
-Find the key for the text you want to modify and change the value.
+The preferred way to modify an existing translation is through Crowdin (see above). This ensures your changes go through
+the review process and are kept in sync with Crowdin's translation memory.
+
+If you need to edit a translation file directly (e.g. for a quick fix during development), open the ``.properties`` file
+for the relevant language in :file:`core/src/main/resources/l10n`. For example, to modify the French translation, open
+:file:`messages_fr.properties`. Find the key for the text you want to modify and change the value.
 
 When you are done, create a pull request with your changes. The maintainers will review your changes and merge them if they are
 appropriate.
@@ -81,31 +119,45 @@ appropriate.
 Creating a New Translation
 ==========================
 
-If you want to create a new translation for a language that is not yet supported, you can create a new language file in the
-:file:`core/src/main/resources/l10n` directory. The file should be named ``messages_xx.properties``, where ``xx`` is the language code
-of the language you want to translate to. For example, to create a translation for Finnish, you would create a file named
-:file:`messages_fi.properties`.
+To add support for a new language, the following steps are required on the code side. The actual translation work is done
+on Crowdin — once the language is added there, Crowdin will push the translated ``.properties`` file automatically.
 
-Copy the contents of the :file:`messages.properties` file into the new file. Translate the English text into the new language and
-save the file.
+**1. Add the language file**
 
-Edit the :file:`swing/src/main/java/info/openrocket/swing/gui/util/SwingPreferences.java` file and add the new language to the
-``SUPPORTED_LOCALES`` array. For example, to add Finnish, you would change this line:
+Create a new file in :file:`core/src/main/resources/l10n` named ``messages_xx.properties``, where ``xx`` is the two-letter
+ISO 639-1 language code. For example, for Finnish: :file:`messages_fi.properties`.
+
+Add at minimum the ``debug.currentFile`` key so the locale can be identified at runtime:
+
+.. code-block:: properties
+
+   debug.currentFile = messages_fi.properties
+
+**2. Register the locale in SwingPreferences**
+
+Edit :file:`swing/src/main/java/info/openrocket/swing/gui/util/SwingPreferences.java` and add the new language code to the
+``SUPPORTED_LOCALES`` array. For example, to add Finnish:
 
 .. code-block:: java
 
    for (String lang : new String[] { "en", "ar", "de", "es", "fr", "it", "nl", "ru", "cs", "pl", "ja", "pt", "tr" }) {
 
-To this (notice the addition of ``"fi"`` at the end)
+becomes:
 
 .. code-block:: java
 
    for (String lang : new String[] { "en", "ar", "de", "es", "fr", "it", "nl", "ru", "cs", "pl", "ja", "pt", "tr", "fi" }) {
 
-Finally, add yourself to the list of translation contributors (you deserve some fame! 🙂). This is done in the
-:file:`swing/src/main/java/info/openrocket/swing/gui/dialogs/AboutDialog.java` and :file:`README.md` files.
-In this file, edit the String 'CREDITS' and add your details to the list after the 'Translations by:'-tag.
+**3. Add yourself to the credits**
 
-When you are done, create a pull request with your changes. The maintainers will review your changes and merge them if they are.
-If you are not at all familiar with git, you can also `create an issue <https://github.com/openrocket/openrocket/issues/new/choose>`__
-with your changes and the maintainers will create the pull request for you.
+Add your name to the list of translation contributors in
+:file:`swing/src/main/java/info/openrocket/swing/gui/dialogs/AboutDialog.java` and :file:`README.md`,
+after the ``Translations by:`` tag.
+
+**4. Add the language on Crowdin**
+
+Ask a maintainer to add the new language to the `Crowdin project <https://crowdin.com/project/openrocket>`__. Once added,
+Crowdin will handle syncing translations into the repository automatically.
+
+When you are done with the code changes, create a pull request. If you are not familiar with git, you can also
+`create an issue <https://github.com/openrocket/openrocket/issues/new/choose>`__ and the maintainers will help.


### PR DESCRIPTION
I was able to get the Crowdin integration with GitHub to work, thus fixes #2490. This PR updates our documentation to link to the new workflow.

Crowdin is a localization platform that manages translation workflows. Instead of contributors manually editing `.properties` files and submitting PRs, translators work through the Crowdin web UI at https://crowdin.com/project/openrocket. The GitHub integration keeps everything in sync automatically: when changes to `messages.properties` are pushed to `unstable`, Crowdin picks up the new source strings; when translators update them on Crowdin, it opens a PR (named "Sync translations from Crowdin") back to the repo with the updated translation files.

I tested adding a few translations in Dutch and the sync worked great. What's neat is that Crowdin has a built-in translator with suggestions. Great for boosting the translation workflow 🙂 .

Note that Crowdin is free for open source projects.