### PR TITLE
Use stable save keys for FlightDataType serialization in .ork files

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/openrocket/OpenRocketSaver.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/OpenRocketSaver.java
@@ -654,7 +654,7 @@ public class OpenRocketSaver extends RocketSaver {
 		for (int i = 0; i < types.length; i++) {
 			if (i > 0)
 				sb.append(",");
-			sb.append(TextUtil.escapeXML(types[i].getName()));
+			sb.append(TextUtil.escapeXML(types[i].getSaveKey()));
 		}
 		sb.append("\">");
 		writeln(sb.toString());

--- a/core/src/main/java/info/openrocket/core/file/openrocket/importt/FlightDataBranchHandler.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/importt/FlightDataBranchHandler.java
@@ -69,41 +69,51 @@ class FlightDataBranchHandler extends AbstractElementHandler {
 		branch.setOptimumAltitude(optimumAltitude);
 	}
 	
-	// Find the full flight data type given name only
+	// Find the full flight data type given the value stored in the XML file.
 	// Note: this way of doing it requires that custom expressions always come before flight data in the file,
 	// not the nicest but this is always the case anyway.
 	private FlightDataType findFlightDataType(String name) {
-		
-		// Kevins version with lookup by key. Not using right now
-		/*
-		if ( key != null ) {
-			for (FlightDataType t : FlightDataType.ALL_TYPES){
-				if (t.getKey().equals(key) ){
-					return t;
-				}
-			}
+		// 1. Try the stable save key (files saved with the current format store e.g. "TYPE_DRAG_COEFF")
+		FlightDataType byKey = FlightDataType.getTypeBySaveKey(name);
+		if (byKey != null) {
+			return byKey;
 		}
-		*/
-		
-		// Look in built in types
+
+		// 2. Try matching by display name (files saved before save keys were introduced)
 		for (FlightDataType t : FlightDataType.ALL_TYPES) {
 			if (t.getName().equals(name)) {
 				return t;
 			}
 		}
 
-		// Replace deprecated 'Position upwind' with new 'Position North of launch' option
+		// 3. Replace deprecated 'Position upwind' with new 'Position North of launch' option
 		if (name.equals(trans.get("FlightDataType.TYPE_UPWIND"))) {
 			return FlightDataType.TYPE_POSITION_Y;
 		}
-		
-		// Look in custom expressions
+
+		// 4. Legacy English name mappings: type names were updated to include symbol suffixes
+		// (e.g. "Drag coefficient" -> "Drag coefficient (CD)"). Maps names from files saved
+		// before that rename so they still load correctly.
+		switch (name) {
+			case "Drag coefficient":           return FlightDataType.TYPE_DRAG_COEFF;
+			case "Axial drag coefficient":     return FlightDataType.TYPE_AXIAL_DRAG_COEFF;
+			case "Friction drag coefficient":  return FlightDataType.TYPE_FRICTION_DRAG_COEFF;
+			case "Pressure drag coefficient":  return FlightDataType.TYPE_PRESSURE_DRAG_COEFF;
+			case "Base drag coefficient":      return FlightDataType.TYPE_BASE_DRAG_COEFF;
+			case "Normal force coefficient":   return FlightDataType.TYPE_NORMAL_FORCE_COEFF;
+			case "Pitch moment coefficient":   return FlightDataType.TYPE_PITCH_MOMENT_COEFF;
+			case "Roll rate":                  return FlightDataType.TYPE_ROLL_RATE;
+			case "Pitch rate":                 return FlightDataType.TYPE_PITCH_RATE;
+			case "Yaw rate":                   return FlightDataType.TYPE_YAW_RATE;
+		}
+
+		// 5. Look in custom expressions
 		for (CustomExpression exp : simHandler.getDocument().getCustomExpressions()) {
 			if (exp.getName().equals(name)) {
 				return exp.getType();
 			}
 		}
-		
+
 		log.warn("Could not find the flight data type '" + name + "' used in the XML file. Substituted type with unknown symbol and units.");
 		return FlightDataType.getType(name, "Unknown", UnitGroup.UNITS_NONE);
 	}

--- a/core/src/main/java/info/openrocket/core/simulation/FlightDataType.java
+++ b/core/src/main/java/info/openrocket/core/simulation/FlightDataType.java
@@ -31,7 +31,7 @@ import info.openrocket.core.util.StringUtils;
  * specific priority
  * numbers, and other types have a default priority number that is after all
  * other types.
- * 
+ *
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
 public class FlightDataType implements Comparable<FlightDataType>, Groupable<FlightDataTypeGroup>, DataType {
@@ -41,315 +41,358 @@ public class FlightDataType implements Comparable<FlightDataType>, Groupable<Fli
 	/** Priority of custom-created variables */
 	private static final int DEFAULT_PRIORITY = 999;
 
-	/** List of existing types. MUST BE DEFINED BEFORE ANY TYPES!! */
-	/** NOTE: The String key here is now the symbol */
+	/** List of existing types keyed by symbol. MUST BE DEFINED BEFORE ANY TYPES!! */
 	private static final Map<String, FlightDataType> EXISTING_TYPES = new HashMap<>();
 
+	/** List of built-in types keyed by save key, for fast .ork deserialization. MUST BE DEFINED BEFORE ANY TYPES!! */
+	private static final Map<String, FlightDataType> SAVE_KEY_TYPES = new HashMap<>();
+
 	//// Time
-	public static final FlightDataType TYPE_TIME = newType(trans.get("FlightDataType.TYPE_TIME"), "t",
+	public static final FlightDataType TYPE_TIME = newType("time", trans.get("FlightDataType.TYPE_TIME"), "t",
 			UnitGroup.UNITS_LONG_TIME,
 			FlightDataTypeGroup.TIME, 0);
 
 	//// Position and motion
 	//// Altitude
-	public static final FlightDataType TYPE_ALTITUDE = newType(trans.get("FlightDataType.TYPE_ALTITUDE"), "h",
+	public static final FlightDataType TYPE_ALTITUDE = newType("altitude", trans.get("FlightDataType.TYPE_ALTITUDE"), "h",
 			UnitGroup.UNITS_DISTANCE,
 			FlightDataTypeGroup.POSITION_AND_MOTION, 0);
 	//// Altitude above sea level
-	public static final FlightDataType TYPE_ALTITUDE_ABOVE_SEA = newType(trans.get("FlightDataType.TYPE_ALTITUDE_ABOVE_SEA"),
+	public static final FlightDataType TYPE_ALTITUDE_ABOVE_SEA = newType("altitude_above_sea",
+			trans.get("FlightDataType.TYPE_ALTITUDE_ABOVE_SEA"),
 			"ha", UnitGroup.UNITS_DISTANCE,
 			FlightDataTypeGroup.POSITION_AND_MOTION, 1);
 	//// Vertical velocity
-	public static final FlightDataType TYPE_VELOCITY_Z = newType(trans.get("FlightDataType.TYPE_VELOCITY_Z"), "Vz",
+	public static final FlightDataType TYPE_VELOCITY_Z = newType("velocity_z",
+			trans.get("FlightDataType.TYPE_VELOCITY_Z"), "Vz",
 			UnitGroup.UNITS_VELOCITY,
 			FlightDataTypeGroup.POSITION_AND_MOTION, 2);
 	//// Total velocity
-	public static final FlightDataType TYPE_VELOCITY_TOTAL = newType(trans.get("FlightDataType.TYPE_VELOCITY_TOTAL"),
+	public static final FlightDataType TYPE_VELOCITY_TOTAL = newType("velocity_total",
+			trans.get("FlightDataType.TYPE_VELOCITY_TOTAL"),
 			"Vt", UnitGroup.UNITS_VELOCITY,
 			FlightDataTypeGroup.POSITION_AND_MOTION, 3);
 	//// Vertical acceleration
-	public static final FlightDataType TYPE_ACCELERATION_Z = newType(trans.get("FlightDataType.TYPE_ACCELERATION_Z"),
+	public static final FlightDataType TYPE_ACCELERATION_Z = newType("acceleration_z",
+			trans.get("FlightDataType.TYPE_ACCELERATION_Z"),
 			"Az", UnitGroup.UNITS_ACCELERATION,
 			FlightDataTypeGroup.POSITION_AND_MOTION, 4);
 	//// X acceleration
-	public static final FlightDataType TYPE_ACCELERATION_X = newType(trans.get("FlightDataType.TYPE_ACCELERATION_X"),
+	public static final FlightDataType TYPE_ACCELERATION_X = newType("acceleration_x",
+			trans.get("FlightDataType.TYPE_ACCELERATION_X"),
 			"Ax", UnitGroup.UNITS_ACCELERATION,
 			FlightDataTypeGroup.POSITION_AND_MOTION, 5);
 	//// Y acceleration
-	public static final FlightDataType TYPE_ACCELERATION_Y = newType(trans.get("FlightDataType.TYPE_ACCELERATION_Y"),
+	public static final FlightDataType TYPE_ACCELERATION_Y = newType("acceleration_y",
+			trans.get("FlightDataType.TYPE_ACCELERATION_Y"),
 			"Ay", UnitGroup.UNITS_ACCELERATION,
 			FlightDataTypeGroup.POSITION_AND_MOTION, 6);
 	//// X body acceleration
-	public static final FlightDataType TYPE_ACCELERATION_BODYX = newType(trans.get("FlightDataType.TYPE_ACCELERATION_BODYX"),
+	public static final FlightDataType TYPE_ACCELERATION_BODYX = newType("acceleration_bodyx",
+			trans.get("FlightDataType.TYPE_ACCELERATION_BODYX"),
 			"Abx", UnitGroup.UNITS_ACCELERATION,
 			FlightDataTypeGroup.POSITION_AND_MOTION, 7);
 	//// Y body acceleration
-	public static final FlightDataType TYPE_ACCELERATION_BODYY = newType(trans.get("FlightDataType.TYPE_ACCELERATION_BODYY"),
+	public static final FlightDataType TYPE_ACCELERATION_BODYY = newType("acceleration_bodyy",
+			trans.get("FlightDataType.TYPE_ACCELERATION_BODYY"),
 			"Aby", UnitGroup.UNITS_ACCELERATION,
 			FlightDataTypeGroup.POSITION_AND_MOTION, 8);
 	//// Z body acceleration
-	public static final FlightDataType TYPE_ACCELERATION_BODYZ = newType(trans.get("FlightDataType.TYPE_ACCELERATION_BODYZ"),
+	public static final FlightDataType TYPE_ACCELERATION_BODYZ = newType("acceleration_bodyz",
+			trans.get("FlightDataType.TYPE_ACCELERATION_BODYZ"),
 			"Abz", UnitGroup.UNITS_ACCELERATION,
 			FlightDataTypeGroup.POSITION_AND_MOTION, 9);
 	//// Total acceleration
-	public static final FlightDataType TYPE_ACCELERATION_TOTAL = newType(
+	public static final FlightDataType TYPE_ACCELERATION_TOTAL = newType("acceleration_total",
 			trans.get("FlightDataType.TYPE_ACCELERATION_TOTAL"), "At", UnitGroup.UNITS_ACCELERATION,
 			FlightDataTypeGroup.POSITION_AND_MOTION, 10);
 
 	//// Lateral position and motion
 	//// Position East of launch
-	public static final FlightDataType TYPE_POSITION_X = newType(trans.get("FlightDataType.TYPE_POSITION_X"), "Px",
+	public static final FlightDataType TYPE_POSITION_X = newType("position_x",
+			trans.get("FlightDataType.TYPE_POSITION_X"), "Px",
 			UnitGroup.UNITS_DISTANCE,
 			FlightDataTypeGroup.POSITION_AND_MOTION, 11);
 	//// Position North of launch
-	public static final FlightDataType TYPE_POSITION_Y = newType(trans.get("FlightDataType.TYPE_POSITION_Y"), "Py",
+	public static final FlightDataType TYPE_POSITION_Y = newType("position_y",
+			trans.get("FlightDataType.TYPE_POSITION_Y"), "Py",
 			UnitGroup.UNITS_DISTANCE,
 			FlightDataTypeGroup.POSITION_AND_MOTION, 12);
 	//// Lateral distance
-	public static final FlightDataType TYPE_POSITION_XY = newType(trans.get("FlightDataType.TYPE_POSITION_XY"), "Pl",
+	public static final FlightDataType TYPE_POSITION_XY = newType("position_xy",
+			trans.get("FlightDataType.TYPE_POSITION_XY"), "Pl",
 			UnitGroup.UNITS_DISTANCE,
 			FlightDataTypeGroup.POSITION_AND_MOTION, 13);
 	//// Lateral direction
-	public static final FlightDataType TYPE_POSITION_DIRECTION = newType(
+	public static final FlightDataType TYPE_POSITION_DIRECTION = newType("position_direction",
 			trans.get("FlightDataType.TYPE_POSITION_DIRECTION"), "\u03b8l", UnitGroup.UNITS_ANGLE,
 			FlightDataTypeGroup.POSITION_AND_MOTION, 14);
 	//// Lateral velocity
-	public static final FlightDataType TYPE_VELOCITY_XY = newType(trans.get("FlightDataType.TYPE_VELOCITY_XY"), "Vl",
+	public static final FlightDataType TYPE_VELOCITY_XY = newType("velocity_xy",
+			trans.get("FlightDataType.TYPE_VELOCITY_XY"), "Vl",
 			UnitGroup.UNITS_VELOCITY,
 			FlightDataTypeGroup.POSITION_AND_MOTION, 15);
 	//// Lateral acceleration
-	public static final FlightDataType TYPE_ACCELERATION_XY = newType(trans.get("FlightDataType.TYPE_ACCELERATION_XY"),
+	public static final FlightDataType TYPE_ACCELERATION_XY = newType("acceleration_xy",
+			trans.get("FlightDataType.TYPE_ACCELERATION_XY"),
 			"Al", UnitGroup.UNITS_ACCELERATION,
 			FlightDataTypeGroup.POSITION_AND_MOTION, 16);
 	//// Latitude
-	public static final FlightDataType TYPE_LATITUDE = newType(trans.get("FlightDataType.TYPE_LATITUDE"), "\u03c6",
+	public static final FlightDataType TYPE_LATITUDE = newType("latitude",
+			trans.get("FlightDataType.TYPE_LATITUDE"), "\u03c6",
 			UnitGroup.UNITS_LATITUDE,
 			FlightDataTypeGroup.POSITION_AND_MOTION, 17);
 	//// Longitude
-	public static final FlightDataType TYPE_LONGITUDE = newType(trans.get("FlightDataType.TYPE_LONGITUDE"), "\u03bb",
+	public static final FlightDataType TYPE_LONGITUDE = newType("longitude",
+			trans.get("FlightDataType.TYPE_LONGITUDE"), "\u03bb",
 			UnitGroup.UNITS_LONGITUDE,
 			FlightDataTypeGroup.POSITION_AND_MOTION, 18);
 
 	// Orientation
 	//// Angle of attack
-	public static final FlightDataType TYPE_AOA = newType(trans.get("FlightDataType.TYPE_AOA"), "\u03b1",
+	public static final FlightDataType TYPE_AOA = newType("aoa", trans.get("FlightDataType.TYPE_AOA"), "\u03b1",
 			UnitGroup.UNITS_ANGLE,
 			FlightDataTypeGroup.ORIENTATION, 0);
 	//// Roll rate
-	public static final FlightDataType TYPE_ROLL_RATE = newType(trans.get("FlightDataType.TYPE_ROLL_RATE"), "d\u03a6",
+	public static final FlightDataType TYPE_ROLL_RATE = newType("roll_rate",
+			trans.get("FlightDataType.TYPE_ROLL_RATE"), "d\u03a6",
 			UnitGroup.UNITS_ROLL,
 			FlightDataTypeGroup.ORIENTATION, 1);
 	//// Pitch rate
-	public static final FlightDataType TYPE_PITCH_RATE = newType(trans.get("FlightDataType.TYPE_PITCH_RATE"), "d\u03b8",
+	public static final FlightDataType TYPE_PITCH_RATE = newType("pitch_rate",
+			trans.get("FlightDataType.TYPE_PITCH_RATE"), "d\u03b8",
 			UnitGroup.UNITS_ROLL,
 			FlightDataTypeGroup.ORIENTATION, 2);
 	//// Yaw rate
-	public static final FlightDataType TYPE_YAW_RATE = newType(trans.get("FlightDataType.TYPE_YAW_RATE"), "d\u03a8",
+	public static final FlightDataType TYPE_YAW_RATE = newType("yaw_rate",
+			trans.get("FlightDataType.TYPE_YAW_RATE"), "d\u03a8",
 			UnitGroup.UNITS_ROLL,
 			FlightDataTypeGroup.ORIENTATION, 3);
 	//// Vertical orientation (zenith)
-	public static final FlightDataType TYPE_ORIENTATION_THETA = newType(
+	public static final FlightDataType TYPE_ORIENTATION_THETA = newType("orientation_theta",
 			trans.get("FlightDataType.TYPE_ORIENTATION_THETA"), "\u0398", UnitGroup.UNITS_ANGLE,
 			FlightDataTypeGroup.ORIENTATION, 4);
 	//// Lateral orientation (azimuth)
-	public static final FlightDataType TYPE_ORIENTATION_PHI = newType(trans.get("FlightDataType.TYPE_ORIENTATION_PHI"),
+	public static final FlightDataType TYPE_ORIENTATION_PHI = newType("orientation_phi",
+			trans.get("FlightDataType.TYPE_ORIENTATION_PHI"),
 			"\u03a6", UnitGroup.UNITS_ANGLE,
 			FlightDataTypeGroup.ORIENTATION, 5);
 	// Mass and inertia
 	//// Mass
-	public static final FlightDataType TYPE_MASS = newType(trans.get("FlightDataType.TYPE_MASS"), "m",
+	public static final FlightDataType TYPE_MASS = newType("mass", trans.get("FlightDataType.TYPE_MASS"), "m",
 			UnitGroup.UNITS_MASS,
 			FlightDataTypeGroup.MASS_AND_INERTIA, 0);
 	//// Motor mass
-	public static final FlightDataType TYPE_MOTOR_MASS = newType(trans.get("FlightDataType.TYPE_MOTOR_MASS"), "mp",
+	public static final FlightDataType TYPE_MOTOR_MASS = newType("motor_mass",
+			trans.get("FlightDataType.TYPE_MOTOR_MASS"), "mp",
 			UnitGroup.UNITS_MASS,
 			FlightDataTypeGroup.MASS_AND_INERTIA, 1);
 	//// Longitudinal moment of inertia
-	public static final FlightDataType TYPE_LONGITUDINAL_INERTIA = newType(
+	public static final FlightDataType TYPE_LONGITUDINAL_INERTIA = newType("longitudinal_inertia",
 			trans.get("FlightDataType.TYPE_LONGITUDINAL_INERTIA"), "Il", UnitGroup.UNITS_INERTIA,
 			FlightDataTypeGroup.MASS_AND_INERTIA, 2);
 	//// Rotational moment of inertia
-	public static final FlightDataType TYPE_ROTATIONAL_INERTIA = newType(
+	public static final FlightDataType TYPE_ROTATIONAL_INERTIA = newType("rotational_inertia",
 			trans.get("FlightDataType.TYPE_ROTATIONAL_INERTIA"), "Ir", UnitGroup.UNITS_INERTIA,
 			FlightDataTypeGroup.MASS_AND_INERTIA, 3);
 	//// Gravity
-	public static final FlightDataType TYPE_GRAVITY = newType(trans.get("FlightDataType.TYPE_GRAVITY"), "g",
+	public static final FlightDataType TYPE_GRAVITY = newType("gravity",
+			trans.get("FlightDataType.TYPE_GRAVITY"), "g",
 			UnitGroup.UNITS_ACCELERATION,
 			FlightDataTypeGroup.MASS_AND_INERTIA, 4);
 
 	// Stability
 	//// CP location
-	public static final FlightDataType TYPE_CP_LOCATION = newType(trans.get("FlightDataType.TYPE_CP_LOCATION"), "Cp",
+	public static final FlightDataType TYPE_CP_LOCATION = newType("cp_location",
+			trans.get("FlightDataType.TYPE_CP_LOCATION"), "Cp",
 			UnitGroup.UNITS_LENGTH,
 			FlightDataTypeGroup.STABILITY, 0);
 	//// CG location
-	public static final FlightDataType TYPE_CG_LOCATION = newType(trans.get("FlightDataType.TYPE_CG_LOCATION"), "Cg",
+	public static final FlightDataType TYPE_CG_LOCATION = newType("cg_location",
+			trans.get("FlightDataType.TYPE_CG_LOCATION"), "Cg",
 			UnitGroup.UNITS_LENGTH,
 			FlightDataTypeGroup.STABILITY, 1);
 	//// Stability margin calibers
-	public static final FlightDataType TYPE_STABILITY = newType(trans.get("FlightDataType.TYPE_STABILITY"), "S",
+	public static final FlightDataType TYPE_STABILITY = newType("stability",
+			trans.get("FlightDataType.TYPE_STABILITY"), "S",
 			UnitGroup.UNITS_COEFFICIENT,
 			FlightDataTypeGroup.STABILITY, 2);
 	//// Damping ratio
-	public static final FlightDataType TYPE_DAMPING_RATIO = newType(
+	public static final FlightDataType TYPE_DAMPING_RATIO = newType("damping_ratio",
 			trans.get("FlightDataType.TYPE_DAMPING_RATIO"), "\u03b6", UnitGroup.UNITS_COEFFICIENT,
 			FlightDataTypeGroup.STABILITY, 3);
 	//// Natural frequency
-	public static final FlightDataType TYPE_NATURAL_FREQUENCY = newType(
+	public static final FlightDataType TYPE_NATURAL_FREQUENCY = newType("natural_frequency",
 			trans.get("FlightDataType.TYPE_NATURAL_FREQUENCY"), "\u03c9n", UnitGroup.UNITS_ROLL,
 			FlightDataTypeGroup.STABILITY, 4);
 
 	// Characteristic numbers
 	//// Mach number
-	public static final FlightDataType TYPE_MACH_NUMBER = newType(trans.get("FlightDataType.TYPE_MACH_NUMBER"), "M",
+	public static final FlightDataType TYPE_MACH_NUMBER = newType("mach_number",
+			trans.get("FlightDataType.TYPE_MACH_NUMBER"), "M",
 			UnitGroup.UNITS_COEFFICIENT,
 			FlightDataTypeGroup.CHARACTERISTIC_NUMBERS, 0);
 	//// Reynolds number
-	public static final FlightDataType TYPE_REYNOLDS_NUMBER = newType(trans.get("FlightDataType.TYPE_REYNOLDS_NUMBER"),
+	public static final FlightDataType TYPE_REYNOLDS_NUMBER = newType("reynolds_number",
+			trans.get("FlightDataType.TYPE_REYNOLDS_NUMBER"),
 			"R", UnitGroup.UNITS_COEFFICIENT,
 			FlightDataTypeGroup.CHARACTERISTIC_NUMBERS, 1);
 
 	// Thrust and drag
 	//// Thrust
-	public static final FlightDataType TYPE_THRUST_FORCE = newType(trans.get("FlightDataType.TYPE_THRUST_FORCE"), "Ft",
+	public static final FlightDataType TYPE_THRUST_FORCE = newType("thrust_force",
+			trans.get("FlightDataType.TYPE_THRUST_FORCE"), "Ft",
 			UnitGroup.UNITS_FORCE,
 			FlightDataTypeGroup.THRUST_AND_DRAG, 0);
 	//// Thrust-to-weight ratio
-	public static final FlightDataType TYPE_THRUST_WEIGHT_RATIO = newType(
+	public static final FlightDataType TYPE_THRUST_WEIGHT_RATIO = newType("thrust_weight_ratio",
 			trans.get("FlightDataType.TYPE_THRUST_WEIGHT_RATIO"), "Twr", UnitGroup.UNITS_COEFFICIENT,
 			FlightDataTypeGroup.THRUST_AND_DRAG, 1);
 	//// Drag force
-	public static final FlightDataType TYPE_DRAG_FORCE = newType(trans.get("FlightDataType.TYPE_DRAG_FORCE"), "Fd",
+	public static final FlightDataType TYPE_DRAG_FORCE = newType("drag_force",
+			trans.get("FlightDataType.TYPE_DRAG_FORCE"), "Fd",
 			UnitGroup.UNITS_FORCE,
 			FlightDataTypeGroup.THRUST_AND_DRAG, 2);
 	//// Drag coefficient
-	public static final FlightDataType TYPE_DRAG_COEFF = newType(trans.get("FlightDataType.TYPE_DRAG_COEFF"), "Cd",
+	public static final FlightDataType TYPE_DRAG_COEFF = newType("drag_coeff",
+			trans.get("FlightDataType.TYPE_DRAG_COEFF"), "Cd",
 			UnitGroup.UNITS_COEFFICIENT,
 			FlightDataTypeGroup.THRUST_AND_DRAG, 3);
 	//// Friction drag coefficient
-	public static final FlightDataType TYPE_FRICTION_DRAG_COEFF = newType(
+	public static final FlightDataType TYPE_FRICTION_DRAG_COEFF = newType("friction_drag_coeff",
 			trans.get("FlightDataType.TYPE_FRICTION_DRAG_COEFF"), "Cdf", UnitGroup.UNITS_COEFFICIENT,
 			FlightDataTypeGroup.THRUST_AND_DRAG, 4);
 	//// Pressure drag coefficient
-	public static final FlightDataType TYPE_PRESSURE_DRAG_COEFF = newType(
+	public static final FlightDataType TYPE_PRESSURE_DRAG_COEFF = newType("pressure_drag_coeff",
 			trans.get("FlightDataType.TYPE_PRESSURE_DRAG_COEFF"), "Cdp", UnitGroup.UNITS_COEFFICIENT,
 			FlightDataTypeGroup.THRUST_AND_DRAG, 5);
 	//// Base drag coefficient
-	public static final FlightDataType TYPE_BASE_DRAG_COEFF = newType(trans.get("FlightDataType.TYPE_BASE_DRAG_COEFF"),
+	public static final FlightDataType TYPE_BASE_DRAG_COEFF = newType("base_drag_coeff",
+			trans.get("FlightDataType.TYPE_BASE_DRAG_COEFF"),
 			"Cdb", UnitGroup.UNITS_COEFFICIENT,
 			FlightDataTypeGroup.THRUST_AND_DRAG, 6);
 	//// Axial drag coefficient
-	public static final FlightDataType TYPE_AXIAL_DRAG_COEFF = newType(
+	public static final FlightDataType TYPE_AXIAL_DRAG_COEFF = newType("axial_drag_coeff",
 			trans.get("FlightDataType.TYPE_AXIAL_DRAG_COEFF"), "Cda", UnitGroup.UNITS_COEFFICIENT,
 			FlightDataTypeGroup.THRUST_AND_DRAG, 7);
 
 	// Coefficients
 	//// Normal force coefficient
-	public static final FlightDataType TYPE_NORMAL_FORCE_COEFF = newType(
+	public static final FlightDataType TYPE_NORMAL_FORCE_COEFF = newType("normal_force_coeff",
 			trans.get("FlightDataType.TYPE_NORMAL_FORCE_COEFF"), "Cn", UnitGroup.UNITS_COEFFICIENT,
 			FlightDataTypeGroup.COEFFICIENTS, 0);
 	//// CP weight (CNa)
-	public static final FlightDataType TYPE_CNA = newType(
+	public static final FlightDataType TYPE_CNA = newType("cna",
 			trans.get("FlightDataType.TYPE_CNA"), "CN" + Chars.ALPHA, UnitGroup.UNITS_COEFFICIENT,
 			FlightDataTypeGroup.COEFFICIENTS, 1);
 	//// Pitch moment coefficient
-	public static final FlightDataType TYPE_PITCH_MOMENT_COEFF = newType(
+	public static final FlightDataType TYPE_PITCH_MOMENT_COEFF = newType("pitch_moment_coeff",
 			trans.get("FlightDataType.TYPE_PITCH_MOMENT_COEFF"), "C\u03b8", UnitGroup.UNITS_COEFFICIENT,
 			FlightDataTypeGroup.COEFFICIENTS, 2);
 	//// Yaw moment coefficient
-	public static final FlightDataType TYPE_YAW_MOMENT_COEFF = newType(
+	public static final FlightDataType TYPE_YAW_MOMENT_COEFF = newType("yaw_moment_coeff",
 			trans.get("FlightDataType.TYPE_YAW_MOMENT_COEFF"), "C\u03c4\u03a8", UnitGroup.UNITS_COEFFICIENT,
 			FlightDataTypeGroup.COEFFICIENTS, 3);
 	//// Side force coefficient
-	public static final FlightDataType TYPE_SIDE_FORCE_COEFF = newType(
+	public static final FlightDataType TYPE_SIDE_FORCE_COEFF = newType("side_force_coeff",
 			trans.get("FlightDataType.TYPE_SIDE_FORCE_COEFF"), "C\u03c4s", UnitGroup.UNITS_COEFFICIENT,
 			FlightDataTypeGroup.COEFFICIENTS, 4);
 	//// Roll moment coefficient
-	public static final FlightDataType TYPE_ROLL_MOMENT_COEFF = newType(
+	public static final FlightDataType TYPE_ROLL_MOMENT_COEFF = newType("roll_moment_coeff",
 			trans.get("FlightDataType.TYPE_ROLL_MOMENT_COEFF"), "C\u03c4\u03a6", UnitGroup.UNITS_COEFFICIENT,
 			FlightDataTypeGroup.COEFFICIENTS, 5);
 	//// Roll forcing coefficient
-	public static final FlightDataType TYPE_ROLL_FORCING_COEFF = newType(
+	public static final FlightDataType TYPE_ROLL_FORCING_COEFF = newType("roll_forcing_coeff",
 			trans.get("FlightDataType.TYPE_ROLL_FORCING_COEFF"), "Cf\u03a6", UnitGroup.UNITS_COEFFICIENT,
 			FlightDataTypeGroup.COEFFICIENTS, 6);
 	//// Roll damping coefficient
-	public static final FlightDataType TYPE_ROLL_DAMPING_COEFF = newType(
+	public static final FlightDataType TYPE_ROLL_DAMPING_COEFF = newType("roll_damping_coeff",
 			trans.get("FlightDataType.TYPE_ROLL_DAMPING_COEFF"), "C\u03b6\u03a6", UnitGroup.UNITS_COEFFICIENT,
 			FlightDataTypeGroup.COEFFICIENTS, 7);
 	//// Pitch damping coefficient
-	public static final FlightDataType TYPE_PITCH_DAMPING_MOMENT_COEFF = newType(
+	public static final FlightDataType TYPE_PITCH_DAMPING_MOMENT_COEFF = newType("pitch_damping_moment_coeff",
 			trans.get("FlightDataType.TYPE_PITCH_DAMPING_MOMENT_COEFF"), "C\u03b6\u03b8", UnitGroup.UNITS_COEFFICIENT,
 			FlightDataTypeGroup.COEFFICIENTS, 8);
 	//// Yaw damping coefficient
-	public static final FlightDataType TYPE_YAW_DAMPING_MOMENT_COEFF = newType(
+	public static final FlightDataType TYPE_YAW_DAMPING_MOMENT_COEFF = newType("yaw_damping_moment_coeff",
 			trans.get("FlightDataType.TYPE_YAW_DAMPING_MOMENT_COEFF"), "C\u03b6\u03a8", UnitGroup.UNITS_COEFFICIENT,
 			FlightDataTypeGroup.COEFFICIENTS, 9);
 	//// Damping moment coefficient
-	public static final FlightDataType TYPE_DAMPING_MOMENT_COEFF = newType(
+	public static final FlightDataType TYPE_DAMPING_MOMENT_COEFF = newType("damping_moment_coeff",
 			trans.get("FlightDataType.TYPE_DAMPING_MOMENT_COEFF"), "Cdm", UnitGroup.UNITS_ANGULAR_MOMENTUM,
 			FlightDataTypeGroup.COEFFICIENTS, 10);
 	//// Damping moment coefficient (aerodynamic part)
 	public static final FlightDataType TYPE_DAMPING_MOMENT_COEFF_AERODYNAMIC = newType(
+			"damping_moment_coeff_aerodynamic",
 			trans.get("FlightDataType.TYPE_DAMPING_MOMENT_COEFF_AERODYNAMIC"), "Cdm_aero",
 			UnitGroup.UNITS_ANGULAR_MOMENTUM,
 			FlightDataTypeGroup.COEFFICIENTS, 11);
 	//// Damping moment coefficient (propulsive part)
 	public static final FlightDataType TYPE_DAMPING_MOMENT_COEFF_PROPULSIVE = newType(
+			"damping_moment_coeff_propulsive",
 			trans.get("FlightDataType.TYPE_DAMPING_MOMENT_COEFF_PROPULSIVE"), "Cdm_prop",
 			UnitGroup.UNITS_ANGULAR_MOMENTUM,
 			FlightDataTypeGroup.COEFFICIENTS, 12);
 	//// Corrective moment coefficient
-	public static final FlightDataType TYPE_CORRECTIVE_MOMENT_COEFF = newType(
+	public static final FlightDataType TYPE_CORRECTIVE_MOMENT_COEFF = newType("corrective_moment_coeff",
 			trans.get("FlightDataType.TYPE_CORRECTIVE_MOMENT_COEFF"), "Ccm", UnitGroup.UNITS_MOMENT,
 			FlightDataTypeGroup.COEFFICIENTS, 13);
 
 	//// Coriolis acceleration
-	public static final FlightDataType TYPE_CORIOLIS_ACCELERATION = newType(
+	public static final FlightDataType TYPE_CORIOLIS_ACCELERATION = newType("coriolis_acceleration",
 			trans.get("FlightDataType.TYPE_CORIOLIS_ACCELERATION"), "Ac", UnitGroup.UNITS_ACCELERATION, 99);
 
 	// Reference values
 	//// Reference length
-	public static final FlightDataType TYPE_REFERENCE_LENGTH = newType(
+	public static final FlightDataType TYPE_REFERENCE_LENGTH = newType("reference_length",
 			trans.get("FlightDataType.TYPE_REFERENCE_LENGTH"), "Lr", UnitGroup.UNITS_LENGTH,
 			FlightDataTypeGroup.REFERENCE_VALUES, 0);
 	//// Reference area
-	public static final FlightDataType TYPE_REFERENCE_AREA = newType(trans.get("FlightDataType.TYPE_REFERENCE_AREA"),
+	public static final FlightDataType TYPE_REFERENCE_AREA = newType("reference_area",
+			trans.get("FlightDataType.TYPE_REFERENCE_AREA"),
 			"Ar", UnitGroup.UNITS_AREA,
 			FlightDataTypeGroup.REFERENCE_VALUES, 1);
 
 	// Atmospheric conditions
 	//// Wind velocity
-	public static final FlightDataType TYPE_WIND_VELOCITY = newType(trans.get("FlightDataType.TYPE_WIND_VELOCITY"),
+	public static final FlightDataType TYPE_WIND_VELOCITY = newType("wind_velocity",
+			trans.get("FlightDataType.TYPE_WIND_VELOCITY"),
 			"Vw", UnitGroup.UNITS_VELOCITY,
 			FlightDataTypeGroup.ATMOSPHERIC_CONDITIONS, 0);
 	//// Wind direction
-	public static final FlightDataType TYPE_WIND_DIRECTION = newType(trans.get("FlightDataType.TYPE_WIND_DIRECTION"),
+	public static final FlightDataType TYPE_WIND_DIRECTION = newType("wind_direction",
+			trans.get("FlightDataType.TYPE_WIND_DIRECTION"),
 			"\u03b8w", UnitGroup.UNITS_ANGLE,
 			FlightDataTypeGroup.ATMOSPHERIC_CONDITIONS, 1);
 	//// Air temperature
-	public static final FlightDataType TYPE_AIR_TEMPERATURE = newType(trans.get("FlightDataType.TYPE_AIR_TEMPERATURE"),
+	public static final FlightDataType TYPE_AIR_TEMPERATURE = newType("air_temperature",
+			trans.get("FlightDataType.TYPE_AIR_TEMPERATURE"),
 			"T", UnitGroup.UNITS_TEMPERATURE,
 			FlightDataTypeGroup.ATMOSPHERIC_CONDITIONS, 2);
 	//// Air pressure
-	public static final FlightDataType TYPE_AIR_PRESSURE = newType(trans.get("FlightDataType.TYPE_AIR_PRESSURE"), "P",
+	public static final FlightDataType TYPE_AIR_PRESSURE = newType("air_pressure",
+			trans.get("FlightDataType.TYPE_AIR_PRESSURE"), "P",
 			UnitGroup.UNITS_PRESSURE,
 			FlightDataTypeGroup.ATMOSPHERIC_CONDITIONS, 3);
 	//// Air density
-	public static final FlightDataType TYPE_AIR_DENSITY = newType(trans.get("FlightDataType.TYPE_AIR_DENSITY"), "\u03C1",
+	public static final FlightDataType TYPE_AIR_DENSITY = newType("air_density",
+			trans.get("FlightDataType.TYPE_AIR_DENSITY"), "\u03C1",
 			UnitGroup.UNITS_DENSITY_BULK,
 			FlightDataTypeGroup.ATMOSPHERIC_CONDITIONS, 4);
 	//// Speed of sound
-	public static final FlightDataType TYPE_SPEED_OF_SOUND = newType(trans.get("FlightDataType.TYPE_SPEED_OF_SOUND"),
+	public static final FlightDataType TYPE_SPEED_OF_SOUND = newType("speed_of_sound",
+			trans.get("FlightDataType.TYPE_SPEED_OF_SOUND"),
 			"Vs", UnitGroup.UNITS_VELOCITY,
 			FlightDataTypeGroup.ATMOSPHERIC_CONDITIONS, 5);
 
 	// Simulation information
 	//// Simulation time step
-	public static final FlightDataType TYPE_TIME_STEP = newType(trans.get("FlightDataType.TYPE_TIME_STEP"), "dt",
+	public static final FlightDataType TYPE_TIME_STEP = newType("time_step",
+			trans.get("FlightDataType.TYPE_TIME_STEP"), "dt",
 			UnitGroup.UNITS_TIME_STEP,
 			FlightDataTypeGroup.SIMULATION_INFORMATION, 0);
 	//// Computation time
-	public static final FlightDataType TYPE_COMPUTATION_TIME = newType(
+	public static final FlightDataType TYPE_COMPUTATION_TIME = newType("computation_time",
 			trans.get("FlightDataType.TYPE_COMPUTATION_TIME"), "tc", UnitGroup.UNITS_SHORT_TIME,
 			FlightDataTypeGroup.SIMULATION_INFORMATION, 1);
 
@@ -433,14 +476,14 @@ public class FlightDataType implements Comparable<FlightDataType>, Groupable<Fli
 	 * unitgroup.
 	 * This returns an existing data type if the symbol matches that of an existing
 	 * type.
-	 * 
+	 *
 	 * If the symbol matches but the unit and description information differ, then
 	 * the old stored datatype
 	 * is erased and the updated version based on the given parameters is returned.
 	 * The only exception is if the description or unitgroup are undefined (null or
 	 * empty string). In this case
 	 * we just get these parameters from the existing type when making the new one.
-	 * 
+	 *
 	 * @param s the string description of the type.
 	 * @param u the unit group the new type should belong to if a new group is
 	 *          created.
@@ -490,9 +533,17 @@ public class FlightDataType implements Comparable<FlightDataType>, Groupable<Fli
 			log.error("Made a new flightdatatype, but did not know what units to use.");
 		}
 
-		// make a new one
+		// make a new one (no save key — this is a custom/dynamic type)
 		type = newType(s, symbol, u, oldPriority);
 		return type;
+	}
+
+	/**
+	 * Return the built-in {@link FlightDataType} with the given save key, or {@code null} if not found.
+	 * Save keys are stable, language-independent identifiers used for .ork serialization.
+	 */
+	public static FlightDataType getTypeBySaveKey(String saveKey) {
+		return SAVE_KEY_TYPES.get(saveKey);
 	}
 
 	/*
@@ -510,42 +561,54 @@ public class FlightDataType implements Comparable<FlightDataType>, Groupable<Fli
 	 */
 
 	/**
-	 * Used while initializing the class.
-	 * 
-	 * @param s        the name of the type.
+	 * Used while initializing the class. Creates a built-in type with a stable save key.
+	 *
+	 * @param saveKey  stable, language-independent key used for .ork serialization.
+	 * @param s        the display name of the type.
 	 * @param symbol   the mathematical symbol of the type.
 	 * @param u        the unit group of the type.
 	 * @param group    the group of the type.
 	 * @param priority the priority of the type within the group.
 	 */
-	private static synchronized FlightDataType newType(String s, String symbol, UnitGroup u, FlightDataTypeGroup group,
-			int priority) {
-		FlightDataType type = new FlightDataType(s, symbol, u, group, priority);
-		// EXISTING_TYPES.put(s.toLowerCase(Locale.ENGLISH), type);
+	private static synchronized FlightDataType newType(String saveKey, String s, String symbol, UnitGroup u,
+			FlightDataTypeGroup group, int priority) {
+		FlightDataType type = new FlightDataType(s, saveKey, symbol, u, group, priority);
 		EXISTING_TYPES.put(symbol, type);
+		SAVE_KEY_TYPES.put(saveKey, type);
 		return type;
 	}
 
+	private static synchronized FlightDataType newType(String saveKey, String s, String symbol, UnitGroup u,
+			int priority) {
+		FlightDataType type = new FlightDataType(s, saveKey, symbol, u, FlightDataTypeGroup.CUSTOM, priority);
+		EXISTING_TYPES.put(symbol, type);
+		SAVE_KEY_TYPES.put(saveKey, type);
+		return type;
+	}
+
+	/** Used by {@link #getType} to create custom/dynamic types with no stable save key. */
 	private static synchronized FlightDataType newType(String s, String symbol, UnitGroup u, int priority) {
-		FlightDataType type = new FlightDataType(s, symbol, u, FlightDataTypeGroup.CUSTOM, priority);
-		// EXISTING_TYPES.put(s.toLowerCase(Locale.ENGLISH), type);
+		FlightDataType type = new FlightDataType(s, null, symbol, u, FlightDataTypeGroup.CUSTOM, priority);
 		EXISTING_TYPES.put(symbol, type);
 		return type;
 	}
 
 	private final String name;
+	private final String saveKey;
 	private final String symbol;
 	private final UnitGroup units;
 	private final FlightDataTypeGroup group;
 	private final int priority;
 	private final int hashCode;
 
-	private FlightDataType(String typeName, String symbol, UnitGroup units, FlightDataTypeGroup group, int priority) {
+	private FlightDataType(String typeName, String saveKey, String symbol, UnitGroup units, FlightDataTypeGroup group,
+			int priority) {
 		if (typeName == null)
 			throw new IllegalArgumentException("typeName is null");
 		if (units == null)
 			throw new IllegalArgumentException("units is null");
 		this.name = typeName;
+		this.saveKey = saveKey;
 		this.symbol = symbol;
 		this.units = units;
 		this.group = group;
@@ -555,6 +618,17 @@ public class FlightDataType implements Comparable<FlightDataType>, Groupable<Fli
 
 	public String getName() {
 		return name;
+	}
+
+	/**
+	 * Returns the stable, language-independent key used to identify this type in .ork files.
+	 * For built-in types this is a fixed string (e.g. {@code "TYPE_DRAG_COEFF"}) that never
+	 * changes regardless of locale or display-name renames.
+	 * For custom/dynamic types (user expressions) that have no fixed save key, this falls back
+	 * to {@link #getName()} to preserve the existing serialisation behaviour.
+	 */
+	public String getSaveKey() {
+		return saveKey != null ? saveKey : name;
 	}
 
 	public String getSymbol() {
@@ -598,7 +672,7 @@ public class FlightDataType implements Comparable<FlightDataType>, Groupable<Fli
 		if (groupCompare != 0) {
 			return groupCompare;
 		}
-		
+
 		return this.priority - o.priority;
 	}
 }


### PR DESCRIPTION
FlightDataType display names are translated and can be renamed, which caused warnings when loading .ork files saved with a previous name (e.g. "Drag coefficient" vs "Drag coefficient (CD)"). For example in "A simple model rocket":

```
1765	11.526	WARN		(OpenFileWorker.java:73)	Could not find the flight data type 'Pressure drag coefficient' used in the XML file. Substituted type with unknown symbol and units.
1767	11.526	WARN		(OpenFileWorker.java:73)	Could not find the flight data type 'Base drag coefficient' used in the XML file. Substituted type with unknown symbol and units.
1769	11.526	WARN		(OpenFileWorker.java:73)	Could not find the flight data type 'Axial drag coefficient' used in the XML file. Substituted type with unknown symbol and units.
1771	11.526	WARN		(OpenFileWorker.java:73)	Could not find the flight data type 'Normal force coefficient' used in the XML file. Substituted type with unknown symbol and units.
1773	11.526	WARN		(OpenFileWorker.java:73)	Could not find the flight data type 'Pitch moment coefficient' used in the XML file. Substituted type with unknown symbol and units.
1776	11.544	WARN		(OpenFileWorker.java:73)	Could not find the flight data type 'Roll rate' used in the XML file. Substituted type with unknown symbol and units.
1778	11.544	WARN		(OpenFileWorker.java:73)	Could not find the flight data type 'Pitch rate' used in the XML file. Substituted type with unknown symbol and units.
1780	11.544	WARN		(OpenFileWorker.java:73)	Could not find the flight data type 'Yaw rate' used in the XML file. Substituted type with unknown symbol and units.
1782	11.544	WARN		(OpenFileWorker.java:73)	Could not find the flight data type 'Drag coefficient' used in the XML file. Substituted type with unknown symbol and units.
1784	11.544	WARN		(OpenFileWorker.java:73)	Could not find the flight data type 'Friction drag coefficient' used in the XML file. Substituted type with unknown symbol and units.
1786	11.544	WARN		(OpenFileWorker.java:73)	Could not find the flight data type 'Pressure drag coefficient' used in the XML file. Substituted type with unknown symbol and units.
1788	11.544	WARN		(OpenFileWorker.java:73)	Could not find the flight data type 'Base drag coefficient' used in the XML file. Substituted type with unknown symbol and units.
1790	11.544	WARN		(OpenFileWorker.java:73)	Could not find the flight data type 'Axial drag coefficient' used in the XML file. Substituted type with unknown symbol and units.
1792	11.544	WARN		(OpenFileWorker.java:73)	Could not find the flight data type 'Normal force coefficient' used in the XML file. Substituted type with unknown symbol and units.
1794	11.544	WARN		(OpenFileWorker.java:73)	Could not find the flight data type 'Pitch moment coefficient' used in the XML file. Substituted type with unknown symbol and units.
1797	11.569	WARN		(OpenFileWorker.java:73)	Could not find the flight data type 'Roll rate' used in the XML file. Substituted type with unknown symbol and units.
```



The loader was also locale-dependent, so a file saved in French could not be loaded correctly in English.

Each built-in FlightDataType now has a stable, language-independent save key (e.g. "drag_coeff") stored in the .ork types attribute instead of the translated display name. The loader tries the save key first, then falls back to display-name matching for backwards compatibility with older files, with additional legacy mappings for the specific types that were renamed in b8d6be97.

