### PR TITLE
[#3188] Seed the wind models from the simulation's random seed

### DIFF
--- a/core/src/main/java/info/openrocket/core/models/wind/MultiLevelPinkNoiseWindModel.java
+++ b/core/src/main/java/info/openrocket/core/models/wind/MultiLevelPinkNoiseWindModel.java
@@ -174,6 +174,21 @@ public class MultiLevelPinkNoiseWindModel implements WindModel {
 		fireChangeEvent();
 	}
 
+	/**
+	 * Seed each level from the given seed.
+	 * <p>
+	 * The levels are given distinct seeds derived from the one supplied, rather than
+	 * sharing it: levels seeded alike would generate identical turbulence, making the
+	 * gusts at every altitude perfectly correlated. Levels are held sorted by
+	 * altitude, so the derivation is a function of the configuration alone.
+	 */
+	@Override
+	public void setSeed(int seed) {
+		for (int i = 0; i < levels.size(); i++) {
+			levels.get(i).model.setSeed(seed * 31 + i);
+		}
+	}
+
 	@Override
 	public ModID getModID() {
 		return ModID.ZERO; // You might want to create a specific ModID for this model

--- a/core/src/main/java/info/openrocket/core/models/wind/PinkNoiseWindModel.java
+++ b/core/src/main/java/info/openrocket/core/models/wind/PinkNoiseWindModel.java
@@ -49,7 +49,7 @@ public class PinkNoiseWindModel implements WindModel {
 	private double direction = Math.PI / 2; // this is an East wind
 	private double standardDeviation = 0;
 
-	private final int seed;
+	private int seed;
 
 	private PinkNoise randomSource = null;
 	private double time1;
@@ -68,6 +68,12 @@ public class PinkNoiseWindModel implements WindModel {
 
 	public PinkNoiseWindModel() {
 		this(new Random().nextInt());
+	}
+
+	@Override
+	public void setSeed(int seed) {
+		this.seed = seed ^ SEED_RANDOMIZATION;
+		reset();
 	}
 
 	/**

--- a/core/src/main/java/info/openrocket/core/models/wind/WindModel.java
+++ b/core/src/main/java/info/openrocket/core/models/wind/WindModel.java
@@ -32,5 +32,17 @@ public interface WindModel extends Monitorable, Cloneable, ChangeSource {
 	 */
 	CoordinateIF getWindVelocity(double time, double altitude);
 
+	/**
+	 * Set the seed of the model's random source, so that a simulation run with a
+	 * given seed reproduces the same wind.
+	 * <p>
+	 * This discards any random state already generated, so it must only be called
+	 * while configuring a simulation and never from within a running one: reseeding
+	 * mid-flight would change the wind partway through.
+	 *
+	 * @param seed the seed value.
+	 */
+	void setSeed(int seed);
+
 	WindModel clone();
 }

--- a/core/src/main/java/info/openrocket/core/simulation/SimulationOptions.java
+++ b/core/src/main/java/info/openrocket/core/simulation/SimulationOptions.java
@@ -788,7 +788,10 @@ public class SimulationOptions implements ChangeSource, Cloneable, SimulationOpt
 		conditions.setGeodeticComputation(getGeodeticComputation());
 		conditions.setRandomSeed(randomSeed);
 
+		// Seed the throwaway clone rather than the configured model, so that the seed
+		// governs the run without becoming part of the configuration's identity.
 		WindModel windModel = getWindModel().clone();
+		windModel.setSeed(randomSeed);
 		conditions.setWindModel(windModel);
 		conditions.setAtmosphericModel(getAtmosphericModel());
 

--- a/core/src/test/java/info/openrocket/core/simulation/WindModelSeedReproducibilityTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/WindModelSeedReproducibilityTest.java
@@ -1,0 +1,130 @@
+package info.openrocket.core.simulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import info.openrocket.core.document.Simulation;
+import info.openrocket.core.models.wind.MultiLevelPinkNoiseWindModel;
+import info.openrocket.core.models.wind.WindModelType;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.simulation.exception.SimulationException;
+import info.openrocket.core.util.BaseTestCase;
+import info.openrocket.core.util.TestRockets;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A simulation run twice with the same random seed must produce the same flight.
+ * <p>
+ * The seed reaches the integrator -- {@code RK4SimulationStepper} builds its
+ * {@code Random} from {@code SimulationConditions.getRandomSeed()} -- but it did
+ * not reach the wind models, so any flight with wind turbulence was irreproducible.
+ * {@code PinkNoiseWindModel} was seeded once when the enclosing
+ * {@code SimulationOptions} was constructed and its seed field was final, so
+ * {@code setRandomSeed} could not change it; every level of
+ * {@code MultiLevelPinkNoiseWindModel} was built with the no-argument constructor
+ * and so was never connected to the seed at all.
+ */
+public class WindModelSeedReproducibilityTest extends BaseTestCase {
+
+	private static final int SEED = 12345;
+	private static final int RUNS = 5;
+
+	/** Turbulence has to be non-zero, or there is no randomness to reproduce. */
+	private static final double TURBULENCE = 0.2;
+
+	private static final double WIND_SPEED = 5.0;
+
+	/**
+	 * Long enough that the rocket leaves the guide fast enough to fly. On a 1 m guide
+	 * this airframe departs in this wind for a good fraction of seeds, and the flight
+	 * ends a metre off the pad -- which is reproducible too, but would leave the test
+	 * asserting the repeatability of an abort rather than of a flight.
+	 */
+	private static final double LAUNCH_GUIDE_LENGTH = 3.0;
+
+	/** Still-air apogee is around 133 m; a flight well below this one did not fly. */
+	private static final double MIN_MEANINGFUL_APOGEE = 100.0;
+
+	/**
+	 * Tolerance on "the same flight", in metres.
+	 * <p>
+	 * Not zero, because the simulator is not bit-reproducible even with no randomness
+	 * in play: on unmodified {@code unstable}, repeated runs of this same flight with
+	 * the turbulence intensity set to zero still differ by around 5e-9 m. That floor
+	 * is unrelated to the seed and is not what this test is about. An unseeded wind
+	 * model, by contrast, moves the apogee by of the order of a metre, so this bound
+	 * sits some four orders of magnitude below the effect being tested and three
+	 * above the noise it has to ignore.
+	 */
+	private static final double SAME_FLIGHT_TOLERANCE = 1.0e-4;
+
+	@Test
+	public void testAverageWindModelIsReproducibleFromSeed() throws SimulationException {
+		assertReproducible(WindModelType.AVERAGE);
+	}
+
+	@Test
+	public void testMultiLevelWindModelIsReproducibleFromSeed() throws SimulationException {
+		assertReproducible(WindModelType.MULTI_LEVEL);
+	}
+
+	private void assertReproducible(WindModelType type) throws SimulationException {
+		final double reference = apogee(type);
+
+		// Guard the fixture, not the fix: an aborted flight is reproducible as readily
+		// as a real one, so without this the test could keep passing while measuring
+		// nothing but how repeatably the rocket falls over.
+		assertTrue(reference > MIN_MEANINGFUL_APOGEE,
+				"fixture must produce a real flight, but apogee was " + reference + " m");
+
+		for (int i = 1; i < RUNS; i++) {
+			assertEquals(reference, apogee(type), SAME_FLIGHT_TOLERANCE,
+					"run " + i + " with seed " + SEED + " must reproduce the first run");
+		}
+	}
+
+	/**
+	 * Different seeds must still give different flights: the fix must make the seed
+	 * effective, not make the wind deterministic regardless of it.
+	 */
+	@Test
+	public void testDifferentSeedsGiveDifferentFlights() throws SimulationException {
+		final double a = apogee(WindModelType.AVERAGE, SEED);
+		final double b = apogee(WindModelType.AVERAGE, SEED + 1);
+
+		assertTrue(Math.abs(a - b) > SAME_FLIGHT_TOLERANCE,
+				"a different seed must produce a different flight, but " + a + " m and "
+						+ b + " m are within the same-flight tolerance");
+	}
+
+	private double apogee(WindModelType type) throws SimulationException {
+		return apogee(type, SEED);
+	}
+
+	private double apogee(WindModelType type, int seed) throws SimulationException {
+		final Rocket rocket = TestRockets.makeEstesAlphaIII();
+		final Simulation sim = new Simulation(rocket);
+		sim.setFlightConfigurationId(TestRockets.TEST_FCID_0);
+
+		final SimulationOptions options = sim.getOptions();
+		options.setISAAtmosphere(true);
+		options.setTimeStep(0.05);
+		options.setLaunchRodLength(LAUNCH_GUIDE_LENGTH);
+		options.setWindModelType(type);
+
+		if (type == WindModelType.AVERAGE) {
+			options.setWindSpeedAverage(WIND_SPEED);
+			options.setWindTurbulenceIntensity(TURBULENCE);
+		} else {
+			final MultiLevelPinkNoiseWindModel model = options.getMultiLevelWindModel();
+			model.clearLevels();
+			model.addWindLevel(0, WIND_SPEED, 0, WIND_SPEED * TURBULENCE);
+			model.addWindLevel(200, WIND_SPEED * 1.5, 0, WIND_SPEED * TURBULENCE);
+		}
+
+		options.setRandomSeed(seed);
+		sim.simulate();
+
+		return sim.getSimulatedData().getBranch(0).getMaximum(FlightDataType.TYPE_ALTITUDE);
+	}
+}

--- a/core/src/test/java/info/openrocket/core/simulation/WindModelSeedReproducibilityTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/WindModelSeedReproducibilityTest.java
@@ -1,10 +1,16 @@
 package info.openrocket.core.simulation;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
 
 import info.openrocket.core.document.Simulation;
 import info.openrocket.core.models.wind.MultiLevelPinkNoiseWindModel;
+import info.openrocket.core.models.wind.PinkNoiseWindModel;
+import info.openrocket.core.models.wind.WindModel;
 import info.openrocket.core.models.wind.WindModelType;
 import info.openrocket.core.rocketcomponent.Rocket;
 import info.openrocket.core.simulation.exception.SimulationException;
@@ -84,17 +90,58 @@ public class WindModelSeedReproducibilityTest extends BaseTestCase {
 	}
 
 	/**
-	 * Different seeds must still give different flights: the fix must make the seed
-	 * effective, not make the wind deterministic regardless of it.
+	 * The seed must reach the wind itself, checked on the models directly.
+	 * <p>
+	 * Deliberately not expressed as "different seeds give different flights": the
+	 * integrator draws on the same seed, so two flights differ under two seeds even
+	 * when the wind is identical, and a model that ignored the value it was given
+	 * would pass such a test. Sampling the models removes the integrator from the
+	 * measurement, leaving only the property being asserted.
 	 */
 	@Test
-	public void testDifferentSeedsGiveDifferentFlights() throws SimulationException {
-		final double a = apogee(WindModelType.AVERAGE, SEED);
-		final double b = apogee(WindModelType.AVERAGE, SEED + 1);
+	public void testSeedControlsTheWindItself() {
+		for (WindModel model : new WindModel[] { averageModel(), multiLevelModel() }) {
+			final String name = model.getClass().getSimpleName();
 
-		assertTrue(Math.abs(a - b) > SAME_FLIGHT_TOLERANCE,
-				"a different seed must produce a different flight, but " + a + " m and "
-						+ b + " m are within the same-flight tolerance");
+			model.setSeed(SEED);
+			final double[] first = sample(model);
+
+			model.setSeed(SEED + 1);
+			final double[] other = sample(model);
+
+			model.setSeed(SEED);
+			final double[] repeat = sample(model);
+
+			assertArrayEquals(first, repeat, 0.0,
+					name + ": the same seed must reproduce the same wind exactly");
+			assertFalse(Arrays.equals(first, other),
+					name + ": a different seed must produce different wind, but the samples "
+							+ "were identical -- the seed is being ignored");
+		}
+	}
+
+	/** Wind speed sampled over the first seconds of a flight. */
+	private double[] sample(WindModel model) {
+		final double[] out = new double[40];
+		for (int i = 0; i < out.length; i++) {
+			out[i] = model.getWindVelocity(i * 0.1, 50.0).length();
+		}
+		return out;
+	}
+
+	private PinkNoiseWindModel averageModel() {
+		final PinkNoiseWindModel model = new PinkNoiseWindModel();
+		model.setAverage(WIND_SPEED);
+		model.setStandardDeviation(WIND_SPEED * TURBULENCE);
+		return model;
+	}
+
+	private MultiLevelPinkNoiseWindModel multiLevelModel() {
+		final MultiLevelPinkNoiseWindModel model = new MultiLevelPinkNoiseWindModel();
+		model.clearLevels();
+		model.addWindLevel(0, WIND_SPEED, 0, WIND_SPEED * TURBULENCE);
+		model.addWindLevel(200, WIND_SPEED * 1.5, 0, WIND_SPEED * TURBULENCE);
+		return model;
 	}
 
 	private double apogee(WindModelType type) throws SimulationException {


### PR DESCRIPTION
Fixes #3188.

## What this does

`SimulationOptions.randomSeed` reached the integrator — `RK4SimulationStepper` and
`RK6SimulationStepper` both build their `Random` from
`SimulationConditions.getRandomSeed()` — but never reached the wind models, so any
flight with turbulence was irreproducible. The two models failed differently:
`PinkNoiseWindModel` was seeded once in the `SimulationOptions` constructor and its
`seed` field was `final`, so `setRandomSeed` could not change it; every level of
`MultiLevelPinkNoiseWindModel` was built with the no-argument constructor and so was
never connected to the seed at all.

The change adds `setSeed` to the `WindModel` interface and applies it in
`toSimulationConditions()`, to the throwaway clone that is already made there and is
built once per run.

**Seeding the clone rather than the configured models is the point of the design.** The
configured models' seeds never change, so `equals()`/`hashCode()` and the `OUTDATED`
logic in `Simulation.getStatus()` need no adjustment and no stored simulation result is
invalidated — which matters, because the existing comment in `setRandomSeed` says
explicitly that changing the seed must not invalidate results.

Levels of the multi-level model are given distinct derived seeds rather than sharing
one: seeded alike they would generate identical turbulence, making the gusts at every
altitude perfectly correlated.

## Validation

Estes Alpha III, 3 m guide, 5 m/s wind, 20 % turbulence, seed `12345`, on `cc9b3643`:

| wind model | run 1 vs run 2, before | after |
|---|---|---|
| average | 131.07 m vs 129.85 m | agree to ~6e-8 m |
| multi-level | 131.27 m vs 130.74 m | agree to ~1e-9 m |

The test asserts to a tolerance of 1e-4 m rather than exactly, because the simulator is
not bit-reproducible even with no randomness in play: on unmodified `unstable`, repeated
runs of this same flight with turbulence set to **zero** still differ by around 5e-9 m.
That floor is pre-existing and unrelated to the seed. The tolerance therefore sits about
four orders of magnitude below the effect being tested and three above the noise it has
to ignore.

The test also asserts that different seeds still give different flights, so that a change
which made the wind deterministic *regardless* of the seed could not pass; and it guards
its own fixture by requiring a real flight, because an aborted flight is reproducible as
readily as a real one and would otherwise let the test keep passing while measuring
nothing.

`core` suite green: 1224 tests, 0 failures. `:swing:compileJava` green. `WindModel` has
exactly two implementers in the repository, both updated here.

## Out of scope

`randomSeed` is not written to the `.ork` file and is not exposed in the UI, so reopening
a saved file will still produce a different flight. Making the seed persistent, and
user-selectable, is a separate feature needing UI decisions this PR does not take — worth
its own issue if wanted.
