### PR TITLE
[#3183] Detect tumbling from a sustained angle of attack, not an instant one

### DIFF
--- a/core/src/main/java/info/openrocket/core/logging/Warning.java
+++ b/core/src/main/java/info/openrocket/core/logging/Warning.java
@@ -50,7 +50,9 @@ public abstract class Warning extends Message {
 		 */
 		public LargeAOA(double aoa) {
 			this.aoa = aoa;
-			setPriority(MessagePriority.NORMAL);
+			// Informative: it reports that the aerodynamic model is out of its envelope,
+			// which is worth knowing on a windy day, not that the flight has gone wrong.
+			setPriority(MessagePriority.LOW);
 		}
 
 		public double getAOA() {

--- a/core/src/main/java/info/openrocket/core/simulation/BasicEventSimulationEngine.java
+++ b/core/src/main/java/info/openrocket/core/simulation/BasicEventSimulationEngine.java
@@ -291,31 +291,53 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 //					}
 //				}
 				
-				// Check for fin stall and either set tumbling or LargeAOA warning depending on
-				// rocket stability margin
+				// Check for tumbling, and otherwise for fin stall.
+				//
+				// Tumbling is decided from how long a high angle of attack has persisted,
+				// measured against the rocket's own pitch period, rather than from its value at
+				// a single step.  A gust cannot sustain it and a tumble cannot avoid it, so no
+				// flight-phase gating is needed in either direction: the launch guide departure
+				// transient does not survive the filter, and descent tumbling does.  Notably the
+				// CP/CG comparison is gone: the CP it consumed was produced by an aerodynamic
+				// model already outside its validity envelope at the angles where the test fired.
+				//
+				// A large instantaneous angle of attack still means the aerodynamic model is out
+				// of its envelope.  It is reported at low priority, since it says the crosswind
+				// is worth knowing about rather than that the flight has failed -- including
+				// while the rocket is departing, where it is the first sign of what follows.
+				//
+				// Not for a separated stage, though.  A spent booster left to fall reaches a
+				// large angle of attack every time, by design, so reporting it says only that
+				// the stage did what stages do.  A warning raised on every flight of every
+				// multi-stage rocket is one nobody reads.
+				//
 				// Inhibited if already tumbling, parachutes deployed, or on the ground
 				if (!currentStatus.isTumbling() &&
 					(currentStatus.getDeployedRecoveryDevices().size() == 0) &&
 					!currentStatus.isLanded()) {
-					final double cp = currentStatus.getFlightDataBranch().getLast(FlightDataType.TYPE_CP_LOCATION);
-					final double cg = currentStatus.getFlightDataBranch().getLast(FlightDataType.TYPE_CG_LOCATION);
-					final double aoa = currentStatus.getFlightDataBranch().getLast(FlightDataType.TYPE_AOA);
-					final double margin =
-						currentStatus.getSimulationConditions().getAerodynamicCalculator().getStallAngle() - aoa;
+					final FlightDataBranch branch = currentStatus.getFlightDataBranch();
+					final double aoa = branch.getLast(FlightDataType.TYPE_AOA);
+					final double stallAngle =
+						currentStatus.getSimulationConditions().getAerodynamicCalculator().getStallAngle();
+					// FlightConditions does not reach here, but its velocity is recoverable:
+					// the recorded Mach number is the air-relative speed over the speed of sound.
+					final double airSpeed = branch.getLast(FlightDataType.TYPE_MACH_NUMBER)
+							* branch.getLast(FlightDataType.TYPE_SPEED_OF_SOUND);
 
-					// large AOA -- stalling.					
-					if (margin < 0) {
-						// If we're stable, put a warning about large AOA
-						// note -- if cp is NaN (which it is while on the rod) cg > cp is false
-						if (cg > cp) {
-							// Not stable, so transition to tumbling
-							currentStatus.addEvent(new FlightEvent(FlightEvent.Type.TUMBLE, currentStatus.getSimulationTime()));
-						} else {
-							// Stable, so warning about AOA
-							if (currentStatus.recordWarnings()) {
-								currentStatus.addWarning(new Warning.LargeAOA(aoa));
-							}
-						}
+					final boolean tumbling = currentStatus.getTumbleDetector().update(
+							currentStatus.getSimulationTime(),
+							currentStatus.isLaunchRodCleared(),
+							aoa,
+							airSpeed,
+							branch.getLast(FlightDataType.TYPE_AIR_DENSITY),
+							branch.getLast(FlightDataType.TYPE_NATURAL_FREQUENCY));
+
+					if (tumbling) {
+						currentStatus.addEvent(new FlightEvent(FlightEvent.Type.TUMBLE, currentStatus.getSimulationTime()));
+					} else if (aoa > stallAngle
+						&& !currentStatus.isSeparatedStage()
+						&& currentStatus.recordWarnings()) {
+						currentStatus.addWarning(new Warning.LargeAOA(aoa));
 					}
 				}
 
@@ -535,6 +557,7 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 
 					// Create a new simulation branch for the booster
 					SimulationStatus boosterStatus = new SimulationStatus(currentStatus);
+					boosterStatus.setSeparatedStage(true);
 
 					// Prepare the new simulation branch
 					boosterStatus.setFlightDataBranch(new FlightDataBranch(boosterStage.getName(), boosterStage, currentStatus.getFlightDataBranch()));

--- a/core/src/main/java/info/openrocket/core/simulation/SimulationStatus.java
+++ b/core/src/main/java/info/openrocket/core/simulation/SimulationStatus.java
@@ -69,7 +69,13 @@ public class SimulationStatus implements Cloneable, Monitorable {
 
 	private double maxZVelocity = Double.NEGATIVE_INFINITY;
 	private double startWarningsTime = RK4SimulationStepper.RECOMMENDED_MAX_TIME;
-	
+
+	/** Kinematic tumble detector, carrying its filter state across steps. */
+	private TumbleDetector tumbleDetector = new TumbleDetector();
+
+	/** Whether this branch simulates a stage that has been separated and left behind. */
+	private boolean separatedStage = false;
+
 	private double effectiveLaunchRodLength;
 
 	// Set of all motors
@@ -205,7 +211,9 @@ public class SimulationStatus implements Cloneable, Monitorable {
 		this.landed = orig.landed;
 		this.maxZVelocity = orig.maxZVelocity;
 		this.startWarningsTime = orig.startWarningsTime;
-		
+		this.tumbleDetector = new TumbleDetector(orig.tumbleDetector);
+		this.separatedStage = orig.separatedStage;
+
 		this.configuration.copyStages(orig.configuration);
 
 		this.deployedRecoveryDevices.clear();
@@ -675,6 +683,32 @@ public class SimulationStatus implements Cloneable, Monitorable {
 		}
 	}
 	
+	/**
+	 * Get the tumble detector for this simulation branch.
+	 *
+	 * @return the tumble detector
+	 */
+	public TumbleDetector getTumbleDetector() {
+		return tumbleDetector;
+	}
+
+	/**
+	 * Whether this branch simulates a stage that has been separated and left behind,
+	 * rather than the rocket that flew on.
+	 *
+	 * @return true for a separated stage's own branch
+	 */
+	public boolean isSeparatedStage() {
+		return separatedStage;
+	}
+
+	/**
+	 * Mark this branch as simulating a separated stage.
+	 */
+	public void setSeparatedStage(boolean separatedStage) {
+		this.separatedStage = separatedStage;
+	}
+
 	/**
 	 * Determine whether (most) flight event warnings are currently being saved.
 	 * Warnings are not saved until 0.25 seconds after leaving the rail, and again

--- a/core/src/main/java/info/openrocket/core/simulation/TumbleDetector.java
+++ b/core/src/main/java/info/openrocket/core/simulation/TumbleDetector.java
@@ -1,0 +1,148 @@
+package info.openrocket.core.simulation;
+
+import info.openrocket.core.util.MathUtil;
+
+/**
+ * Decides whether the rocket is tumbling, from how long its angle of attack has
+ * persisted rather than from its instantaneous value.
+ * <p>
+ * The previous criterion combined an instantaneous angle of attack above the
+ * stall angle with a CP/CG stability comparison. Both halves are problematic.
+ * The angle of attack is measured against the apparent airflow, which includes
+ * the modelled wind, and a turbulence sample is a discontinuous function of
+ * time: the angle of attack can therefore step across the stall threshold in a
+ * single integration step without the rocket's state having changed. And the CP
+ * the stability test consumes is produced by an aerodynamic model that is
+ * outside its validity envelope above the stall angle -- that is, in exactly the
+ * regime where the test is evaluated -- so the test draws its conclusion from a
+ * quantity it has itself declared unreliable.
+ * <p>
+ * What distinguishes a tumbling rocket from a gust is not the size of the angle
+ * of attack at one instant but whether the rocket recovers. A statically stable
+ * rocket returns to alignment within about a pitch period; a tumbling rocket
+ * does not. This detector therefore low-pass filters the angle of attack with a
+ * time constant taken from the rocket's own pitch natural frequency, and
+ * declares tumbling only once the filtered value is sustained. No aerodynamic
+ * coefficient enters the decision, and no flight-phase gating is needed in
+ * either direction: the launch guide departure transient does not survive the
+ * filter, and descent tumbling does.
+ * <p>
+ * The angle is measured against the air-relative velocity rather than the
+ * ground-relative trajectory. A stable rocket aligns itself with the air, not
+ * with the ground, so in a crosswind its axis is offset from its ground track by
+ * atan(wind / airspeed) purely as a matter of geometry -- an offset that reaches
+ * tens of degrees at the low speeds just after launch guide departure, which is
+ * precisely where the detector must not fire.
+ */
+public class TumbleDetector {
+
+	/**
+	 * Filtered angle of attack above which the rocket is considered to be tumbling.
+	 * Normal flight sits below the stall angle, while a rocket whose axis is
+	 * uncorrelated with the airflow averages 90 degrees; the threshold sits in the
+	 * gap between the two populations rather than close to either.
+	 */
+	private static final double TUMBLE_THRESHOLD = 60 * Math.PI / 180;
+
+	/**
+	 * Dynamic pressure below which the airflow direction carries no usable
+	 * information. At sea level this corresponds to roughly 1.3 m/s.
+	 */
+	private static final double MIN_DYNAMIC_PRESSURE = 1.0;
+
+	/** Filter time constant, expressed in pitch natural periods. */
+	private static final double DWELL_PERIODS = 2.0;
+
+	private static final double MIN_TIME_CONSTANT = 0.05;
+	private static final double MAX_TIME_CONSTANT = 2.0;
+
+	private double filteredAOA = 0.0;
+	private double lastTime = Double.NaN;
+
+	public TumbleDetector() {
+	}
+
+	/**
+	 * Copy constructor, so that a branch created at stage separation inherits the
+	 * filter state accumulated by its parent.
+	 *
+	 * @param orig the detector to copy
+	 */
+	public TumbleDetector(TumbleDetector orig) {
+		this.filteredAOA = orig.filteredAOA;
+		this.lastTime = orig.lastTime;
+	}
+
+	/**
+	 * Advance the detector by one simulation step and report whether the rocket
+	 * should be considered to be tumbling.
+	 *
+	 * @param time             current simulation time, s
+	 * @param guideCleared     whether the rocket has left the launch guide, and so is
+	 *                         free to rotate at all
+	 * @param aoa              angle of attack, radians
+	 * @param airSpeed         speed relative to the air, m/s
+	 * @param airDensity       ambient air density, kg/m^3
+	 * @param naturalFrequency pitch natural frequency in rad/s, or NaN when the
+	 *                         rocket is statically unstable and so has no restoring
+	 *                         dynamics to wait out
+	 * @return true if the rocket is tumbling
+	 */
+	public boolean update(double time, boolean guideCleared, double aoa, double airSpeed,
+			double airDensity, double naturalFrequency) {
+		final double dt = Double.isNaN(lastTime) ? 0.0 : time - lastTime;
+		lastTime = time;
+
+		final double dynamicPressure = 0.5 * airDensity * airSpeed * airSpeed;
+
+		// Observability gate.  A rocket still on the launch guide is held on course and
+		// cannot tumble, yet a crosswind across a stationary rocket puts the angle of
+		// attack near 90 degrees, so the angle carries no information until the rocket
+		// is free.  Below the dynamic pressure floor the airflow direction is likewise
+		// meaningless.  Hold rather than reset, so that a spell of negligible airflow --
+		// passing through apogee, for instance -- does not discard evidence accumulated
+		// before it.
+		if (dt <= 0 || !guideCleared || Double.isNaN(aoa) || Double.isNaN(dynamicPressure)
+				|| dynamicPressure < MIN_DYNAMIC_PRESSURE) {
+			return isTumbling();
+		}
+
+		final double alpha = 1.0 - Math.exp(-dt / timeConstant(naturalFrequency));
+		filteredAOA += alpha * (aoa - filteredAOA);
+
+		return isTumbling();
+	}
+
+	/**
+	 * @return true if the filtered angle of attack currently exceeds the tumbling
+	 *         threshold
+	 */
+	public boolean isTumbling() {
+		return filteredAOA > TUMBLE_THRESHOLD;
+	}
+
+	/**
+	 * @return the current filtered angle of attack, in radians
+	 */
+	public double getFilteredAOA() {
+		return filteredAOA;
+	}
+
+	/**
+	 * Filter time constant, expressed in the rocket's own pitch periods so that the
+	 * detector waits proportionally longer for a slowly responding airframe than for
+	 * a stiff one.
+	 *
+	 * @param naturalFrequency pitch natural frequency in rad/s
+	 * @return the time constant to use, in seconds
+	 */
+	private static double timeConstant(double naturalFrequency) {
+		if (Double.isNaN(naturalFrequency) || naturalFrequency <= 0) {
+			// Statically unstable, or not yet computable: there is no restoring
+			// oscillation to wait out, so respond at the shortest sensible scale.
+			return MIN_TIME_CONSTANT;
+		}
+		return MathUtil.clamp(DWELL_PERIODS * 2 * Math.PI / naturalFrequency,
+				MIN_TIME_CONSTANT, MAX_TIME_CONSTANT);
+	}
+}

--- a/core/src/test/java/info/openrocket/core/simulation/DeterministicWind.java
+++ b/core/src/test/java/info/openrocket/core/simulation/DeterministicWind.java
@@ -1,0 +1,56 @@
+package info.openrocket.core.simulation;
+
+import info.openrocket.core.simulation.listeners.AbstractSimulationListener;
+import info.openrocket.core.util.Coordinate;
+import info.openrocket.core.util.CoordinateIF;
+
+/**
+ * Supplies a fully specified wind field, overriding the simulation's own wind
+ * model.
+ * <p>
+ * The bundled {@code PinkNoiseWindModel} is seeded from
+ * {@code SimulationOptions.randomSeed} as it stood when the options object was
+ * constructed, and {@code setRandomSeed} does not re-seed it. Turbulent runs are
+ * therefore not reproducible from the seed alone, which makes them unusable as
+ * test fixtures. Overriding {@code preWindModel} sidesteps that entirely: the
+ * gust is written down rather than sampled, so the scenario is identical on
+ * every run and on every machine.
+ */
+public class DeterministicWind extends AbstractSimulationListener {
+
+	private final double baseSpeed;
+	private final double gustSpeed;
+	private final double gustStart;
+	private final double gustEnd;
+
+	/**
+	 * @param baseSpeed steady crosswind, m/s, blowing along +X
+	 * @param gustSpeed additional crosswind during the gust, m/s
+	 * @param gustStart time at which the gust starts, s
+	 * @param gustEnd   time at which the gust ends, s
+	 */
+	public DeterministicWind(double baseSpeed, double gustSpeed, double gustStart, double gustEnd) {
+		this.baseSpeed = baseSpeed;
+		this.gustSpeed = gustSpeed;
+		this.gustStart = gustStart;
+		this.gustEnd = gustEnd;
+	}
+
+	/** A steady crosswind with no gust. */
+	public static DeterministicWind steady(double speed) {
+		return new DeterministicWind(speed, 0, 0, 0);
+	}
+
+	@Override
+	public CoordinateIF preWindModel(SimulationStatus status) {
+		final double time = status.getSimulationTime();
+		final boolean gusting = time >= gustStart && time < gustEnd;
+		return new Coordinate(baseSpeed + (gusting ? gustSpeed : 0), 0, 0);
+	}
+
+	@Override
+	public boolean isSystemListener() {
+		// Run as a system listener so that nested simulations keep the same wind.
+		return true;
+	}
+}

--- a/core/src/test/java/info/openrocket/core/simulation/FlightEventsTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/FlightEventsTest.java
@@ -125,6 +125,10 @@ public class FlightEventsTest extends BaseTestCase {
 		sim.getOptions().setISAAtmosphere(true);
 		sim.getOptions().setTimeStep(0.05);
 		sim.getOptions ().getAverageWindModel().setAverage(0.1);
+		// Tumbling is declared after a dwell rather than at a single step, which makes its
+		// time sensitive to the integrator's random perturbation.  Pin the seed so the event
+		// times asserted below are a property of the rocket rather than of the run.
+		sim.getOptions().setRandomSeed(1);
 		rocket.getSelectedConfiguration().setAllStages();
 		FlightConfigurationId fcid = rocket.getSelectedConfiguration().getFlightConfigurationID();
 		sim.setFlightConfigurationId(fcid);
@@ -135,6 +139,9 @@ public class FlightEventsTest extends BaseTestCase {
 		sustainerMount.setMotorConfig(motorConfig, fcid);
 
 		Warning warn = new Warning.HighSpeedDeployment(53.2, chute);
+
+		// LargeAOA does not compare its angle, so the value here is immaterial.
+		Warning largeAOA = new Warning.LargeAOA(0);
 
 		sim.simulate();
 
@@ -167,7 +174,9 @@ public class FlightEventsTest extends BaseTestCase {
 					new FlightEvent(FlightEvent.Type.BURNOUT, 2.0, boosterMount),
 					new FlightEvent(FlightEvent.Type.EJECTION_CHARGE, 2.0, booster),
 					new FlightEvent(FlightEvent.Type.STAGE_SEPARATION, 2.0, booster),
-					new FlightEvent(FlightEvent.Type.TUMBLE, 2.1, null),
+					// No large-AOA warning here: this branch is the separated booster, whose
+					// tumble is expected rather than worth reporting.
+					new FlightEvent(FlightEvent.Type.TUMBLE, 2.16, null),
 					new FlightEvent(FlightEvent.Type.APOGEE, 3.5, rocket),
 					new FlightEvent(FlightEvent.Type.GROUND_HIT, 1200, null),
 					new FlightEvent(FlightEvent.Type.SIMULATION_END, 1200, null)
@@ -193,6 +202,10 @@ public class FlightEventsTest extends BaseTestCase {
 		sim.getOptions().setISAAtmosphere(true);
 		sim.getOptions().setTimeStep(0.05);
 		sim.getOptions ().getAverageWindModel().setAverage(0.1);
+		// Tumbling is declared after a dwell rather than at a single step, which makes its
+		// time sensitive to the integrator's random perturbation.  Pin the seed so the event
+		// times asserted below are a property of the rocket rather than of the run.
+		sim.getOptions().setRandomSeed(1);
 		rocket.getSelectedConfiguration().setAllStages();
 		FlightConfigurationId fcid = rocket.getSelectedConfiguration().getFlightConfigurationID();
 		sim.setFlightConfigurationId(fcid);
@@ -217,7 +230,10 @@ public class FlightEventsTest extends BaseTestCase {
 		SimulationAbort simAbort = new SimulationAbort(SimulationAbort.Cause.TUMBLE_UNDER_THRUST);
 		
 		Warning warn = new Warning.HighSpeedDeployment(53.2, sideChutes);
-		
+
+		// LargeAOA does not compare its angle, so the value here is immaterial.
+		Warning largeAOA = new Warning.LargeAOA(0);
+
 		// events whose time is too variable to check are given a time of the max sim time
 		for (int b = 0; b < actualBranchCount; b++) {
 			FlightEvent[] expectedEvents = switch (b) {
@@ -235,6 +251,9 @@ public class FlightEventsTest extends BaseTestCase {
 						new FlightEvent(FlightEvent.Type.EJECTION_CHARGE, 2.11, centerBooster),
 						new FlightEvent(FlightEvent.Type.STAGE_SEPARATION, 2.11, centerBooster),
 						new FlightEvent(FlightEvent.Type.IGNITION, 2.11, sustainerBody),
+						// Tumbling is declared once a high angle of attack has persisted, so the
+						// angle is reported before the departure it is the onset of.
+						new FlightEvent(FlightEvent.Type.SIM_WARN, 2.37, null, largeAOA),
 						new FlightEvent(FlightEvent.Type.SIM_ABORT, RK4SimulationStepper.RECOMMENDED_MAX_TIME, null, simAbort)
 				};
 
@@ -282,7 +301,7 @@ public class FlightEventsTest extends BaseTestCase {
 	private void checkEvents(FlightEvent[] expectedEvents, Simulation sim, int branchNo) {
 
 		FlightEvent[] actualEvents = sim.getSimulatedData().getBranch(branchNo).getEvents().toArray(new FlightEvent[0]);
-			
+
 		// Test that all expected events are present, in the right order, at the right
 		// time, from the right sources
 		for (int i = 0; i < Math.min(expectedEvents.length, actualEvents.length); i++) {
@@ -311,6 +330,10 @@ public class FlightEventsTest extends BaseTestCase {
 				// event times that are dependent on simulation step time shouldn't be held to
 				// tighter bounds than that
 				double epsilon = (actual.getType() == FlightEvent.Type.TUMBLE) ||
+					// A large-AOA warning is raised on the first step past the stall angle, so
+					// it is as sensitive to step size and to the wind sample as a tumble is.
+					// Other warnings are tied to deterministic events and stay held to EPSILON.
+					(actualWarning instanceof Warning.LargeAOA) ||
 					(actual.getType() == FlightEvent.Type.APOGEE) ||
 					(actual.getType() == FlightEvent.Type.GROUND_HIT) ||
 					(actual.getType() == FlightEvent.Type.SIMULATION_END) ? (5 * sim.getOptions().getTimeStep())

--- a/core/src/test/java/info/openrocket/core/simulation/TumbleDetectorTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/TumbleDetectorTest.java
@@ -1,0 +1,260 @@
+package info.openrocket.core.simulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import info.openrocket.core.document.Simulation;
+import info.openrocket.core.logging.SimulationAbort;
+import info.openrocket.core.rocketcomponent.AxialStage;
+import info.openrocket.core.rocketcomponent.BodyTube;
+import info.openrocket.core.rocketcomponent.FinSet;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.rocketcomponent.RocketComponent;
+import info.openrocket.core.simulation.exception.SimulationException;
+import info.openrocket.core.util.BaseTestCase;
+import info.openrocket.core.util.TestRockets;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for kinematic tumble detection.
+ * <p>
+ * The unit tests drive {@link TumbleDetector} directly, so that the properties
+ * being asserted -- what the detector does at low speed, on descent, and under a
+ * transient excursion -- are exercised deterministically rather than inferred
+ * from a whole flight. The integration tests then confirm the behaviour that
+ * issue #3183 is about, on a real airframe in a real crosswind.
+ */
+public class TumbleDetectorTest extends BaseTestCase {
+
+	private static final double SEA_LEVEL_DENSITY = 1.225;
+
+	/** Representative pitch natural frequency for a small model rocket, rad/s. */
+	private static final double OMEGA_N = 10.0;
+
+	/** One pitch period at OMEGA_N, s. */
+	private static final double PITCH_PERIOD = 2 * Math.PI / OMEGA_N;
+
+	/**
+	 * Drive a detector for the given duration at a fixed angle of attack.
+	 *
+	 * @param detector  the detector to drive
+	 * @param aoaDeg    angle of attack to hold, degrees
+	 * @param airSpeed  air-relative speed, m/s
+	 * @param duration  how long to hold this state, s
+	 * @param startTime simulation time at which to start
+	 * @return the simulation time after the last step
+	 */
+	private double drive(TumbleDetector detector, double aoaDeg, double airSpeed,
+			double duration, double startTime) {
+		final double dt = 0.01;
+		double time = startTime;
+		for (int i = 0; i < Math.round(duration / dt); i++) {
+			time += dt;
+			detector.update(time, true, Math.toRadians(aoaDeg), airSpeed, SEA_LEVEL_DENSITY, OMEGA_N);
+		}
+		return time;
+	}
+
+	@Test
+	public void testAlignedFlightIsNotTumbling() {
+		final TumbleDetector detector = new TumbleDetector();
+		drive(detector, 5, 100.0, 5.0, 0.0);
+
+		assertFalse(detector.isTumbling(),
+				"a rocket flying along its own axis must never be reported as tumbling");
+	}
+
+	@Test
+	public void testSustainedHighAOAIsTumbling() {
+		final TumbleDetector detector = new TumbleDetector();
+		drive(detector, 120, 20.0, 5.0, 0.0);
+
+		assertTrue(detector.isTumbling(),
+				"a sustained high angle of attack must be reported as tumbling");
+	}
+
+	/**
+	 * The regression that issue #3183 is really about: a brief excursion must not
+	 * latch the detector. A statically stable rocket recovers from a gust-induced
+	 * excursion within a fraction of its pitch period.
+	 */
+	@Test
+	public void testBriefExcursionIsNotTumbling() {
+		final TumbleDetector detector = new TumbleDetector();
+
+		double time = drive(detector, 2, 60.0, 1.0, 0.0);
+		// The excursion lasts a tenth of a pitch period.
+		time = drive(detector, 150, 60.0, PITCH_PERIOD / 10, time);
+		drive(detector, 2, 60.0, 1.0, time);
+
+		assertFalse(detector.isTumbling(),
+				"a transient excursion shorter than a pitch period must not trigger tumbling");
+	}
+
+	/**
+	 * The measurement that motivates filtering rather than thresholding: a single
+	 * step above the stall angle, which a turbulence sample can produce on its own,
+	 * must not be enough.
+	 */
+	@Test
+	public void testSingleStepSpikeIsNotTumbling() {
+		final TumbleDetector detector = new TumbleDetector();
+
+		double time = drive(detector, 3, 20.0, 1.0, 0.0);
+		time = drive(detector, 179, 20.0, 0.01, time);
+
+		assertFalse(detector.isTumbling(),
+				"one integration step at a high angle of attack must not trigger tumbling");
+	}
+
+	/**
+	 * The case raised in review: tumbling must still be detected on the way down,
+	 * for rockets that recover by tumbling rather than under a parachute. The
+	 * detector must not be gated on flight phase.
+	 */
+	@Test
+	public void testDescentTumblingIsDetected() {
+		final TumbleDetector detector = new TumbleDetector();
+		// Descending at 15 m/s broadside to the airflow.
+		drive(detector, 95, 15.0, 5.0, 0.0);
+
+		assertTrue(detector.isTumbling(),
+				"descent tumbling must be detected; the criterion must not be gated on flight phase");
+	}
+
+	/**
+	 * Near apogee the velocity direction is ill-conditioned. The detector must hold
+	 * its state rather than accumulate noise, and must not reset what it learned
+	 * before apogee.
+	 */
+	@Test
+	public void testStateIsHeldWhileAirflowIsNegligible() {
+		final TumbleDetector detector = new TumbleDetector();
+		drive(detector, 120, 20.0, 5.0, 0.0);
+		assertTrue(detector.isTumbling(), "precondition: detector has latched onto tumbling");
+
+		final double before = detector.getFilteredAOA();
+		// Below the dynamic pressure gate: ~1.3 m/s at sea level.
+		drive(detector, 0, 0.5, 2.0, 5.0);
+
+		assertEquals(before, detector.getFilteredAOA(), 1e-12,
+				"filter state must be held, not updated, while the airflow direction is meaningless");
+		assertTrue(detector.isTumbling(),
+				"passing through apogee must not discard evidence accumulated before it");
+	}
+
+	@Test
+	public void testCopyPreservesFilterState() {
+		final TumbleDetector detector = new TumbleDetector();
+		drive(detector, 120, 20.0, 5.0, 0.0);
+
+		final TumbleDetector copy = new TumbleDetector(detector);
+
+		assertEquals(detector.getFilteredAOA(), copy.getFilteredAOA(), 1e-12,
+				"a branch created at stage separation must inherit its parent's filter state");
+		assertEquals(detector.isTumbling(), copy.isTumbling());
+	}
+
+	// ---------------------------------------------------------------- integration
+
+	/**
+	 * Issue #3183. A steady 6 m/s crosswind -- no gust, no turbulence, nothing
+	 * random anywhere in the scenario -- aborted every run under the previous
+	 * criterion. The wind is supplied by a listener rather than by the bundled pink
+	 * noise model, because that model is seeded when the options object is built and
+	 * {@code setRandomSeed} does not re-seed it, so turbulent runs are not
+	 * reproducible.
+	 */
+	@Test
+	public void testSteadyCrosswindDoesNotAbort() throws SimulationException {
+		final Simulation simulation = crosswindSimulation(TestRockets.makeEstesAlphaIII(), 6.0);
+		simulation.simulate(DeterministicWind.steady(6.0));
+
+		final FlightDataBranch branch = simulation.getSimulatedData().getBranch(0);
+		assertNotNull(branch);
+
+		for (FlightEvent event : branch.getEvents()) {
+			if (event.getType() == FlightEvent.Type.SIM_ABORT) {
+				final SimulationAbort abort = (SimulationAbort) event.getData();
+				assertFalse(abort.getCause() == SimulationAbort.Cause.TUMBLE_UNDER_THRUST,
+						"a stable rocket in a steady crosswind must not abort as tumbling under thrust");
+			}
+		}
+	}
+
+	/**
+	 * The recovered flights must be healthy ones, not aborts traded for nonsense
+	 * trajectories: the 6 m/s flight must reach an apogee close to the still-air one.
+	 */
+	@Test
+	public void testRecoveredFlightReachesExpectedApogee() throws SimulationException {
+		final Simulation calm = crosswindSimulation(TestRockets.makeEstesAlphaIII(), 0.0);
+		calm.simulate(DeterministicWind.steady(0.0));
+		final double calmApogee = calm.getSimulatedData().getBranch(0)
+				.getMaximum(FlightDataType.TYPE_ALTITUDE);
+
+		final Simulation windy = crosswindSimulation(TestRockets.makeEstesAlphaIII(), 6.0);
+		windy.simulate(DeterministicWind.steady(6.0));
+		final double windyApogee = windy.getSimulatedData().getBranch(0)
+				.getMaximum(FlightDataType.TYPE_ALTITUDE);
+
+		assertTrue(Math.abs(windyApogee - calmApogee) < 0.10 * calmApogee,
+				"recovered flight apogee " + windyApogee + " m should be close to the "
+						+ calmApogee + " m reached in still air");
+	}
+
+	/**
+	 * The complementary guarantee: removing the fins makes the rocket genuinely
+	 * unstable, and that must still be detected.
+	 */
+	@Test
+	public void testUnstableRocketIsStillDetected() throws SimulationException {
+		final Rocket rocket = TestRockets.makeEstesAlphaIII();
+		removeFins(rocket);
+
+		final Simulation simulation = crosswindSimulation(rocket, 2.0);
+		simulation.simulate(DeterministicWind.steady(2.0));
+
+		final FlightDataBranch branch = simulation.getSimulatedData().getBranch(0);
+		assertNotNull(branch);
+
+		boolean detected = false;
+		for (FlightEvent event : branch.getEvents()) {
+			if (event.getType() == FlightEvent.Type.TUMBLE) {
+				detected = true;
+			}
+			if (event.getType() == FlightEvent.Type.SIM_ABORT
+					&& ((SimulationAbort) event.getData()).getCause() == SimulationAbort.Cause.TUMBLE_UNDER_THRUST) {
+				detected = true;
+			}
+		}
+
+		assertTrue(detected, "a finless rocket must still be detected as tumbling");
+	}
+
+	private Simulation crosswindSimulation(Rocket rocket, double windSpeed) {
+		final Simulation simulation = new Simulation(rocket);
+		simulation.setFlightConfigurationId(TestRockets.TEST_FCID_0);
+		simulation.getOptions().setISAAtmosphere(true);
+		simulation.getOptions().setTimeStep(0.05);
+		simulation.getOptions().setLaunchRodLength(1.0);
+		simulation.getOptions().setWindSpeedAverage(windSpeed);
+		simulation.getOptions().setWindTurbulenceIntensity(0.0);
+		return simulation;
+	}
+
+	private void removeFins(RocketComponent component) {
+		final List<RocketComponent> children = List.copyOf(component.getChildren());
+		for (RocketComponent child : children) {
+			if (child instanceof FinSet) {
+				component.removeChild(child);
+			} else if (child instanceof BodyTube || child instanceof AxialStage) {
+				removeFins(child);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #3183. Replaces #3186, which took the approach you and I agreed to abandon.

## What this does

The previous criterion combined an instantaneous angle of attack above the stall angle
with a `cg > cp` stability comparison. Following your suggestion to wait for real
kinematic evidence, tumbling is now decided from how long a high angle of attack has
persisted, measured against the rocket's own pitch period.

Both halves of the old test were unsound, and the second is the one that mattered. The
angle of attack is measured against the apparent airflow, so a single integration step
can carry it across the threshold without the rocket's state having changed. And the CP
the stability comparison consumes is produced by an aerodynamic model that is outside its
validity envelope above the stall angle — that is, in exactly the regime where the test
is evaluated. It drew its conclusion from a quantity it had itself declared unreliable.

`TumbleDetector` low-pass filters the angle of attack with a time constant taken from
`TYPE_NATURAL_FREQUENCY`, so the wait scales with the airframe rather than being a
constant tuned to one rocket. No aerodynamic coefficient enters the decision, and no
flight-phase gating is needed in either direction: the guide departure transient does not
survive the filter, and descent tumbling does — which is the tumble-recovery case you
raised against #3186.

Since you asked, this measures the angle against the **air-relative** velocity, which is
what `TYPE_AOA` already is. So it is your original suggestion — orientation against the
velocity vector — with the dwell added.

## The warning

`Warning.LargeAOA` is now `MessagePriority.LOW`, which `ExampleFilesTest` already counts
as "informative". There is no `INFO` level in `MessagePriority`; if you would rather have
one added than reuse `LOW`, say so and I will.

It is now raised during a departure as well, since that is the first sign of what
follows — but **not for a separated stage**. A spent booster reaches a large angle of
attack every time, by design, so reporting it says only that the stage did what stages
do. It would appear on every flight of every multi-stage rocket, and a warning that
always appears is one nobody reads. That judgement is easy to reverse if you disagree:
it is one condition in `BasicEventSimulationEngine`.

The happy consequence is that no example baseline changes. `ExampleFilesTest` is
untouched by this PR.

## Validation

Estes Alpha III, 1 m guide, wind supplied by a listener rather than the pink noise model
and the integrator's seed pinned, so there is nothing random anywhere in the scenario and
every row below is reproducible exactly.

**Steady crosswind, no gust:**

| wind | before | after |
|---|---|---|
| 0 m/s | 133.1 m | 133.1 m |
| 2 m/s | 132.2 m | 132.2 m |
| 4 m/s | 130.7 m | 130.7 m |
| 6 m/s | **abort, 1.1 m** | **132.0 m** |
| 8 m/s | abort, 1.1 m | abort, 5.5 m |

The first three rows are numerically identical before and after: flights that already
worked are untouched. The 6 m/s row is issue #3183 — a steady crosswind, no gust and no
turbulence, aborting every time on `unstable`.

**A 0.1 s, +6 m/s gust swept across the whole guide-departure window, 12 positions:**

| steady wind | aborts before | aborts after |
|---|---|---|
| 0 m/s | 2/12 | **0/12** |
| 2 m/s | 3/12 | **0/12** |
| 4 m/s | 3/12 | 3/12 |
| 6 m/s | **12/12** | 4/12 |

**The rows where aborts remain are ones I checked individually, and they should stay.** A
1 m guide is short: this airframe leaves it at about 10 m/s, so a 6 m/s crosswind puts
the angle of attack at roughly `atan(6/10) ≈ 32°` at the moment of departure, past the
stall angle, with the fins unable to generate a restoring moment. Tracing one of them,
the angle climbs monotonically from 27° to 94° without recovering while `vz` falls under
thrust, and `TYPE_NATURAL_FREQUENCY` is `NaN` throughout — the simulator's own statement
that the rocket has no static stability. Those rockets really do flip over.

One honest note on the "after" column: at 2 m/s steady the worst surviving flight reaches
99.7 m rather than the usual ~130 m. It recovers and flies, but it loses altitude doing
it.

Regression check, from `TumbleDetectorTest`: removing the fins makes the airframe
genuinely unstable, and that is still detected.

## Tests

`core` suite green, 1231 tests. `:swing:compileJava` green.

`FlightEventsTest` now pins the simulation seed in the two multi-stage cases. Tumbling is
declared after a dwell rather than at a single step, which makes its time sensitive to
the integrator's random perturbation: the centre booster's tumble time ranged over 2.25 s
to 2.77 s across 100 runs, which is wider than the tolerance the test allows. Pinning the
seed collapses that to a single value, so the asserted times are a property of the rocket
rather than of the run. I preferred that to widening the tolerance until it passed.

Every assertion added here was checked by mutation — the separated-stage condition, when
removed, is caught by three tests.

## Note

This branch is based on `unstable`, not on #3189, so the two are independent. #3189 would
make the wind in these tests reproducible as well; here I sidestepped it with a listener.
