### PR TITLE
Fix calculation edge cases

### DIFF
--- a/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanStabilityCalculator.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanStabilityCalculator.java
@@ -135,8 +135,9 @@ public class BarrowmanStabilityCalculator implements StabilityCalculator {
 		SymmetricComponent prevComp = null;
 		if ((component instanceof ComponentAssembly) &&
 				(!(component instanceof Rocket)) &&
-				(component.getChildCount() > 0)) {
-			prevComp = ((SymmetricComponent) (component.getChild(0))).getPreviousSymmetricComponent();
+				(component.getChildCount() > 0) &&
+				(component.getChild(0) instanceof SymmetricComponent firstChild)) {
+			prevComp = firstChild.getPreviousSymmetricComponent();
 		}
 
 		while (queue.peek() != null) {

--- a/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/FinSetCalc.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/FinSetCalc.java
@@ -220,7 +220,9 @@ public class FinSetCalc extends RocketComponentCalc {
 	 * Pre-calculates the fin geometry values.
 	 */
 	protected void calculateFinGeometry(FinSet component) {
-		
+
+		geometryWarnings.clear();
+
 		span = component.getSpan();
 		finArea = component.getPlanformArea();
 		if (finArea < MathUtil.EPSILON) {
@@ -229,11 +231,10 @@ public class FinSetCalc extends RocketComponentCalc {
 		} else {
 			ar = 2 * pow2(span) / finArea;
 		}
-		
+
 		// Check geometry; don't consider points along fin root for this
 		// (doing so will cause spurious jagged fin warnings)
 		CoordinateIF[] points = component.getFinPoints();
-		geometryWarnings.clear();
 		boolean down = false;
 		for (int i = 1; i < points.length; i++) {
 			if ((points[i].getY() > points[i - 1].getY() + 0.001) && down) {

--- a/core/src/main/java/info/openrocket/core/simulation/customexpression/RangeExpression.java
+++ b/core/src/main/java/info/openrocket/core/simulation/customexpression/RangeExpression.java
@@ -84,6 +84,9 @@ public class RangeExpression extends CustomExpression {
 
 		List<Double> data = dataBranch.getClone(type);
 		List<Double> time = dataBranch.getClone(FlightDataType.TYPE_TIME);
+		if (data == null || time == null || time.isEmpty()) {
+			return new Variable("Unknown");
+		}
 		LinearInterpolator interp = new LinearInterpolator(time, data);
 
 		// Evaluate the expression to get the start and end of the range
@@ -97,6 +100,14 @@ public class RangeExpression extends CustomExpression {
 		} catch (java.util.EmptyStackException e) {
 			log.info(Markers.USER_MARKER, "Unable to calculate time index for range expression " + getSymbol()
 					+ " due to empty stack exception");
+			return new Variable("Unknown");
+		}
+
+		// A range that runs backwards selects no data at all.  Reporting it as unknown
+		// keeps it out of any aggregate built on top of this expression.
+		if (startTime > endTime) {
+			log.info(Markers.USER_MARKER, "Range expression " + getSymbol() + " starts at " + startTime
+					+ ", after its end at " + endTime);
 			return new Variable("Unknown");
 		}
 

--- a/core/src/main/java/info/openrocket/core/util/ArrayUtils.java
+++ b/core/src/main/java/info/openrocket/core/util/ArrayUtils.java
@@ -7,10 +7,21 @@ public class ArrayUtils {
 	/**
 	 * Returns a double array with values from start to end with given step.
 	 * Starts exactly at start and stops at the multiple of step <= stop.
+	 * An empty array is returned if the step is not positive, if either bound is
+	 * NaN, or if stop is before start.
 	 */
 	public static double[] range(double start, double stop, double step) {
 
-		int size = (int) Math.floor(((stop - start) / step)) + 1;
+		if (!(step > 0) || Double.isNaN(start) || Double.isNaN(stop)) {
+			return new double[0];
+		}
+
+		double count = Math.floor((stop - start) / step) + 1;
+		if (!(count > 0)) {
+			return new double[0];
+		}
+
+		int size = (int) count;
 
 		// System.out.println("Range from "+start+" to "+stop+" step "+step+" has length
 		// "+size);
@@ -28,24 +39,32 @@ public class ArrayUtils {
 	}
 
 	/**
-	 * Return the mean of an array
+	 * Return the mean of an array, ignoring any NaN values.
+	 * Returns NaN if the array contains no usable values.
 	 */
 	public static double mean(double[] vals) {
 		double subtotal = 0;
+		int count = 0;
 		for (double val : vals) {
 			if (!Double.isNaN(val)) {
 				subtotal += val;
+				count++;
 			}
 		}
-		subtotal = subtotal / vals.length;
-		return subtotal;
+		if (count == 0) {
+			return Double.NaN;
+		}
+		return subtotal / count;
 	}
 
 	/**
-	 * Returns the maximum value in the array.
+	 * Returns the maximum value in the array, or NaN if the array is empty.
 	 */
 
 	public static double max(double[] vals) {
+		if (vals.length == 0) {
+			return Double.NaN;
+		}
 		double m = vals[0];
 		for (int i = 1; i < vals.length; i++)
 			m = Math.max(m, vals[i]);
@@ -53,10 +72,13 @@ public class ArrayUtils {
 	}
 
 	/**
-	 * Returns the minimum value in the array.
+	 * Returns the minimum value in the array, or NaN if the array is empty.
 	 */
 
 	public static double min(double[] vals) {
+		if (vals.length == 0) {
+			return Double.NaN;
+		}
 		double m = vals[0];
 		for (int i = 1; i < vals.length; i++)
 			m = Math.min(m, vals[i]);
@@ -64,19 +86,25 @@ public class ArrayUtils {
 	}
 
 	/**
-	 * Returns the variance of the array of doubles
+	 * Returns the variance of the array of doubles, ignoring any NaN values.
+	 * Returns NaN if the array contains no usable values.
 	 */
 	public static double variance(double[] vals) {
 		double mu = mean(vals);
 		double sumsq = 0.0;
 		double temp = 0;
+		int count = 0;
 		for (double val : vals) {
 			if (!Double.isNaN(val)) {
 				temp = (mu - val);
 				sumsq += temp * temp;
+				count++;
 			}
 		}
-		return sumsq / (vals.length);
+		if (count == 0) {
+			return Double.NaN;
+		}
+		return sumsq / count;
 	}
 
 	/**

--- a/core/src/main/java/info/openrocket/core/util/ArrayUtils.java
+++ b/core/src/main/java/info/openrocket/core/util/ArrayUtils.java
@@ -129,21 +129,19 @@ public class ArrayUtils {
 	 * zero
 	 */
 	public static double trapz(double[] y, double dt) {
-		double stop = (y.length - 1) * dt;
-
 		if (y.length <= 1 || dt <= 0)
 			return 0;
 
-		double[] x = range(0, stop, dt);
-
+		// The samples are evenly spaced, so the width of every interval is dt.  Building
+		// the matching x array first only risked it coming out a point short of y.
 		double sum = 0.0;
-		for (int i = 1; i < x.length; i++) {
-			double temp = (x[i] - x[i - 1]) * (y[i] + y[i - 1]);
+		for (int i = 1; i < y.length; i++) {
+			double temp = y[i] + y[i - 1];
 			if (!Double.isNaN(temp)) {
 				sum += temp;
 			}
 		}
-		return sum * 0.5;
+		return sum * 0.5 * dt;
 	}
 
 	/**

--- a/core/src/main/java/info/openrocket/core/util/GeodeticComputationStrategy.java
+++ b/core/src/main/java/info/openrocket/core/util/GeodeticComputationStrategy.java
@@ -2,6 +2,9 @@ package info.openrocket.core.util;
 
 import java.util.Locale;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import info.openrocket.core.l10n.Translator;
 import info.openrocket.core.startup.Application;
 
@@ -138,9 +141,20 @@ public enum GeodeticComputationStrategy {
 		}
 	};
 
+	private static final Logger log = LoggerFactory.getLogger(GeodeticComputationStrategy.class);
+
 	private static final Translator trans = Application.getTranslator();
 
 	private static final double PRECISION_LIMIT = 0.5e-13;
+
+	/**
+	 * Maximum number of iterations of the Vincenty direct solution. The direct
+	 * solution converges in a handful of iterations and has no known non-convergent
+	 * case; it is the inverse solution that struggles near antipodal points. This
+	 * bound is only here because nothing else stops the loop, so that degenerate
+	 * input cannot hang the simulation thread.
+	 */
+	private static final int MAX_ITERATIONS = 100;
 
 	/**
 	 * Return the name of this geodetic computation method.
@@ -255,6 +269,7 @@ public enum GeodeticComputationStrategy {
 		double y = tu;
 
 		double sy, cy, cz, e;
+		int iterations = 0;
 		do {
 			sy = Math.sin(y);
 			cy = Math.cos(y);
@@ -266,7 +281,13 @@ public enum GeodeticComputationStrategy {
 			y = e + e - 1.0;
 			y = (((sy * sy * 4.0 - 3.0) * y * cz * d / 6.0 + x) *
 					d / 4.0 - cz) * sy * d + tu;
-		} while (Math.abs(y - c) > PRECISION_LIMIT);
+			iterations++;
+		} while ((Math.abs(y - c) > PRECISION_LIMIT) && (iterations < MAX_ITERATIONS));
+
+		if (iterations >= MAX_ITERATIONS) {
+			log.warn("Vincenty direct solution did not converge after " + iterations +
+					" iterations, using last value; dist=" + dist + " azimuth=" + azimuth);
+		}
 
 		baz = cu * cy * cf - su * sy;
 		c = r * Math.sqrt(sa * sa + baz * baz);

--- a/core/src/main/java/info/openrocket/core/util/LinearInterpolator.java
+++ b/core/src/main/java/info/openrocket/core/util/LinearInterpolator.java
@@ -71,7 +71,7 @@ public class LinearInterpolator implements Cloneable {
 					" y=" + y.size());
 		}
 		for (int i = 0; i < x.size(); i++) {
-			sortMap.put((Double) x.toArray()[i], (Double) y.toArray()[i]);
+			sortMap.put(x.get(i), y.get(i));
 		}
 	}
 

--- a/core/src/main/java/info/openrocket/core/util/Quaternion.java
+++ b/core/src/main/java/info/openrocket/core/util/Quaternion.java
@@ -103,8 +103,8 @@ public class Quaternion implements Cloneable {
 	 */
 	public static Quaternion rotation(CoordinateIF axis, double angle) {
 		CoordinateIF a = axis.normalize();
-		double sin = Math.sin(angle);
-		double cos = Math.cos(angle);
+		double sin = Math.sin(angle / 2);
+		double cos = Math.cos(angle / 2);
 		return new Quaternion(cos, sin * a.getX(), sin * a.getY(), sin * a.getZ());
 	}
 

--- a/core/src/test/java/info/openrocket/core/aerodynamics/FinSetCalcTest.java
+++ b/core/src/test/java/info/openrocket/core/aerodynamics/FinSetCalcTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import info.openrocket.core.logging.Warning;
 import info.openrocket.core.logging.WarningSet;
 import info.openrocket.core.rocketcomponent.FinSet;
 import info.openrocket.core.rocketcomponent.RocketComponent;
@@ -126,6 +127,15 @@ public class FinSetCalcTest {
 		fins.setHeight(0.0);
 
 		assertEquals(0.0, fins.getPlanformArea(), EPSILON, "Zero-area fin should have zero planform area");
+
+		// The user should be told about it
+		WarningSet warnings = new WarningSet();
+		new FinSetCalc(fins).calculateNonaxialForces(
+				new FlightConditions(rocket.getSelectedConfiguration()),
+				Transformation.IDENTITY, new AerodynamicForces(), warnings);
+		assertTrue(warnings.stream().anyMatch(w -> w.getMessageDescription()
+						.equals(Warning.ZERO_AREA_FIN.getMessageDescription())),
+				"Zero-area fin should raise a warning");
 
 		// Calculate forces
 		AerodynamicForces forces = sumFins(fins, rocket);

--- a/core/src/test/java/info/openrocket/core/simulation/customexpression/RangeExpressionTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/customexpression/RangeExpressionTest.java
@@ -1,0 +1,66 @@
+package info.openrocket.core.simulation.customexpression;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import info.openrocket.core.document.OpenRocketDocument;
+import info.openrocket.core.document.OpenRocketDocumentFactory;
+import info.openrocket.core.document.Simulation;
+import info.openrocket.core.rocketcomponent.FlightConfiguration;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.simulation.FlightDataBranch;
+import info.openrocket.core.simulation.FlightDataType;
+import info.openrocket.core.simulation.SimulationConditions;
+import info.openrocket.core.simulation.SimulationStatus;
+import info.openrocket.core.util.BaseTestCase;
+import info.openrocket.core.util.TestRockets;
+
+import de.congrace.exp4j.Variable;
+
+import org.junit.jupiter.api.Test;
+
+public class RangeExpressionTest extends BaseTestCase {
+
+	/**
+	 * Build a status carrying a short stretch of flight data, enough for a range
+	 * expression to be evaluated against.
+	 */
+	private SimulationStatus statusWithTimeData() {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		FlightConfiguration config = rocket.getFlightConfigurationByIndex(0, false);
+
+		Simulation simulation = new Simulation(OpenRocketDocumentFactory.createDocumentFromRocket(rocket), rocket);
+		simulation.getOptions().setTimeStep(0.05);
+
+		SimulationConditions conditions = new SimulationConditions();
+		conditions.setSimulation(simulation);
+
+		SimulationStatus status = new SimulationStatus(config, conditions);
+
+		FlightDataBranch branch = new FlightDataBranch("test", FlightDataType.TYPE_TIME);
+		for (int i = 0; i <= 20; i++) {
+			branch.addPoint();
+			branch.setValue(FlightDataType.TYPE_TIME, i * 0.05);
+			branch.setValue(FlightDataType.TYPE_ALTITUDE, i);
+		}
+		status.setFlightDataBranch(branch);
+
+		return status;
+	}
+
+	@Test
+	public void reversedRangeIsUnknown() {
+		OpenRocketDocument doc = OpenRocketDocumentFactory.createNewRocket();
+		SimulationStatus status = statusWithTimeData();
+
+		// Start after the end: this selects no data, so it must not quietly come back
+		// as the single sample at the end of the range
+		RangeExpression reversed = new RangeExpression(doc, "0.8", "0.4", "h");
+		Variable result = reversed.evaluate(status);
+		assertEquals("Unknown", result.getName());
+
+		// A range the right way round still resolves
+		RangeExpression forward = new RangeExpression(doc, "0.4", "0.8", "h");
+		assertTrue(forward.evaluate(status).getArrayValue().length > 1);
+	}
+}

--- a/core/src/test/java/info/openrocket/core/util/ArrayUtilsTest.java
+++ b/core/src/test/java/info/openrocket/core/util/ArrayUtilsTest.java
@@ -216,6 +216,35 @@ public class ArrayUtilsTest {
 	}
 
 	@Test
+	public void testRangeWithDegenerateInputsReturnsEmpty() {
+		// stop before start would previously compute a negative array size
+		assertEquals(0, ArrayUtils.range(5.0, 0.0, 0.05).length);
+		assertEquals(0, ArrayUtils.range(1.0e9, 5.0, 0.05).length);
+		assertEquals(0, ArrayUtils.range(0.0, 10.0, 0.0).length);
+		assertEquals(0, ArrayUtils.range(0.0, 10.0, -1.0).length);
+		assertEquals(0, ArrayUtils.range(Double.NaN, 10.0, 1.0).length);
+		assertEquals(0, ArrayUtils.range(0.0, Double.NaN, 1.0).length);
+	}
+
+	@Test
+	public void testStatisticsIgnoreNaNValues() {
+		double[] values = new double[] { 1.0, Double.NaN, 3.0 };
+
+		assertEquals(2.0, ArrayUtils.mean(values), 1.0e-12);
+		assertEquals(1.0, ArrayUtils.variance(values), 1.0e-12);
+	}
+
+	@Test
+	public void testStatisticsOfEmptyArray() {
+		double[] empty = new double[0];
+
+		assertTrue(Double.isNaN(ArrayUtils.mean(empty)));
+		assertTrue(Double.isNaN(ArrayUtils.max(empty)));
+		assertTrue(Double.isNaN(ArrayUtils.min(empty)));
+		assertTrue(Double.isNaN(ArrayUtils.variance(empty)));
+	}
+
+	@Test
 	public void testRangeProducesMonotonicSequence() {
 		double[] ary = ArrayUtils.range(-1.0, 1.0, 0.25);
 		for (int i = 1; i < ary.length; i++) {

--- a/core/src/test/java/info/openrocket/core/util/QuaternionTest.java
+++ b/core/src/test/java/info/openrocket/core/util/QuaternionTest.java
@@ -44,6 +44,24 @@ public class QuaternionTest {
 	}
 
 	@Test
+	public void rotationAboutAxisMatchesRotationVector() {
+		// A quarter turn about z takes the x axis onto the y axis
+		Quaternion q = Quaternion.rotation(Coordinate.Z_UNIT, Math.PI / 2);
+		CoordinateIF c = q.rotate(Coordinate.X_UNIT);
+
+		assertEquals(0.0, c.getX(), 1.0e-12);
+		assertEquals(1.0, c.getY(), 1.0e-12);
+		assertEquals(0.0, c.getZ(), 1.0e-12);
+
+		// and must agree with the rotation vector form of the same rotation
+		Quaternion v = Quaternion.rotation(new Coordinate(0, 0, Math.PI / 2));
+		assertEquals(v.getW(), q.getW(), 1.0e-12);
+		assertEquals(v.getX(), q.getX(), 1.0e-12);
+		assertEquals(v.getY(), q.getY(), 1.0e-12);
+		assertEquals(v.getZ(), q.getZ(), 1.0e-12);
+	}
+
+	@Test
 	public void rotationVectorZeroLengthReturnsIdentityQuaternion() {
 		Quaternion q = Quaternion.rotation(new Coordinate(0, 0, 0));
 		assertEquals(1.0, q.getW(), 1.0e-12);


### PR DESCRIPTION
This PR fixes several edge cases in the calculations that could cause crashes or incorrect results.

- Fix `ArrayUtils.range` for invalid ranges and non-positive steps.
- Prevent the Vincenty direct calculation from looping indefinitely.
- Make `ArrayUtils.min` and `max` return `NaN` for empty arrays.
- Fix `trapz` occasionally dropping the last interval.
- Fix mean and variance when the input contains `NaN` values.
- Preserve the `ZERO_AREA_FIN` warning from `calculateFinGeometry`.
- Fix `Quaternion.rotation(axis, angle)` using twice the requested angle.
- Avoid assuming the first child in `checkGeometry` is a `SymmetricComponent`.
- Avoid repeated `toArray()` calls in `LinearInterpolator.addPoints`.