### PR TITLE
Small fixes

### DIFF
--- a/core/src/main/java/info/openrocket/core/database/AsynchronousDatabaseLoader.java
+++ b/core/src/main/java/info/openrocket/core/database/AsynchronousDatabaseLoader.java
@@ -101,13 +101,18 @@ public abstract class AsynchronousDatabaseLoader {
 	 * 
 	 */
 	private void doLoad() {
-
-		// Pause for indicated startup time
-		pauseForStartupTime();
-
-		loadDatabase();
-
-		markAsLoaded();
+		try {
+			// Pause for indicated startup time
+			pauseForStartupTime();
+			loadDatabase();
+		} finally {
+			/*
+			 * Always release waiting threads, even if loading fails. Otherwise callers such
+			 * as the Swing motor loading dialog can block forever after a background loading
+			 * exception.
+			 */
+			markAsLoaded();
+		}
 	}
 
 	/**

--- a/swing/src/main/java/info/openrocket/swing/gui/util/DummyFrameMenuOSX.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/util/DummyFrameMenuOSX.java
@@ -73,7 +73,7 @@ public class DummyFrameMenuOSX extends JFrame {
         item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_Q, GUIUtil.getMenuShortcutKeyMask()));
         //// Quit the program
         item.getAccessibleContext().setAccessibleDescription(trans.get("main.menu.file.quit.desc"));
-        item.setIcon(Icons.FILE_QUIT);
+        item.setIcon(Icons.deriveMenuIcon(Icons.FILE_QUIT));
         item.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {


### PR DESCRIPTION
A few minor fixes:
- On macOS, the Quit icon wasn't properly rendering in the menu
- Added a cleanup to motor database loader. I noticed that OR can sometimes hang at startup during the motor database loading. I think this may fix it