### PR TITLE
[#3183] Gate tumble detection on recordWarnings() to skip rod-exit tr…

### DIFF
--- a/core/src/main/java/info/openrocket/core/simulation/BasicEventSimulationEngine.java
+++ b/core/src/main/java/info/openrocket/core/simulation/BasicEventSimulationEngine.java
@@ -308,8 +308,14 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 						// If we're stable, put a warning about large AOA
 						// note -- if cp is NaN (which it is while on the rod) cg > cp is false
 						if (cg > cp) {
-							// Not stable, so transition to tumbling
-							currentStatus.addEvent(new FlightEvent(FlightEvent.Type.TUMBLE, currentStatus.getSimulationTime()));
+							// Not stable, so transition to tumbling.
+							// Gated on recordWarnings() so the brief, geometrically unavoidable
+							// high-AOA transient just after launch rod clearance (while weathercocking
+							// into the wind) does not trigger a spurious tumble -- and, under thrust,
+							// an unrecoverable TUMBLE_UNDER_THRUST abort. See issue #3183.
+							if (currentStatus.recordWarnings()) {
+								currentStatus.addEvent(new FlightEvent(FlightEvent.Type.TUMBLE, currentStatus.getSimulationTime()));
+							}
 						} else {
 							// Stable, so warning about AOA
 							if (currentStatus.recordWarnings()) {


### PR DESCRIPTION
Fixes #3183.

## What this does

`recordWarnings()` already suppresses the sibling `LargeAOA` warning during the
0.25 s window after launch rod clearance; this change gates the `TUMBLE` event
emission on the same check. A one-step, gust-driven high-AOA transient at rod
exit — geometrically unavoidable in any crosswind launch — no longer emits a
spurious `TUMBLE`, and therefore no longer produces an unrecoverable
`TUMBLE_UNDER_THRUST` abort while the motor is burning.

This follows the direction suggested in the issue discussion (reuse the existing
post-rod window rather than adding a persistence timer), keeping the handling of
aerodynamic events consistent with the existing warning logic.

## Validation

Repro rocket from the issue (3FNC cardboard/balsa, 1.9 cal margin, bundled
AeroTech E15, 1.0 m rod), 24 random seeds per wind speed, 10% turbulence:

| wind (m/s) | spurious aborts **before** | spurious aborts **after** | apogee of successful flights |
|---|---|---|---|
| 8  | 8%  | **0%** | ~591 m (unchanged) |
| 9  | 38% | **0%** | ~590 m (unchanged) |
| 10 | 75% | **0%** | ~590 m (unchanged) |
| 11 | 88% | **0%** | ~589 m (unchanged) |

Regression check — a genuinely unstable (finless) rocket must still be detected
as tumbling:

| wind (m/s) | tumble/abort detected, before | after |
|---|---|---|
| 2 | 100% | **100%** |
| 5 | 100% | **100%** |

So the spurious aborts are eliminated, the flights that already succeeded are
numerically unchanged, and genuine tumble detection is preserved. The existing
`core` test suite (63 tests) passes.

## A note on scope — a cleaner "surgical" variant worth considering

`recordWarnings()` returns `false` under three conditions: (a) still on the rod,
(b) within 0.25 s of rod clearance, and (c) during descent
(`Z velocity < 20% of max`). This fix relies on **(b)** to suppress the rod-exit
transient — and because the spurious abort always occurs *under thrust*, i.e.
during high-velocity ascent, condition (c) never affects the bug itself.

However, reusing the full `recordWarnings()` also brings condition **(c)** into
the tumble path. For rockets with a recovery device this is a non-issue — the
stall check is already skipped once recovery deploys. But for **no-parachute
tumble-recovery rockets**, condition (c) becomes active from apogee onward
(where `Z velocity ≈ 0 < 20% of max`), which would suppress the `TUMBLE`
transition exactly when such a rocket is meant to detect it on descent.

If preserving descent tumble detection for that class of rocket matters, a more
surgical gate that keys only on the post-rod time window (conditions a + b,
without c) would fix #3183 without touching descent behavior — at the cost of a
small dedicated helper rather than reusing `recordWarnings()` directly. I kept
this PR to the minimal, consistent change per the issue discussion, but I'm
happy to switch to the surgical variant if you'd prefer to protect that case.