### PR TITLE
[#3144] Reject virtual save locations

### DIFF
--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -1969,6 +1969,8 @@ RASAeroExport.error33 = Invalid component '%s' in sustainer stage.
 ! SaveAsFileChooser
 SaveAsFileChooser.illegalFilename.title = Illegal filename
 SaveAsFileChooser.illegalFilename.message = The filename '%s' may not contain the character ' %c '. Please remove it.
+SaveAsFileChooser.invalidDirectory.title = Invalid save location
+SaveAsFileChooser.invalidDirectory.message = Select a folder on a local or network drive before saving. Files cannot be saved directly in this location.
 
 ! StorageOptionChooser
 StorageOptChooser.lbl.Simdatatostore = Simulated data to store:

--- a/swing/src/main/java/info/openrocket/swing/gui/widgets/SaveFileChooser.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/widgets/SaveFileChooser.java
@@ -9,6 +9,7 @@ import javax.swing.ActionMap;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
+import javax.swing.filechooser.FileSystemView;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.util.List;
@@ -115,6 +116,12 @@ public class SaveFileChooser extends JFileChooser {
 
     @Override
     public void approveSelection() {
+        File targetDirectory = getFileSelectionMode() == JFileChooser.DIRECTORIES_ONLY ? currentFile : cwd;
+        if (!isFileSystemDirectory(targetDirectory, getFileSystemView())) {
+            showInvalidSaveLocationWarning();
+            return;
+        }
+
         Character c = FileUtils.getIllegalFilenameChar(fileName);
         if (c != null) {
             // Illegal character found
@@ -128,6 +135,30 @@ public class SaveFileChooser extends JFileChooser {
             setCurrentDirectory(cwd);
             super.approveSelection();
         }
+    }
+
+    /**
+     * Shows the warning used when a virtual shell location cannot contain a saved file.
+     */
+    protected void showInvalidSaveLocationWarning() {
+        JOptionPane.showMessageDialog(getParent(),
+                trans.get("SaveAsFileChooser.invalidDirectory.message"),
+                trans.get("SaveAsFileChooser.invalidDirectory.title"),
+                JOptionPane.WARNING_MESSAGE);
+    }
+
+    /**
+     * Checks that a save destination is backed by the filesystem.  Windows exposes
+     * virtual shell nodes such as "This PC" as {@link File} instances even though
+     * files cannot be written directly inside them.
+     *
+     * @param directory the directory selected as, or containing, the save target
+     * @param fileSystemView the platform file-system view used by the chooser
+     * @return {@code true} when the directory is a real filesystem directory
+     */
+    static boolean isFileSystemDirectory(File directory, FileSystemView fileSystemView) {
+        return directory != null && fileSystemView != null
+                && fileSystemView.isFileSystem(directory) && directory.isDirectory();
     }
 
     /**

--- a/swing/src/test/java/info/openrocket/swing/gui/widgets/SaveFileChooserTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/widgets/SaveFileChooserTest.java
@@ -1,0 +1,125 @@
+package info.openrocket.swing.gui.widgets;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.swing.JFileChooser;
+import javax.swing.filechooser.FileSystemView;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests validation of filesystem-backed save destinations.
+ */
+public class SaveFileChooserTest {
+	@TempDir
+	Path tempDirectory;
+
+	/**
+	 * A normal directory accepted by the platform file-system view is a valid destination.
+	 */
+	@Test
+	public void testAcceptsFileSystemDirectory() {
+		File directory = tempDirectory.toFile();
+		FileSystemView fileSystemView = FileSystemView.getFileSystemView();
+
+		assertTrue(SaveFileChooser.isFileSystemDirectory(directory, fileSystemView));
+	}
+
+	/**
+	 * Virtual Windows shell nodes, such as "This PC", must not be used as save directories.
+	 */
+	@Test
+	public void testRejectsVirtualShellDirectory() {
+		File virtualDirectory = tempDirectory.toFile();
+		FileSystemView fileSystemView = mock(FileSystemView.class);
+		when(fileSystemView.isFileSystem(virtualDirectory)).thenReturn(false);
+
+		assertFalse(SaveFileChooser.isFileSystemDirectory(virtualDirectory, fileSystemView));
+	}
+
+	/**
+	 * A filesystem path must also exist as a directory before it can contain a saved file.
+	 */
+	@Test
+	public void testRejectsMissingDirectory() {
+		File directory = tempDirectory.resolve("missing").toFile();
+		FileSystemView fileSystemView = FileSystemView.getFileSystemView();
+
+		assertFalse(SaveFileChooser.isFileSystemDirectory(directory, fileSystemView));
+	}
+
+	/**
+	 * Approval must remain inside the chooser when the current location is a virtual shell node.
+	 */
+	@Test
+	public void testVirtualShellDirectoryPreventsApproval() {
+		File directory = tempDirectory.toFile();
+		FileSystemView fileSystemView = mock(FileSystemView.class);
+		when(fileSystemView.isFileSystem(directory)).thenReturn(false);
+		TestSaveFileChooser chooser = new TestSaveFileChooser();
+		chooser.setCurrentDirectory(directory);
+		chooser.setSelectedFile(new File(directory, "rocket.obj"));
+		chooser.setTestFileSystemView(fileSystemView);
+		AtomicBoolean approved = new AtomicBoolean(false);
+		chooser.addActionListener(event -> approved.set(
+				JFileChooser.APPROVE_SELECTION.equals(event.getActionCommand())));
+
+		chooser.approveSelection();
+
+		assertTrue(chooser.isInvalidLocationWarningShown());
+		assertFalse(approved.get());
+	}
+
+	/**
+	 * Approval must proceed normally when the current location is a filesystem directory.
+	 */
+	@Test
+	public void testFileSystemDirectoryAllowsApproval() {
+		File directory = tempDirectory.toFile();
+		TestSaveFileChooser chooser = new TestSaveFileChooser();
+		chooser.setCurrentDirectory(directory);
+		chooser.setSelectedFile(new File(directory, "rocket.obj"));
+		AtomicBoolean approved = new AtomicBoolean(false);
+		chooser.addActionListener(event -> approved.set(
+				JFileChooser.APPROVE_SELECTION.equals(event.getActionCommand())));
+
+		chooser.approveSelection();
+
+		assertFalse(chooser.isInvalidLocationWarningShown());
+		assertTrue(approved.get());
+	}
+
+	/**
+	 * Test chooser that records warnings without displaying a modal dialog.
+	 */
+	private static final class TestSaveFileChooser extends SaveFileChooser {
+		private FileSystemView testFileSystemView;
+		private boolean invalidLocationWarningShown;
+
+		@Override
+		public FileSystemView getFileSystemView() {
+			return testFileSystemView != null ? testFileSystemView : super.getFileSystemView();
+		}
+
+		@Override
+		protected void showInvalidSaveLocationWarning() {
+			invalidLocationWarningShown = true;
+		}
+
+		private void setTestFileSystemView(FileSystemView fileSystemView) {
+			testFileSystemView = fileSystemView;
+		}
+
+		private boolean isInvalidLocationWarningShown() {
+			return invalidLocationWarningShown;
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes #3144. Windows shows virtual locations such as “This PC” inside the file chooser. These locations look like folders but do not have a real filesystem path, so Java cannot save files directly inside them. When a user tried to write to this, this would create a path such as “ShellFolder: 0x11”, an exception was thrown.

This PR checks that the selected location is a real filesystem directory before saving. If it is not, the file chooser remains open and displays a warning.