### PR TITLE
[#3209] Refresh UI elements after theme changes

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/figure3d/RocketFigure3d.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/figure3d/RocketFigure3d.java
@@ -106,6 +106,8 @@ public class RocketFigure3d extends JPanel implements GLEventListener {
 
 	private static Color backgroundColor;
 	private Color customBackgroundColor = null;
+	/** Strong reference required because UI theme listeners are stored weakly. */
+	private final Runnable themeChangeListener;
 
 	static {
 		initColors();
@@ -114,6 +116,8 @@ public class RocketFigure3d extends JPanel implements GLEventListener {
 	public RocketFigure3d(final OpenRocketDocument document) {
 		this.document = document;
 		this.rkt = document.getRocket();
+		this.themeChangeListener = this::refreshAfterThemeChange;
+		UITheme.Theme.addUIThemeChangeListener(themeChangeListener);
 		this.setLayout(new BorderLayout());
 		
 		//Only initialize GL if 3d is enabled.
@@ -134,6 +138,15 @@ public class RocketFigure3d extends JPanel implements GLEventListener {
 
 	public static void updateColors() {
 		backgroundColor = UITheme.getColor(UITheme.Keys.BACKGROUND);
+	}
+
+	/**
+	 * Refresh the OpenGL canvas after Swing has finished updating the component tree.
+	 * Deferring the repaint prevents the look-and-feel refresh from replacing the
+	 * rendered custom background with the theme default.
+	 */
+	void refreshAfterThemeChange() {
+		SwingUtilities.invokeLater(this::repaint);
 	}
 
 	/**

--- a/swing/src/main/java/info/openrocket/swing/gui/figureelements/CaliperLine.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/figureelements/CaliperLine.java
@@ -223,7 +223,6 @@ public class CaliperLine implements FigureElement {
 
 			double handleX_screen = screenPoint.x;
 			double siblingXScreen = siblingLine != null ? siblingLine.getScreenX(transform) : Double.NaN;
-			double handleY_screen = 0.0;  // Start at the very top
 
 			// Reset transform to draw in screen coordinates
 			g2Screen.setTransform(new AffineTransform());
@@ -234,11 +233,14 @@ public class CaliperLine implements FigureElement {
 			if (g2Screen.getClipBounds() != null) {
 				screenVisible = g2Screen.getClipBounds();
 			}
+			double handleY_screen = getHandleY(screenVisible);
 			
-			// Draw vertical line covering the full viewport height
-			// We draw in screen coordinates, from Y=0 to a very large number (e.g. 20000)
-			// The clip will ensure it doesn't draw outside the viewport
-			Line2D.Double screenLine = new Line2D.Double(handleX_screen, 0, handleX_screen, 20000);
+			// Draw the line across the visible viewport and keep its handle at the viewport's top edge.
+			double lineBottom = screenVisible != null
+					? screenVisible.y + screenVisible.height
+					: 20000;
+			Line2D.Double screenLine = new Line2D.Double(
+					handleX_screen, handleY_screen, handleX_screen, lineBottom);
 			float lineWidth = isHovered ? LINE_WIDTH_HOVER : LINE_WIDTH_NORMAL;
 
 			// Apply 50% transparency in snap mode
@@ -255,7 +257,7 @@ public class CaliperLine implements FigureElement {
 
 			double diamondCenterY = handleY_screen + DIAMOND_HALF_HEIGHT;
 
-			// Diamond shape: top tip at y=0, bottom tip pointing down toward the line
+			// Diamond shape: top tip at the viewport edge, bottom tip pointing down toward the line
 			marker.moveTo(handleX_screen, handleY_screen);                             // Top tip
 			marker.lineTo(handleX_screen + DIAMOND_HALF_WIDTH, diamondCenterY);       // Right point
 			marker.lineTo(handleX_screen, handleY_screen + DIAMOND_HALF_HEIGHT * 2);  // Bottom tip
@@ -330,9 +332,10 @@ public class CaliperLine implements FigureElement {
 	 * Get the bounds of the handle in screen coordinates for hit testing.
 	 *
 	 * @param transform the transform from model to screen coordinates
+	 * @param visible the visible viewport rectangle (for determining the handle Y position)
 	 * @return the handle bounds in screen coordinates, or null if invalid
 	 */
-	public Rectangle2D.Double getHandleBounds(AffineTransform transform) {
+	public Rectangle2D.Double getHandleBounds(AffineTransform transform, Rectangle visible) {
 		Point2D.Double modelPoint = new Point2D.Double(x, 0);
 		Point2D.Double screenPoint = new Point2D.Double();
 		transform.transform(modelPoint, screenPoint);
@@ -342,7 +345,7 @@ public class CaliperLine implements FigureElement {
 		}
 		
 		double handleX_screen = screenPoint.x;
-		double handleY_screen = 0.0;  // Start at the very top
+		double handleY_screen = getHandleY(visible);
 
 		// Return bounds that encompass the diamond handle
 		double minX = handleX_screen - DIAMOND_HALF_WIDTH;
@@ -358,6 +361,16 @@ public class CaliperLine implements FigureElement {
 			(maxX - minX) + 2 * padding,
 			(maxY - minY) + 2 * padding
 		);
+	}
+
+	/**
+	 * Return the top edge of the currently visible viewport in figure coordinates.
+	 *
+	 * @param visible the visible viewport rectangle, or null when painting without a viewport
+	 * @return the Y coordinate where the vertical handle should be anchored
+	 */
+	private static double getHandleY(Rectangle visible) {
+		return visible != null ? visible.y : 0.0;
 	}
 	
 	/**

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
@@ -91,6 +91,9 @@ import javax.swing.JViewport;
 import javax.swing.ListCellRenderer;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
+import javax.swing.border.CompoundBorder;
+import javax.swing.border.EmptyBorder;
+import javax.swing.border.LineBorder;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.TreeSelectionEvent;
@@ -107,6 +110,7 @@ import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.GraphicsConfiguration;
+import java.awt.Insets;
 import java.awt.Rectangle;
 import java.awt.Window;
 import java.awt.Graphics2D;
@@ -127,6 +131,7 @@ import java.awt.event.ComponentEvent;
 import java.awt.event.InputEvent;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
+import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -242,6 +247,8 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 	/* Caliper tool */
 	private CaliperManager caliperManager = null;
 	private JPanel ribbon = null;  // Reference to ribbon for panel positioning
+	/** Strong reference required because UI theme listeners are stored weakly. */
+	private Runnable caliperThemeChangeListener;
 
 	private double cpAOA = Double.NaN;
 	private double cpTheta = Double.NaN;
@@ -2248,11 +2255,11 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		horizontalModeIcon.setToolTipText(trans.get("RocketPanel.radio.CaliperHorizontal.ttip"));
 		verticalModeIcon.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 		horizontalModeIcon.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-		verticalModeIcon.addMouseListener(new java.awt.event.MouseAdapter() {
-			@Override public void mouseClicked(java.awt.event.MouseEvent e) { verticalRadio.doClick(); }
+		verticalModeIcon.addMouseListener(new MouseAdapter() {
+			@Override public void mouseClicked(MouseEvent e) { verticalRadio.doClick(); }
 		});
-		horizontalModeIcon.addMouseListener(new java.awt.event.MouseAdapter() {
-			@Override public void mouseClicked(java.awt.event.MouseEvent e) { horizontalRadio.doClick(); }
+		horizontalModeIcon.addMouseListener(new MouseAdapter() {
+			@Override public void mouseClicked(MouseEvent e) { horizontalRadio.doClick(); }
 		});
 		modeGroup.add(verticalRadio);
 		modeGroup.add(horizontalRadio);
@@ -2282,9 +2289,9 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		distanceField.setOpaque(true);
 		distanceField.setBackground(valueBg);
 		distanceField.setForeground(valueFg);
-		distanceField.setBorder(new javax.swing.border.CompoundBorder(
-				new javax.swing.border.LineBorder(caliperColor, 1, true),
-				new javax.swing.border.EmptyBorder(1, 4, 1, 4)));
+		distanceField.setBorder(new CompoundBorder(
+				new LineBorder(caliperColor, 1, true),
+				new EmptyBorder(1, 4, 1, 4)));
 		distanceField.setFont(distanceField.getFont().deriveFont(Font.BOLD));
 		distanceField.setHorizontalAlignment(JTextField.CENTER);
 
@@ -2297,7 +2304,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		diamond1Btn.setBorderPainted(false);
 		diamond1Btn.setContentAreaFilled(false);
 		diamond1Btn.setFocusPainted(false);
-		diamond1Btn.setMargin(new java.awt.Insets(0, 0, 0, 0));
+		diamond1Btn.setMargin(new Insets(0, 0, 0, 0));
 		diamond1Btn.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 		diamond1Btn.setToolTipText(trans.get("RocketPanel.popup.CaliperDiamond1.ttip"));
 		diamond1Btn.addActionListener(e -> showCaliperPositionPopup(1, diamond1Btn));
@@ -2308,7 +2315,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		diamond2Btn.setBorderPainted(false);
 		diamond2Btn.setContentAreaFilled(false);
 		diamond2Btn.setFocusPainted(false);
-		diamond2Btn.setMargin(new java.awt.Insets(0, 0, 0, 0));
+		diamond2Btn.setMargin(new Insets(0, 0, 0, 0));
 		diamond2Btn.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 		diamond2Btn.setToolTipText(trans.get("RocketPanel.popup.CaliperDiamond2.ttip"));
 		diamond2Btn.addActionListener(e -> showCaliperPositionPopup(2, diamond2Btn));
@@ -2364,7 +2371,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		});
 
 		// Update colors when the UI theme changes
-		UITheme.Theme.addUIThemeChangeListener(() -> {
+		caliperThemeChangeListener = () -> {
 			Color newCaliperColor = GUIUtil.getUITheme().getCaliperColor();
 			Color newValueBg = GUIUtil.getUITheme().getCaliperValueBackgroundColor();
 			Color newValueFg = GUIUtil.getUITheme().getCaliperValueForegroundColor();
@@ -2378,9 +2385,9 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 
 			distanceField.setBackground(newValueBg);
 			distanceField.setForeground(newValueFg);
-			distanceField.setBorder(new javax.swing.border.CompoundBorder(
-					new javax.swing.border.LineBorder(newCaliperColor, 1, true),
-					new javax.swing.border.EmptyBorder(1, 4, 1, 4)));
+			distanceField.setBorder(new CompoundBorder(
+					new LineBorder(newCaliperColor, 1, true),
+					new EmptyBorder(1, 4, 1, 4)));
 
 			Color newHoverColor = ColorConversion.brightenColor(newCaliperColor, 50);
 			diamond1Btn.setIcon(createCaliperDiamondIcon("1", newCaliperColor, newDiamondLabelColor));
@@ -2389,7 +2396,11 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 			diamond2Btn.setRolloverIcon(createCaliperDiamondIcon("2", newHoverColor, newDiamondLabelColor));
 
 			panel.repaint();
-		});
+			// Reattach and repaint figure elements, which live outside Swing's UI delegate hierarchy.
+			updateCaliperElements();
+			figure.updateFigure();
+		};
+		UITheme.Theme.addUIThemeChangeListener(caliperThemeChangeListener);
 
 		return panel;
 	}

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/caliper/CaliperManager.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/caliper/CaliperManager.java
@@ -364,7 +364,7 @@ public class CaliperManager {
 			// Check vertical caliper lines - try handle first, then line
 			if (caliper1Line != null) {
 				// Check handle bounds
-				java.awt.geom.Rectangle2D.Double handleBounds = caliper1Line.getHandleBounds(transform);
+				java.awt.geom.Rectangle2D.Double handleBounds = caliper1Line.getHandleBounds(transform, visibleRect);
 				boolean hitHandle = handleBounds != null && handleBounds.contains(screenPoint.x, screenPoint.y);
 				
 				// Check if near the line itself
@@ -381,7 +381,7 @@ public class CaliperManager {
 			}
 			if (caliper2Line != null) {
 				// Check handle bounds
-				java.awt.geom.Rectangle2D.Double handleBounds = caliper2Line.getHandleBounds(transform);
+				java.awt.geom.Rectangle2D.Double handleBounds = caliper2Line.getHandleBounds(transform, visibleRect);
 				boolean hitHandle = handleBounds != null && handleBounds.contains(screenPoint.x, screenPoint.y);
 				
 				// Check if near the line itself
@@ -714,7 +714,7 @@ public class CaliperManager {
 
 	private boolean isHandleOrLineHit(CaliperLine line, Point screenPoint,
 									  java.awt.geom.AffineTransform transform, Rectangle visibleRect) {
-		java.awt.geom.Rectangle2D.Double handleBounds = line.getHandleBounds(transform);
+		java.awt.geom.Rectangle2D.Double handleBounds = line.getHandleBounds(transform, visibleRect);
 		boolean hitHandle = handleBounds != null && handleBounds.contains(screenPoint.x, screenPoint.y);
 		boolean hitLine = line.isPointNearLine(screenPoint.x, screenPoint.y, transform, visibleRect);
 		return hitHandle || hitLine;
@@ -1073,11 +1073,11 @@ public class CaliperManager {
 		Rectangle visibleRect = figure.getVisibleRect();
 		if (mode == CaliperMode.VERTICAL) {
 			if (caliper1Line != null) {
-				java.awt.geom.Rectangle2D.Double b = caliper1Line.getHandleBounds(transform);
+				java.awt.geom.Rectangle2D.Double b = caliper1Line.getHandleBounds(transform, visibleRect);
 				if (b != null && b.contains(screenX, screenY)) return 1;
 			}
 			if (caliper2Line != null) {
-				java.awt.geom.Rectangle2D.Double b = caliper2Line.getHandleBounds(transform);
+				java.awt.geom.Rectangle2D.Double b = caliper2Line.getHandleBounds(transform, visibleRect);
 				if (b != null && b.contains(screenX, screenY)) return 2;
 			}
 		} else {
@@ -1621,4 +1621,3 @@ public class CaliperManager {
 		return true;
 	}
 }
-

--- a/swing/src/main/java/info/openrocket/swing/gui/theme/UITheme.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/theme/UITheme.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.swing.Icon;
 import javax.swing.JRootPane;
+import javax.swing.RootPaneContainer;
 import javax.swing.UIManager;
 import javax.swing.border.Border;
 import javax.swing.border.CompoundBorder;
@@ -32,6 +33,7 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.border.LineBorder;
 import java.awt.Color;
 import java.awt.Font;
+import java.awt.Window;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -238,7 +240,14 @@ public class UITheme {
         // Static list of listeners (weak to avoid leaks)
         static List<WeakReference<Runnable>> themeChangeListeners = new ArrayList<>();
 
-        // Static method to add a listener
+        /**
+         * Add a weak theme-change listener.
+         *
+         * <p>Callers using a capturing lambda or instance method reference must keep a strong
+         * reference to the runnable for as long as they expect to receive notifications.</p>
+         *
+         * @param listener listener to invoke after a theme change
+         */
         static void addUIThemeChangeListener(Runnable listener) {
             if (listener == null) {
                 return;
@@ -2054,7 +2063,35 @@ public class UITheme {
 
         // Update all components
         FlatLaf.updateUI();
+
+        // Root-pane client properties are application overrides and survive FlatLaf.updateUI().
+        // Reapply them after the component trees have adopted their new theme colors.
+        applyThemeToOpenRootPanes(theme);
         FlatAnimatedLafChange.hideSnapshotWithAnimation();
+    }
+
+    /**
+     * Refresh theme-specific root-pane properties on every existing Swing window.
+     *
+     * @param theme the newly applied UI theme
+     */
+    private static void applyThemeToOpenRootPanes(Theme theme) {
+        applyThemeToRootPanes(theme, Window.getWindows());
+    }
+
+    /**
+     * Apply the theme to the root pane of each supplied Swing window.
+     *
+     * @param theme the newly applied UI theme
+     * @param windows candidate windows to refresh
+     */
+    static void applyThemeToRootPanes(Theme theme, Window[] windows) {
+        for (Window window : windows) {
+            if (window instanceof RootPaneContainer) {
+                RootPaneContainer rootPaneContainer = (RootPaneContainer) window;
+                theme.applyThemeToRootPane(rootPaneContainer.getRootPane());
+            }
+        }
     }
 
     private static void commonApplyThemeToRootPane(JRootPane rootPane, Color TextColor) {

--- a/swing/src/main/java/info/openrocket/swing/gui/util/GUIUtil.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/util/GUIUtil.java
@@ -246,7 +246,9 @@ public class GUIUtil {
 	public static double getDPI() {
 		int dpi = Application.getPreferences().getInt("DPI", 0); // Tenths of a dpi
 		
-		if (dpi < 10) {
+		// Headless environments cannot query the display toolkit, so retain the
+		// standard 96-DPI fallback used below when no preference is configured.
+		if (dpi < 10 && !GraphicsEnvironment.isHeadless()) {
 			dpi = Toolkit.getDefaultToolkit().getScreenResolution() * 10;
 		}
 		if (dpi < 10)

--- a/swing/src/test/java/info/openrocket/swing/gui/figure3d/RocketFigure3dTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/figure3d/RocketFigure3dTest.java
@@ -1,0 +1,75 @@
+package info.openrocket.swing.gui.figure3d;
+
+import info.openrocket.core.document.OpenRocketDocument;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.swing.util.BaseTestCase;
+import org.junit.jupiter.api.Test;
+
+import javax.swing.SwingUtilities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests theme-related refresh behavior of the 3D rocket figure.
+ */
+class RocketFigure3dTest extends BaseTestCase {
+
+	@Test
+	void refreshesCanvasAfterCurrentThemeUpdateCompletes() throws Exception {
+		String originalDisable3D = System.getProperty("openrocket.3d.disable");
+		System.setProperty("openrocket.3d.disable", "true");
+		try {
+			OpenRocketDocument document = mock(OpenRocketDocument.class);
+			when(document.getRocket()).thenReturn(mock(Rocket.class));
+			TrackingRocketFigure3d figure = new TrackingRocketFigure3d(document);
+			figure.startTrackingRepaints();
+
+			SwingUtilities.invokeAndWait(() -> {
+				figure.refreshAfterThemeChange();
+				assertEquals(0, figure.getTrackedRepaintCount(),
+						"The canvas repaint must wait until the look-and-feel update has finished");
+			});
+
+			SwingUtilities.invokeAndWait(() -> {
+				// Drain the event queue so the deferred repaint can run.
+			});
+			assertEquals(1, figure.getTrackedRepaintCount());
+		} finally {
+			if (originalDisable3D == null) {
+				System.clearProperty("openrocket.3d.disable");
+			} else {
+				System.setProperty("openrocket.3d.disable", originalDisable3D);
+			}
+		}
+	}
+
+	/**
+	 * Records repaints requested after construction without initializing OpenGL.
+	 */
+	private static class TrackingRocketFigure3d extends RocketFigure3d {
+		private boolean trackRepaints;
+		private int trackedRepaintCount;
+
+		TrackingRocketFigure3d(OpenRocketDocument document) {
+			super(document);
+		}
+
+		void startTrackingRepaints() {
+			trackRepaints = true;
+		}
+
+		int getTrackedRepaintCount() {
+			return trackedRepaintCount;
+		}
+
+		@Override
+		public void repaint() {
+			if (trackRepaints) {
+				trackedRepaintCount++;
+			}
+			super.repaint();
+		}
+	}
+}

--- a/swing/src/test/java/info/openrocket/swing/gui/figureelements/CaliperLineTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/figureelements/CaliperLineTest.java
@@ -1,0 +1,63 @@
+package info.openrocket.swing.gui.figureelements;
+
+import info.openrocket.swing.util.BaseTestCase;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests screen-space positioning of vertical caliper handles.
+ */
+class CaliperLineTest extends BaseTestCase {
+
+	@Test
+	void handleTracksTopOfShiftedViewport() {
+		CaliperLine line = new CaliperLine(200.0);
+		AffineTransform transform = new AffineTransform();
+		Rectangle initialViewport = new Rectangle(0, 0, 800, 600);
+		Rectangle shiftedViewport = new Rectangle(0, 125, 800, 600);
+
+		Rectangle2D.Double initialBounds = line.getHandleBounds(transform, initialViewport);
+		Rectangle2D.Double shiftedBounds = line.getHandleBounds(transform, shiftedViewport);
+
+		assertEquals(initialBounds.x, shiftedBounds.x, 0.0,
+				"Vertical scrolling must not change the handle's X position");
+		assertEquals(shiftedViewport.y - initialViewport.y, shiftedBounds.y - initialBounds.y, 0.0,
+				"The handle must remain anchored to the viewport's top edge");
+	}
+
+	@Test
+	void paintsHandleInsideShiftedViewport() {
+		int caliperX = 200;
+		CaliperLine line = new CaliperLine(caliperX);
+		Rectangle shiftedViewport = new Rectangle(0, 125, 400, 200);
+		BufferedImage image = new BufferedImage(400, 400, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D graphics = image.createGraphics();
+		try {
+			graphics.setClip(shiftedViewport);
+			line.paint(graphics, 1.0, shiftedViewport);
+		} finally {
+			graphics.dispose();
+		}
+
+		boolean handlePainted = false;
+		for (int y = shiftedViewport.y; y < shiftedViewport.y + 60 && !handlePainted; y++) {
+			for (int x = caliperX - 30; x <= caliperX + 30; x++) {
+				// Ignore the narrow vertical line and look for pixels belonging to the diamond handle.
+				if (Math.abs(x - caliperX) > 4 && (image.getRGB(x, y) >>> 24) != 0) {
+					handlePainted = true;
+					break;
+				}
+			}
+		}
+
+		assertTrue(handlePainted, "The handle must be painted within the shifted viewport clip");
+	}
+}

--- a/swing/src/test/java/info/openrocket/swing/gui/theme/UIThemeTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/theme/UIThemeTest.java
@@ -1,0 +1,35 @@
+package info.openrocket.swing.gui.theme;
+
+import info.openrocket.swing.util.BaseTestCase;
+import org.junit.jupiter.api.Test;
+
+import javax.swing.JRootPane;
+import javax.swing.RootPaneContainer;
+import java.awt.Window;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ * Tests runtime theme updates that are not handled by Swing's component-tree refresh.
+ */
+class UIThemeTest extends BaseTestCase {
+
+	@Test
+	void appliesThemeToEveryRootPaneWindow() {
+		UITheme.Theme theme = mock(UITheme.Theme.class);
+		JRootPane rootPane = new JRootPane();
+		Window rootPaneWindow = mock(Window.class, withSettings().extraInterfaces(RootPaneContainer.class));
+		RootPaneContainer rootPaneContainer = (RootPaneContainer) rootPaneWindow;
+		when(rootPaneContainer.getRootPane()).thenReturn(rootPane);
+
+		Window ordinaryWindow = mock(Window.class);
+		UITheme.applyThemeToRootPanes(theme, new Window[] { ordinaryWindow, rootPaneWindow });
+
+		verify(theme).applyThemeToRootPane(rootPane);
+		verifyNoMoreInteractions(theme);
+	}
+}


### PR DESCRIPTION
Fixes #3209 by also updating root panes (untested, I didn't have my Windows machine on hand) and the calipers after a UI theme change. Calipers now also remain in view when changing the theme.