### PR TITLE
OpenRocket tests running on Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,10 +103,8 @@ subprojects {
     }
 
     spotbugs {
-        // Note: string-to-enum coercion is deprecated in Gradle 9, will error in Gradle 10.
-        // TODO: Replace with Effort.MAX / Confidence.HIGH when upgrading to Gradle 10+.
-        effort = 'max'
-        reportLevel = 'high'
+        effort = com.github.spotbugs.snom.Effort.valueOf('MAX')
+        reportLevel = com.github.spotbugs.snom.Confidence.valueOf('HIGH')
         excludeFilter = rootProject.file('config/spotbugs/excludeFilter.xml')
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,63 @@ allprojects {
 
 subprojects {
     apply plugin: 'java'
+
+    // Workaround for Windows "CreateProcess error=206" (command line too long).
+    //
+    // Windows limits CreateProcess to 32,767 chars. A JPMS build produces two sources of
+    // length: (a) -classpath with every JAR/directory, and (b) --module-path (added by the
+    // module plugin as a JVM arg) with every module JAR. Both must be shortened.
+    //
+    // Strategy:
+    //   (a) Classpath → manifest JAR: a tiny JAR whose Class-Path manifest attribute lists
+    //       every real entry. Directory entries need a trailing '/' or the JVM treats them as
+    //       ZIPs. Use setFrom() to mutate the FileCollection in-place (Gradle's worker
+    //       infrastructure holds a reference to the same object).
+    //   (b) JVM args → @argfile: Java 9+ supports "@/path/to/file" as a command-line
+    //       argument; the launcher expands it before parsing. Writing all JVM args to a temp
+    //       file and replacing jvmArgs with a single "@<path>" entry keeps that part short.
+    //
+    // The block MUST be registered before the module plugin is applied so that Gradle's
+    // LIFO doFirst ordering puts our action AFTER the module plugin's doFirst. The plugin
+    // then runs first (populating --module-path in jvmArgs), and our action runs second
+    // (moving everything to files).
+    if (System.properties['os.name'].toLowerCase().contains('windows')) {
+
+        Closure windowsLongCpFix = { task ->
+            doFirst {
+                // (a) Wrap classpath in a manifest JAR
+                def cpFiles = task.classpath.files
+                if (cpFiles) {
+                    def mf = new java.util.jar.Manifest()
+                    mf.mainAttributes.put(java.util.jar.Attributes.Name.MANIFEST_VERSION, '1.0')
+                    mf.mainAttributes.put(java.util.jar.Attributes.Name.CLASS_PATH,
+                        cpFiles.collect { f ->
+                            def url = f.toURI().toURL().toString()
+                            (f.isDirectory() && !url.endsWith('/')) ? url + '/' : url
+                        }.join(' '))
+                    def cpJar = new File(task.temporaryDir, 'classpath-manifest.jar')
+                    cpJar.parentFile.mkdirs()
+                    new java.util.jar.JarOutputStream(new java.io.FileOutputStream(cpJar), mf).close()
+                    task.classpath.setFrom(cpJar)
+                }
+
+                // (b) Move all JVM args into a @argfile so --module-path doesn't blow the limit.
+                //     One arg per line; quote entries that contain spaces.
+                def currentArgs = task.jvmArgs as List<String>
+                if (currentArgs) {
+                    def argFile = new File(task.temporaryDir, 'jvm.argfile')
+                    argFile.text = currentArgs.collect { arg ->
+                        arg.contains(' ') ? '"' + arg.replace('\\', '\\\\').replace('"', '\\"') + '"' : arg
+                    }.join('\n')
+                    task.jvmArgs = ['@' + argFile.absolutePath.replace('\\', '/')]
+                }
+            }
+        }
+
+        tasks.withType(Test).configureEach(windowsLongCpFix)
+        tasks.withType(JavaExec).configureEach(windowsLongCpFix)
+    }
+
     apply plugin: "org.javamodularity.moduleplugin"
     apply plugin: 'jacoco'
     apply plugin: 'com.github.spotbugs'

--- a/core/src/main/java/info/openrocket/core/util/JarUtil.java
+++ b/core/src/main/java/info/openrocket/core/util/JarUtil.java
@@ -80,6 +80,9 @@ public class JarUtil {
 				uri = new URI(url.getProtocol(), url.getUserInfo(), url.getHost(),
 						url.getPort(), url.getPath(), url.getQuery(), url.getRef());
 			} catch (URISyntaxException e1) {
+				if ("file".equals(url.getProtocol())) {
+					return new File(url.getPath());
+				}
 				throw new IllegalArgumentException("Broken URL: " + url);
 			}
 		}

--- a/core/src/test/java/info/openrocket/core/utils/L10NGeneratorTest.java
+++ b/core/src/test/java/info/openrocket/core/utils/L10NGeneratorTest.java
@@ -40,14 +40,14 @@ class L10NGeneratorTest {
 	void outputRemovesDiacriticsAndPrintsMapping() throws Exception {
 		invokeOutput('é');
 		String generated = captured.toString(StandardCharsets.UTF_8);
-		assertEquals("m.put('\\u00e9', \"e\");" + System.lineSeparator(), generated);
+		assertEquals("m.put('\\u00e9', \"e\");" + "\n", generated);
 	}
 
 	@Test
 	void outputMapsFractionSlashToForwardSlash() throws Exception {
 		invokeOutput(Chars.FRACTION);
 		String generated = captured.toString(StandardCharsets.UTF_8);
-		assertEquals("m.put('\\u2044', \"/\");" + System.lineSeparator(), generated);
+		assertEquals("m.put('\\u2044', \"/\");" + "\n", generated);
 	}
 
 	@Test


### PR DESCRIPTION
Pull request to get OpenRocket tests running on Windows
===========================================

Gradle Tests, mainly the Core requests, do not run in Windows 11 CLI environment.   This request resolved in step #1 which then exposed to specific tests that did not complete successfully under Windows.

Tested this both under Windows 11 Pro in CMD and Powershell, as we as Ubuntu (WSL) 24.04.3 LTS in command line.  Also ran it in IntelliJ on Windows 11.

1. CreateProcess error=206 -- command line too long
----------------------------------------------------

WHY IT HAPPENS

Windows' CreateProcess API hard-limits the total command line to 32,767 characters.
A JPMS (Java Module System) build produces two independent sources of length on the
forked test worker command:

  - -classpath <all JARs and output directories>  -- dozens of entries with long
    absolute Windows paths
  - --module-path <all named-module JARs>  -- added by the
    org.javamodularity.moduleplugin as a JVM argument

Either one alone can exceed the limit.


FIX A -- manifest JAR for -classpath

A tiny placeholder JAR is created at task run-time. Its MANIFEST.MF contains a
Class-Path: attribute that lists every real classpath entry as a file:/... URL.
The JVM reads this attribute at startup and loads all the real JARs/directories
transparently. The command line only carries "-cp classpath-manifest.jar", which
is ~50 chars.

Two subtleties:

  - Directory entries (e.g. build/classes/java/test) must have a trailing '/' in
    the Class-Path value -- without it the JVM treats them as ZIP files, cannot
    find .class files inside, and silently skips them.

  - setFrom() not '='  --  Gradle's test-worker infrastructure captures a reference
    to the task's FileCollection object when building the process spec. Assigning
    "classpath = files(jar)" replaces the task's field but the worker still sees
    the old object. "classpath.setFrom(jar)" mutates the same object in place and
    is visible to the worker.


FIX B -- @argfile for --module-path

Java 9+ supports "@/path/to/file" as a command-line argument; the JVM launcher
expands the file's contents as individual arguments before processing. All JVM args
(including the long --module-path list) are written to a temp file, and task.jvmArgs
is replaced with a single "@<path>" token. The forked java invocation ends up as:

    java.exe @D:/tmp/.../jvm.argfile -cp classpath-manifest.jar ... TestWorkerMain


FIX C -- plugin registration order

The configureEach hooks that register the doFirst actions must be applied BEFORE
"apply plugin: org.javamodularity.moduleplugin". Gradle's doFirst uses LIFO execution
order:

  - Actions registered later run first.
  - The module plugin's doFirst must run first (it populates --module-path in jvmArgs
    and moves named modules off the classpath).
  - Our doFirst must run second (after it can see the final jvmArgs and the trimmed
    classpath).

Registering our hooks before the plugin apply call ensures the plugin's doFirst sits
later in the list and therefore executes first.

2. L10NGeneratorTest -- invisible line-ending mismatch
------------------------------------------------------

FAILURE OUTPUT

    expected: <m.put('u00e9', "e");
    > but was: <m.put('u00e9', "e");
    >

The two strings look identical -- a classic sign of a hidden character.
L10NGenerator.print() uses a hard-coded \n in its printf format string. The test
used System.lineSeparator(), which is \r\n on Windows. The test expected ...\r\n;
the actual output was ...\n. In terminal output \r moves the cursor to the start of
the line and overwrites the display, so both lines appear the same.

Since the generator emits Java source code (not platform text files), \n is the
correct and intentional line ending. The test was fixed to assert against the literal
"\n" rather than System.lineSeparator(). This is a no-op on Linux/macOS where
System.lineSeparator() is already \n.


3. JarUtilTest -- urlToFile throws on Windows paths with invalid % sequences
-----------------------------------------------------------------------------

FAILURE

    java.lang.IllegalArgumentException: Broken URL:
        file:C:/Users/.../jar util/test%zz

urlToFile had a two-level fallback:

  1. url.toURI()  --  fails because the space is unescaped and %zz is an invalid
     percent-sequence.

  2. new URI(scheme, userInfo, host, port, path, query, ref)  --  fails on Windows
     because url.getHost() returns "" (empty string, not null). When host is non-null
     the URI has an authority component, which forces the path to start with '/'. A
     Windows absolute path like "C:/Users/..." does not start with '/', so the
     constructor throws URISyntaxException.

Both paths threw, reaching the "throw new IllegalArgumentException" line.

The fix adds a third fallback: if the protocol is "file:", call new File(url.getPath())
directly. File does not interpret percent-sequences, so %zz is preserved verbatim in
the path string, which is exactly what callers (like getCurrentJarFile) need when
dealing with paths the OS gave them containing unusual characters. Non-file: URLs
still propagate IllegalArgumentException as before.

4. Spot Bugs

This was a Gradle 9 deprecation notification that was going to be deprecated in Gradle 10.