### PR TITLE
[#3103] Avoid motor loading deadlock during startup update check

### DIFF
--- a/core/src/main/java/info/openrocket/core/database/AsynchronousDatabaseLoader.java
+++ b/core/src/main/java/info/openrocket/core/database/AsynchronousDatabaseLoader.java
@@ -34,12 +34,23 @@ public abstract class AsynchronousDatabaseLoader {
 	 * 
 	 * @throws IllegalStateException if this method has already been called.
 	 */
-	public void startLoading() {
+	public synchronized void startLoading() {
 		if (startedLoading) {
 			throw new IllegalStateException("Already called startLoading");
 		}
 		startedLoading = true;
 		new LoadingThread().start();
+	}
+
+	/**
+	 * Return whether background loading has already been started.
+	 * This is used by Swing startup code to avoid deadlocks when modal dialogs
+	 * pump the EDT before the normal startup sequence reaches startLoading().
+	 *
+	 * @return whether startLoading() has already been called
+	 */
+	public boolean hasStartedLoading() {
+		return startedLoading;
 	}
 
 	/**

--- a/swing/src/main/java/info/openrocket/swing/startup/GuiModule.java
+++ b/swing/src/main/java/info/openrocket/swing/startup/GuiModule.java
@@ -80,7 +80,15 @@ public class GuiModule extends AbstractModule {
 			MotorDatabaseInitializer.initialize();
 			// Check for a newer remote database and optionally install it before loading
 			MotorDatabaseUpdateChecker.checkForUpdatesAndInstallIfRequested();
-			motorLoader.startLoading();
+			/*
+			 * Modal dialogs shown during the update check can pump the EDT and trigger a
+			 * re-entrant motor database request. In that case the provider starts the
+			 * loader early to avoid an infinite "Loading motors" dialog, so only call
+			 * startLoading() here when startup has not already done so.
+			 */
+			if (!motorLoader.hasStartedLoading()) {
+				motorLoader.startLoading();
+			}
 		} else {
 			motorLoader.markAsLoaded();
 		}

--- a/swing/src/main/java/info/openrocket/swing/startup/providers/BlockingMotorDatabaseProvider.java
+++ b/swing/src/main/java/info/openrocket/swing/startup/providers/BlockingMotorDatabaseProvider.java
@@ -59,6 +59,19 @@ public class BlockingMotorDatabaseProvider implements Provider<ThrustCurveMotorS
 		if (loader.isLoaded()) {
 			return;
 		}
+
+		/*
+		 * Startup currently performs the motor database update check before the normal
+		 * motor loader start call. Because that update check uses modal dialogs, the EDT
+		 * can re-enter startup code and request the motor database early. If we only show
+		 * the loading dialog here, it can wait forever because the original startup stack
+		 * has not yet resumed to call startLoading(). Starting the loader on demand breaks
+		 * that cycle and lets startup continue.
+		 */
+		if (!loader.hasStartedLoading()) {
+			log.info("Motor database requested before background loading started, starting it now");
+			loader.startLoading();
+		}
 		
 		SplashScreen splash = Splash.getSplashScreen();
 		if (splash == null || !splash.isVisible()) {


### PR DESCRIPTION
This fixes #3103. The root cause was a re-entrant EDT path during the motor database update check: modal update dialogs could pump the EDT before the normal motor loader had been started, and an early motor database request would then block on a loader that had never begun. The fix keeps the intended startup order intact, but allows the motor loader to start on demand in that re-entrant case and avoids double-starting it later in normal startup.