### PR TITLE
Close BufferedWriter in marshalToRASAero

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/rasaero/export/RASAeroSaver.java
+++ b/core/src/main/java/info/openrocket/core/file/rasaero/export/RASAeroSaver.java
@@ -1,6 +1,7 @@
 package info.openrocket.core.file.rasaero.export;
 
 import info.openrocket.core.document.OpenRocketDocument;
+import info.openrocket.core.util.BugException;
 import info.openrocket.core.document.StorageOptions;
 import info.openrocket.core.file.RocketSaver;
 import info.openrocket.core.logging.ErrorSet;
@@ -69,9 +70,13 @@ public class RASAeroSaver extends RocketSaver {
             ErrorSet errors) throws IOException {
         log.info("Saving .CDX1 file");
 
-        BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(dest, StandardCharsets.UTF_8));
-        writer.write(marshalToRASAero(doc, warnings, errors));
-        writer.flush();
+        try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(dest, StandardCharsets.UTF_8))) {
+            writer.write(marshalToRASAero(doc, warnings, errors));
+            writer.flush();
+        } catch (IOException e) {
+            log.warn("Failed to write RASAero export: " + e.getMessage());
+            throw new BugException(e);
+        }
     }
 
     @Override


### PR DESCRIPTION
I think marshalToRASAero might be doing a bit more work than it needs to here, but I could be wrong. The resource opened there can leak if marshalToRASAero exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.