### PR TITLE
[#3175] Update license text: replace dead Slack link, drop unused Ant clause

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement by sending them a 
-private email, message on Slack, or any other communication method that you find 
+private email, message on Discord, or any other communication method that you find 
 suitable.
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Explain the new feature in detail:
 * Why is this new feature important
 
 ## Development
-Please read our [Developer's Guide](https://openrocket.readthedocs.io/en/latest/dev_guide/development_overview.html). If you still have questions about how to set up your environment, with which issues you should start etc., then don't be afraid to send us a message on [Slack](https://join.slack.com/t/openrocket/shared_invite/zt-dh0wtpc4-WmkSK1ysqAOqHa6eFN7zgA).
+Please read our [Developer's Guide](https://openrocket.readthedocs.io/en/latest/dev_guide/development_overview.html). If you still have questions about how to set up your environment, with which issues you should start etc., then don't be afraid to send us a message on [Discord](https://discord.gg/qD2G5v2FAw).
 
 Developing OpenRocket may be daunting at first, but if you keep Google, your IDE's search and debug features, and the other developers as close friends, then you will easily create your first pull request.
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.github.jengelman.gradle.plugins.shadow.transformers.ApacheNoticeResourceTransformer
 
 plugins {
     id 'com.gradleup.shadow' version '9.2.2'
@@ -207,8 +208,52 @@ tasks.named('check') {
 jar {
     archiveBaseName = 'OpenRocket'
 
+    // The license dialog links to this file inside the JAR
+    from(rootProject.file('LICENSE.TXT'))
+
     manifest {
         attributes(baseManifestAttributes)
+    }
+}
+
+// Collects the license and notice file of every bundled dependency into a directory of
+// its own. Dependencies that use the standard META-INF names all end up at the same path
+// in the shaded JAR, where the last file copied silently wins: 29 of the bundled JARs
+// ship a META-INF/LICENSE* and 18 a META-INF/NOTICE*, but only one file per name survives.
+def thirdPartyLicenseDir = layout.buildDirectory.dir('third-party-licenses')
+
+def collectThirdPartyLicenses = tasks.register('collectThirdPartyLicenses') {
+    group = 'build'
+    description = 'Collects the license and notice file of every bundled dependency.'
+
+    def runtimeClasspath = configurations.runtimeClasspath
+    inputs.files(runtimeClasspath).withPropertyName('runtimeClasspath')
+    outputs.dir(thirdPartyLicenseDir).withPropertyName('thirdPartyLicenseDir')
+
+    doLast {
+        def target = thirdPartyLicenseDir.get().asFile
+        delete(target)
+
+        runtimeClasspath.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+            def module = artifact.moduleVersion.id
+            copy {
+                from(zipTree(artifact.file)) {
+                    include 'META-INF/LICENSE*'
+                    include 'META-INF/NOTICE*'
+                    // Flatten, so the files do not land in a nested META-INF directory
+                    eachFile { details -> details.path = details.name }
+                    includeEmptyDirs = false
+                }
+                into new File(target, "${module.group}.${module.name}")
+            }
+        }
+
+        // Drop the directories of the dependencies that ship no license file at all
+        target.listFiles()?.each { file ->
+            if (file.directory && file.list().length == 0) {
+                file.delete()
+            }
+        }
     }
 }
 
@@ -219,11 +264,39 @@ dependencies {
 }
 
 tasks.named('shadowJar', ShadowJar) {
-    dependsOn(':core:processResources')
+    dependsOn(':core:processResources', collectThirdPartyLicenses)
     archiveBaseName = 'OpenRocket'
     archiveVersion = '' + version
     archiveClassifier = ''
     dependsOn(distTar, distZip)
+
+    // The license dialog links to this file inside the JAR
+    from(rootProject.file('LICENSE.TXT'))
+
+    // Keep the license text of every dependency, not just the last one copied
+    from(thirdPartyLicenseDir) {
+        into 'META-INF/third-party-licenses'
+    }
+
+    // Concatenate the NOTICE files, as section 4d of the Apache License 2.0 requires,
+    // instead of letting one dependency's notice overwrite all of the others
+    transform(ApacheNoticeResourceTransformer) {
+        projectName = 'OpenRocket'
+    }
+
+    // Concatenate the service files as well, so no service provider is lost: both
+    // graal-js and its regex language register a Truffle language provider.
+    mergeServiceFiles()
+
+    // The task drops duplicate paths before the transformers above ever see them, which
+    // would leave only one of the ~18 notices and one of the two Truffle providers. Let
+    // the files that get merged through in full, while classes keep the default strategy:
+    // both a modular and a non-modular JNA are on the class path, and copying duplicate
+    // class entries into the JAR is exactly what the default strategy is there to avoid.
+    filesMatching(['META-INF/NOTICE', 'META-INF/NOTICE.txt', 'META-INF/NOTICE.md',
+                   'META-INF/services/*']) {
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
 
     manifest {
         attributes(baseManifestAttributes)

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/LicenseDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/LicenseDialog.java
@@ -84,7 +84,7 @@ public class LicenseDialog extends JDialog {
 			"<br>" +
 			"Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this work except in compliance with the License. " +
 			"You may view the License " +
-			"<a href=\"" + jarUrl + "!/datafiles/presets/LICENSE\">here</a>.<br>" +
+			"<a href=\"" + jarUrl + "!/datafiles/components/database/LICENSE\">here</a>.<br>" +
 			"You may also obtain a copy of the License at " +
 			"<a href=\"https://www.apache.org/licenses/LICENSE-2.0\">https://www.apache.org/licenses/LICENSE-2.0</a><br>" +
 			"<br>";

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/LicenseDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/LicenseDialog.java
@@ -63,12 +63,12 @@ public class LicenseDialog extends JDialog {
 			"without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. " +
 			"See the GNU General Public License for more details.<br>" + 
 			"<br>" +
-			"You should have received a copy of the GNU Public License along with this program.  If not, you may obtain a copy at " +
+			"You should have received a copy of the GNU General Public License along with this program.  If not, you may obtain a copy at " +
 			"<a href=\"https://www.gnu.org/licenses/gpl-3.0.html\">https://www.gnu.org/licenses/gpl-3.0.html</a><br>" + 
 			"<br>" + 
 			"OpenRocket developers may be contacted electronically at:<br>" + 
 			"<a href=\"mailto:openrocket-devel@lists.sourceforge.net\">mailto:openrocket-devel@lists.sourceforge.net</a><br>" +
-			"<a href=\"https://openrocket.slack.com\">https://openrocket.slack.com</a><br>" +
+			"<a href=\"https://discord.gg/qD2G5v2FAw\">https://discord.gg/qD2G5v2FAw</a><br>" +
 			"<a href=\"https://github.com/openrocket\">https://github.com/openrocket</a><br>" +
 			"<br>";
 		
@@ -85,20 +85,8 @@ public class LicenseDialog extends JDialog {
 			"Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this work except in compliance with the License. " +
 			"You may view the License " +
 			"<a href=\"" + jarUrl + "!/datafiles/presets/LICENSE\">here</a>.<br>" +
-			"You may also obtain a copy of the License at " + 
-			"<a href=\"http://www.apache.org/licenses/LICENSE-2.0\">http://www.apache.org/licenses/LICENSE-2.0</a><br>" +
-			"<br>" +
-			"OpenRocket uses the Work or Derivative Works of Ant, a product which includes software developed by the Apache " +
-			"Software Foundation<br>" +
-			"<br>" +
-			"Ant also includes software developed by:" +
-			"<ul style=\"margin-top: 0;\">" +
-			"<li>the W3C Consortium (<a href=\"http://www.w3c.org\">http://www.w3c.org</a>)</li>" +
-			"<li>the SAX project (<a href=\"http://www.saxproject.org\">http://www.saxproject.org</a></li>" +
-			"</ul>" +
-			"The names \"Ant\" and \"Apache Software Foundation\" must not be used to endorse or " +
-			"promote products derived from this software without prior written permission.  For written permission, "+
-			"please contact <a href=\"mailto:apache@apache.org\">apache@apache.org</a>.<br>" +
+			"You may also obtain a copy of the License at " +
+			"<a href=\"https://www.apache.org/licenses/LICENSE-2.0\">https://www.apache.org/licenses/LICENSE-2.0</a><br>" +
 			"<br>";
 
 		/*****************************************************************************************************************************/
@@ -112,7 +100,7 @@ public class LicenseDialog extends JDialog {
 			"Bitstream Vera is a trademark of Bitstream, Inc.<br>" +
 			"DejaVu changes are in the public domain<br>" +
 			"Glyphs imported from Arev Fonts Copyright " + Chars.COPY + " 2006 by Tavmjong Bah. All Rights Reserved.<br>" +
-			"Project page: <a href=\"https://github.com/dejavu-fonts/dejavu-fonts/\">https://github.com/dejavu-fonts/dejavu-fonts/<a/><br>" +
+			"Project page: <a href=\"https://github.com/dejavu-fonts/dejavu-fonts/\">https://github.com/dejavu-fonts/dejavu-fonts/</a><br>" +
 			"<br>" +
 			"Licensed according to the Bitstream Vera Font License which may be found " +
 			"<a href=\"" + jarUrl + "!/dejavu-font/LICENSE\">here</a>." +
@@ -129,7 +117,7 @@ public class LicenseDialog extends JDialog {
 		    "<br>" +
 			"OpenRocket makes use of the Commonmark-Java Library<br>" +
 			"Copyright " + Chars.COPY + " 2015-2016 Atlassian Pty Ltd. All rights reserved.<br>" +
-			"Project page: <a href=\"https://github.com/commonmark/commonmark-java/\">https://github.com/commonmark/commonmark-java/<a/><br>" +
+			"Project page: <a href=\"https://github.com/commonmark/commonmark-java/\">https://github.com/commonmark/commonmark-java/</a><br>" +
 			"<br>" +
 			"You may obtain a copy of the License at <a href=\"https://github.com/commonmark/commonmark-java/blob/main/LICENSE.txt\">https://github.com/commonmark/commonmark-java/blob/main/LICENSE.txt</a>." +
 			"<br>";


### PR DESCRIPTION
Fixes #3175. Bitstream Vera / DejaVu are still in use. The copyright year is already correctly defined in `build.properties`and interpolated at runtime. The 2025 is probably from an old build version.

The licensing was not properly included in the `shadowJar` build, and thus the final OpenRocket JAR. This should be resolved now.