### PR TITLE
[#3142] Increase storage precision of simulation data points

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/openrocket/OpenRocketSaver.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/OpenRocketSaver.java
@@ -433,25 +433,25 @@ public class OpenRocketSaver extends RocketSaver {
 		if (data != null) {
 			String str = "<flightdata";
 			if (!Double.isNaN(data.getMaxAltitude()))
-				str += " maxaltitude=\"" + TextUtil.doubleToString(data.getMaxAltitude()) + "\"";
+				str += " maxaltitude=\"" + TextUtil.doubleToString(data.getMaxAltitude(), TextUtil.STORAGE_DECIMAL_PLACES) + "\"";
 			if (!Double.isNaN(data.getMaxVelocity()))
-				str += " maxvelocity=\"" + TextUtil.doubleToString(data.getMaxVelocity()) + "\"";
+				str += " maxvelocity=\"" + TextUtil.doubleToString(data.getMaxVelocity(), TextUtil.STORAGE_DECIMAL_PLACES) + "\"";
 			if (!Double.isNaN(data.getMaxAcceleration()))
-				str += " maxacceleration=\"" + TextUtil.doubleToString(data.getMaxAcceleration()) + "\"";
+				str += " maxacceleration=\"" + TextUtil.doubleToString(data.getMaxAcceleration(), TextUtil.STORAGE_DECIMAL_PLACES) + "\"";
 			if (!Double.isNaN(data.getMaxMachNumber()))
-				str += " maxmach=\"" + TextUtil.doubleToString(data.getMaxMachNumber()) + "\"";
+				str += " maxmach=\"" + TextUtil.doubleToString(data.getMaxMachNumber(), TextUtil.STORAGE_DECIMAL_PLACES) + "\"";
 			if (!Double.isNaN(data.getTimeToApogee()))
-				str += " timetoapogee=\"" + TextUtil.doubleToString(data.getTimeToApogee()) + "\"";
+				str += " timetoapogee=\"" + TextUtil.doubleToString(data.getTimeToApogee(), TextUtil.STORAGE_DECIMAL_PLACES) + "\"";
 			if (!Double.isNaN(data.getFlightTime()))
-				str += " flighttime=\"" + TextUtil.doubleToString(data.getFlightTime()) + "\"";
+				str += " flighttime=\"" + TextUtil.doubleToString(data.getFlightTime(), TextUtil.STORAGE_DECIMAL_PLACES) + "\"";
 			if (!Double.isNaN(data.getGroundHitVelocity()))
-				str += " groundhitvelocity=\"" + TextUtil.doubleToString(data.getGroundHitVelocity()) + "\"";
+				str += " groundhitvelocity=\"" + TextUtil.doubleToString(data.getGroundHitVelocity(), TextUtil.STORAGE_DECIMAL_PLACES) + "\"";
 			if (!Double.isNaN(data.getLaunchRodVelocity()))
-				str += " launchrodvelocity=\"" + TextUtil.doubleToString(data.getLaunchRodVelocity()) + "\"";
+				str += " launchrodvelocity=\"" + TextUtil.doubleToString(data.getLaunchRodVelocity(), TextUtil.STORAGE_DECIMAL_PLACES) + "\"";
 			if (!Double.isNaN(data.getDeploymentVelocity()))
-				str += " deploymentvelocity=\"" + TextUtil.doubleToString(data.getDeploymentVelocity()) + "\"";
+				str += " deploymentvelocity=\"" + TextUtil.doubleToString(data.getDeploymentVelocity(), TextUtil.STORAGE_DECIMAL_PLACES) + "\"";
 			if (!Double.isNaN(data.getOptimumDelay()))
-				str += " optimumdelay=\"" + TextUtil.doubleToString(data.getOptimumDelay()) + "\"";
+				str += " optimumdelay=\"" + TextUtil.doubleToString(data.getOptimumDelay(), TextUtil.STORAGE_DECIMAL_PLACES) + "\"";
 			str += ">";
 			writeln(str);
 			indent++;
@@ -662,7 +662,7 @@ public class OpenRocketSaver extends RocketSaver {
 		
 		// Write events
 		for (FlightEvent event : branch.getEvents()) {
-			String eventStr = "<event time=\"" + TextUtil.doubleToString(event.getTime()) + "\" "
+			String eventStr = "<event time=\"" + TextUtil.doubleToString(event.getTime(), TextUtil.STORAGE_DECIMAL_PLACES) + "\" "
 				+ "type=\"" + enumToXMLName(event.getType()) + "\" "
 				+ "id=\"" + event.getID().toString() + "\"";
 			
@@ -732,7 +732,7 @@ public class OpenRocketSaver extends RocketSaver {
 		for (int j = 0; j < data.size(); j++) {
 			if (j > 0)
 				sb.append(",");
-			sb.append(TextUtil.doubleToString(data.get(j).get(index)));
+			sb.append(TextUtil.doubleToString(data.get(j).get(index), TextUtil.STORAGE_DECIMAL_PLACES));
 		}
 		sb.append("</datapoint>");
 		writeln(sb.toString());

--- a/core/src/main/java/info/openrocket/core/util/TextUtil.java
+++ b/core/src/main/java/info/openrocket/core/util/TextUtil.java
@@ -6,6 +6,7 @@ import java.util.Locale;
 
 public class TextUtil {
 	public static final int DEFAULT_DECIMAL_PLACES = 3;
+	public static final int STORAGE_DECIMAL_PLACES = 8;
 
 	private static final char[] HEX = {
 			'0', '1', '2', '3', '4', '5', '6', '7',

--- a/core/src/main/java/info/openrocket/core/util/TextUtil.java
+++ b/core/src/main/java/info/openrocket/core/util/TextUtil.java
@@ -6,7 +6,7 @@ import java.util.Locale;
 
 public class TextUtil {
 	public static final int DEFAULT_DECIMAL_PLACES = 3;
-	public static final int STORAGE_DECIMAL_PLACES = 8;
+	public static final int STORAGE_DECIMAL_PLACES = 6;
 
 	private static final char[] HEX = {
 			'0', '1', '2', '3', '4', '5', '6', '7',

--- a/core/src/test/java/info/openrocket/core/file/openrocket/OpenRocketSaverTest.java
+++ b/core/src/test/java/info/openrocket/core/file/openrocket/OpenRocketSaverTest.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import info.openrocket.core.ServicesForTesting;
@@ -24,6 +25,10 @@ import info.openrocket.core.database.motor.ThrustCurveMotorSetDatabase;
 import info.openrocket.core.document.OpenRocketDocument;
 import info.openrocket.core.document.OpenRocketDocumentFactory;
 import info.openrocket.core.document.Simulation;
+import info.openrocket.core.simulation.FlightData;
+import info.openrocket.core.simulation.FlightDataBranch;
+import info.openrocket.core.simulation.FlightDataType;
+import info.openrocket.core.simulation.SimulationOptions;
 import info.openrocket.core.document.StorageOptions;
 import info.openrocket.core.file.GeneralRocketLoader;
 import info.openrocket.core.file.GeneralRocketSaver;
@@ -460,11 +465,63 @@ public class OpenRocketSaverTest {
 	}
 	
 
+	@Test
+	public void testDatapointPrecision() {
+		// Build a minimal rocket
+		Rocket rocket = new Rocket();
+		AxialStage stage = new AxialStage();
+		rocket.addChild(stage);
+		BodyTube tube = new BodyTube(0.3, 0.025, 0.002);
+		stage.addChild(tube);
+		rocket.enableEvents();
+		OpenRocketDocument doc = OpenRocketDocumentFactory.createDocumentFromRocket(rocket);
+
+		// A time value in the 0.001–0.1 s range: %.3f would store "0.012" (off by ~0.345 ms)
+		// but STORAGE_DECIMAL_PLACES=8 stores "0.01234568" (within 2 ns of the original).
+		double precisionValue = 0.012345678;
+
+		FlightDataBranch branch = new FlightDataBranch("Sustainer",
+				FlightDataType.TYPE_TIME, FlightDataType.TYPE_ALTITUDE);
+		branch.addPoint();
+		branch.setValue(FlightDataType.TYPE_TIME, precisionValue);
+		branch.setValue(FlightDataType.TYPE_ALTITUDE, 1000.123456789);
+		branch.immute();
+
+		FlightData flightData = new FlightData(branch);
+
+		Simulation sim = new Simulation(doc, rocket, Simulation.Status.UPTODATE, "precision test",
+				new SimulationOptions(), Collections.emptyList(), flightData);
+		doc.addSimulation(sim);
+
+		StorageOptions opts = new StorageOptions();
+		opts.setSaveSimulationData(true);
+		File file = saveRocket(doc, opts);
+
+		OpenRocketDocument loaded = loadRocket(file.getPath());
+		assertNotNull(loaded);
+		assertFalse(loaded.getSimulations().isEmpty());
+
+		FlightData loadedData = loaded.getSimulations().get(0).getSimulatedData();
+		assertNotNull(loadedData, "Simulation data must be saved when saveSimulationData=true");
+
+		FlightDataBranch loadedBranch = loadedData.getBranch(0);
+		assertNotNull(loadedBranch);
+
+		List<Double> times = loadedBranch.get(FlightDataType.TYPE_TIME);
+		assertNotNull(times);
+		assertFalse(times.isEmpty());
+
+		// Tolerance of 1e-8 s (10 ns): passes with STORAGE_DECIMAL_PLACES=8,
+		// would fail with the old DEFAULT_DECIMAL_PLACES=3 which stores only "0.012".
+		assertEquals(precisionValue, times.get(0), 1e-8,
+				"Time value lost precision in .ork round-trip — check STORAGE_DECIMAL_PLACES");
+	}
+
 	////////////////////////////////
 	/*
 	 * Utility Functions
 	 */
-	
+
 	private int getCalculatedFileVersion(OpenRocketDocument rocketDoc) {
 		int fileVersion = this.saver.testAccessor_calculateNecessaryFileVersion(rocketDoc, null);
 		return fileVersion;

--- a/core/src/test/java/info/openrocket/core/file/openrocket/OpenRocketSaverTest.java
+++ b/core/src/test/java/info/openrocket/core/file/openrocket/OpenRocketSaverTest.java
@@ -13,6 +13,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -465,6 +468,57 @@ public class OpenRocketSaverTest {
 	}
 	
 
+	/**
+	 * Verifies that re-saving an example file with STORAGE_DECIMAL_PLACES=6 keeps the
+	 * compressed file size within a reasonable multiple of the original (which was saved
+	 * with the old 3dp format).  This acts as a regression guard: if precision or data
+	 * volume accidentally balloons, this test fails before users notice multi-MB files.
+	 *
+	 * Baseline (3dp, on-disk): "A simple model rocket.ork" ≈ 53,634 B compressed,
+	 * 2,580 datapoints.  With 6dp the uncompressed XML grows slightly, but ZIP's
+	 * DEFLATE compression keeps the compressed delta much smaller.
+	 */
+	@Test
+	public void testSavedFileSizeWithSimulationData() {
+		String resourcePath = "/datafiles/examples/A simple model rocket.ork";
+		URL url = OpenRocketSaverTest.class.getResource(resourcePath);
+		assertNotNull(url, "Example file not found on classpath: " + resourcePath);
+
+		File originalFile;
+		try {
+			originalFile = new File(new URI(url.toString().replace(" ", "%20")));
+		} catch (URISyntaxException e) {
+			fail("Could not resolve example file URI: " + e.getMessage());
+			return;
+		}
+		long originalSize = originalFile.length();  // ~53,634 B (3dp format, on-disk)
+		assertTrue(originalSize > 0, "Original example file is empty or missing");
+
+		OpenRocketDocument doc = loadRocket(originalFile.getPath());
+		assertNotNull(doc);
+
+		// Save without simulation data — establishes the component-only baseline.
+		StorageOptions optsNoSim = new StorageOptions();
+		optsNoSim.setSaveSimulationData(false);
+		long sizeNoSim = saveRocketAsZip(doc, optsNoSim).length();
+
+		// Save with simulation data — datapoints written at STORAGE_DECIMAL_PLACES=6.
+		StorageOptions optsWithSim = new StorageOptions();
+		optsWithSim.setSaveSimulationData(true);
+		long sizeWithSim = saveRocketAsZip(doc, optsWithSim).length();
+
+		// Simulation data must actually contribute to the file size.
+		assertTrue(sizeWithSim > sizeNoSim,
+				String.format("File with sim data (%,d B) should exceed file without (%,d B)", sizeWithSim, sizeNoSim));
+
+		// With 6dp the file grows compared to the 3dp original, but ZIP compression
+		// keeps growth well bounded.  4× is generous enough to handle the precision
+		// increase while catching accidental format regressions (e.g. STORAGE_DECIMAL_PLACES=100).
+		assertTrue(sizeWithSim < originalSize * 4,
+				String.format("Re-saved file (%,d B) exceeds 4× the original 3dp file (%,d B); "
+						+ "check STORAGE_DECIMAL_PLACES or unexpected data-volume changes", sizeWithSim, originalSize));
+	}
+
 	@Test
 	public void testDatapointPrecision() {
 		// Build a minimal rocket
@@ -477,7 +531,7 @@ public class OpenRocketSaverTest {
 		OpenRocketDocument doc = OpenRocketDocumentFactory.createDocumentFromRocket(rocket);
 
 		// A time value in the 0.001–0.1 s range: %.3f would store "0.012" (off by ~0.345 ms)
-		// but STORAGE_DECIMAL_PLACES=8 stores "0.01234568" (within 2 ns of the original).
+		// but STORAGE_DECIMAL_PLACES=6 stores "0.012346" (within 1 µs of the original).
 		double precisionValue = 0.012345678;
 
 		FlightDataBranch branch = new FlightDataBranch("Sustainer",
@@ -511,9 +565,9 @@ public class OpenRocketSaverTest {
 		assertNotNull(times);
 		assertFalse(times.isEmpty());
 
-		// Tolerance of 1e-8 s (10 ns): passes with STORAGE_DECIMAL_PLACES=8,
+		// Tolerance of 1e-6 s (1 µs): passes with STORAGE_DECIMAL_PLACES=6,
 		// would fail with the old DEFAULT_DECIMAL_PLACES=3 which stores only "0.012".
-		assertEquals(precisionValue, times.get(0), 1e-8,
+		assertEquals(precisionValue, times.get(0), 1e-6,
 				"Time value lost precision in .ork round-trip — check STORAGE_DECIMAL_PLACES");
 	}
 

--- a/core/src/test/java/info/openrocket/core/util/TextUtilTest.java
+++ b/core/src/test/java/info/openrocket/core/util/TextUtilTest.java
@@ -283,31 +283,31 @@ public class TextUtilTest {
 
 	@Test
 	public void storageDecimalPlacesTest() {
-		assertEquals(8, TextUtil.STORAGE_DECIMAL_PLACES);
+		assertEquals(6, TextUtil.STORAGE_DECIMAL_PLACES);
 
 		// Values in the 0.001–0.1 m range where %.3f loses significant digits.
-		// 12.5 mm radius: %.3f → "0.013" (error); %.8f → "0.0125"
+		// 12.5 mm radius: %.3f → "0.013" (error); %.6f → "0.0125"
 		assertEquals("0.0125", TextUtil.doubleToString(0.0125, TextUtil.STORAGE_DECIMAL_PLACES));
-		// 24.73 mm diameter: %.3f → "0.025"; %.8f → "0.02473"
+		// 24.73 mm diameter: %.3f → "0.025"; %.6f → "0.02473"
 		assertEquals("0.02473", TextUtil.doubleToString(0.02473, TextUtil.STORAGE_DECIMAL_PLACES));
-		// 1.234 mm: %.3f → "0.001" (only 1 sig fig); %.8f → "0.001234"
+		// 1.234 mm: %.3f → "0.001" (only 1 sig fig); %.6f → "0.001234"
 		assertEquals("0.001234", TextUtil.doubleToString(0.001234, TextUtil.STORAGE_DECIMAL_PLACES));
 
 		// Reference area for a 25 mm diameter rocket (< 0.001 m², uses exp notation).
-		// Both formats use exp notation, but STORAGE_DECIMAL_PLACES gives 9 sig figs vs 4.
+		// Both formats use exp notation, but STORAGE_DECIMAL_PLACES gives 7 sig figs vs 4.
 		double refArea = Math.PI * 0.0125 * 0.0125;
 		String storedRefArea = TextUtil.doubleToString(refArea, TextUtil.STORAGE_DECIMAL_PLACES);
-		assertEquals(refArea, Double.parseDouble(storedRefArea), refArea * 1e-7);
+		assertEquals(refArea, Double.parseDouble(storedRefArea), refArea * 1e-5);
 
 		// Confirm the old DEFAULT_DECIMAL_PLACES (3) was insufficient for these values.
 		assertNotEquals("0.0125", TextUtil.doubleToString(0.0125, TextUtil.DEFAULT_DECIMAL_PLACES));
 		assertNotEquals("0.02473", TextUtil.doubleToString(0.02473, TextUtil.DEFAULT_DECIMAL_PLACES));
 
-		// Round-trip: all values survive parse with relative error < 1e-7.
+		// Round-trip: all values survive parse with relative error < 1e-5.
 		double[] values = { 0.001234, 0.0125, 0.02473, 0.12345678, 1.23456789, 12345.6789, 1.23456789e-5 };
 		for (double v : values) {
 			String s = TextUtil.doubleToString(v, TextUtil.STORAGE_DECIMAL_PLACES);
-			assertEquals(v, Double.parseDouble(s), Math.abs(v) * 1e-7, "Round-trip failed for " + v);
+			assertEquals(v, Double.parseDouble(s), Math.abs(v) * 1e-5, "Round-trip failed for " + v);
 		}
 	}
 

--- a/core/src/test/java/info/openrocket/core/util/TextUtilTest.java
+++ b/core/src/test/java/info/openrocket/core/util/TextUtilTest.java
@@ -3,6 +3,7 @@ package info.openrocket.core.util;
 import static java.lang.Math.PI;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -277,6 +278,36 @@ public class TextUtilTest {
 			String s = TextUtil.doubleToString(orig);
 			result = Double.parseDouble(s);
 			assertEquals(expected, result, 0.001);
+		}
+	}
+
+	@Test
+	public void storageDecimalPlacesTest() {
+		assertEquals(8, TextUtil.STORAGE_DECIMAL_PLACES);
+
+		// Values in the 0.001–0.1 m range where %.3f loses significant digits.
+		// 12.5 mm radius: %.3f → "0.013" (error); %.8f → "0.0125"
+		assertEquals("0.0125", TextUtil.doubleToString(0.0125, TextUtil.STORAGE_DECIMAL_PLACES));
+		// 24.73 mm diameter: %.3f → "0.025"; %.8f → "0.02473"
+		assertEquals("0.02473", TextUtil.doubleToString(0.02473, TextUtil.STORAGE_DECIMAL_PLACES));
+		// 1.234 mm: %.3f → "0.001" (only 1 sig fig); %.8f → "0.001234"
+		assertEquals("0.001234", TextUtil.doubleToString(0.001234, TextUtil.STORAGE_DECIMAL_PLACES));
+
+		// Reference area for a 25 mm diameter rocket (< 0.001 m², uses exp notation).
+		// Both formats use exp notation, but STORAGE_DECIMAL_PLACES gives 9 sig figs vs 4.
+		double refArea = Math.PI * 0.0125 * 0.0125;
+		String storedRefArea = TextUtil.doubleToString(refArea, TextUtil.STORAGE_DECIMAL_PLACES);
+		assertEquals(refArea, Double.parseDouble(storedRefArea), refArea * 1e-7);
+
+		// Confirm the old DEFAULT_DECIMAL_PLACES (3) was insufficient for these values.
+		assertNotEquals("0.0125", TextUtil.doubleToString(0.0125, TextUtil.DEFAULT_DECIMAL_PLACES));
+		assertNotEquals("0.02473", TextUtil.doubleToString(0.02473, TextUtil.DEFAULT_DECIMAL_PLACES));
+
+		// Round-trip: all values survive parse with relative error < 1e-7.
+		double[] values = { 0.001234, 0.0125, 0.02473, 0.12345678, 1.23456789, 12345.6789, 1.23456789e-5 };
+		for (double v : values) {
+			String s = TextUtil.doubleToString(v, TextUtil.STORAGE_DECIMAL_PLACES);
+			assertEquals(v, Double.parseDouble(s), Math.abs(v) * 1e-7, "Round-trip failed for " + v);
 		}
 	}
 

--- a/fileformat.txt
+++ b/fileformat.txt
@@ -97,3 +97,4 @@ The following file format versions exist:
       Added <baserelativehumidity> to the atmosphere model in simulation conditions.
       Support 'auto' line length for parachute and shock cord.
       Added 2D and 3D background and text color preferences to <docprefs>.
+      Increased decimal precision of simulation <flightdata>, <event>, and <datapoint> values to 6 digits after the decimal point.


### PR DESCRIPTION
Fixes #3142 by increasing the decimal precision of simulation <flightdata>, <event>, and <datapoint> values to 6 digits after the decimal point. Do note that this increase the .ork file size. For example, 'A simple model rocket' with 15 simulations (duplicated the existing sims twice) went from 777 kB to 1.4 MB. Still very small compared to today's standards, but just something to note.