### PR TITLE
[#3095] Fix plot line highlighting for multi-stage rockets with extra variables

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/plot/Plot.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/Plot.java
@@ -475,11 +475,6 @@ public abstract class Plot<T extends DataType, B extends DataBranch<T>, C extend
 		}
 
 		@Override
-		public Stroke lookupSeriesStroke(int series) {
-			return super.lookupSeriesStroke(series / branchCount);
-		}
-
-		@Override
 		public Stroke lookupSeriesOutlineStroke(int series) {
 			return super.lookupSeriesOutlineStroke(series / branchCount);
 		}

--- a/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationChart.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationChart.java
@@ -34,6 +34,7 @@ import org.jfree.chart.entity.EntityCollection;
 import org.jfree.chart.entity.LegendItemEntity;
 import org.jfree.chart.plot.XYPlot;
 import org.jfree.chart.renderer.xy.XYItemRenderer;
+import info.openrocket.swing.gui.plot.Plot.MetadataXYSeries;
 import org.jfree.data.xy.XYSeriesCollection;
 
 import com.jogamp.newt.event.InputEvent;
@@ -287,7 +288,14 @@ public class SimulationChart extends ChartPanel {
                 BasicStroke base = (BasicStroke) baseStrokes.computeIfAbsent(key, k -> renderer.getSeriesStroke(finalS));
 
                 BasicStroke stroke = base;
-                if (hasHighlight && labelsToHighlight.contains(dataset.getSeries(s).getDescription())) {
+                // Match by base name so all branches of a variable are highlighted together.
+                // For MetadataXYSeries, the legend label equals the base name (branch 0 has no prefix),
+                // so checking baseName works for every branch regardless of which stage is selected.
+                String matchKey = dataset.getSeries(s).getDescription();
+                if (dataset.getSeries(s) instanceof MetadataXYSeries) {
+                    matchKey = ((MetadataXYSeries) dataset.getSeries(s)).getBaseName();
+                }
+                if (hasHighlight && labelsToHighlight.contains(matchKey)) {
                     stroke = new BasicStroke(base.getLineWidth() * 3.0f, base.getEndCap(), base.getLineJoin(), base.getMiterLimit(), base.getDashArray(), base.getDashPhase());
                 }
 


### PR DESCRIPTION
Two bugs prevented highlighting from working correctly:
1. ModifiedXYItemRenderer.lookupSeriesStroke() divided the series index by branchCount, so setting a stroke on series N was rendered using the stroke of series N/branchCount instead. This caused every variable after the first on a given axis to ignore its highlighted stroke.

2. applyLegendHighlight() matched series by description (e.g. "Sustainer: Altitude"), but legend labels always use the branch-0 description (e.g. "Altitude"). Only branch-0 series ever matched, so selecting a non-main stage in the combobox showed no highlighting.

Fixed (1) by removing the lookupSeriesStroke override — all series share the same base stroke so the division was unnecessary and broke per-series control. Fix (2) by matching on MetadataXYSeries.getBaseName() so all branches of a variable highlight together regardless of which stage is selected.

Fixes #3095.

<img width="1056" height="892" alt="image" src="https://github.com/user-attachments/assets/8e68b02d-7b79-44e4-a4dc-d39ffa402846" />
