### PR TITLE
[#3161] Fix NaN mass calculation for zero-volume slices

### DIFF
--- a/core/src/main/java/info/openrocket/core/rocketcomponent/SymmetricComponent.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/SymmetricComponent.java
@@ -492,7 +492,10 @@ public abstract class SymmetricComponent extends BodyComponent implements BoxBou
 
 			final double dFullV = fullCG.getWeight();
 			final double dV = fullCG.getWeight() - innerCG.getWeight();
-			final double dCG = (fullCG.getX() * fullCG.getWeight() - innerCG.getX() * innerCG.getWeight()) / dV;
+			// Some discontinuous profiles contain slices with no material.  Their CG is
+			// irrelevant, but it must remain finite so that 0 * dCG does not become NaN.
+			final double dCG = dV == 0.0 ? l / 2.0
+					: (fullCG.getX() * fullCG.getWeight() - innerCG.getX() * innerCG.getWeight()) / dV;
 
 			// First moment, used later for CG calculation
 			final double dCGx = dV * (x1 + dCG);

--- a/core/src/test/java/info/openrocket/core/simulation/BansheeMk2SimulationTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/BansheeMk2SimulationTest.java
@@ -1,0 +1,58 @@
+package info.openrocket.core.simulation;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+
+import info.openrocket.core.document.Simulation;
+import info.openrocket.core.rocketcomponent.BodyTube;
+import info.openrocket.core.rocketcomponent.NoseCone;
+import info.openrocket.core.rocketcomponent.PodSet;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.rocketcomponent.Transition;
+import info.openrocket.core.util.BaseTestCase;
+import info.openrocket.core.util.TestRockets;
+
+/**
+ * Regression coverage for GitHub issue #3161, reported with the Banshee Mk2
+ * design by GitHub user Enderdyls (Dylan Cole).
+ */
+public class BansheeMk2SimulationTest extends BaseTestCase {
+
+	/**
+	 * Verifies that zero-volume integration slices in a short Power-series tail
+	 * cone do not contaminate the complete rocket's center of mass with NaN.
+	 */
+	@Test
+	public void testSimulationWithZeroVolumeTailConeSlices() {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		BodyTube bodyTube = (BodyTube) rocket.getStage(0).getChild(1);
+
+		PodSet podSet = new PodSet();
+		podSet.setInstanceCount(1);
+		bodyTube.addChild(podSet);
+
+		NoseCone podNoseCone = new NoseCone(Transition.Shape.HAACK, 0.15, 0.011);
+		podNoseCone.setShapeParameter(0.0);
+		podSet.addChild(podNoseCone);
+
+		// These are the dimensions and shape settings that triggered the original failure.
+		NoseCone tailCone = new NoseCone(Transition.Shape.POWER, 0.001, 0.011);
+		tailCone.setShapeParameter(0.0);
+		tailCone.setThickness(0.002);
+		tailCone.setFlipped(true);
+		podSet.addChild(tailCone);
+
+		Simulation simulation = new Simulation(rocket);
+		simulation.setFlightConfigurationId(TestRockets.TEST_FCID_0);
+		simulation.getOptions().setISAAtmosphere(true);
+		simulation.getOptions().setTimeStep(0.05);
+		simulation.getOptions().setRandomSeed(0x3161);
+
+		assertDoesNotThrow(() -> {
+			simulation.simulate();
+		});
+		assertFalse(simulation.hasErrors(), simulation::getStatusDescription);
+	}
+}


### PR DESCRIPTION
This PR fixes #3161. The original Banshee Mk2 design from @Enderdyls contains a 1 mm-long Power-series tail cone with parameter 0. Since symmetric components are integrated in 128 slices, one slice has zero volume.

The mass calculation divided its zero moment by its zero volume, producing a NaN that contaminated the rocket’s center of mass and stopped the simulation.

Zero-volume slices now use their midpoint as a finite placeholder. Their position cannot affect the result because they have no mass.

Added a regression test.

  