### PR TITLE
Small clean-ups to Calipers feature

### DIFF
--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -95,12 +95,12 @@ ScaleSelector.btn.ZoomIn.ttip = Zoom in
 ScaleSelector.btn.ZoomFit.ttip = Zoom to fit
 RocketPanel.checkbox.ShowCGCP = Show CG/CP
 RocketPanel.checkbox.ShowCGCP.ttip = Disabling this checkbox hides the CG and CP markings in the rocket view.
-RocketPanel.checkbox.Calipers = Caliper
-RocketPanel.checkbox.Calipers.ttip = Show/hide the caliper in the rocket view. The caliper tool can be used to measure distances between points and edges in the rocket design.
+RocketPanel.checkbox.Calipers = Calipers
+RocketPanel.checkbox.Calipers.ttip = Show/hide the calipers in the rocket view. The calipers tool can be used to measure distances between points and edges in the rocket design.
 RocketPanel.checkbox.CaliperSnap = Snap
 RocketPanel.checkbox.CaliperSnap.ttip = Enable snapping to rocket geometry when dragging caliper lines.
-RocketPanel.radio.CaliperVertical.ttip = Vertical caliper, measures horizontal distances
-RocketPanel.radio.CaliperHorizontal.ttip = Horizontal caliper, measures vertical distances
+RocketPanel.radio.CaliperVertical.ttip = Vertical calipers, measures horizontal distances
+RocketPanel.radio.CaliperHorizontal.ttip = Horizontal calipers, measures vertical distances
 RocketPanel.lbl.CaliperUnits = Units:
 RocketPanel.popup.CaliperPosition = Position:
 RocketPanel.popup.CaliperSnapClick.ttip = Click to snap this caliper to a geometry feature (Escape to cancel)
@@ -140,13 +140,13 @@ RocketPanel.dlg.saveAsDefault.alreadyDefault.message = Your current settings are
 RocketPanel.dlg.saveAsDefault.alreadyDefault.funny = Your settings are already at default. Are you testing if something will happen if you keep pressing this button? Well, it worked!
 
 ! CaliperManager
-CaliperManager.btn.Caliper = Caliper tool
+CaliperManager.btn.Caliper = Calipers tool
 CaliperManager.btn.CaliperSnap = Snap caliper {%d} to geometry
 CaliperManager.snapModeMessage = Select the edge or point to snap caliper %d to
 CaliperManager.snapModeEscapeHint = Press Escape or click empty space to exit
 RocketPanel.lbl.infoMessage.snapMode = <html>Select edge or point to snap to &nbsp;&nbsp; Press Escape or click empty space to exit
-CaliperDialog.title = Caliper Tool
-CaliperDialog.lbl.mode = Caliper mode:
+CaliperDialog.title = Calipers Tool
+CaliperDialog.lbl.mode = Calipers mode:
 CaliperDialog.radio.vertical = Vertical
 CaliperDialog.radio.horizontal = Horizontal
 CaliperDialog.lbl.distance = Distance:
@@ -154,9 +154,9 @@ CaliperDialog.lbl.caliperPosition = Line %d position:
 CaliperDialog.btn.snap = Snap to geometry
 CaliperDialog.btn.snap.ttip = Snap caliper %d to the rocket geometry by selecting an edge or point in the rocket figure.
 CaliperDialog.btn.minimize = Minimize window
-CaliperDialog.btn.minimize.ttip = Minimize the caliper window to a small toolbar that only displays the distance.
-CaliperDialog.info = You can adjust the caliper line positions in several ways:<br><br>• <b>Click and drag</b> the caliper lines directly in the rocket view<br>• <b>Manually change</b> the line positions using the position spinners<br>• <b>Click the "Snap to geometry" button</b> to enter snap mode, then select an edge or point in the rocket figure<br>• <b>Hold Shift and drag</b> a caliper line to snap it to nearby geometry targets
-CaliperDialog.btn.ComponentInfo.ttip = Show/hide caliper tool help information
+CaliperDialog.btn.minimize.ttip = Minimize the calipers window to a small toolbar that only displays the distance.
+CaliperDialog.info = You can adjust the calipers line positions in several ways:<br><br>• <b>Click and drag</b> the caliper lines directly in the rocket view<br>• <b>Manually change</b> the line positions using the position spinners<br>• <b>Click the "Snap to geometry" button</b> to enter snap mode, then select an edge or point in the rocket figure<br>• <b>Hold Shift and drag</b> a caliper line to snap it to nearby geometry targets
+CaliperDialog.btn.ComponentInfo.ttip = Show/hide calipers tool help information
 
 ! BasicFrame
 BasicFrame.tab.Rocketdesign = Rocket design

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
@@ -2240,8 +2240,8 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		ButtonGroup modeGroup = new ButtonGroup();
 		JRadioButton verticalRadio = new JRadioButton();
 		JRadioButton horizontalRadio = new JRadioButton();
-		JLabel verticalModeIcon = new JLabel(createCaliperDoubleArrowIcon(true, caliperColor));
-		JLabel horizontalModeIcon = new JLabel(createCaliperDoubleArrowIcon(false, caliperColor));
+		JLabel verticalModeIcon = new JLabel(createCaliperDoubleDiamondIcon(true, caliperColor));
+		JLabel horizontalModeIcon = new JLabel(createCaliperDoubleDiamondIcon(false, caliperColor));
 		verticalRadio.setToolTipText(trans.get("RocketPanel.radio.CaliperVertical.ttip"));
 		horizontalRadio.setToolTipText(trans.get("RocketPanel.radio.CaliperHorizontal.ttip"));
 		verticalModeIcon.setToolTipText(trans.get("RocketPanel.radio.CaliperVertical.ttip"));
@@ -2370,8 +2370,8 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 			Color newValueFg = GUIUtil.getUITheme().getCaliperValueForegroundColor();
 			Color newDiamondLabelColor = GUIUtil.getUITheme().getCaliperDiamondLabelColor();
 
-			verticalModeIcon.setIcon(createCaliperDoubleArrowIcon(true, newCaliperColor));
-			horizontalModeIcon.setIcon(createCaliperDoubleArrowIcon(false, newCaliperColor));
+			verticalModeIcon.setIcon(createCaliperDoubleDiamondIcon(true, newCaliperColor));
+			horizontalModeIcon.setIcon(createCaliperDoubleDiamondIcon(false, newCaliperColor));
 
 			leftArrow.setIcon(createCaliperSingleArrowIcon(true, newCaliperColor));
 			rightArrow.setIcon(createCaliperSingleArrowIcon(false, newCaliperColor));
@@ -2440,38 +2440,40 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 	}
 
 	/**
-	 * Create a twin-arrow icon for the caliper mode radio buttons.
-	 * Vertical mode shows two upward arrows side by side (↑↑);
-	 * horizontal mode shows two leftward arrows stacked (←←).
+	 * Create a twin-caliper (line + diamond) icon for the caliper mode radio buttons.
+	 * Vertical mode shows two upward calipers side by side (↑↑);
+	 * horizontal mode shows two leftward calipers stacked (←←).
 	 *
 	 * @param vertical true for vertical mode (↑↑), false for horizontal (←←)
-	 * @param color    the arrow color
-	 * @return an ImageIcon of the twin arrows
+	 * @param color    the caliper color
+	 * @return an ImageIcon of the twin calipers
 	 */
-	private ImageIcon createCaliperDoubleArrowIcon(boolean vertical, Color color) {
+	private ImageIcon createCaliperDoubleDiamondIcon(boolean vertical, Color color) {
 		int size = 16;
 		BufferedImage image = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
 		Graphics2D g2 = image.createGraphics();
 		g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 		g2.setColor(color);
 
-		int head = 4; // arrowhead depth
-		int hw = 3;   // arrowhead half-width
-		int stemTop = head + 1;
+		int head = 3; // diamond half-depth
+		int hw = 3;   // diamond half-width
+		int stemTop = head;
 		int stemBot = size - 2;
 
 		g2.setStroke(new BasicStroke(1.5f));
 		if (vertical) {
-			// Two upward arrows side by side at x=4 and x=11
+			// Two upward calipers side by side at x=4 and x=11
 			for (int cx : new int[]{4, 11}) {
-				g2.drawLine(cx, stemTop, cx, stemBot);
-				g2.fillPolygon(new int[]{cx - hw, cx, cx + hw}, new int[]{head, 0, head}, 3);
+				g2.drawLine(cx-1, stemTop, cx-1, stemBot);
+				g2.fillPolygon(new int[]{cx - hw - 1, cx, cx}, new int[]{head, 0, head*2}, 3);
+				g2.fillPolygon(new int[]{cx-1, cx + hw, cx-1}, new int[]{0, head, head*2}, 3);
 			}
 		} else {
-			// Two leftward arrows stacked at y=4 and y=11
+			// Two leftward calipers stacked at y=4 and y=11
 			for (int cy : new int[]{4, 11}) {
-				g2.drawLine(stemTop, cy, stemBot, cy);
-				g2.fillPolygon(new int[]{head, 0, head}, new int[]{cy - hw, cy, cy + hw}, 3);
+				g2.drawLine(stemTop, cy-1, stemBot, cy-1);
+				g2.fillPolygon(new int[]{head, 0, head*2}, new int[]{cy - hw - 1, cy, cy}, 3);
+				g2.fillPolygon(new int[]{0, head, head*2}, new int[]{cy-1, cy + hw, cy-1}, 3);
 			}
 		}
 
@@ -2493,16 +2495,18 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 		g2.setColor(color);
 
-		int head = 4;
+		int head = 5;
 		int cy = h / 2;
 
 		g2.setStroke(new BasicStroke(1.5f));
 		if (left) {
 			g2.drawLine(head, cy, w - 1, cy);
-			g2.fillPolygon(new int[]{head, 0, head}, new int[]{cy - head, cy, cy + head}, 3);
+			g2.fillPolygon(new int[]{head, 0, head}, new int[]{cy+1, cy+1, cy + 1 - head}, 3);
+			g2.fillPolygon(new int[]{head, 0, head}, new int[]{cy + head, cy, cy}, 3);
 		} else {
 			g2.drawLine(0, cy, w - head, cy);
-			g2.fillPolygon(new int[]{w - head, w, w - head}, new int[]{cy - head, cy, cy + head}, 3);
+			g2.fillPolygon(new int[]{w - head, w, w - head}, new int[]{cy+1, cy+1, cy+1 - head}, 3);
+			g2.fillPolygon(new int[]{w - head, w, w - head}, new int[]{cy + head, cy, cy}, 3);
 		}
 
 		g2.dispose();


### PR DESCRIPTION
This PR contains two bits of very nit-picky clean-up to the Calipers feature.
1) In tooltips and other messages, the plural "Calipers" is used to refer to the feature, whereas the single "Caliper" is used when referring to an operation on a single caliper.  Previously, singular was used pretty much everywhere.

2) The arrowheads in the horizontal/vertical controls were converted to diamonds to more closely match the actual appearance of the calipers, and they were centered on and connected to the stems.    Also, the left and right arrowheads in the toolbar showing the inter-caliper distance were adjusted to be properly centered on their stems.

Before:
<img width="383" height="90" alt="image" src="https://github.com/user-attachments/assets/ef39a15d-2bf3-4f9e-9696-f105dd3598f5" />

After:
<img width="383" height="90" alt="image" src="https://github.com/user-attachments/assets/e77467f0-8423-443a-83c2-44c2ce26ca6b" />
