### PR TITLE
Repace meta keymask with platform-dependent keystroke

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/FreeformFinSetConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/FreeformFinSetConfig.java
@@ -81,6 +81,7 @@ import info.openrocket.swing.gui.scalefigure.ScaleScrollPane;
 import info.openrocket.swing.gui.scalefigure.ScaleSelector;
 import info.openrocket.swing.gui.util.CustomFinImporter;
 import info.openrocket.swing.gui.util.FileHelper;
+import info.openrocket.swing.gui.util.GUIUtil;
 import info.openrocket.swing.gui.widgets.DropdownButton;
 
 @SuppressWarnings("serial")
@@ -1108,9 +1109,9 @@ public class FreeformFinSetConfig extends FinSetConfig {
 	private void installFinPointUndoRedoKeyBindings(JComponent component) {
 		// Always consume the keystroke while editing fin points so global (document-level) undo/redo isn't triggered.
 		component.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(
-				KeyStroke.getKeyStroke(KeyEvent.VK_Z, InputEvent.META_DOWN_MASK), "finPointUndo");
+				KeyStroke.getKeyStroke(KeyEvent.VK_Z, GUIUtil.getMenuShortcutKeyMask()), "finPointUndo");
 		component.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(
-				KeyStroke.getKeyStroke(KeyEvent.VK_Y, InputEvent.META_DOWN_MASK), "finPointRedo");
+				KeyStroke.getKeyStroke(KeyEvent.VK_Y, GUIUtil.getMenuShortcutKeyMask()), "finPointRedo");
 
 		component.getActionMap().put("finPointUndo", new AbstractAction() {
 			@Override

--- a/swing/src/main/java/info/openrocket/swing/gui/main/BasicFrame.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/BasicFrame.java
@@ -502,7 +502,7 @@ private static final Translator trans = Application.getTranslator();
 
 		//// 	Save
 		item = new JMenuItem(trans.get("main.menu.file.save"), KeyEvent.VK_S);
-		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.META_DOWN_MASK));
+		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, GUIUtil.getMenuShortcutKeyMask()));
 		//// Save the current rocket design
 		item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.file.save.desc"));
 		item.setIcon(Icons.deriveMenuIcon(Icons.FILE_SAVE));
@@ -518,7 +518,7 @@ private static final Translator trans = Application.getTranslator();
 		//// 	Save as...
 		item = new JMenuItem(trans.get("main.menu.file.saveAs"), KeyEvent.VK_A);
 		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S,
-				InputEvent.SHIFT_DOWN_MASK | InputEvent.META_DOWN_MASK));
+				InputEvent.SHIFT_DOWN_MASK | GUIUtil.getMenuShortcutKeyMask()));
 		//// Save the current rocket design to a new file
 		item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.file.saveAs.desc"));
 		item.setIcon(Icons.deriveMenuIcon(Icons.FILE_SAVE_AS));
@@ -619,7 +619,7 @@ private static final Translator trans = Application.getTranslator();
 
 		//// 	Print design info...
 		item = new JMenuItem(trans.get("main.menu.file.print"), KeyEvent.VK_P);
-		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, InputEvent.META_DOWN_MASK));
+		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, GUIUtil.getMenuShortcutKeyMask()));
 		item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.file.print.desc"));
 		item.setIcon(Icons.deriveMenuIcon(Icons.FILE_PRINT));
 		item.addActionListener(new ActionListener() {
@@ -645,7 +645,7 @@ private static final Translator trans = Application.getTranslator();
 		item = new JMenuItem(trans.get("main.menu.file.properties"), KeyEvent.VK_I);
 		item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.file.properties.desc"));
 		item.setIcon(Icons.deriveMenuIcon(Icons.CONFIGURE));
-		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_I, InputEvent.META_DOWN_MASK));
+		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_I, GUIUtil.getMenuShortcutKeyMask()));
 		item.addActionListener(new ActionListener(){
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -657,7 +657,7 @@ private static final Translator trans = Application.getTranslator();
 
 		////	Close
 		item = new JMenuItem(trans.get("main.menu.file.close"), KeyEvent.VK_C);
-		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_W, InputEvent.META_DOWN_MASK));
+		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_W, GUIUtil.getMenuShortcutKeyMask()));
 		//// Close the current rocket design
 		item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.file.close.desc"));
 		item.setIcon(Icons.deriveMenuIcon(Icons.FILE_CLOSE));
@@ -675,7 +675,7 @@ private static final Translator trans = Application.getTranslator();
 
 		////	Quit
 		item = new JMenuItem(trans.get("main.menu.file.quit"), KeyEvent.VK_Q);
-		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Q, InputEvent.META_DOWN_MASK));
+		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Q, GUIUtil.getMenuShortcutKeyMask()));
 		//// Quit the program
 		item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.file.quit.desc"));
 		item.setIcon(Icons.deriveMenuIcon(Icons.FILE_QUIT));
@@ -698,7 +698,7 @@ private static final Translator trans = Application.getTranslator();
 
 		Action action = UndoRedoAction.newUndoAction(document);
 		item = createMenuItemFromAction(action);
-		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Z, InputEvent.META_DOWN_MASK));
+		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Z, GUIUtil.getMenuShortcutKeyMask()));
 		item.setMnemonic(KeyEvent.VK_U);
 
 		////	Undo the previous operation
@@ -708,7 +708,7 @@ private static final Translator trans = Application.getTranslator();
 
 		action = UndoRedoAction.newRedoAction(document);
 		item = createMenuItemFromAction(action);
-		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Y, InputEvent.META_DOWN_MASK));
+		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Y, GUIUtil.getMenuShortcutKeyMask()));
 		item.setMnemonic(KeyEvent.VK_R);
 
 		////	Redo the previously undone operation
@@ -1085,7 +1085,7 @@ private static final Translator trans = Application.getTranslator();
 
 		//// New
 		item = new JMenuItem(trans.get("main.menu.file.new"), KeyEvent.VK_N);
-		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, InputEvent.META_DOWN_MASK));
+		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_N, GUIUtil.getMenuShortcutKeyMask()));
 		item.setMnemonic(KeyEvent.VK_N);
 		item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.file.new.desc"));
 		item.setIcon(Icons.deriveMenuIcon(Icons.FILE_NEW));
@@ -1103,7 +1103,7 @@ private static final Translator trans = Application.getTranslator();
 
 		//// 	Open...
 		item = new JMenuItem(trans.get("main.menu.file.open"), KeyEvent.VK_O);
-		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.META_DOWN_MASK));
+		item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, GUIUtil.getMenuShortcutKeyMask()));
 		item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.file.open.desc"));
 		item.setIcon(Icons.deriveMenuIcon(Icons.FILE_OPEN));
 		item.addActionListener(new ActionListener() {

--- a/swing/src/main/java/info/openrocket/swing/gui/main/DesignPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/DesignPanel.java
@@ -31,7 +31,6 @@ import javax.swing.event.TreeSelectionListener;
 import javax.swing.tree.TreePath;
 import java.awt.Component;
 import java.awt.Font;
-import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
@@ -61,13 +60,13 @@ public class DesignPanel extends JSplitPane {
 
         // Remove JTree key events that interfere with menu accelerators
         InputMap im = SwingUtilities.getUIInputMap(tree, JComponent.WHEN_FOCUSED);
-        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_X, InputEvent.META_DOWN_MASK), "none");
-        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.META_DOWN_MASK), "none");
-        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_V, InputEvent.META_DOWN_MASK), "none");
-        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_A, InputEvent.META_DOWN_MASK), "none");
-        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.META_DOWN_MASK), "none");
-        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.META_DOWN_MASK), "none");
-        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_N, InputEvent.META_DOWN_MASK), "none");
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_X, GUIUtil.getMenuShortcutKeyMask()), "none");
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_C, GUIUtil.getMenuShortcutKeyMask()), "none");
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_V, GUIUtil.getMenuShortcutKeyMask()), "none");
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_A, GUIUtil.getMenuShortcutKeyMask()), "none");
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_S, GUIUtil.getMenuShortcutKeyMask()), "none");
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_O, GUIUtil.getMenuShortcutKeyMask()), "none");
+        im.put(KeyStroke.getKeyStroke(KeyEvent.VK_N, GUIUtil.getMenuShortcutKeyMask()), "none");
 
         // Highlight all child components of a stage/rocket/podset when it is selected
         tree.getSelectionModel().addTreeSelectionListener(new TreeSelectionListener() {
@@ -108,7 +107,7 @@ public class DesignPanel extends JSplitPane {
                         component.clearConfigListeners();
 
                         // Multi-component edit if shift/meta key is pressed
-                        if ((e.isShiftDown() || e.isMetaDown()) && tree.getSelectionPaths() != null) {
+                        if ((e.isShiftDown() || GUIUtil.isMenuShortcutDown(e)) && tree.getSelectionPaths() != null) {
                             // Add the other selected components as listeners to the last selected component
                             for (TreePath p : tree.getSelectionPaths()) {
                                 if (p != null) {

--- a/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/SimulationPanel.java
@@ -15,7 +15,6 @@ import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.event.ActionEvent;
-import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.ItemEvent;
 import java.awt.event.MouseAdapter;
@@ -261,12 +260,12 @@ public class SimulationPanel extends JPanel {
 
 		// Unregister the default actions that would otherwise conflict with RocketActions and their acceleration keys
 		InputMap im = simulationTable.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT);
-		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_E, InputEvent.META_DOWN_MASK), "none");
-		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_X, InputEvent.META_DOWN_MASK), "none");
-		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_C, InputEvent.META_DOWN_MASK), "none");
-		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_V, InputEvent.META_DOWN_MASK), "none");
-		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_D, InputEvent.META_DOWN_MASK), "none");
-		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, InputEvent.META_DOWN_MASK), "none");
+		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_E, GUIUtil.getMenuShortcutKeyMask()), "none");
+		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_X, GUIUtil.getMenuShortcutKeyMask()), "none");
+		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_C, GUIUtil.getMenuShortcutKeyMask()), "none");
+		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_V, GUIUtil.getMenuShortcutKeyMask()), "none");
+		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_D, GUIUtil.getMenuShortcutKeyMask()), "none");
+		im.put(KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, GUIUtil.getMenuShortcutKeyMask()), "none");
 
 		// Context menu
 		pm = new JPopupMenu();

--- a/swing/src/main/java/info/openrocket/swing/gui/main/componenttree/ComponentTree.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/componenttree/ComponentTree.java
@@ -5,6 +5,7 @@ import javax.swing.ToolTipManager;
 
 import info.openrocket.core.document.OpenRocketDocument;
 import info.openrocket.swing.gui.components.BasicTree;
+import info.openrocket.swing.gui.util.GUIUtil;
 
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
@@ -23,7 +24,7 @@ public class ComponentTree extends BasicTree {
 
 			@Override
 			public void keyPressed(KeyEvent e) {
-				if ((e.getKeyCode() == KeyEvent.VK_A) && ((e.getModifiersEx() & KeyEvent.META_DOWN_MASK) != 0)) {
+				if ((e.getKeyCode() == KeyEvent.VK_A) && ((e.getModifiersEx() & GUIUtil.getMenuShortcutKeyMask()) != 0)) {
 					setSelectionInterval(1, getRowCount());		// Don't select the rocket (row 0)
 				}
 			}

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
@@ -48,6 +48,7 @@ import info.openrocket.swing.gui.main.BasicFrame;
 import info.openrocket.swing.gui.main.componenttree.ComponentTreeModel;
 import info.openrocket.swing.gui.simulation.SimulationWorker;
 import info.openrocket.swing.gui.util.FileHelper;
+import info.openrocket.swing.gui.util.GUIUtil;
 import info.openrocket.swing.gui.util.Icons;
 import info.openrocket.swing.gui.util.SwingPreferences;
 import info.openrocket.swing.utils.CustomClickCountListener;
@@ -799,7 +800,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 
 	private void handleDoubleComponentClick(RocketComponent[] clicked, MouseEvent event, List<RocketComponent> selectedComponents) {
 		// Multi-component edit if shift/meta key is pressed
-		if (!selectedComponents.isEmpty() && (event.isShiftDown() || event.isMetaDown())) {
+		if (!selectedComponents.isEmpty() && (event.isShiftDown() || GUIUtil.isMenuShortcutDown(event))) {
 			List<TreePath> paths = new ArrayList<>(Arrays.asList(selectionModel.getSelectionPaths()));
 			RocketComponent component = selectedComponents.get(selectedComponents.size() - 1);
 			component.clearConfigListeners();
@@ -846,7 +847,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 
 	private void handleSingleComponentClick(RocketComponent[] clicked, MouseEvent event, List<RocketComponent> selectedComponents) {
 		// If the shift-button is held, add a newly clicked component to the selection path
-		if (event.isShiftDown() || event.isMetaDown()) {
+		if (event.isShiftDown() || GUIUtil.isMenuShortcutDown(event)) {
 			List<TreePath> paths = new ArrayList<>(Arrays.asList(selectionModel.getSelectionPaths()));
 			for (int i = 0; i < clicked.length; i++) {
 				if (!selectedComponents.contains(clicked[i])) {

--- a/swing/src/main/java/info/openrocket/swing/gui/util/DummyFrameMenuOSX.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/util/DummyFrameMenuOSX.java
@@ -16,7 +16,6 @@ import javax.swing.KeyStroke;
 import java.awt.Color;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 
 /**
@@ -71,7 +70,7 @@ public class DummyFrameMenuOSX extends JFrame {
 
         ////	Quit
         item = new JMenuItem(trans.get("main.menu.file.quit"), KeyEvent.VK_Q);
-        item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Q, InputEvent.META_DOWN_MASK));
+        item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Q, GUIUtil.getMenuShortcutKeyMask()));
         //// Quit the program
         item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.file.quit.desc"));
         item.setIcon(Icons.FILE_QUIT);

--- a/swing/src/main/java/info/openrocket/swing/gui/util/GUIUtil.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/util/GUIUtil.java
@@ -14,6 +14,7 @@ import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ComponentAdapter;
+import java.awt.event.InputEvent;
 import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
 import java.awt.event.FocusListener;
@@ -116,6 +117,21 @@ public class GUIUtil {
 		} catch (IOException ignore) {
 			ignore.printStackTrace();
 		}
+	}
+
+	/**
+	 * Returns the modifier mask for the platform's menu shortcut key:
+	 * {@link InputEvent#META_DOWN_MASK} on macOS, {@link InputEvent#CTRL_DOWN_MASK} on Windows and Linux.
+	 */
+	public static int getMenuShortcutKeyMask() {
+		return Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx();
+	}
+
+	/**
+	 * Returns true if the platform's menu shortcut key (Cmd on macOS, Ctrl on Windows/Linux) is held down.
+	 */
+	public static boolean isMenuShortcutDown(InputEvent e) {
+		return (e.getModifiersEx() & getMenuShortcutKeyMask()) != 0;
 	}
 
 	public static void loadCustomFonts() {


### PR DESCRIPTION
We've been using the meta_down key mask in numerous places, thinking that it was universal for all platforms, e.g. meta_down + s would be Cmd + s on macOS and Ctrl + s on Windows/Linux. Turns out this is not the case...

I noticed that in the packaged Windows app, the meta keys actually map correctly to Ctrl, so maybe one of the packaging steps translates the key mask, but we shouldn't trust on it. Also, if you build the source code on Windows, you see the Meta + ... shortcuts in the app ribbon.

This PR uses a universal `GUIUtil.getMenuShortcutKeyMask()` utility method that uses `Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()` to resolve the keymask.