### PR TITLE
Fix propulsive damping coefficient sign

### DIFF
--- a/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
@@ -573,12 +573,14 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 		 * @return the propulsive part of the damping moment coefficient
 		 */
 		private double computePropulsiveDampingMomentCoefficient(SimulationStatus status, FlightDataBranch dataBranch) {
-			// mdot := d(motor mass)/dt, estimated using the last two stored points.
-			// Avoids reaching into motor internals.
-			double mdot = computeMotorMassDerivative(dataBranch);
-			if (Double.isNaN(mdot)) {
+			double motorMassDerivative = computeMotorMassDerivative(dataBranch);
+			if (Double.isNaN(motorMassDerivative)) {
 				return 0;
 			}
+
+			// The damping equation uses the positive mass-expulsion rate, while the remaining motor mass
+			// decreases during the burn. Therefore, massExpulsionRate = -d(motor mass)/dt.
+			double massExpulsionRate = -motorMassDerivative;
 
 			double cg = rocketMass.getCM().getX();
 
@@ -592,7 +594,7 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 				}
 			}
 
-			return mdot * MathUtil.pow2(nozzleDistance - cg);
+			return massExpulsionRate * MathUtil.pow2(nozzleDistance - cg);
 		}
 
 		/**

--- a/core/src/test/java/info/openrocket/core/simulation/DampingMomentCoefficientTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/DampingMomentCoefficientTest.java
@@ -86,6 +86,7 @@ public class DampingMomentCoefficientTest extends BaseTestCase {
 			}
 
 			assertEquals(t, a + p, SUM_TOLERANCE);
+			assertTrue(p >= 0.0, "Propulsive damping moment coefficient should not be negative");
 			foundNonZeroAerodynamic |= Math.abs(a) > NON_ZERO_THRESHOLD;
 			foundNonZeroPropulsive |= Math.abs(p) > NON_ZERO_THRESHOLD;
 		}
@@ -94,4 +95,3 @@ public class DampingMomentCoefficientTest extends BaseTestCase {
 		assertTrue(foundNonZeroPropulsive, "Expected at least one non-zero propulsive contribution");
 	}
 }
-


### PR DESCRIPTION
Peak of Flight no. 195 defines the motor mass-flow term as a positive mass-expulsion rate, but OpenRocket used the negative derivative of remaining motor mass directly. This PR fixes the sign, matching the expected propulsive damping behavior and the RockSim results.

New results:
<img width="1056" height="892" alt="image" src="https://github.com/user-attachments/assets/99f99bfb-a1f7-43dd-8ed1-63e27a636f8b" />

Rocksim results:
<img width="3164" height="1232" alt="image" src="https://github.com/user-attachments/assets/6c2f7364-917a-4ec5-9d76-451547178da0" />
