### PR TITLE
[#3114] Guard plot auto-axis selection against non-finite custom expression scores

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/plot/PlotConfiguration.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/PlotConfiguration.java
@@ -182,6 +182,10 @@ public class PlotConfiguration<T extends DataType, B extends DataBranch<T>> impl
 	@SuppressWarnings("unchecked")
 	public <C extends PlotConfiguration<T, B>> C fillAutoAxes(B data) {
 		C config = (C) recursiveFillAutoAxes(data).getU();
+		if (config == null) {
+			// Keep plotting functional even if every axis combination scores as NaN/Infinity.
+			config = (C) this.cloneConfiguration();
+		}
 		config.fitAxes(data);
 		return config;
 	}
@@ -219,13 +223,25 @@ public class PlotConfiguration<T extends DataType, B extends DataBranch<T>> impl
 		for (int i = 0; i < axesCount; i++) {
 			copy.plotDataAxes.set(autoindex, i);
 			Pair<PlotConfiguration<T, B>, Double> result = copy.recursiveFillAutoAxes(data);
-			if (result.getV() > bestValue) {
+			if (best == null || isBetterGoodness(result.getV(), bestValue)) {
 				best = result.getU();
 				bestValue = result.getV();
 			}
 		}
 
 		return new Pair<>(best, bestValue);
+	}
+
+	/**
+	 * Prefer finite goodness values when choosing an automatic axis assignment.
+	 * If every candidate score is non-finite, keep the first result as a fallback
+	 * so plotting can continue instead of returning a null configuration.
+	 */
+	private boolean isBetterGoodness(double candidateValue, double bestValue) {
+		if (!Double.isFinite(candidateValue)) {
+			return false;
+		}
+		return !Double.isFinite(bestValue) || candidateValue > bestValue;
 	}
 
 

--- a/swing/src/test/java/info/openrocket/swing/gui/plot/PlotConfigurationTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/plot/PlotConfigurationTest.java
@@ -1,0 +1,57 @@
+package info.openrocket.swing.gui.plot;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import info.openrocket.core.simulation.FlightDataBranch;
+import info.openrocket.core.simulation.FlightDataType;
+import info.openrocket.swing.util.BaseTestCase;
+
+/**
+ * Regression tests for plot configuration auto-axis selection.
+ */
+public class PlotConfigurationTest extends BaseTestCase {
+
+	/**
+	 * A custom expression can yield only non-finite values for the auto-axis scorer.
+	 * The recursive chooser must still return a configuration instead of bubbling up
+	 * a null result that later throws a NullPointerException.
+	 */
+	@Test
+	public void testFillAutoAxesFallsBackWhenGoodnessIsNaN() {
+		FlightDataBranch branch = new FlightDataBranch("test", FlightDataType.TYPE_TIME, FlightDataType.TYPE_ALTITUDE);
+		branch.addPoint();
+		branch.setValue(FlightDataType.TYPE_TIME, 0.0);
+		branch.setValue(FlightDataType.TYPE_ALTITUDE, 10.0);
+
+		NaNGoodnessSimulationPlotConfiguration configuration =
+				new NaNGoodnessSimulationPlotConfiguration("NaN goodness test");
+		configuration.addPlotDataType(FlightDataType.TYPE_ALTITUDE);
+
+		SimulationPlotConfiguration filled = assertDoesNotThrow(
+				() -> configuration.fillAutoAxes(branch),
+				"Auto-axis selection should not fail when every candidate scores as NaN"
+		);
+
+		assertNotNull(filled, "Auto-axis selection must always return a configuration");
+		assertTrue(filled.getAxis(0) >= 0, "The plotted type should be assigned to a concrete axis");
+	}
+
+	/**
+	 * Test helper that simulates a custom expression producing only non-finite
+	 * auto-axis goodness scores.
+	 */
+	private static final class NaNGoodnessSimulationPlotConfiguration extends SimulationPlotConfiguration {
+		private NaNGoodnessSimulationPlotConfiguration(String name) {
+			super(name);
+		}
+
+		@Override
+		protected double getGoodnessValue(FlightDataBranch data) {
+			return Double.NaN;
+		}
+	}
+}


### PR DESCRIPTION
While not being able to replicate the original issue, I think this fixes #3114.