### PR TITLE
Retain Component Analysis settings on dialog close/data type switch

### DIFF
--- a/core/src/main/java/info/openrocket/core/componentanalysis/CADataType.java
+++ b/core/src/main/java/info/openrocket/core/componentanalysis/CADataType.java
@@ -121,13 +121,8 @@ public class CADataType implements Comparable<CADataType>, Groupable<CADataTypeG
 	 * @return true if the component is relevant for the given CADataType, false otherwise
 	 */
 	public static boolean isComponentRelevantForType(RocketComponent component, CADataType type) {
-		// Only aerodynamic and rockets are relevant for any CADataType
+		// Only aerodynamic components and the rocket-level totals are relevant.
 		if (!component.isAerodynamic() && !(component instanceof Rocket)) {
-			return false;
-		}
-
-		// Doesn't make sense to calculate per-instance drag for rockets
-		if (component instanceof Rocket && type.equals(CADataType.PER_INSTANCE_CD)) {
 			return false;
 		}
 
@@ -137,7 +132,7 @@ public class CADataType implements Comparable<CADataType>, Groupable<CADataTypeG
 			return true;
 		} else if (type.equals(CADataType.ROLL_FORCING_COEFFICIENT) || type.equals(CADataType.ROLL_DAMPING_COEFFICIENT) ||
 				type.equals(CADataType.TOTAL_ROLL_COEFFICIENT)) {
-			return component instanceof FinSet;
+			return component instanceof FinSet || component instanceof Rocket;
 		}
 		return false;
 	}

--- a/core/src/main/java/info/openrocket/core/componentanalysis/CADomainDataType.java
+++ b/core/src/main/java/info/openrocket/core/componentanalysis/CADomainDataType.java
@@ -17,7 +17,7 @@ public class CADomainDataType extends CADataType {
 	public static final CADomainDataType AOA = new CADomainDataType(trans.get("CADomainDataType.lbl.angleofattack"),
 			"a", UnitGroup.UNITS_ANGLE, CADataTypeGroup.DOMAIN_PARAMETER, 0.0, Math.PI, Math.PI / 30, Math.PI / 1800, 1);
 	public static final CADomainDataType MACH = new CADomainDataType(trans.get("CADomainDataType.lbl.machnumber"),
-			"M", UnitGroup.UNITS_COEFFICIENT, CADataTypeGroup.DOMAIN_PARAMETER, 0, 3.0, 0.025, 0.001, 2);
+			"M", UnitGroup.UNITS_COEFFICIENT, CADataTypeGroup.DOMAIN_PARAMETER, 0, 5.0, 0.025, 0.001, 2);
 	public static final CADomainDataType ROLL_RATE = new CADomainDataType(trans.get("CADomainDataType.lbl.rollrate"),
 			"r", UnitGroup.UNITS_ROLL, CADataTypeGroup.DOMAIN_PARAMETER, -20 * 2 * Math.PI, 20 * 2 * Math.PI,
 			Math.PI, Math.PI / 10, 3);

--- a/core/src/test/java/info/openrocket/core/componentanalysis/CADataTypeTest.java
+++ b/core/src/test/java/info/openrocket/core/componentanalysis/CADataTypeTest.java
@@ -55,13 +55,14 @@ class CADataTypeTest extends ComponentAnalysisTestBase {
 	}
 
 	@Test
-	void rocketIsExcludedFromPerInstanceDrag() {
-		assertFalse(CADataType.isComponentRelevantForType(rocket, CADataType.PER_INSTANCE_CD));
+	void rocketProvidesFallbackDataForPerInstanceDrag() {
+		assertTrue(CADataType.isComponentRelevantForType(rocket, CADataType.PER_INSTANCE_CD));
 	}
 
 	@Test
-	void rollCoefficientsAreLimitedToFinSets() {
+	void rollCoefficientsAreLimitedToFinSetsAndRocketTotal() {
 		assertTrue(CADataType.isComponentRelevantForType(finSet, CADataType.ROLL_FORCING_COEFFICIENT));
+		assertTrue(CADataType.isComponentRelevantForType(rocket, CADataType.ROLL_FORCING_COEFFICIENT));
 		assertFalse(CADataType.isComponentRelevantForType(aerodynamicComponent, CADataType.ROLL_FORCING_COEFFICIENT));
 	}
 
@@ -85,7 +86,7 @@ class CADataTypeTest extends ComponentAnalysisTestBase {
 	}
 
 	@Test
-	void calculateComponentsForRollTypesOnlyReturnsFinSets() {
+	void calculateComponentsForRollTypesReturnsRocketTotalAndFinSets() {
 		when(configuration.getAllActiveComponents()).thenReturn(List.of(
 				rocket,
 				finSet,
@@ -95,7 +96,8 @@ class CADataTypeTest extends ComponentAnalysisTestBase {
 
 		List<RocketComponent> components = CADataType.calculateComponentsForType(configuration, CADataType.ROLL_DAMPING_COEFFICIENT);
 
-		assertEquals(1, components.size());
-		assertEquals(finSet, components.get(0));
+		assertEquals(2, components.size());
+		assertEquals(rocket, components.get(0));
+		assertEquals(finSet, components.get(1));
 	}
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/CAExportPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/CAExportPanel.java
@@ -44,6 +44,11 @@ public class CAExportPanel extends CSVExportPanel<CADataType> {
 	private static final int OPTION_FIELD_DESCRIPTIONS = 1;
 
 	public CAExportPanel(ComponentAnalysisPlotExportPanel parent, CADataType[] types, boolean[] selected) {
+		this(parent, types, selected, null);
+	}
+
+	private CAExportPanel(ComponentAnalysisPlotExportPanel parent, CADataType[] types, boolean[] selected,
+						  Settings initialSettings) {
 		super(types, selected,
 				new CsvOptionPanel(CAExportPanel.class, true,
 						trans.get("CAExportPanel.checkbox.Includecadesc"),
@@ -56,9 +61,19 @@ public class CAExportPanel extends CSVExportPanel<CADataType> {
 
 		// Initialize selected components map
 		for (int i = 0; i < types.length; i++) {
-			updateSelectedComponents(types[i], new ArrayList<>(), parent.getComponentsForType(types[i]),
+			List<RocketComponent> initialComponents = initialSettings != null ?
+					initialSettings.selectedComponents.get(types[i]) : null;
+			updateSelectedComponents(types[i], initialComponents, parent.getComponentsForType(types[i]),
 					selectedComponentsLabels.get(i), selectedComponentsScrollPanes.get(i));
+			if (initialSettings != null && initialSettings.units.containsKey(types[i])) {
+				setSelectedUnit(i, initialSettings.units.get(types[i]));
+			}
 		}
+	}
+
+	@Override
+	protected boolean hasExtraComponent() {
+		return true;
 	}
 
 	@Override
@@ -97,7 +112,10 @@ public class CAExportPanel extends CSVExportPanel<CADataType> {
 					selectedComponentsMap.get(type)
 			);
 			List<RocketComponent> newSelectedComponents = dialog.showDialog();
-			updateSelectedComponents(type, newSelectedComponents, availableComponents, selectedComponentsLabel, scrollPane);
+			if (newSelectedComponents != null) {
+				updateSelectedComponents(type, newSelectedComponents, availableComponents,
+						selectedComponentsLabel, scrollPane);
+			}
 		});
 
 		return panel;
@@ -111,7 +129,7 @@ public class CAExportPanel extends CSVExportPanel<CADataType> {
 	private void updateSelectedComponents(CADataType type, List<RocketComponent> components,
 										  List<RocketComponent> componentsForType, JTextArea label,
 										  JScrollPane scrollPane) {
-		components = (components != null && !components.isEmpty()) ? components : componentsForType.subList(0, 1);
+		components = CAPlotTypeSelector.retainValidComponentsOrRocket(components, componentsForType);
 		List<RocketComponent> selectedComponentsList = this.selectedComponentsMap.computeIfAbsent(type, k -> new ArrayList<>());
 		selectedComponentsList.clear();
 		selectedComponentsList.addAll(components);
@@ -130,13 +148,49 @@ public class CAExportPanel extends CSVExportPanel<CADataType> {
 		scrollPane.repaint();
 	}
 
-	public static CAExportPanel create(ComponentAnalysisPlotExportPanel parent, CADataType[] types) {
+	public static CAExportPanel create(ComponentAnalysisPlotExportPanel parent, CADataType[] types,
+									   Settings initialSettings) {
 		boolean[] selected = new boolean[types.length];
 		for (int i = 0; i < types.length; i++) {
-			selected[i] = ((SwingPreferences) Application.getPreferences()).isComponentAnalysisDataTypeExportSelected(types[i]);
+			if (initialSettings != null && initialSettings.selected.containsKey(types[i])) {
+				selected[i] = initialSettings.selected.get(types[i]);
+			} else {
+				selected[i] = ((SwingPreferences) Application.getPreferences())
+						.isComponentAnalysisDataTypeExportSelected(types[i]);
+			}
 		}
 
-		return new CAExportPanel(parent, types, selected);
+		return new CAExportPanel(parent, types, selected, initialSettings);
+	}
+
+	/**
+	 * Capture export choices before the component-analysis dialog is disposed.
+	 */
+	Settings getSettings() {
+		csvOptions.storePreferences();
+		Map<CADataType, Boolean> selectedSettings = new HashMap<>();
+		Map<CADataType, Unit> unitSettings = new HashMap<>();
+		Map<CADataType, List<RocketComponent>> componentSettings = new HashMap<>();
+		for (int i = 0; i < types.length; i++) {
+			selectedSettings.put(types[i], selected[i]);
+			unitSettings.put(types[i], units[i]);
+			componentSettings.put(types[i], new ArrayList<>(selectedComponentsMap.get(types[i])));
+			prefs.setComponentAnalysisExportSelected(types[i], selected[i]);
+		}
+		return new Settings(selectedSettings, unitSettings, componentSettings);
+	}
+
+	static final class Settings {
+		private final Map<CADataType, Boolean> selected;
+		private final Map<CADataType, Unit> units;
+		private final Map<CADataType, List<RocketComponent>> selectedComponents;
+
+		private Settings(Map<CADataType, Boolean> selected, Map<CADataType, Unit> units,
+						 Map<CADataType, List<RocketComponent>> selectedComponents) {
+			this.selected = selected;
+			this.units = units;
+			this.selectedComponents = selectedComponents;
+		}
 	}
 
 	@Override

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/CAPlotConfiguration.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/CAPlotConfiguration.java
@@ -53,6 +53,12 @@ public class CAPlotConfiguration extends PlotConfiguration<CADataType, CADataBra
 		plotDataComponents.add(null);
 	}
 
+	@Override
+	public void removePlotDataType(int index) {
+		super.removePlotDataType(index);
+		plotDataComponents.remove(index);
+	}
+
 	public List<RocketComponent> getComponents(int index) {
 		return plotDataComponents.get(index);
 	}

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/CAPlotPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/CAPlotPanel.java
@@ -37,17 +37,20 @@ public class CAPlotPanel extends PlotPanel<CADataType, CADataBranch, CADataTypeG
 		PRESET_ARRAY[PRESET_ARRAY.length - 1] = CUSTOM_CONFIGURATION;
 	}
 
-	private CAPlotPanel(ComponentAnalysisPlotExportPanel parent, CADomainDataType[] typesX, CADataType[] typesY) {
-		super(typesX, typesY, CUSTOM_CONFIGURATION, PRESET_ARRAY, DEFAULT_CONFIGURATION, null, null);
+	private CAPlotPanel(ComponentAnalysisPlotExportPanel parent, CADomainDataType[] typesX, CADataType[] typesY,
+						CAPlotConfiguration initialConfiguration) {
+		super(typesX, typesY, CUSTOM_CONFIGURATION, PRESET_ARRAY,
+				initialConfiguration != null ? initialConfiguration : DEFAULT_CONFIGURATION, null, null);
 
 		this.parent = parent;
 		updatePlots();
 	}
 
-	public static CAPlotPanel create(ComponentAnalysisPlotExportPanel parent, CADataType[] typesY) {
+	public static CAPlotPanel create(ComponentAnalysisPlotExportPanel parent, CADataType[] typesY,
+									 CAPlotConfiguration initialConfiguration) {
 		CADomainDataType[] typesX = new CADomainDataType[] { parent.getSelectedParameter() };
 
-		return new CAPlotPanel(parent, typesX, typesY);
+		return new CAPlotPanel(parent, typesX, typesY, initialConfiguration);
 	}
 
 	@Override

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/CAPlotTypeSelector.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/CAPlotTypeSelector.java
@@ -3,6 +3,7 @@ package info.openrocket.swing.gui.dialogs.componentanalysis;
 import info.openrocket.core.componentanalysis.CADataType;
 import info.openrocket.core.componentanalysis.CADataTypeGroup;
 import info.openrocket.core.document.OpenRocketDocument;
+import info.openrocket.core.rocketcomponent.Rocket;
 import info.openrocket.core.rocketcomponent.RocketComponent;
 import info.openrocket.core.startup.Application;
 import info.openrocket.core.unit.Unit;
@@ -83,7 +84,8 @@ public class CAPlotTypeSelector extends PlotTypeSelector<CADataType, CADataTypeG
 				CADataType type = (CADataType) typeSelector.getSelectedItem();
 				List<RocketComponent> componentsForType = parent.getComponentsForType(type);
 				setComponentsForType(type, componentsForType);
-				updateSelectedComponents(null, componentsForType, configuration, plotIndex);
+				updateSelectedComponents(CAPlotTypeSelector.this.selectedComponents, componentsForType,
+						configuration, plotIndex);
 			}
 		});
 	}
@@ -97,13 +99,42 @@ public class CAPlotTypeSelector extends PlotTypeSelector<CADataType, CADataTypeG
 
 	private void updateSelectedComponents(List<RocketComponent> components, List<RocketComponent> componentsForType,
 										  CAPlotConfiguration configuration, int plotIndex) {
-		components = (components != null && !components.isEmpty()) ? components : componentsForType.subList(0, 1);
+		components = retainValidComponentsOrRocket(components, componentsForType);
 		this.selectedComponents.clear();
 		this.selectedComponents.addAll(components);
 
 		updateSelectedComponentsLabel(this.selectedComponents);
 		configuration.setPlotDataComponents(plotIndex, this.selectedComponents);
 		notifyComponentSelectionListeners();
+	}
+
+	/**
+	 * Retain selected components supported by a new data type.  If none remain,
+	 * select the rocket-level result, which is available for every analysis type.
+	 */
+	static List<RocketComponent> retainValidComponentsOrRocket(List<RocketComponent> selectedComponents,
+														 List<RocketComponent> componentsForType) {
+		List<RocketComponent> retained = new ArrayList<>();
+		if (selectedComponents != null) {
+			for (RocketComponent component : selectedComponents) {
+				if (componentsForType.contains(component)) {
+					retained.add(component);
+				}
+			}
+		}
+
+		if (!retained.isEmpty()) {
+			return retained;
+		}
+
+		for (RocketComponent component : componentsForType) {
+			if (component instanceof Rocket) {
+				return List.of(component);
+			}
+		}
+
+		// Defensive fallback for custom data types which do not provide a rocket total.
+		return componentsForType.subList(0, 1);
 	}
 
 	private void updateSelectedComponentsLabel(List<RocketComponent> components) {

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/ComponentAnalysisDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/ComponentAnalysisDialog.java
@@ -25,9 +25,12 @@ import net.miginfocom.swing.MigLayout;
 public class ComponentAnalysisDialog extends JDialog {
 	private static final long serialVersionUID = 9131240570600307935L;
 	private static ComponentAnalysisDialog singletonDialog = null;
+	private static OpenRocketDocument retainedDocument;
+	private static DialogSettings retainedSettings;
 	private static final Translator trans = Application.getTranslator();
 
 	private JButton okButton;
+	private boolean retainSettingsOnClose = true;
 
 	public ComponentAnalysisDialog(OpenRocketDocument document, RocketPanel rocketPanel) {
 		//// Component analysis
@@ -37,6 +40,7 @@ public class ComponentAnalysisDialog extends JDialog {
 		add(panel);
 
 		JTabbedPane tabbedPane = new JTabbedPane();
+		DialogSettings initialSettings = document == retainedDocument ? retainedSettings : null;
 
 		// General tab
 		ComponentAnalysisGeneralPanel generalTab = new ComponentAnalysisGeneralPanel(this, rocketPanel);
@@ -44,8 +48,13 @@ public class ComponentAnalysisDialog extends JDialog {
 
 		// Plot export tab
 		ComponentAnalysisPlotExportPanel plotExportTab = new ComponentAnalysisPlotExportPanel(this, document,
-				generalTab.getParameters(), generalTab.getAerodynamicCalculator(), generalTab.getRocket());
+				generalTab.getParameters(), generalTab.getAerodynamicCalculator(), generalTab.getRocket(),
+				initialSettings != null ? initialSettings.plotExportSettings : null);
 		tabbedPane.addTab(trans.get("ComponentAnalysisDialog.tab.PlotExport"), plotExportTab);
+		if (initialSettings != null && initialSettings.selectedTab >= 0 &&
+				initialSettings.selectedTab < tabbedPane.getTabCount()) {
+			tabbedPane.setSelectedIndex(initialSettings.selectedTab);
+		}
 
 		panel.add(tabbedPane, "span, pushy, grow, wrap");
 
@@ -53,6 +62,10 @@ public class ComponentAnalysisDialog extends JDialog {
 		this.addWindowListener(new WindowAdapter() {
 			@Override
 			public void windowClosed(WindowEvent e) {
+				if (retainSettingsOnClose) {
+					retainedDocument = document;
+					retainedSettings = new DialogSettings(tabbedPane.getSelectedIndex(), plotExportTab.getSettings());
+				}
 				singletonDialog = null;
 			}
 		});
@@ -78,6 +91,7 @@ public class ComponentAnalysisDialog extends JDialog {
 				showOkButton(tabbedPane.getSelectedComponent() == plotExportTab);
 			}
 		});
+		showOkButton(tabbedPane.getSelectedComponent() == plotExportTab);
 
 		this.setLocationByPlatform(true);
 		setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
@@ -103,7 +117,25 @@ public class ComponentAnalysisDialog extends JDialog {
 	}
 
 	public static void hideDialog() {
-		if (singletonDialog != null)
+		if (singletonDialog != null) {
+			singletonDialog.retainSettingsOnClose = false;
 			singletonDialog.dispose();
+		}
+		retainedDocument = null;
+		retainedSettings = null;
+	}
+
+	/**
+	 * Settings which should survive closing and reopening the dialog for the same document.
+	 */
+	private static final class DialogSettings {
+		private final int selectedTab;
+		private final ComponentAnalysisPlotExportPanel.Settings plotExportSettings;
+
+		private DialogSettings(int selectedTab,
+							   ComponentAnalysisPlotExportPanel.Settings plotExportSettings) {
+			this.selectedTab = selectedTab;
+			this.plotExportSettings = plotExportSettings;
+		}
 	}
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/ComponentAnalysisDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/ComponentAnalysisDialog.java
@@ -43,7 +43,8 @@ public class ComponentAnalysisDialog extends JDialog {
 		DialogSettings initialSettings = document == retainedDocument ? retainedSettings : null;
 
 		// General tab
-		ComponentAnalysisGeneralPanel generalTab = new ComponentAnalysisGeneralPanel(this, rocketPanel);
+		ComponentAnalysisGeneralPanel generalTab = new ComponentAnalysisGeneralPanel(this, rocketPanel,
+				initialSettings != null ? initialSettings.generalSettings : null);
 		tabbedPane.addTab(trans.get("ComponentAnalysisDialog.tab.General"), generalTab);
 
 		// Plot export tab
@@ -64,7 +65,8 @@ public class ComponentAnalysisDialog extends JDialog {
 			public void windowClosed(WindowEvent e) {
 				if (retainSettingsOnClose) {
 					retainedDocument = document;
-					retainedSettings = new DialogSettings(tabbedPane.getSelectedIndex(), plotExportTab.getSettings());
+					retainedSettings = new DialogSettings(tabbedPane.getSelectedIndex(), generalTab.getSettings(),
+							plotExportTab.getSettings());
 				}
 				singletonDialog = null;
 			}
@@ -130,11 +132,13 @@ public class ComponentAnalysisDialog extends JDialog {
 	 */
 	private static final class DialogSettings {
 		private final int selectedTab;
+		private final ComponentAnalysisGeneralPanel.Settings generalSettings;
 		private final ComponentAnalysisPlotExportPanel.Settings plotExportSettings;
 
-		private DialogSettings(int selectedTab,
+		private DialogSettings(int selectedTab, ComponentAnalysisGeneralPanel.Settings generalSettings,
 							   ComponentAnalysisPlotExportPanel.Settings plotExportSettings) {
 			this.selectedTab = selectedTab;
+			this.generalSettings = generalSettings;
 			this.plotExportSettings = plotExportSettings;
 		}
 	}

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/ComponentAnalysisGeneralPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/ComponentAnalysisGeneralPanel.java
@@ -89,9 +89,11 @@ public class ComponentAnalysisGeneralPanel extends JPanel implements StateChange
 	private final Rocket rocket;
 	private final DoubleModel theta, aoa, mach, roll;
 	private final JToggleButton worstToggle;
+	private final JTabbedPane analysisTabbedPane;
 	private boolean fakeChange = false;
 	private final AerodynamicCalculator aerodynamicCalculator;
 	private final CAParameters parameters;
+	private Settings closedSettings;
 
 	private final ColumnTableModel longitudeStabilityTableModel;
 	private final ColumnTableModel dragTableModel;
@@ -106,6 +108,10 @@ public class ComponentAnalysisGeneralPanel extends JPanel implements StateChange
 
 
 	public ComponentAnalysisGeneralPanel(Window parent, final RocketPanel rocketPanel) {
+		this(parent, rocketPanel, null);
+	}
+
+	public ComponentAnalysisGeneralPanel(Window parent, final RocketPanel rocketPanel, Settings initialSettings) {
 		super(new MigLayout("fill", "[120lp][70lp][50lp][]"));
 
 		this.rocket = rocketPanel.getDocument().getRocket();
@@ -115,12 +121,24 @@ public class ComponentAnalysisGeneralPanel extends JPanel implements StateChange
 
 		// Create CAParameters
 		this.parameters = new CAParameters(rocket, rocketPanel.getFigure().getRotation());
-		this.parameters.addListener(rocketPanel);
+		if (initialSettings != null) {
+			parameters.setTheta(initialSettings.theta);
+			parameters.setAOA(initialSettings.aoa);
+			parameters.setMach(initialSettings.mach);
+			parameters.setRollRate(initialSettings.rollRate);
+		}
+		parameters.addListener(rocketPanel);
 
 		this.aoa = new DoubleModel(parameters, "AOA", UnitGroup.UNITS_ANGLE, 0, Math.PI);
 		this.mach = new DoubleModel(parameters, "Mach", UnitGroup.UNITS_COEFFICIENT, 0, 6.0);
 		this.theta = new DoubleModel(parameters, "Theta", UnitGroup.UNITS_ANGLE, 0, 2 * Math.PI);
 		this.roll = new DoubleModel(parameters, "RollRate", UnitGroup.UNITS_ROLL);
+		if (initialSettings != null) {
+			theta.setCurrentUnit(initialSettings.thetaUnit);
+			aoa.setCurrentUnit(initialSettings.aoaUnit);
+			mach.setCurrentUnit(initialSettings.machUnit);
+			roll.setCurrentUnit(initialSettings.rollRateUnit);
+		}
 
 		//// Wind direction:
 		this.add(new JLabel(trans.get("ComponentAnalysisGeneralTab.lbl.winddir")));
@@ -134,7 +152,7 @@ public class ComponentAnalysisGeneralPanel extends JPanel implements StateChange
 		this.add(slider, "growx, split 2");
 		//// Worst button
 		this.worstToggle = new JToggleButton(trans.get("ComponentAnalysisGeneralTab.ToggleBut.worst"));
-		this.worstToggle.setSelected(true);
+		this.worstToggle.setSelected(initialSettings == null || initialSettings.worstSelected);
 		this.worstToggle.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -203,8 +221,8 @@ public class ComponentAnalysisGeneralPanel extends JPanel implements StateChange
 
 		// Tabbed pane
 
-		JTabbedPane tabbedPane = new JTabbedPane();
-		this.add(tabbedPane, "spanx, growx, growy, pushy");
+		this.analysisTabbedPane = new JTabbedPane();
+		this.add(analysisTabbedPane, "spanx, growx, growy, pushy");
 
 
 		// Create the Longitudinal Stability (CM vs CP) data table
@@ -296,7 +314,7 @@ public class ComponentAnalysisGeneralPanel extends JPanel implements StateChange
 		scrollpane.setPreferredSize(new Dimension(600, 200));
 
 		//// Stability and Stability information
-		tabbedPane.addTab(trans.get("ComponentAnalysisGeneralTab.TabStability"),
+		analysisTabbedPane.addTab(trans.get("ComponentAnalysisGeneralTab.TabStability"),
 				null, scrollpane, trans.get("ComponentAnalysisGeneralTab.TabStability.ttip"));
 
 
@@ -385,7 +403,7 @@ public class ComponentAnalysisGeneralPanel extends JPanel implements StateChange
 		scrollpane.setPreferredSize(new Dimension(600, 200));
 
 		//// Drag characteristics and Drag characteristics tooltip
-		tabbedPane.addTab(trans.get("ComponentAnalysisGeneralTab.dragTabchar"), null, scrollpane,
+		analysisTabbedPane.addTab(trans.get("ComponentAnalysisGeneralTab.dragTabchar"), null, scrollpane,
 				trans.get("ComponentAnalysisGeneralTab.dragTabchar.ttip"));
 
 
@@ -454,8 +472,12 @@ public class ComponentAnalysisGeneralPanel extends JPanel implements StateChange
 		scrollpane.setPreferredSize(new Dimension(600, 200));
 
 		//// Roll dynamics and Roll dynamics tooltip
-		tabbedPane.addTab(trans.get("ComponentAnalysisGeneralTab.rollTableModel"), null, scrollpane,
+		analysisTabbedPane.addTab(trans.get("ComponentAnalysisGeneralTab.rollTableModel"), null, scrollpane,
 				trans.get("ComponentAnalysisGeneralTab.rollTableModel.ttip"));
+		if (initialSettings != null && initialSettings.selectedTab >= 0 &&
+				initialSettings.selectedTab < analysisTabbedPane.getTabCount()) {
+			analysisTabbedPane.setSelectedIndex(initialSettings.selectedTab);
+		}
 
 
 		//// Reference length:
@@ -504,23 +526,18 @@ public class ComponentAnalysisGeneralPanel extends JPanel implements StateChange
 		dragTable.getSelectionModel().addListSelectionListener(new CAListSelectionListener(rocketPanel, dragTable));
 		rollTable.getSelectionModel().addListSelectionListener(new CAListSelectionListener(rocketPanel, rollTable));
 
-		// Remove listeners when closing window
+		// Remove listeners when closing the window, but keep the current analysis
+		// conditions in the design view so reopening starts from the same state.
 		parent.addWindowListener(new WindowAdapter() {
 			@Override
 			public void windowClosed(WindowEvent e) {
-				theta.setValue(parameters.getInitialTheta());
-
-				//System.out.println("Closing method called: " + this);
+				closedSettings = captureSettings();
+				parameters.removeListener(rocketPanel);
 				rocket.removeChangeListener(ComponentAnalysisGeneralPanel.this);
 				mach.removeChangeListener(ComponentAnalysisGeneralPanel.this);
 				theta.removeChangeListener(ComponentAnalysisGeneralPanel.this);
 				aoa.removeChangeListener(ComponentAnalysisGeneralPanel.this);
 				roll.removeChangeListener(ComponentAnalysisGeneralPanel.this);
-				//System.out.println("SETTING NAN VALUES");
-				rocketPanel.setCPAOA(Double.NaN);
-				rocketPanel.setCPTheta(Double.NaN);
-				rocketPanel.setCPMach(Double.NaN);
-				rocketPanel.setCPRoll(Double.NaN);
 			}
 		});
 	}
@@ -552,6 +569,46 @@ public class ComponentAnalysisGeneralPanel extends JPanel implements StateChange
 
 	public Rocket getRocket() {
 		return rocket;
+	}
+
+	/**
+	 * Return the user-adjustable state which should be restored when the dialog is reopened.
+	 */
+	Settings getSettings() {
+		return closedSettings != null ? closedSettings : captureSettings();
+	}
+
+	private Settings captureSettings() {
+		return new Settings(parameters.getTheta(), parameters.getAOA(), parameters.getMach(),
+				parameters.getRollRate(), theta.getCurrentUnit(), aoa.getCurrentUnit(), mach.getCurrentUnit(),
+				roll.getCurrentUnit(), worstToggle.isSelected(), analysisTabbedPane.getSelectedIndex());
+	}
+
+	static final class Settings {
+		private final double theta;
+		private final double aoa;
+		private final double mach;
+		private final double rollRate;
+		private final Unit thetaUnit;
+		private final Unit aoaUnit;
+		private final Unit machUnit;
+		private final Unit rollRateUnit;
+		private final boolean worstSelected;
+		private final int selectedTab;
+
+		private Settings(double theta, double aoa, double mach, double rollRate, Unit thetaUnit,
+						 Unit aoaUnit, Unit machUnit, Unit rollRateUnit, boolean worstSelected, int selectedTab) {
+			this.theta = theta;
+			this.aoa = aoa;
+			this.mach = mach;
+			this.rollRate = rollRate;
+			this.thetaUnit = thetaUnit;
+			this.aoaUnit = aoaUnit;
+			this.machUnit = machUnit;
+			this.rollRateUnit = rollRateUnit;
+			this.worstSelected = worstSelected;
+			this.selectedTab = selectedTab;
+		}
 	}
 
 	/**

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/ComponentAnalysisGeneralPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/ComponentAnalysisGeneralPanel.java
@@ -118,7 +118,7 @@ public class ComponentAnalysisGeneralPanel extends JPanel implements StateChange
 		this.parameters.addListener(rocketPanel);
 
 		this.aoa = new DoubleModel(parameters, "AOA", UnitGroup.UNITS_ANGLE, 0, Math.PI);
-		this.mach = new DoubleModel(parameters, "Mach", UnitGroup.UNITS_COEFFICIENT, 0);
+		this.mach = new DoubleModel(parameters, "Mach", UnitGroup.UNITS_COEFFICIENT, 0, 6.0);
 		this.theta = new DoubleModel(parameters, "Theta", UnitGroup.UNITS_ANGLE, 0, 2 * Math.PI);
 		this.roll = new DoubleModel(parameters, "RollRate", UnitGroup.UNITS_ROLL);
 

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/ComponentAnalysisPlotExportPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/ComponentAnalysisPlotExportPanel.java
@@ -11,6 +11,7 @@ import info.openrocket.core.l10n.Translator;
 import info.openrocket.core.rocketcomponent.Rocket;
 import info.openrocket.core.rocketcomponent.RocketComponent;
 import info.openrocket.core.startup.Application;
+import info.openrocket.core.unit.Unit;
 import info.openrocket.swing.gui.adaptors.DoubleModel;
 import info.openrocket.swing.gui.components.EditableSpinner;
 import info.openrocket.swing.gui.components.UnitSelector;
@@ -66,7 +67,7 @@ public class ComponentAnalysisPlotExportPanel extends JPanel implements PlotPane
 
 	public ComponentAnalysisPlotExportPanel(ComponentAnalysisDialog parent, OpenRocketDocument document,
 											CAParameters parameters, AerodynamicCalculator aerodynamicCalculator,
-											Rocket rocket) {
+											Rocket rocket, Settings initialSettings) {
 		super(new MigLayout("fill, height 500px!", "[]", "[grow]"));
 
 		this.parent = parent;
@@ -79,19 +80,21 @@ public class ComponentAnalysisPlotExportPanel extends JPanel implements PlotPane
 		this.types = getValidTypes();
 
 		// ======== Top panel ========
-		addTopPanel();
+		addTopPanel(initialSettings);
 
 		// ======== Tabbed pane ========
 		this.tabbedPane = new JTabbedPane();
 		this.add(tabbedPane, "spanx, growx, growy, pushy, wrap");
 
 		//// Plot data
-		this.plotTab = CAPlotPanel.create(this, types);
+		this.plotTab = CAPlotPanel.create(this, types,
+				initialSettings != null ? initialSettings.plotConfiguration : null);
 		this.tabbedPane.addTab(trans.get("CAPlotExportDialog.tab.Plot"), null, this.plotTab);
 		this.plotTab.addPlotConfigurationListener(this);
 
 		//// Export data
-		this.exportTab = CAExportPanel.create(this, types);
+		this.exportTab = CAExportPanel.create(this, types,
+				initialSettings != null ? initialSettings.exportSettings : null);
 		this.tabbedPane.addTab(trans.get("CAPlotExportDialog.tab.Export"), null, this.exportTab);
 
 		// Create the OK button
@@ -115,6 +118,10 @@ public class ComponentAnalysisPlotExportPanel extends JPanel implements PlotPane
 				}
 			}
 		});
+		if (initialSettings != null && initialSettings.selectedTab >= 0 &&
+				initialSettings.selectedTab < tabbedPane.getTabCount()) {
+			tabbedPane.setSelectedIndex(initialSettings.selectedTab);
+		}
 
 		validate();
 
@@ -122,7 +129,7 @@ public class ComponentAnalysisPlotExportPanel extends JPanel implements PlotPane
 		rocket.addComponentChangeListener(e -> invalidateCache());
 	}
 
-	private void addTopPanel() {
+	private void addTopPanel(Settings initialSettings) {
 		JPanel topPanel = new JPanel(new MigLayout("fill, ins unrel unrel 0 unrel"));
 		TitledBorder border = BorderFactory.createTitledBorder(trans.get("CAPlotExportDialog.XAxisConfiguration"));
 		topPanel.setBorder(border);
@@ -131,11 +138,18 @@ public class ComponentAnalysisPlotExportPanel extends JPanel implements PlotPane
 		topPanel.add(new JLabel(trans.get("CAPlotExportDialog.lbl.XAxis")), "top, split 2");
 		this.parameterSelector = new JComboBox<>(CADomainDataType.ALL_DOMAIN_TYPES);
 		this.parameterSelector.setToolTipText(trans.get("CAPlotExportDialog.lbl.XAxis.ttip"));
-		parameterSelector.setSelectedItem(CADomainDataType.MACH);
+		CADomainDataType initialParameter = initialSettings != null ?
+				initialSettings.selectedParameter : CADomainDataType.MACH;
+		parameterSelector.setSelectedItem(initialParameter);
 		topPanel.add(parameterSelector, "top, growx");
 
 		// Update the models
 		updateModels(getSelectedParameter());
+		if (initialSettings != null) {
+			minModel.setCurrentUnit(initialSettings.minUnit);
+			maxModel.setCurrentUnit(initialSettings.maxUnit);
+			deltaModel.setCurrentUnit(initialSettings.deltaUnit);
+		}
 
 		JPanel minMaxPanel = new JPanel(new MigLayout("fill, ins 0"));
 
@@ -336,5 +350,36 @@ public class ComponentAnalysisPlotExportPanel extends JPanel implements PlotPane
 	public void onPlotConfigurationChanged(CAPlotConfiguration newConfiguration) {
 		CADomainDataType type = (CADomainDataType) newConfiguration.getDomainAxisType();
 		this.parameterSelector.setSelectedItem(type);
+	}
+
+	/**
+	 * Capture all plot/export choices which should be restored when this document's dialog is reopened.
+	 */
+	Settings getSettings() {
+		return new Settings(getSelectedParameter(), tabbedPane.getSelectedIndex(),
+				plotTab.getConfiguration().cloneConfiguration(), exportTab.getSettings(),
+				minModel.getCurrentUnit(), maxModel.getCurrentUnit(), deltaModel.getCurrentUnit());
+	}
+
+	static final class Settings {
+		private final CADomainDataType selectedParameter;
+		private final int selectedTab;
+		private final CAPlotConfiguration plotConfiguration;
+		private final CAExportPanel.Settings exportSettings;
+		private final Unit minUnit;
+		private final Unit maxUnit;
+		private final Unit deltaUnit;
+
+		private Settings(CADomainDataType selectedParameter, int selectedTab,
+						 CAPlotConfiguration plotConfiguration, CAExportPanel.Settings exportSettings,
+						 Unit minUnit, Unit maxUnit, Unit deltaUnit) {
+			this.selectedParameter = selectedParameter;
+			this.selectedTab = selectedTab;
+			this.plotConfiguration = plotConfiguration;
+			this.exportSettings = exportSettings;
+			this.minUnit = minUnit;
+			this.maxUnit = maxUnit;
+			this.deltaUnit = deltaUnit;
+		}
 	}
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/widgets/CSVExportPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/widgets/CSVExportPanel.java
@@ -60,7 +60,7 @@ public class CSVExportPanel<T extends UnitValue> extends JPanel {
 
 		JPanel exportPanel = new JPanel(new MigLayout("ins 0, fill"));
 
-		boolean addExtras = createExtraComponent(types[0], 0) != null;
+		boolean addExtras = hasExtraComponent();
 		JPanel contentPanel = new JPanel(new GridBagLayout());
 		contentPanel.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
 		GridBagConstraints c = new GridBagConstraints();
@@ -171,8 +171,24 @@ public class CSVExportPanel<T extends UnitValue> extends JPanel {
 		return "CSVExportPanel.lbl.Extra";
 	}
 
+	/**
+	 * Return whether every data row includes an extra component.
+	 * Subclasses with stateful extra-component creation should override this method.
+	 */
+	protected boolean hasExtraComponent() {
+		return createExtraComponent(types[0], 0) != null;
+	}
+
 	protected Component createExtraComponent(T type, int index) {
 		return null;
+	}
+
+	/**
+	 * Restore a unit selection in both the export model and its selector.
+	 */
+	protected void setSelectedUnit(int index, Unit unit) {
+		units[index] = unit;
+		dataTypeRows.get(index).unitSelector.setSelectedUnit(unit);
 	}
 
 	protected class DataTypeRow {

--- a/swing/src/test/java/info/openrocket/swing/gui/dialogs/componentanalysis/CAPlotTypeSelectorTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/dialogs/componentanalysis/CAPlotTypeSelectorTest.java
@@ -1,0 +1,70 @@
+package info.openrocket.swing.gui.dialogs.componentanalysis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import info.openrocket.core.componentanalysis.CADataType;
+import info.openrocket.core.rocketcomponent.BodyTube;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.rocketcomponent.RocketComponent;
+import info.openrocket.core.rocketcomponent.TrapezoidFinSet;
+import info.openrocket.swing.util.BaseTestCase;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * Tests component retention while changing a component-analysis plot data type.
+ */
+class CAPlotTypeSelectorTest extends BaseTestCase {
+
+	@Test
+	void retainsComponentsSupportedByTheNewType() {
+		Rocket rocket = new Rocket();
+		BodyTube bodyTube = new BodyTube();
+		TrapezoidFinSet finSet = new TrapezoidFinSet();
+
+		List<RocketComponent> retained = CAPlotTypeSelector.retainValidComponentsOrRocket(
+				List.of(bodyTube, finSet), List.of(rocket, bodyTube, finSet));
+
+		assertEquals(List.of(bodyTube, finSet), retained);
+	}
+
+	@Test
+	void dropsInvalidComponentsWhileRetainingValidSelections() {
+		Rocket rocket = new Rocket();
+		BodyTube bodyTube = new BodyTube();
+		TrapezoidFinSet finSet = new TrapezoidFinSet();
+
+		List<RocketComponent> retained = CAPlotTypeSelector.retainValidComponentsOrRocket(
+				List.of(bodyTube, finSet), List.of(rocket, finSet));
+
+		assertEquals(List.of(finSet), retained);
+	}
+
+	@Test
+	void fallsBackToRocketWhenNoSelectedComponentIsSupported() {
+		Rocket rocket = new Rocket();
+		BodyTube bodyTube = new BodyTube();
+		TrapezoidFinSet finSet = new TrapezoidFinSet();
+
+		List<RocketComponent> retained = CAPlotTypeSelector.retainValidComponentsOrRocket(
+				List.of(bodyTube), List.of(rocket, finSet));
+
+		assertEquals(List.of(rocket), retained);
+	}
+
+	@Test
+	void removingAPlotTypeKeepsItsComponentSelectionAligned() {
+		Rocket rocket = new Rocket();
+		TrapezoidFinSet finSet = new TrapezoidFinSet();
+		CAPlotConfiguration configuration = new CAPlotConfiguration("test");
+		configuration.addPlotDataType(CADataType.TOTAL_CD);
+		configuration.setPlotDataComponents(0, List.of(rocket));
+		configuration.addPlotDataType(CADataType.TOTAL_ROLL_COEFFICIENT);
+		configuration.setPlotDataComponents(1, List.of(finSet));
+
+		configuration.removePlotDataType(0);
+
+		assertEquals(List.of(finSet), configuration.getComponents(0));
+	}
+}


### PR DESCRIPTION
This PR fixes a few minor annoyances with the Component Analysis dialog, namely that any setting you entered would be cleared when you closed the window. Additionally, in the plot/export panel, if i selected a component for a data type and then changed the data type, the component selection was cleared.

Now, all settings are retained - when closing the dialog, or changing the CA sweep data type. I also increased the max Mach limit from 3.0 to 5.0. Not that it's an interesting regime for OpenRocket, but some people may like the extended range.