### PR TITLE
Use 0.1 as spinner increment for fin fillet

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/adaptors/DoubleModel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/adaptors/DoubleModel.java
@@ -67,6 +67,26 @@ public class DoubleModel implements StateChangeListener, ChangeSource, Invalidat
 	public class ValueSpinnerModel extends AbstractSpinnerModel implements Invalidatable {
 		
 		private ExpressionParser parser = new ExpressionParser();
+		private final double stepSize;
+
+		/**
+		 * Create a spinner model that uses the increment defined by the selected unit.
+		 */
+		public ValueSpinnerModel() {
+			this.stepSize = Double.NaN;
+		}
+
+		/**
+		 * Create a spinner model with a fixed increment in the selected display unit.
+		 *
+		 * @param stepSize spinner increment in the currently selected unit
+		 */
+		private ValueSpinnerModel(double stepSize) {
+			if (!Double.isFinite(stepSize) || stepSize <= 0) {
+				throw new IllegalArgumentException("Spinner step size must be finite and positive");
+			}
+			this.stepSize = stepSize;
+		}
 		
 		@Override
 		public Object getValue() {
@@ -125,7 +145,7 @@ public class DoubleModel implements StateChangeListener, ChangeSource, Invalidat
 			double max = inverted ? currentUnit.toUnit(minValue) : currentUnit.toUnit(maxValue);
 			if (MathUtil.equals(d, max))
 				return null;
-			d = currentUnit.getNextValue(d);
+			d = Double.isNaN(stepSize) ? currentUnit.getNextValue(d) : d + stepSize;
 			if (d > max)
 				d = max;
 			return d;
@@ -138,7 +158,7 @@ public class DoubleModel implements StateChangeListener, ChangeSource, Invalidat
 			double min = inverted ? currentUnit.toUnit(maxValue) : currentUnit.toUnit(minValue);
 			if (MathUtil.equals(d, min))
 				return null;
-			d = currentUnit.getPreviousValue(d);
+			d = Double.isNaN(stepSize) ? currentUnit.getPreviousValue(d) : d - stepSize;
 			if (d < min)
 				d = min;
 			return d;
@@ -168,6 +188,18 @@ public class DoubleModel implements StateChangeListener, ChangeSource, Invalidat
 	 */
 	public SpinnerModel getSpinnerModel() {
 		return new ValueSpinnerModel();
+	}
+
+	/**
+	 * Returns a new SpinnerModel that increments by the specified amount in the
+	 * currently selected display unit.  The same numeric increment is retained when
+	 * the user selects another unit.
+	 *
+	 * @param stepSize spinner increment in the currently selected unit
+	 * @return a compatibility layer for a SpinnerModel
+	 */
+	public SpinnerModel getSpinnerModel(double stepSize) {
+		return new ValueSpinnerModel(stepSize);
 	}
 	
 	////////////  JSlider model  ////////////

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/FinSetConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/FinSetConfig.java
@@ -553,7 +553,7 @@ public abstract class FinSetConfig extends RocketComponentConfig {
 	    DoubleModel m = new DoubleModel(component, "FilletRadius", UnitGroup.UNITS_LENGTH, 0);
 		register(m);
 
-	    JSpinner spin = new JSpinner(m.getSpinnerModel());
+	    JSpinner spin = new JSpinner(m.getSpinnerModel(0.1));
 	    spin.setEditor(new SpinnerEditor(spin));
 	    spin.setToolTipText(tip);
 	    filletPanel.add(spin, "growx, w 40");

--- a/swing/src/test/java/info/openrocket/swing/gui/adaptors/DoubleModelTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/adaptors/DoubleModelTest.java
@@ -5,14 +5,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.swing.SpinnerModel;
 import javax.swing.event.ChangeListener;
 
 import org.junit.jupiter.api.Test;
 
+import info.openrocket.core.unit.Unit;
+import info.openrocket.core.unit.UnitGroup;
 import info.openrocket.core.util.ChangeSource;
 import info.openrocket.core.util.StateChangeListener;
 
 class DoubleModelTest {
+	private static final double EPSILON = 1.0e-12;
+
 	@Test
 	void externalChangeSourceUpdatesModelListeners() {
 		StubSource source = new StubSource(1.0);
@@ -27,6 +32,31 @@ class DoubleModelTest {
 		assertEquals(1, eventCount[0]);
 
 		model.removeChangeListener(listener);
+		model.invalidateMe();
+	}
+
+	@Test
+	void spinnerUsesCustomIncrementInSelectedUnit() {
+		DoubleModel model = new DoubleModel(0.01, UnitGroup.UNITS_LENGTH, 0);
+		SpinnerModel spinnerModel = model.getSpinnerModel(0.1);
+		Unit centimeters = UnitGroup.UNITS_LENGTH.getUnit("cm");
+		Unit inches = UnitGroup.UNITS_LENGTH.getUnit("in");
+
+		model.setCurrentUnit(centimeters);
+		assertEquals(1.1, ((Number) spinnerModel.getNextValue()).doubleValue(), EPSILON);
+		assertEquals(0.9, ((Number) spinnerModel.getPreviousValue()).doubleValue(), EPSILON);
+		spinnerModel.setValue(spinnerModel.getNextValue());
+		assertEquals(0.011, model.getValue(), EPSILON);
+
+		model.setCurrentUnit(inches);
+		double valueInInches = inches.toUnit(model.getValue());
+		assertEquals(valueInInches + 0.1,
+				((Number) spinnerModel.getNextValue()).doubleValue(), EPSILON);
+		assertEquals(valueInInches - 0.1,
+				((Number) spinnerModel.getPreviousValue()).doubleValue(), EPSILON);
+		spinnerModel.setValue(spinnerModel.getNextValue());
+		assertEquals(0.011 + inches.fromUnit(0.1), model.getValue(), EPSILON);
+
 		model.invalidateMe();
 	}
 


### PR DESCRIPTION
The fin fillet spinner step increment is currently quite large (e.g. ± 1 cm). This PR refines that step size to 0.1 of the currently selected unit. E.g. "0.1 cm" when the unit is centimeters, "0.1 inch" when in inches...