### PR TITLE
[#3037] Handle incompatible components in OpenRocket files

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/openrocket/importt/ComponentHandler.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/importt/ComponentHandler.java
@@ -48,6 +48,15 @@ class ComponentHandler extends AbstractElementHandler {
 			throw Reflection.handleWrappedException(e);
 		}
 
+		// Malformed and legacy files may contain component hierarchies that the
+		// current model cannot represent. Ignore the complete subtree instead of
+		// aborting the document load in RocketComponent.addChild().
+		if (!parent.isCompatible(c)) {
+			warnings.add(Warning.fromString(c.getComponentName() + " cannot be attached to "
+					+ parent.getComponentName() + "; ignoring this component and its subcomponents."));
+			return null;
+		}
+
 		parent.addChild(c);
 
 		return new ComponentParameterHandler(c, context);

--- a/core/src/test/java/info/openrocket/core/file/openrocket/importt/ComponentHandlerTest.java
+++ b/core/src/test/java/info/openrocket/core/file/openrocket/importt/ComponentHandlerTest.java
@@ -1,0 +1,78 @@
+package info.openrocket.core.file.openrocket.importt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+
+import info.openrocket.core.document.OpenRocketDocument;
+import info.openrocket.core.file.GeneralRocketLoader;
+import info.openrocket.core.file.RocketLoadException;
+import info.openrocket.core.rocketcomponent.AxialStage;
+import info.openrocket.core.rocketcomponent.BodyTube;
+import info.openrocket.core.rocketcomponent.PodSet;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.util.BaseTestCase;
+
+/**
+ * Tests recovery from invalid component hierarchies in OpenRocket files.
+ */
+public class ComponentHandlerTest extends BaseTestCase {
+
+	/**
+	 * A legacy development version allowed pod sets directly below stages. The
+	 * invalid pod and its descendants should be ignored without losing valid
+	 * siblings that follow it.
+	 */
+	@Test
+	public void testIncompatibleComponentIsIgnoredWithWarning() throws RocketLoadException {
+		String xml = """
+				<?xml version="1.0" encoding="utf-8"?>
+				<openrocket version="1.10" creator="OpenRocket 15.03dev">
+				  <rocket>
+				    <name>Invalid component hierarchy</name>
+				    <subcomponents>
+				      <stage>
+				        <name>Sustainer</name>
+				        <subcomponents>
+				          <podset>
+				            <name>Invalid pod set</name>
+				            <subcomponents>
+				              <bodytube>
+				                <name>Ignored pod body</name>
+				              </bodytube>
+				            </subcomponents>
+				          </podset>
+				          <bodytube>
+				            <name>Valid body tube</name>
+				            <length>0.3</length>
+				            <thickness>0.001</thickness>
+				            <radius>0.02</radius>
+				          </bodytube>
+				        </subcomponents>
+				      </stage>
+				    </subcomponents>
+				  </rocket>
+				</openrocket>
+				""";
+
+		GeneralRocketLoader loader = new GeneralRocketLoader((File) null);
+		ByteArrayInputStream input = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+		OpenRocketDocument document = loader.load(input, "invalid-component-hierarchy");
+
+		Rocket rocket = document.getRocket();
+		AxialStage stage = rocket.getStage(0);
+		assertEquals(1, stage.getChildCount());
+		BodyTube bodyTube = assertInstanceOf(BodyTube.class, stage.getChild(0));
+		assertEquals("Valid body tube", bodyTube.getName());
+		assertEquals(1, loader.getWarnings().size());
+		String expectedWarning = new PodSet().getComponentName() + " cannot be attached to "
+				+ stage.getComponentName() + "; ignoring this component and its subcomponents.";
+		assertEquals(expectedWarning,
+				loader.getWarnings().iterator().next().toString());
+	}
+}


### PR DESCRIPTION
Fixes #3037 by showing a warning message when trying to attach a child to an incompatible parent component during .ork loading.

<img width="583" height="293" alt="image" src="https://github.com/user-attachments/assets/91b43afa-145d-4af5-a9ae-0991a4ef5c63" />
