### PR TITLE
[#3198] Fix simulation plot selector layout

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/plot/PlotPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/PlotPanel.java
@@ -123,6 +123,12 @@ public class PlotPanel<T extends DataType & Groupable<G>,
 		this.add(new JLabel(trans.get("simplotpanel.lbl.Xaxistype")), "spanx, split");
 		domainTypeSelector = new GroupableAndSearchableComboBox<>(Arrays.asList(typesX), trans.get("FlightDataComboBox.placeholder"));
 		domainTypeSelector.setSelectedItem(configuration.getDomainAxisType());
+		updateDomainTypeSelectorTooltip();
+		domainTypeSelector.addItemListener(e -> {
+			if (e.getStateChange() == ItemEvent.SELECTED) {
+				updateDomainTypeSelectorTooltip();
+			}
+		});
 		domainTypeSelector.addItemListener(new ItemListener() {
 			@Override
 			public void itemStateChanged(ItemEvent e) {
@@ -138,7 +144,8 @@ public class PlotPanel<T extends DataType & Groupable<G>,
 				setToCustom();
 			}
 		});
-		this.add(domainTypeSelector, "gapright para");
+		// Keep long localized data type names from determining the dialog width.
+		this.add(domainTypeSelector, "width " + PlotTypeSelector.DATA_TYPE_SELECTOR_WIDTH + ", gapright unrel");
 
 		//// Unit:
 		this.add(new JLabel(trans.get("simplotpanel.lbl.Unit")));
@@ -152,7 +159,7 @@ public class PlotPanel<T extends DataType & Groupable<G>,
 				configuration.setDomainAxisUnit(domainUnitSelector.getSelectedUnit());
 			}
 		});
-		this.add(domainUnitSelector, "width 40lp, gapright para");
+		this.add(domainUnitSelector, "width 40lp, gapright unrel");
 
 		// Extra X widgets
 		if (extraWidgetsX != null) {
@@ -166,6 +173,14 @@ public class PlotPanel<T extends DataType & Groupable<G>,
 		} else {
 			this.add(new JLabel(), "wrap unrel");
 		}
+	}
+
+	/**
+	 * Shows the complete X-axis data type name when its fixed-width selector truncates the label.
+	 */
+	private void updateDomainTypeSelectorTooltip() {
+		T selectedType = (T) domainTypeSelector.getSelectedItem();
+		domainTypeSelector.setToolTipText(selectedType != null ? selectedType.toString() : null);
 	}
 
 	protected JPanel addYAxisSelector(T[] typesY, Component[] extraWidgetsY) {

--- a/swing/src/main/java/info/openrocket/swing/gui/plot/PlotTypeSelector.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/PlotTypeSelector.java
@@ -11,6 +11,7 @@ import info.openrocket.swing.gui.components.UnitSelector;
 import info.openrocket.swing.gui.util.Icons;
 
 import java.awt.event.ActionListener;
+import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.io.Serial;
 import java.util.List;
@@ -26,6 +27,8 @@ import javax.swing.JPanel;
 public class PlotTypeSelector<T extends Groupable<G> & UnitValue, G extends Group> extends JPanel {
 	protected static final Translator trans = Application.getTranslator();
 	private static final long serialVersionUID = 9056324972817542570L;
+	/** Fixed logical width shared by the X- and Y-axis data type selectors. */
+	static final String DATA_TYPE_SELECTOR_WIDTH = "200lp!";
 
 	private final String[] POSITIONS = {Util.PlotAxisSelection.AUTO.getName(),
 			Util.PlotAxisSelection.LEFT.getName(), Util.PlotAxisSelection.RIGHT.getName()};
@@ -52,14 +55,21 @@ public class PlotTypeSelector<T extends Groupable<G> & UnitValue, G extends Grou
 			}
 		};
 		typeSelector.setSelectedItem(type);
-		this.add(typeSelector, "gapright para, top");
+		updateTypeSelectorTooltip();
+		typeSelector.addItemListener(e -> {
+			if (e.getStateChange() == ItemEvent.SELECTED) {
+				updateTypeSelectorTooltip();
+			}
+		});
+		// Keep long localized data type names from hiding the controls at the end of the row.
+		this.add(typeSelector, "width " + DATA_TYPE_SELECTOR_WIDTH + ", gapright unrel, top");
 
 		this.add(new JLabel("Unit:"), "top");
 		unitSelector = new UnitSelector(type.getUnitGroup());
 		if (unit != null) {
 			unitSelector.setSelectedUnit(unit);
 		}
-		this.add(unitSelector, "width 40lp, gapright para, top");
+		this.add(unitSelector, "width 40lp, gapright unrel, top");
 
 		this.add(new JLabel("Axis:"), "top");
 		axisSelector = new JComboBox<>(POSITIONS);
@@ -88,6 +98,14 @@ public class PlotTypeSelector<T extends Groupable<G> & UnitValue, G extends Grou
 
 	public T getSelectedType() {
 		return (T) typeSelector.getSelectedItem();
+	}
+
+	/**
+	 * Shows the complete data type name when the fixed-width selector truncates the label.
+	 */
+	private void updateTypeSelectorTooltip() {
+		T selectedType = getSelectedType();
+		typeSelector.setToolTipText(selectedType != null ? getDisplayString(selectedType) : null);
 	}
 
 	public Unit getSelectedUnit() {

--- a/swing/src/main/java/info/openrocket/swing/gui/widgets/GroupableAndSearchableComboBox.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/widgets/GroupableAndSearchableComboBox.java
@@ -21,6 +21,7 @@ import javax.swing.JList;
 import javax.swing.JMenu;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
+import javax.swing.MenuElement;
 import javax.swing.MenuSelectionManager;
 import javax.swing.SwingUtilities;
 import javax.swing.event.ListDataEvent;
@@ -238,10 +239,12 @@ public class GroupableAndSearchableComboBox<G extends Group, T extends Groupable
 	}
 
 	static class DeselectMenuListener extends MouseAdapter {
+		final JPopupMenu parentPopup;
 		final List<JMenu> groupMenus;
 		final JMenu ownMenu;
 
-		DeselectMenuListener(List<JMenu> groupMenus, JMenu ownMenu) {
+		DeselectMenuListener(JPopupMenu parentPopup, List<JMenu> groupMenus, JMenu ownMenu) {
+			this.parentPopup = parentPopup;
 			this.groupMenus = groupMenus;
 			this.ownMenu = ownMenu;
 		}
@@ -263,6 +266,13 @@ public class GroupableAndSearchableComboBox<G extends Group, T extends Groupable
 				if (ownMenu != null) {
 					ownMenu.setSelected(true);
 					ownMenu.setPopupMenuVisible(true);
+					// Register the submenu as part of the active hierarchy so a quick pointer transition into it does not
+					// cancel the parent popup.
+					MenuSelectionManager.defaultManager().setSelectedPath(new MenuElement[] {
+							parentPopup, ownMenu, ownMenu.getPopupMenu()
+					});
+				} else if (parentPopup.isVisible()) {
+					MenuSelectionManager.defaultManager().setSelectedPath(new MenuElement[] { parentPopup });
 				}
 			});
 		}
@@ -290,7 +300,7 @@ public class GroupableAndSearchableComboBox<G extends Group, T extends Groupable
 
 		// Add the search field at the top
 		menu.add(searchFieldGroups);
-		searchFieldGroups.addMouseListener(new DeselectMenuListener(groupMenus, null));
+		searchFieldGroups.addMouseListener(new DeselectMenuListener(menu, groupMenus, null));
 		menu.addSeparator();
 
 		// Fill the menu with the groups
@@ -318,14 +328,14 @@ public class GroupableAndSearchableComboBox<G extends Group, T extends Groupable
 
 			groupMenus.add(groupMenu);
 			menu.add(groupMenu);
-			groupMenu.addMouseListener(new DeselectMenuListener(groupMenus, groupMenu));
+			groupMenu.addMouseListener(new DeselectMenuListener(menu, groupMenus, groupMenu));
 		}
 
 		// Extra widgets
 		if (extraGroupPopupWidgets != null) {
 			for (Component widget : extraGroupPopupWidgets) {
 				menu.add(widget);
-				widget.addMouseListener(new DeselectMenuListener(groupMenus, null));
+				widget.addMouseListener(new DeselectMenuListener(menu, groupMenus, null));
 			}
 		}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/widgets/GroupableAndSearchableComboBox.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/widgets/GroupableAndSearchableComboBox.java
@@ -21,9 +21,12 @@ import javax.swing.JList;
 import javax.swing.JMenu;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
+import javax.swing.MenuSelectionManager;
 import javax.swing.SwingUtilities;
 import javax.swing.event.ListDataEvent;
 import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
 import javax.swing.plaf.basic.BasicArrowButton;
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -247,6 +250,10 @@ public class GroupableAndSearchableComboBox<G extends Group, T extends Groupable
 		public void mouseEntered(MouseEvent e) {
 			super.mouseEntered(e);
 			SwingUtilities.invokeLater(() -> {
+				// A queued hover event can run after the parent popup has already closed.
+				if (ownMenu != null && !ownMenu.isShowing()) {
+					return;
+				}
 				for (JMenu groupMenu : groupMenus) {
 					if (groupMenu != ownMenu) {
 						groupMenu.setSelected(false);
@@ -264,6 +271,22 @@ public class GroupableAndSearchableComboBox<G extends Group, T extends Groupable
 	private JPopupMenu createGroupsPopup() {
 		final JPopupMenu menu = new JPopupMenu();
 		final List<JMenu> groupMenus = new ArrayList<>();
+		menu.addPopupMenuListener(new PopupMenuListener() {
+			@Override
+			public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
+				// No action is required when the parent popup opens.
+			}
+
+			@Override
+			public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {
+				hideGroupSubmenus(menu);
+			}
+
+			@Override
+			public void popupMenuCanceled(PopupMenuEvent e) {
+				hideGroupSubmenus(menu);
+			}
+		});
 
 		// Add the search field at the top
 		menu.add(searchFieldGroups);
@@ -360,13 +383,34 @@ public class GroupableAndSearchableComboBox<G extends Group, T extends Groupable
 	}
 
 	private void showGroupsPopup() {
+		// Clear any submenu left selected by a different combo box before opening this popup.
+		MenuSelectionManager.defaultManager().clearSelectedPath();
+		hideGroupSubmenus(groupsPopup);
 		groupsPopup.show(this, 0, getHeight());
 		searchFieldSearch.setText("");
 		searchFieldGroups.setText("");
 	}
 
 	private void hideGroupsPopup() {
+		hideGroupSubmenus(groupsPopup);
 		groupsPopup.setVisible(false);
+	}
+
+	/**
+	 * Closes and deselects every group submenu owned by a combo box popup.
+	 *
+	 * @param popup the parent popup containing the group menus
+	 */
+	static void hideGroupSubmenus(JPopupMenu popup) {
+		if (popup == null) {
+			return;
+		}
+		for (Component component : popup.getComponents()) {
+			if (component instanceof JMenu groupMenu) {
+				groupMenu.setPopupMenuVisible(false);
+				groupMenu.setSelected(false);
+			}
+		}
 	}
 
 	private void showSearchPopup() {
@@ -715,4 +759,3 @@ public class GroupableAndSearchableComboBox<G extends Group, T extends Groupable
 	}
 
 }
-

--- a/swing/src/test/java/info/openrocket/swing/gui/plot/PlotTypeSelectorTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/plot/PlotTypeSelectorTest.java
@@ -1,0 +1,87 @@
+package info.openrocket.swing.gui.plot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Component;
+import java.util.Arrays;
+
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+
+import org.junit.jupiter.api.Test;
+
+import info.openrocket.core.simulation.FlightDataBranch;
+import info.openrocket.core.simulation.FlightDataType;
+import info.openrocket.core.simulation.FlightDataTypeGroup;
+import info.openrocket.swing.gui.components.UnitSelector;
+import info.openrocket.swing.util.BaseTestCase;
+import net.miginfocom.swing.MigLayout;
+
+/**
+ * Regression tests for the bounded data type selectors in the plot configuration panel.
+ */
+public class PlotTypeSelectorTest extends BaseTestCase {
+
+	/**
+	 * Long data type names must not widen the X- or Y-axis selectors, and their full text must remain available as a
+	 * tooltip after the selection changes.
+	 */
+	@Test
+	public void testDataTypeSelectorsUseFixedWidthAndFullNameTooltips() throws Exception {
+		SwingUtilities.invokeAndWait(() -> {
+			FlightDataType longType = FlightDataType.TYPE_DAMPING_MOMENT_COEFF_AERODYNAMIC;
+			FlightDataType shortType = FlightDataType.TYPE_ALTITUDE;
+
+			PlotTypeSelector<FlightDataType, FlightDataTypeGroup> yAxisSelector = new PlotTypeSelector<>(
+					0, longType, longType.getUnitGroup().getDefaultUnit(), -1,
+					Arrays.asList(longType, shortType));
+			assertEquals(longType.toString(), yAxisSelector.typeSelector.getToolTipText());
+			assertFixedDataTypeSelectorWidth(yAxisSelector, yAxisSelector.typeSelector);
+			assertCompactRightGap(yAxisSelector, yAxisSelector.typeSelector);
+			Component unitSelector = Arrays.stream(yAxisSelector.getComponents())
+					.filter(UnitSelector.class::isInstance)
+					.findFirst()
+					.orElseThrow();
+			assertCompactRightGap(yAxisSelector, unitSelector);
+
+			yAxisSelector.typeSelector.setSelectedItem(shortType);
+			assertEquals(shortType.toString(), yAxisSelector.typeSelector.getToolTipText());
+
+			SimulationPlotConfiguration customConfiguration = new SimulationPlotConfiguration("Custom", longType);
+			SimulationPlotConfiguration defaultConfiguration = new SimulationPlotConfiguration("Default", longType);
+			SimulationPlotConfiguration[] presets = { defaultConfiguration, customConfiguration };
+			FlightDataType[] availableTypes = { longType, shortType };
+			PlotPanel<FlightDataType, FlightDataBranch, FlightDataTypeGroup, SimulationPlotConfiguration,
+					PlotTypeSelector<FlightDataType, FlightDataTypeGroup>> plotPanel = new PlotPanel<>(
+					availableTypes, availableTypes, customConfiguration, presets, defaultConfiguration,
+					null, null);
+
+			assertEquals(longType.toString(), plotPanel.domainTypeSelector.getToolTipText());
+			assertFixedDataTypeSelectorWidth(plotPanel, plotPanel.domainTypeSelector);
+			assertCompactRightGap(plotPanel, plotPanel.domainTypeSelector);
+
+			plotPanel.domainTypeSelector.setSelectedItem(shortType);
+			assertEquals(shortType.toString(), plotPanel.domainTypeSelector.getToolTipText());
+		});
+	}
+
+	/**
+	 * Verifies that MigLayout receives the exact logical width constraint for the selector.
+	 */
+	private static void assertFixedDataTypeSelectorWidth(JPanel panel, Component selector) {
+		MigLayout layout = (MigLayout) panel.getLayout();
+		String constraints = assertInstanceOf(String.class, layout.getComponentConstraints(selector));
+		assertTrue(constraints.contains("width " + PlotTypeSelector.DATA_TYPE_SELECTOR_WIDTH));
+	}
+
+	/**
+	 * Verifies that adjacent selector groups retain a small visual separation without paragraph-sized whitespace.
+	 */
+	private static void assertCompactRightGap(JPanel panel, Component component) {
+		MigLayout layout = (MigLayout) panel.getLayout();
+		String constraints = assertInstanceOf(String.class, layout.getComponentConstraints(component));
+		assertTrue(constraints.contains("gapright unrel"));
+	}
+}

--- a/swing/src/test/java/info/openrocket/swing/gui/widgets/GroupableAndSearchableComboBoxTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/widgets/GroupableAndSearchableComboBoxTest.java
@@ -1,0 +1,104 @@
+package info.openrocket.swing.gui.widgets;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.event.MouseEvent;
+import java.util.List;
+
+import javax.swing.JMenu;
+import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the popup lifecycle of {@link GroupableAndSearchableComboBox}.
+ */
+public class GroupableAndSearchableComboBoxTest {
+
+	/**
+	 * A hover callback queued before the parent popup closes must not reopen its submenu afterward.
+	 */
+	@Test
+	public void testDelayedHoverDoesNotReopenHiddenSubmenu() throws Exception {
+		TrackingMenu groupMenu = new TrackingMenu();
+		GroupableAndSearchableComboBox.DeselectMenuListener listener =
+				new GroupableAndSearchableComboBox.DeselectMenuListener(List.of(groupMenu), groupMenu);
+
+		listener.mouseEntered(new MouseEvent(groupMenu, MouseEvent.MOUSE_ENTERED, 0, 0, 0, 0, 0, false));
+		SwingUtilities.invokeAndWait(() -> {
+			// Flush the hover callback queued by the listener.
+		});
+
+		assertFalse(groupMenu.isSelected());
+		assertFalse(groupMenu.isPopupMenuVisible());
+	}
+
+	/**
+	 * Closing a parent popup must also close and deselect all of its group submenus.
+	 */
+	@Test
+	public void testHideGroupSubmenusClearsEveryGroupMenu() {
+		JPopupMenu parentPopup = new JPopupMenu();
+		TrackingMenu firstGroup = new TrackingMenu();
+		TrackingMenu secondGroup = new TrackingMenu();
+		parentPopup.add(firstGroup);
+		parentPopup.add(secondGroup);
+		firstGroup.setSelected(true);
+		firstGroup.setPopupMenuVisible(true);
+		secondGroup.setSelected(true);
+		secondGroup.setPopupMenuVisible(true);
+
+		GroupableAndSearchableComboBox.hideGroupSubmenus(parentPopup);
+
+		assertFalse(firstGroup.isSelected());
+		assertFalse(firstGroup.isPopupMenuVisible());
+		assertFalse(secondGroup.isSelected());
+		assertFalse(secondGroup.isPopupMenuVisible());
+	}
+
+	/**
+	 * A menu that is still showing should continue to open normally on hover.
+	 */
+	@Test
+	public void testHoverOpensVisibleSubmenu() throws Exception {
+		TrackingMenu groupMenu = new TrackingMenu();
+		groupMenu.setShowing(true);
+		GroupableAndSearchableComboBox.DeselectMenuListener listener =
+				new GroupableAndSearchableComboBox.DeselectMenuListener(List.of(groupMenu), groupMenu);
+
+		listener.mouseEntered(new MouseEvent(groupMenu, MouseEvent.MOUSE_ENTERED, 0, 0, 0, 0, 0, false));
+		SwingUtilities.invokeAndWait(() -> {
+			// Flush the hover callback queued by the listener.
+		});
+
+		assertTrue(groupMenu.isSelected());
+		assertTrue(groupMenu.isPopupMenuVisible());
+	}
+
+	/** JMenu test double that does not require a visible native window. */
+	private static final class TrackingMenu extends JMenu {
+		private boolean popupMenuVisible;
+		private boolean showing;
+
+		@Override
+		public void setPopupMenuVisible(boolean visible) {
+			popupMenuVisible = visible;
+		}
+
+		@Override
+		public boolean isPopupMenuVisible() {
+			return popupMenuVisible;
+		}
+
+		@Override
+		public boolean isShowing() {
+			return showing;
+		}
+
+		private void setShowing(boolean showing) {
+			this.showing = showing;
+		}
+	}
+}

--- a/swing/src/test/java/info/openrocket/swing/gui/widgets/GroupableAndSearchableComboBoxTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/widgets/GroupableAndSearchableComboBoxTest.java
@@ -1,5 +1,6 @@
 package info.openrocket.swing.gui.widgets;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -8,23 +9,32 @@ import java.util.List;
 
 import javax.swing.JMenu;
 import javax.swing.JPopupMenu;
+import javax.swing.MenuElement;
+import javax.swing.MenuSelectionManager;
 import javax.swing.SwingUtilities;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 /**
  * Tests the popup lifecycle of {@link GroupableAndSearchableComboBox}.
  */
 public class GroupableAndSearchableComboBoxTest {
+	@AfterEach
+	public void clearMenuSelectionPath() {
+		MenuSelectionManager.defaultManager().clearSelectedPath();
+	}
 
 	/**
 	 * A hover callback queued before the parent popup closes must not reopen its submenu afterward.
 	 */
 	@Test
 	public void testDelayedHoverDoesNotReopenHiddenSubmenu() throws Exception {
+		JPopupMenu parentPopup = new JPopupMenu();
 		TrackingMenu groupMenu = new TrackingMenu();
+		parentPopup.add(groupMenu);
 		GroupableAndSearchableComboBox.DeselectMenuListener listener =
-				new GroupableAndSearchableComboBox.DeselectMenuListener(List.of(groupMenu), groupMenu);
+				new GroupableAndSearchableComboBox.DeselectMenuListener(parentPopup, List.of(groupMenu), groupMenu);
 
 		listener.mouseEntered(new MouseEvent(groupMenu, MouseEvent.MOUSE_ENTERED, 0, 0, 0, 0, 0, false));
 		SwingUtilities.invokeAndWait(() -> {
@@ -63,10 +73,12 @@ public class GroupableAndSearchableComboBoxTest {
 	 */
 	@Test
 	public void testHoverOpensVisibleSubmenu() throws Exception {
+		JPopupMenu parentPopup = new JPopupMenu();
 		TrackingMenu groupMenu = new TrackingMenu();
+		parentPopup.add(groupMenu);
 		groupMenu.setShowing(true);
 		GroupableAndSearchableComboBox.DeselectMenuListener listener =
-				new GroupableAndSearchableComboBox.DeselectMenuListener(List.of(groupMenu), groupMenu);
+				new GroupableAndSearchableComboBox.DeselectMenuListener(parentPopup, List.of(groupMenu), groupMenu);
 
 		listener.mouseEntered(new MouseEvent(groupMenu, MouseEvent.MOUSE_ENTERED, 0, 0, 0, 0, 0, false));
 		SwingUtilities.invokeAndWait(() -> {
@@ -75,6 +87,8 @@ public class GroupableAndSearchableComboBoxTest {
 
 		assertTrue(groupMenu.isSelected());
 		assertTrue(groupMenu.isPopupMenuVisible());
+		assertArrayEquals(new MenuElement[] { parentPopup, groupMenu, groupMenu.getPopupMenu() },
+				MenuSelectionManager.defaultManager().getSelectedPath());
 	}
 
 	/** JMenu test double that does not require a visible native window. */


### PR DESCRIPTION
Fixes #3198. I also fixed some small issues with hovering in the GroupableAndSearchableComboBox.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/36f84a2e-8735-4feb-bbf0-fd65161213a0" />

The width is small enough to be able to fit the delete button in screen, but wide enough to fit the text of most data types.