### PR TITLE
[#2092] Fix recovery device deployment with motors in pods

### DIFF
--- a/core/src/main/java/info/openrocket/core/rocketcomponent/DeploymentConfiguration.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/DeploymentConfiguration.java
@@ -2,6 +2,7 @@ package info.openrocket.core.rocketcomponent;
 
 import info.openrocket.core.l10n.Translator;
 import info.openrocket.core.simulation.FlightEvent;
+import info.openrocket.core.simulation.MotorClusterState;
 import info.openrocket.core.startup.Application;
 import info.openrocket.core.unit.UnitGroup;
 import info.openrocket.core.util.ArrayList;
@@ -25,6 +26,14 @@ public class DeploymentConfiguration implements FlightConfigurableParameter<Depl
 			public boolean isActivationEvent(DeploymentConfiguration config, FlightEvent e, RocketComponent source) {
 				if (e.getType() != FlightEvent.Type.EJECTION_CHARGE)
 					return false;
+
+				// An ejection charge only pressurizes the airframe assembly its motor sits in, so a motor
+				// in a pod cannot deploy a recovery device in the parent airframe, and vice versa.
+				if (e.getData() instanceof MotorClusterState motorState) {
+					return motorState.getMount().getAssembly().equals(source.getAssembly());
+				}
+
+				// Fall back on the stage of the ejection charge if we don't know which motor fired it
 				RocketComponent charge = e.getSource();
 				return charge.getStageNumber() == source.getStageNumber();
 			}

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/MotorMount.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/MotorMount.java
@@ -84,6 +84,9 @@ public interface MotorMount extends ChangeSource, FlightConfigurableComponent {
 	public AxialStage getStage();
 
 	// duplicate of RocketComponent
+	public ComponentAssembly getAssembly();
+
+	// duplicate of RocketComponent
 	public CoordinateIF[] getComponentLocations();
 
 	/**

--- a/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/RocketComponent.java
@@ -2336,18 +2336,20 @@ public abstract class RocketComponent implements ChangeSource, Cloneable, Iterab
 	}
 	
 	/**
-	 * Return the first component assembly component that this component belongs to.
+	 * Return the innermost component assembly (pod set, stage, ...) that this component belongs to.
+	 * If this component is itself a component assembly, it is returned.
 	 *
-	 * @return	The Stage component this component belongs to.
-	 * @throws	IllegalStateException   if we cannot find an AxialStage above <code>this</code> 
+	 * @return	The ComponentAssembly this component belongs to.
+	 * @throws	IllegalStateException   if we cannot find a ComponentAssembly above <code>this</code>
 	 */
 	public final ComponentAssembly getAssembly() {
 		checkState();
 
 		RocketComponent curComponent = this;
 		while (null != curComponent) {
-			if (ComponentAssembly.class.isAssignableFrom(curComponent.getClass()))
+			if (curComponent instanceof ComponentAssembly)
 				return (ComponentAssembly) curComponent;
+			curComponent = curComponent.parent;
 		}
 		throw new IllegalStateException("getAssembly() called on hierarchy without a ComponentAssembly.");
 	}

--- a/core/src/main/java/info/openrocket/core/simulation/BasicEventSimulationEngine.java
+++ b/core/src/main/java/info/openrocket/core/simulation/BasicEventSimulationEngine.java
@@ -401,6 +401,10 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 			for (RocketComponent c : currentStatus.getConfiguration().getActiveComponents()) {
 				if (!(c instanceof RecoveryDevice))
 					continue;
+				// A recovery device can only deploy once, so ignore any further triggers (for example the
+				// ejection charge of a second motor in the same airframe).
+				if (currentStatus.getDeployedRecoveryDevices().contains(c))
+					continue;
 				DeploymentConfiguration deployConfig = ((RecoveryDevice) c).getDeploymentConfigurations().get(this.fcid);
 				if (deployConfig.isActivationEvent(event, c)) {
 					// Delay event by at least 1ms to allow stage separation to occur first
@@ -579,8 +583,11 @@ public class BasicEventSimulationEngine implements SimulationEngine {
 				RocketComponent c = event.getSource();
 				int n = c.getStageNumber();
 
-				// Ignore event if stage not active
-				if (currentStatus.getConfiguration().isStageActive(n)) {
+				// Ignore event if stage not active, or if the device is already deployed.  The latter
+				// can still happen after the check made when the event was queued, since two motors may
+				// fire their ejection charges at the very same instant.
+				if (currentStatus.getConfiguration().isStageActive(n) &&
+						!currentStatus.getDeployedRecoveryDevices().contains(c)) {
 					// TODO: HIGH: Check stage activeness for other events as well?
 
 					// Check whether any motor in the active stages is active anymore

--- a/core/src/main/java/info/openrocket/core/util/TestRockets.java
+++ b/core/src/main/java/info/openrocket/core/util/TestRockets.java
@@ -1941,6 +1941,95 @@ public class TestRockets {
 		return rocket;
 	}
 
+	/**
+	 * Alpha III with a pair of externally strapped-on, motorized pods.  The pod motors are A10-0s,
+	 * so they burn out and fire their ejection charges long before the sustainer motor does.  This
+	 * makes the design useful for verifying that pod motors don't fire events in the parent airframe.
+	 *
+	 * This function is used for unit, integration tests, DO NOT CHANGE (without updating tests).
+	 *
+	 * @return an Estes Alpha III carrying two motorized pods
+	 */
+	public static final Rocket makeEstesAlphaIIIWithMotorPods() {
+		final Rocket rocket = makeEstesAlphaIII();
+		rocket.setName("Alpha III with motor pods");
+
+		final AxialStage stage = rocket.getStage(0);
+		final BodyTube bodyTube = (BodyTube) stage.getChild(1);
+
+		final PodSet podSet = new PodSet();
+		podSet.setName("Motor Pods");
+		bodyTube.addChild(podSet);
+		podSet.setInstanceCount(2);
+		podSet.setAxialMethod(AxialMethod.BOTTOM);
+		podSet.setAxialOffset(0.0);
+		podSet.setRadiusMethod(RadiusMethod.RELATIVE);
+		podSet.setRadiusOffset(0.0);
+
+		final BodyTube podBody = new BodyTube(0.06, 0.0075, 0.0003);
+		podBody.setName("Pod Body Tube");
+		podSet.addChild(podBody);
+
+		final InnerTube podMount = new InnerTube();
+		podMount.setName("Pod Motor Mount");
+		podMount.setAxialMethod(AxialMethod.BOTTOM);
+		podMount.setAxialOffset(0.0);
+		podMount.setLength(0.045);
+		podMount.setOuterRadius(0.0065);
+		podMount.setThickness(0.0003);
+		podMount.setMotorMount(true);
+		podBody.addChild(podMount);
+
+		// The pod motors have no ejection delay, so their charges fire the instant they burn out.
+		for (FlightConfigurationId fcid : new FlightConfigurationId[] { TEST_FCID_0, TEST_FCID_1, TEST_FCID_2,
+				TEST_FCID_3, TEST_FCID_4 }) {
+			final MotorConfiguration motorConfig = new MotorConfiguration(podMount, fcid);
+			motorConfig.setMotor(generateMotor_A10_13mm());
+			motorConfig.setEjectionDelay(0.0);
+			podMount.setMotorConfig(motorConfig, fcid);
+		}
+
+		return rocket;
+	}
+
+	/**
+	 * Alpha III with a second motor mount next to the original one in the sustainer body tube.  The
+	 * second motor is an A10-5, whose ejection charge fires about a second after the main motor's,
+	 * so the design is useful for verifying that only the first ejection charge in an airframe
+	 * deploys its recovery devices.
+	 *
+	 * This function is used for unit, integration tests, DO NOT CHANGE (without updating tests).
+	 *
+	 * @return an Estes Alpha III with two motor mounts in its body tube
+	 */
+	public static final Rocket makeEstesAlphaIIIWithSecondMotor() {
+		final Rocket rocket = makeEstesAlphaIII();
+		rocket.setName("Alpha III with a second motor");
+
+		final AxialStage stage = rocket.getStage(0);
+		final BodyTube bodyTube = (BodyTube) stage.getChild(1);
+
+		final InnerTube secondMount = new InnerTube();
+		secondMount.setName("Second Motor Mount Tube");
+		bodyTube.addChild(secondMount);
+		secondMount.setAxialMethod(AxialMethod.TOP);
+		secondMount.setAxialOffset(0.06);
+		secondMount.setLength(0.045);
+		secondMount.setOuterRadius(0.0065);
+		secondMount.setThickness(0.0003);
+		secondMount.setMotorMount(true);
+
+		for (FlightConfigurationId fcid : new FlightConfigurationId[] { TEST_FCID_0, TEST_FCID_1, TEST_FCID_2,
+				TEST_FCID_3, TEST_FCID_4 }) {
+			final MotorConfiguration motorConfig = new MotorConfiguration(secondMount, fcid);
+			motorConfig.setMotor(generateMotor_A10_13mm());
+			motorConfig.setEjectionDelay(5.0);
+			secondMount.setMotorConfig(motorConfig, fcid);
+		}
+
+		return rocket;
+	}
+
 	// Alpha III modified to have an inline pod
 	public static final Rocket makeEstesAlphaIIIwithInlinePod() {
 

--- a/core/src/test/java/info/openrocket/core/simulation/FlightEventsTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/FlightEventsTest.java
@@ -275,6 +275,92 @@ public class FlightEventsTest extends BaseTestCase {
 		}
 	}
 
+	/**
+	 * A motor in a pod fires its ejection charge inside the pod, so it must not deploy a recovery
+	 * device in the airframe the pod is strapped to.
+	 * See <a href="https://github.com/openrocket/openrocket/issues/2092">GitHub issue #2092</a>.
+	 */
+	@Test
+	public void testPodMotorDoesNotDeployParentRecoveryDevice() throws SimulationException {
+		final Rocket rocket = TestRockets.makeEstesAlphaIIIWithMotorPods();
+		final BodyTube bodyTube = (BodyTube) rocket.getStage(0).getChild(1);
+		final Parachute parachute = (Parachute) bodyTube.getChild(3);
+
+		final Simulation sim = simulate(rocket);
+
+		assertEquals(1, sim.getSimulatedData().getBranchCount(), "Motor pods should not create a new branch");
+
+		// The pod A10-0s fire their ejection charges the instant they burn out, the sustainer's B4-3
+		// only fires its charge three seconds after its own burnout.
+		final List<FlightEvent> ejections = getEvents(sim, FlightEvent.Type.EJECTION_CHARGE);
+		assertEquals(2, ejections.size(), "Expected an ejection charge from both the pod and the sustainer motors");
+		assertEquals(1.05, ejections.get(0).getTime(), EPSILON, "Pod motor ejection charge at wrong time");
+		assertEquals(5.0, ejections.get(1).getTime(), EPSILON, "Sustainer motor ejection charge at wrong time");
+
+		// Only the sustainer's charge may deploy the sustainer's parachute
+		final List<FlightEvent> deployments = getEvents(sim, FlightEvent.Type.RECOVERY_DEVICE_DEPLOYMENT);
+		assertEquals(1, deployments.size(), "Parachute should be deployed exactly once");
+		assertEquals(parachute, deployments.get(0).getSource(), "Wrong recovery device deployed");
+		assertEquals(5.001, deployments.get(0).getTime(), EPSILON, "Parachute deployed at wrong time");
+
+		// Deploying on the pod motors' charges would have blown the parachute open under thrust
+		assertTrue(getEvents(sim, FlightEvent.Type.SIM_ABORT).isEmpty(), "Simulation should not have aborted");
+		assertEquals(3.19, sim.getSimulatedData().getDeploymentVelocity(), 0.05, "Wrong deployment velocity");
+	}
+
+	/**
+	 * Only the <em>first</em> ejection charge in an airframe deploys its recovery devices; the charge
+	 * of a second motor with a longer delay must not deploy an already deployed parachute again.
+	 * See <a href="https://github.com/openrocket/openrocket/issues/2092">GitHub issue #2092</a>.
+	 */
+	@Test
+	public void testOnlyFirstEjectionChargeDeploys() throws SimulationException {
+		final Rocket rocket = TestRockets.makeEstesAlphaIIIWithSecondMotor();
+		final BodyTube bodyTube = (BodyTube) rocket.getStage(0).getChild(1);
+		final Parachute parachute = (Parachute) bodyTube.getChild(3);
+
+		final Simulation sim = simulate(rocket);
+
+		// The B4-3 fires its charge at t = 5.0 s, the A10-5 alongside it only at t = 6.05 s
+		final List<FlightEvent> ejections = getEvents(sim, FlightEvent.Type.EJECTION_CHARGE);
+		assertEquals(2, ejections.size(), "Expected an ejection charge from both motors");
+		assertEquals(5.0, ejections.get(0).getTime(), EPSILON, "First ejection charge at wrong time");
+		assertEquals(6.05, ejections.get(1).getTime(), EPSILON, "Second ejection charge at wrong time");
+
+		final List<FlightEvent> deployments = getEvents(sim, FlightEvent.Type.RECOVERY_DEVICE_DEPLOYMENT);
+		assertEquals(1, deployments.size(), "Parachute should be deployed exactly once");
+		assertEquals(parachute, deployments.get(0).getSource(), "Wrong recovery device deployed");
+		assertEquals(5.001, deployments.get(0).getTime(), EPSILON, "Parachute deployed at wrong time");
+
+		// The deployment velocity must be the one of the real deployment, not of the phantom second one
+		assertEquals(10.21, sim.getSimulatedData().getDeploymentVelocity(), 0.05, "Wrong deployment velocity");
+	}
+
+	/*
+	 * run a simulation of the rocket's TEST_FCID_1 configuration under the conditions the tests in
+	 * this class share
+	 */
+	private Simulation simulate(Rocket rocket) throws SimulationException {
+		final Simulation sim = new Simulation(rocket);
+		sim.getOptions().setISAAtmosphere(true);
+		sim.getOptions().setTimeStep(0.05);
+		sim.getOptions().getAverageWindModel().setAverage(0.1);
+		sim.setFlightConfigurationId(TestRockets.TEST_FCID_1);
+
+		sim.simulate();
+
+		return sim;
+	}
+
+	/*
+	 * collect the events of a single type from the simulation's main branch, in the order they occurred
+	 */
+	private List<FlightEvent> getEvents(Simulation sim, FlightEvent.Type type) {
+		return sim.getSimulatedData().getBranch(0).getEvents().stream()
+				.filter(e -> e.getType() == type)
+				.toList();
+	}
+
 	/*
 	 * make sure expected and actual events match
 	 *


### PR DESCRIPTION
This PR fixes #2092. There turned out to be two separate bugs behind the strange deployment behavior.

First, `DeploymentConfiguration.DeployEvent.EJECTION` matched ejection charges to recovery devices using stage numbers alone. Because pods belong to their parent stage, a pod motor’s ejection charge could incorrectly deploy the sustainer’s parachute. The check now compares the motor mount and recovery device by their innermost `ComponentAssembly`, reflecting that an ejection charge only pressurizes its own airframe assembly. If the firing motor is unavailable, the previous stage-based check remains as a fallback. Stage-separation behavior is unchanged.

Second, recovery devices could deploy multiple times. Each later ejection charge queued another `RECOVERY_DEVICE_DEPLOYMENT` event, and `FlightData.calculateInterestingValues` used the last event to calculate deployment velocity, producing the incorrect value reported in #2092. Deployment is now ignored when the device is already deployed, both when queueing and handling the event to cover simultaneous ejection charges. This also matches the UI description: “First ejection charge of this stage.”

The new assembly check exposed a dormant bug in `RocketComponent.getAssembly`, which never advanced to the parent and could loop indefinitely. The first commit fixes that and adds a `MotorMount.getAssembly` pass-through matching `getStage`.

---

One behavior change is worth noting: a recovery device inside a pod is now triggered only by motors in that same pod, including inline coaxial pods. Designs that place a parachute in a coaxial pod while keeping the motor in the main airframe will need another trigger.