### PR TITLE
Fix data branch consistency and component analysis sweeps

### DIFF
--- a/core/src/main/java/info/openrocket/core/componentanalysis/CADataBranch.java
+++ b/core/src/main/java/info/openrocket/core/componentanalysis/CADataBranch.java
@@ -29,8 +29,19 @@ public class CADataBranch extends DataBranch<CADataType> {
 
 	@Override
 	public void addType(CADataType type) {
+		final int length = getLength();
+
 		super.addType(type);
+
 		if (!(type instanceof CADomainDataType)) {
+			// Component data lives in componentValues; the entry in values only exists so
+			// that getTypes() reports the type.  Pad it to the current length, otherwise a
+			// type added after the first data point stays permanently shorter than the rest.
+			ArrayList<Double> list = values.get(type);
+			for (int i = 0; i < length; i++) {
+				list.add(Double.NaN);
+			}
+
 			componentValues.put(type, new HashMap<>());
 			componentMinValues.put(type, new HashMap<>());
 			componentMaxValues.put(type, new HashMap<>());

--- a/core/src/main/java/info/openrocket/core/componentanalysis/CAParameterSweep.java
+++ b/core/src/main/java/info/openrocket/core/componentanalysis/CAParameterSweep.java
@@ -9,11 +9,16 @@ import info.openrocket.core.rocketcomponent.Rocket;
 import info.openrocket.core.rocketcomponent.RocketComponent;
 import info.openrocket.core.util.MathUtil;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 public class CAParameterSweep {
+	/** Highest number of decimals the sweep values are rounded to. */
+	private static final int MAX_SCALE = 10;
+
 	private final CAParameters parameters;
 	private final AerodynamicCalculator aerodynamicCalculator;
 	private final Rocket rocket;
@@ -59,23 +64,30 @@ public class CAParameterSweep {
 
 	private List<Double> generateSweepValues(double min, double max, double delta) {
 		List<Double> values = new ArrayList<>();
-		int scale = determineScale(delta);
-		double multiplier = Math.pow(10, scale);
+		if (!(delta > 0) || Double.isNaN(min) || Double.isNaN(max) || max < min) {
+			return values;
+		}
 
-		for (double value = min; value <= max; value += delta) {
-			double roundedValue = Math.round(value * multiplier) / multiplier;
-			values.add(roundedValue);
+		int scale = determineScale(delta);
+
+		// Step off min rather than accumulating delta, so that rounding error cannot
+		// build up over the sweep and drop the last value
+		int steps = (int) Math.floor((max - min) / delta + 1.0e-9);
+		for (int i = 0; i <= steps; i++) {
+			double value = min + i * delta;
+			values.add(BigDecimal.valueOf(value).setScale(scale, RoundingMode.HALF_UP).doubleValue());
 		}
 		return values;
 	}
 
+	/**
+	 * Number of decimals the sweep values are rounded to, taken from the step size.
+	 * Reading it off the plain string form of the step got this wrong for any step
+	 * small enough to be printed in scientific notation.
+	 */
 	private int determineScale(double delta) {
-		String deltaStr = Double.toString(Math.abs(delta));
-		int indexOfDecimal = deltaStr.indexOf(".");
-		if (indexOfDecimal == -1) {
-			return 0;
-		}
-		return deltaStr.length() - indexOfDecimal - 1;
+		int scale = BigDecimal.valueOf(Math.abs(delta)).stripTrailingZeros().scale();
+		return MathUtil.clamp(scale, 0, MAX_SCALE);
 	}
 
 	private void setParameterValue(CADomainDataType parameterType, double value) {

--- a/core/src/main/java/info/openrocket/core/simulation/DataBranch.java
+++ b/core/src/main/java/info/openrocket/core/simulation/DataBranch.java
@@ -67,26 +67,10 @@ public abstract class DataBranch<T extends DataType> implements Monitorable {
 	 */
 	public void addPoint() {
 		mutable.check();
-		for (Map.Entry<T, ArrayList<Double>> entry : values.entrySet()) {
-			sanityCheckValues(entry.getKey(), Double.NaN);
-			entry.getValue().add(Double.NaN);
+		for (ArrayList<Double> list : values.values()) {
+			list.add(Double.NaN);
 		}
 		modID = new ModID();
-	}
-
-	private void sanityCheckValues(T type, Double value) {
-		ArrayList<Double> list = values.get(type);
-
-		if (list == null) {
-			list = new info.openrocket.core.util.ArrayList<>();
-			int n = getLength();
-			for (int i = 0; i < n; i++) {
-				list.add(Double.NaN);
-			}
-			values.put(type, list);
-			minValues.put(type, value);
-			maxValues.put(type, value);
-		}
 	}
 
 	/**
@@ -233,7 +217,20 @@ public abstract class DataBranch<T extends DataType> implements Monitorable {
 	@SuppressWarnings("unchecked")
 	public T[] getTypes() {
 		Set<T> keySet = values.keySet();
-		T[] array = (T[]) Array.newInstance(keySet.iterator().next().getClass(), keySet.size());
+		if (keySet.isEmpty()) {
+			throw new IllegalStateException("No data types have been added to branch " + name);
+		}
+
+		// The types are not necessarily all of the same class, so walk up to one that
+		// can hold all of them
+		Class<?> componentType = keySet.iterator().next().getClass();
+		for (T type : keySet) {
+			while (!componentType.isInstance(type)) {
+				componentType = componentType.getSuperclass();
+			}
+		}
+
+		T[] array = (T[]) Array.newInstance(componentType, keySet.size());
 		keySet.toArray(array);
 		Arrays.sort(array);
 		return array;

--- a/core/src/test/java/info/openrocket/core/componentanalysis/CADataBranchTest.java
+++ b/core/src/test/java/info/openrocket/core/componentanalysis/CADataBranchTest.java
@@ -84,6 +84,26 @@ class CADataBranchTest {
 	}
 
 	@Test
+	void typeAddedAfterFirstPointKeepsSeriesLengthsAligned() {
+		// This is how CAParameterSweep builds a branch: only the domain type is known
+		// up front, the component types are registered on the first setValue call
+		CADataBranch sweep = new CADataBranch("sweep", CADomainDataType.MACH);
+
+		sweep.addPoint();
+		sweep.setDomainValue(CADomainDataType.MACH, 0.5);
+		sweep.setValue(CADataType.CP_X, component, 1.0);
+
+		sweep.addPoint();
+		sweep.setDomainValue(CADomainDataType.MACH, 0.6);
+		sweep.setValue(CADataType.CP_X, component, 2.0);
+
+		assertEquals(2, sweep.getLength());
+		assertEquals(sweep.getLength(), sweep.get(CADomainDataType.MACH).size());
+		assertEquals(sweep.getLength(), sweep.get(CADataType.CP_X).size());
+		assertEquals(sweep.getLength(), sweep.get(CADataType.CP_X, component).size());
+	}
+
+	@Test
 	void missingComponentDataReturnsNaN() {
 		assertTrue(Double.isNaN(branch.getMinimum(CADataType.CP_X, component)));
 		assertTrue(Double.isNaN(branch.getMaximum(CADataType.CP_X, component)));

--- a/core/src/test/java/info/openrocket/core/componentanalysis/CADataBranchTest.java
+++ b/core/src/test/java/info/openrocket/core/componentanalysis/CADataBranchTest.java
@@ -104,6 +104,15 @@ class CADataBranchTest {
 	}
 
 	@Test
+	void getTypesHandlesDomainAndComponentTypesTogether() {
+		CADataBranch sweep = new CADataBranch("sweep", CADomainDataType.MACH);
+		sweep.addPoint();
+		sweep.setValue(CADataType.CP_X, component, 1.0);
+
+		assertEquals(2, sweep.getTypes().length);
+	}
+
+	@Test
 	void missingComponentDataReturnsNaN() {
 		assertTrue(Double.isNaN(branch.getMinimum(CADataType.CP_X, component)));
 		assertTrue(Double.isNaN(branch.getMaximum(CADataType.CP_X, component)));

--- a/core/src/test/java/info/openrocket/core/componentanalysis/CAParameterSweepTest.java
+++ b/core/src/test/java/info/openrocket/core/componentanalysis/CAParameterSweepTest.java
@@ -113,6 +113,27 @@ class CAParameterSweepTest extends ComponentAnalysisTestBase {
 		assertEquals(2, branch.getLength());
 	}
 
+	@Test
+	void sweepWithAFineStepKeepsTheDomainValuesMonotonic() {
+		CAParameterSweep sweep = new CAParameterSweep(parameters, aerodynamicCalculator, rocket);
+
+		when(aerodynamicCalculator.getForceAnalysis(any(), any(), any()))
+				.thenReturn(new LinkedHashMap<>());
+
+		// The smallest wind direction step the GUI allows.  Its plain string form has
+		// enough decimals that scaling the domain values by 10^decimals used to run
+		// past the range of a long.
+		double delta = Math.PI / 1800;
+		CADataBranch branch = sweep.sweep(CADomainDataType.WIND_DIRECTION, 6.0, 2 * Math.PI, delta, 0.15);
+
+		List<Double> direction = branch.get(CADomainDataType.WIND_DIRECTION);
+		assertEquals(branch.getLength(), direction.size());
+		for (int i = 1; i < direction.size(); i++) {
+			assertEquals(delta, direction.get(i) - direction.get(i - 1), 1e-6,
+					"domain values are not evenly spaced at index " + i);
+		}
+	}
+
 	private AerodynamicForces createRocketForces(RocketComponent component, double cpX, double cna, double pressureCd,
 			double baseCd, double frictionCd, double perInstanceCd) {
 		AerodynamicForces forces = new AerodynamicForces();


### PR DESCRIPTION
This fixes a few issues in `DataBranch`, `CADataBranch`, and `CAParameterSweep`.

- Keep newly added `CADataBranch` series aligned with the existing data.
- Fix `DataBranch.getTypes()` for branches containing different `DataType` subclasses.
- Fix component analysis sweeps for very small step sizes.
- Avoid accumulated floating-point error when generating sweep values.

The sweep calculation now uses `BigDecimal` for rounding and generates values relative to the range minimum.

This can slightly change sweep values compared to the previous implementation, especially the final point of a sweep.

`getTypes()` still has a limitation when unrelated implementations of `DataType` are stored in the same branch, but that requires a bigger change.
