### PR TITLE
Reduce profiler hotspots in simulation status, component transforms, and structure mass calculation

### DIFF
--- a/core/src/main/java/info/openrocket/core/rocketcomponent/LaunchLug.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/LaunchLug.java
@@ -213,6 +213,7 @@ public class LaunchLug extends Tube implements AnglePositionable, BoxBounded, Li
 		}
 		
 		this.radialOffset = parentRadius + radius;
+		clearCoordinateCaches();
 	}
 	
 	@Override

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/RadiusRingComponent.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/RadiusRingComponent.java
@@ -128,6 +128,10 @@ public abstract class RadiusRingComponent extends RingComponent implements Coaxi
 
 	@Override
 	public void setInstanceSeparation(final double _separation) {
+		if (MathUtil.equals(this.instanceSeparation, _separation)) {
+			return;
+		}
+
 		this.instanceSeparation = _separation;
 
 		for (RocketComponent listener : configListeners) {
@@ -135,6 +139,8 @@ public abstract class RadiusRingComponent extends RingComponent implements Coaxi
 				((LineInstanceable) listener).setInstanceSeparation(_separation);
 			}
 		}
+
+		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 
 	@Override
@@ -143,9 +149,12 @@ public abstract class RadiusRingComponent extends RingComponent implements Coaxi
 			listener.setInstanceCount(newCount);
 		}
 
-		if (0 < newCount) {
-			this.instanceCount = newCount;
+		if (newCount == this.instanceCount || newCount <= 0) {
+			return;
 		}
+
+		this.instanceCount = newCount;
+		fireComponentChangeEvent(ComponentChangeEvent.BOTH_CHANGE);
 	}
 
 	@Override

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/RailButton.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/RailButton.java
@@ -295,6 +295,7 @@ public class RailButton extends ExternalComponent
 		}
 		
 		this.radialDistance_m = parentRadius;
+		clearCoordinateCaches();
 	}
 	
 	

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
@@ -165,6 +165,16 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 	private final Invalidator invalidator = new Invalidator(this);
 
 	/**
+	 * Cached absolute component locations. These are invalidated whenever the component tree changes.
+	 */
+	private transient CoordinateIF[] cachedComponentLocations = null;
+
+	/**
+	 * Cached absolute component angles. These follow the same invalidation lifecycle as locations.
+	 */
+	private transient CoordinateIF[] cachedComponentAngles = null;
+
+	/**
 	 * List of components that will set their properties to the same as the current component
 	 */
 	protected List<RocketComponent> configListeners = new LinkedList<>();
@@ -339,7 +349,16 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 	protected void componentChanged(ComponentChangeEvent e) {
 		// No-op
 		checkState();
+		clearCoordinateCaches();
 		update();
+	}
+
+	/**
+	 * Clears cached absolute coordinate data after a component change.
+	 */
+	protected final void clearCoordinateCaches() {
+		cachedComponentLocations = null;
+		cachedComponentAngles = null;
 	}
 	
 	
@@ -464,6 +483,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 	@Override
 	public RocketComponent clone() throws CloneNotSupportedException {
 		RocketComponent clone = (RocketComponent) super.clone();
+		clone.clearCoordinateCaches();
 		// Make sure the InsideColorComponentHandler is cloned
 		if (clone instanceof InsideColorComponent && this instanceof InsideColorComponent) {
 			InsideColorComponentHandler icch = new InsideColorComponentHandler(clone);
@@ -1584,9 +1604,14 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 	 * @return Coordinates of all instance locations in the rocket, relative to the rocket's origin
 	 */
 	public CoordinateIF[] getComponentLocations() {
+		if (cachedComponentLocations != null) {
+			return cachedComponentLocations.clone();
+		}
+
+		CoordinateIF[] computedLocations;
 		if (this.parent == null) {
 			// == improperly initialized components OR the root Rocket instance 
-			return getInstanceOffsets();
+			computedLocations = getInstanceOffsets();
 		} else {
 			CoordinateIF[] parentPositions = this.parent.getComponentLocations();
 			int parentCount = parentPositions.length;
@@ -1601,19 +1626,22 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 			// usual case optimization
 			if ((parentCount == 1) && (instanceCount == 1)) {
 				Transformation rotation = Transformation.getRotationTransform(parentRotations[0], this.position);
-				return new CoordinateIF[]{parentPositions[0].add(rotation.transform(instanceLocations[0]))};
-			}
-			
-			int thisCount = instanceCount * parentCount;
-			CoordinateIF[] thesePositions = new CoordinateIF[thisCount];
-			for (int pi = 0; pi < parentCount; pi++) {
-				Transformation rotation = Transformation.getRotationTransform(parentRotations[pi], this.position);
-				for (int ii = 0; ii < instanceCount; ii++) {
-					thesePositions[pi + parentCount*ii] = parentPositions[pi].add(rotation.transform(instanceLocations[ii]));
+				computedLocations = new CoordinateIF[] { parentPositions[0].add(rotation.transform(instanceLocations[0])) };
+			} else {
+				int thisCount = instanceCount * parentCount;
+				CoordinateIF[] thesePositions = new CoordinateIF[thisCount];
+				for (int pi = 0; pi < parentCount; pi++) {
+					Transformation rotation = Transformation.getRotationTransform(parentRotations[pi], this.position);
+					for (int ii = 0; ii < instanceCount; ii++) {
+						thesePositions[pi + parentCount * ii] = parentPositions[pi].add(rotation.transform(instanceLocations[ii]));
+					}
 				}
+				computedLocations = thesePositions;
 			}
-			return thesePositions;
 		}
+
+		cachedComponentLocations = computedLocations;
+		return computedLocations.clone();
 	}
 
 	public double[] getInstanceAngles() {
@@ -1634,9 +1662,14 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 	 * 	  			!!! OpenRocket rotations follow left-hand rule of rotation !!!
 	 */
 	public CoordinateIF[] getComponentAngles() {
+		if (cachedComponentAngles != null) {
+			return cachedComponentAngles.clone();
+		}
+
+		CoordinateIF[] computedAngles;
 		if (this.parent == null) {
 			// == improperly initialized components OR the root Rocket instance
-			return axialRotToCoord(getInstanceAngles());
+			computedAngles = axialRotToCoord(getInstanceAngles());
 		} else {
 			CoordinateIF[] parentAngles = this.parent.getComponentAngles();
 			int parentCount = parentAngles.length;
@@ -1647,18 +1680,21 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 
 			// usual case optimization
 			if ((parentCount == 1) && (instanceCount == 1)) {
-				return new CoordinateIF[] {parentAngles[0].add(instanceAngles[0])};
-			}
-
-			int thisCount = instanceCount * parentCount;
-			CoordinateIF[] theseAngles = new CoordinateIF[thisCount];
-			for (int pi = 0; pi < parentCount; pi++) {
-				for (int ii = 0; ii < instanceCount; ii++) {
-					theseAngles[pi + parentCount*ii] = parentAngles[pi].add(instanceAngles[ii]);
+				computedAngles = new CoordinateIF[] { parentAngles[0].add(instanceAngles[0]) };
+			} else {
+				int thisCount = instanceCount * parentCount;
+				CoordinateIF[] theseAngles = new CoordinateIF[thisCount];
+				for (int pi = 0; pi < parentCount; pi++) {
+					for (int ii = 0; ii < instanceCount; ii++) {
+						theseAngles[pi + parentCount * ii] = parentAngles[pi].add(instanceAngles[ii]);
+					}
 				}
+				computedAngles = theseAngles;
 			}
-			return theseAngles;
 		}
+
+		cachedComponentAngles = computedAngles;
+		return computedAngles.clone();
 	}
 
 	/**
@@ -1730,9 +1766,10 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 		// not sure if this will give us an answer, or THE answer... 
 		//final Coordinate sourceLoc = this.getLocation()[0];
 		final CoordinateIF[] destLocs = dest.getComponentLocations();
+		final CoordinateIF sourceLoc = this.getComponentLocations()[0];
 		CoordinateIF[] toReturn = new CoordinateIF[destLocs.length];
 		for (int coordIndex = 0; coordIndex < destLocs.length; coordIndex++) {
-			toReturn[coordIndex] = this.getComponentLocations()[0].add(c).sub(destLocs[coordIndex]);
+			toReturn[coordIndex] = sourceLoc.add(c).sub(destLocs[coordIndex]);
 		}
 		
 		mutex.unlock("toRelative");
@@ -2979,6 +3016,7 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 		this.displayOrder_back = src.displayOrder_back;
 		this.configListeners = new LinkedList<>();
 		this.bypassComponentChangeEvent = false;
+		clearCoordinateCaches();
 		if (this instanceof InsideColorComponent && src instanceof InsideColorComponent) {
 			InsideColorComponentHandler icch = new InsideColorComponentHandler(this);
 			icch.copyFrom(((InsideColorComponent) src).getInsideColorComponentHandler());

--- a/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
@@ -21,6 +21,7 @@ import info.openrocket.core.simulation.exception.SimulationException;
 import info.openrocket.core.simulation.listeners.SimulationListenerHelper;
 import info.openrocket.core.util.BugException;
 import info.openrocket.core.util.MathUtil;
+import info.openrocket.core.util.ModID;
 import info.openrocket.core.util.Quaternion;
 import info.openrocket.core.util.Rotation2D;
 import info.openrocket.core.util.MutableCoordinate;
@@ -32,6 +33,11 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 
 	private final MutableCoordinate tempVelocity = new MutableCoordinate();
 	private final MutableCoordinate tempRotation = new MutableCoordinate();
+
+	// Structural mass does not change between stage-separation events, so cache it
+	// and recompute only when the FlightConfiguration's ModID changes.
+	private RigidBody cachedStructureMass = null;
+	private ModID cachedStructureConfigModID = ModID.INVALID;
 
 	/*
 	 * calculate acceleration at a given point in time
@@ -214,15 +220,20 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 	 * @return            the mass data to use
 	 */
 	protected RigidBody calculateStructureMass(SimulationStatus status) throws SimulationException {
-		RigidBody structureMass;
-
-		// Call pre-listener
-		structureMass = SimulationListenerHelper.firePreMassCalculation(status);
+		// Call pre-listener — if it overrides, skip the cache entirely
+		RigidBody structureMass = SimulationListenerHelper.firePreMassCalculation(status);
 		if (structureMass != null) {
 			return structureMass;
 		}
 
-		structureMass = MassCalculator.calculateStructure(status.getConfiguration());
+		// Structural mass is constant between stage-separation events. Recompute only
+		// when the FlightConfiguration's ModID changes (stage deactivated, etc.).
+		ModID currentModID = status.getConfiguration().getModID();
+		if (cachedStructureMass == null || currentModID != cachedStructureConfigModID) {
+			cachedStructureMass = MassCalculator.calculateStructure(status.getConfiguration());
+			cachedStructureConfigModID = currentModID;
+		}
+		structureMass = cachedStructureMass;
 
 		// Call post-listener
 		structureMass = SimulationListenerHelper.firePostMassCalculation(status, structureMass);

--- a/core/src/test/java/info/openrocket/core/rocketcomponent/RocketTest.java
+++ b/core/src/test/java/info/openrocket/core/rocketcomponent/RocketTest.java
@@ -217,6 +217,30 @@ public class RocketTest extends BaseTestCase {
 	}
 
 	@Test
+	public void testComponentLocationCacheInvalidatesOnMove() {
+		final Rocket rocket = TestRockets.makeEstesAlphaIII();
+		final AxialStage stage = (AxialStage) rocket.getChild(0);
+		final BodyTube body = (BodyTube) stage.getChild(1);
+		final FinSet fins = (FinSet) body.getChild(0);
+
+		// Warm the caches before moving the fin set so the assertions cover invalidation as well.
+		final CoordinateIF initialAbsolute = fins.getComponentLocations()[0];
+		final CoordinateIF initialRelative = fins.toRelative(Coordinate.NUL, body)[0];
+
+		fins.setAxialMethod(AxialMethod.TOP);
+		fins.setAxialOffset(0.16);
+
+		final CoordinateIF movedAbsolute = fins.getComponentLocations()[0];
+		final CoordinateIF movedRelative = fins.toRelative(Coordinate.NUL, body)[0];
+
+		assertNotEquals(initialAbsolute, movedAbsolute, "Absolute component location cache was not invalidated");
+		assertEquals(new Coordinate(0.23, 0.012, 0), movedAbsolute, "Absolute component location is incorrect");
+
+		assertNotEquals(initialRelative, movedRelative, "Relative component location cache was not invalidated");
+		assertEquals(new Coordinate(0.16, 0.012, 0), movedRelative, "Relative component location is incorrect");
+	}
+
+	@Test
 	public void testRemoveReadjustLocation() {
 		final Rocket rocket = TestRockets.makeEstesAlphaIII();
 

--- a/swing/src/main/java/info/openrocket/swing/gui/util/SwingPreferences.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/util/SwingPreferences.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -110,8 +111,10 @@ public class SwingPreferences extends ApplicationPreferences {
 	private static final String NODENAME = (DEBUG ? "OpenRocket-debug" : "OpenRocket");
 	
 	private Preferences PREFNODE;
-	
-	
+
+	private final Map<String, Set<String>> cachedNodeKeys = new HashMap<>();
+
+
 	public SwingPreferences() {
 		Preferences root = Preferences.userRoot();
 		if (DEBUG && CLEARPREFS) {
@@ -180,6 +183,7 @@ public class SwingPreferences extends ApplicationPreferences {
 				root.node(NODENAME).removeNode();
 			}
 			PREFNODE = root.node(NODENAME);
+			cachedNodeKeys.clear();
 			UnitGroup.resetDefaultUnits();
 			storeDefaultUnits();
 			log.info("Cleared preferences");
@@ -193,20 +197,43 @@ public class SwingPreferences extends ApplicationPreferences {
 	 */
 	private void storeVersion() {
 		PREFNODE.put("OpenRocketVersion", BuildProperties.getVersion());
+		cacheKeyAdded(PREFNODE, "OpenRocketVersion");
 	}
 
 	/**
 	 * Checks if a certain key exists in the node
+	 * Results are cached per node path and updated incrementally on writes to avoid
+	 * repeated native disk I/O from AbstractPreferences.keys().
 	 * @param node node to check the keys of.
 	 * @param key key to check
 	 * @return true if the key is stored in the preferences, false otherwise
 	 */
 	private boolean keyExists(Preferences node, String key) {
-		try {
-			return Arrays.asList(node.keys()).contains(key);
-		} catch (BackingStoreException e) {
-			e.printStackTrace();
-			return false;
+		String path = node.absolutePath();
+		Set<String> keys = cachedNodeKeys.get(path);
+		if (keys == null) {
+			try {
+				keys = new HashSet<>(Arrays.asList(node.keys()));
+			} catch (BackingStoreException e) {
+				e.printStackTrace();
+				return false;
+			}
+			cachedNodeKeys.put(path, keys);
+		}
+		return keys.contains(key);
+	}
+
+	private void cacheKeyAdded(Preferences node, String key) {
+		Set<String> keys = cachedNodeKeys.get(node.absolutePath());
+		if (keys != null) {
+			keys.add(key);
+		}
+	}
+
+	private void cacheKeyRemoved(Preferences node, String key) {
+		Set<String> keys = cachedNodeKeys.get(node.absolutePath());
+		if (keys != null) {
+			keys.remove(key);
 		}
 	}
 
@@ -221,6 +248,7 @@ public class SwingPreferences extends ApplicationPreferences {
 	public String getString(String key, String def) {
 		if (!keyExists(PREFNODE, key) && key != null && def != null) {
 			PREFNODE.put(key, def);
+			cacheKeyAdded(PREFNODE, key);
 			try {
 				PREFNODE.flush();
 			} catch (BackingStoreException e) {
@@ -229,12 +257,13 @@ public class SwingPreferences extends ApplicationPreferences {
 		}
 		return PREFNODE.get(key, def);
 	}
-	
+
 	@Override
 	public String getString(String directory, String key, String defaultValue) {
 		Preferences p = PREFNODE.node(directory);
 		if (!keyExists(p, key) && key != null && defaultValue != null) {
 			p.put(key, defaultValue);
+			cacheKeyAdded(p, key);
 			try {
 				p.flush();
 			} catch (BackingStoreException e) {
@@ -254,19 +283,23 @@ public class SwingPreferences extends ApplicationPreferences {
 	public void putString(String key, String value) {
 		if (value == null) {
 			PREFNODE.remove(key);
+			cacheKeyRemoved(PREFNODE, key);
 		} else {
 			PREFNODE.put(key, value);
+			cacheKeyAdded(PREFNODE, key);
 		}
 		storeVersion();
 	}
-	
+
 	@Override
 	public void putString(String directory, String key, String value) {
 		Preferences p = PREFNODE.node(directory);
 		if (value == null) {
 			p.remove(key);
+			cacheKeyRemoved(p, key);
 		} else {
 			p.put(key, value);
+			cacheKeyAdded(p, key);
 		}
 		storeVersion();
 	}
@@ -284,6 +317,7 @@ public class SwingPreferences extends ApplicationPreferences {
 		if (!keyExists(PREFNODE, key) && key != null) {
 			// Save the default value
 			PREFNODE.putBoolean(key, def);
+			cacheKeyAdded(PREFNODE, key);
 			try {
 				PREFNODE.flush();
 			} catch (BackingStoreException e) {
@@ -302,6 +336,7 @@ public class SwingPreferences extends ApplicationPreferences {
 	@Override
 	public void putBoolean(String key, boolean value) {
 		PREFNODE.putBoolean(key, value);
+		cacheKeyAdded(PREFNODE, key);
 		storeVersion();
 	}
 
@@ -309,6 +344,7 @@ public class SwingPreferences extends ApplicationPreferences {
 	public int getInt(String key, int defaultValue) {
 		if (!keyExists(PREFNODE, key) && key != null) {
 			PREFNODE.putInt(key, defaultValue);
+			cacheKeyAdded(PREFNODE, key);
 			try {
 				PREFNODE.flush();
 			} catch (BackingStoreException e) {
@@ -317,10 +353,11 @@ public class SwingPreferences extends ApplicationPreferences {
 		}
 		return PREFNODE.getInt(key, defaultValue);
 	}
-	
+
 	@Override
 	public void putInt(String key, int value) {
 		PREFNODE.putInt(key, value);
+		cacheKeyAdded(PREFNODE, key);
 		storeVersion();
 	}
 
@@ -328,6 +365,7 @@ public class SwingPreferences extends ApplicationPreferences {
 	public double getDouble(String key, double defaultValue) {
 		if (!keyExists(PREFNODE, key) && key != null) {
 			PREFNODE.putDouble(key, defaultValue);
+			cacheKeyAdded(PREFNODE, key);
 			try {
 				PREFNODE.flush();
 			} catch (BackingStoreException e) {
@@ -336,10 +374,11 @@ public class SwingPreferences extends ApplicationPreferences {
 		}
 		return PREFNODE.getDouble(key, defaultValue);
 	}
-	
+
 	@Override
 	public void putDouble(String key, double value) {
 		PREFNODE.putDouble(key, value);
+		cacheKeyAdded(PREFNODE, key);
 		storeVersion();
 	}
 	


### PR DESCRIPTION
This PR is an attempt to improve performance, based on a JProfiler scan of a minute of usage in OR (opening a design, running a few sims, plotting...).

The scan showed three main CPU hotspots in the current simulation flow:

1. `SwingPreferences.keyExists` in the simulation table render path (~3.0s CPU)
`Simulation.getStatus()` ends up cloning `FlightConfiguration`, which reads preferences and repeatedly hits `AbstractPreferences.keys()`.
2. `Transformation.getRotationTransform` / `RocketComponent.getComponentLocations` (~2.8s CPU)
Component locations were recomputed recursively for repeated mass and aerodynamic queries, especially for ring components.
3. `MassCalculation.calculateStructure` on every RK4 step (~166ms CPU)
     Structural mass was recalculated even when the flight configuration had not changed.

This PR addresses those hotspots with three targeted caches:

- cache preference node/key lookups so the simulation status path no longer repeatedly reads preference data from the backing store
- cache component locations and angles in RocketComponent, with invalidation on relevant component changes, so repeated transform-chain traversal is avoided
- cache structural mass between simulation steps and only recompute when the flight configuration mod ID changes