### PR TITLE
[#2318] Put appearance 2D and 3D in dedicated sections

### DIFF
--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -1414,8 +1414,7 @@ MotorDbUpdate.Failed.title = Motor database update
 MotorDbUpdate.Failed.message = Unable to download and install the motor database update.
 
 ! AppearanceConfig
-AppearanceCfg.lbl.Appearance = Appearance
-AppearanceCfg.lbl.Usedefault = Use default
+AppearanceCfg.lbl.Usedefault = Use default appearance
 AppearanceCfg.but.edit = Edit
 AppearanceCfg.but.createTexture = Create texture
 AppearanceCfg.but.createTexture.ttip.unsupported = Automatic texture creation is not supported for this component type
@@ -1456,6 +1455,8 @@ AppearanceCfg.lbl.AppearanceEdges = Appearance for edges:
 AppearanceCfg.lbl.ttip.AppearanceEdges = Select the appearance that should be used for the edges
 AppearanceCfg.placeholder.HexColor = Hex color
 AppearanceCfg.ttip.HexColor = Hexadecimal representation of the color
+AppearanceCfg.TitledBorder.2DFigureStyle = 2D Figure Style
+AppearanceCfg.TitledBorder.3DAppearance = 3D Appearance
 
 ! Texture Wrap Modes
 TextureWrap.Repeat = Repeat
@@ -1518,10 +1519,9 @@ RocketCompCfg.lbl.CDOverriddenBy.ttip = <html>The C<sub>D</sub> of this componen
 RocketCompCfg.lbl.longB1 = <html>The overridden mass and center of gravity does not include motors. <br>
 RocketCompCfg.lbl.longB2 = The center of gravity is measured from the front end of the
 RocketCompCfg.lbl.Commentsonthe = Comments on the
-RocketCompCfg.lbl.Figurestyle = Figure style:
 RocketCompCfg.lbl.Componentcolor = Component color:
 RocketCompCfg.lbl.Choosecolor = Choose color
-RocketCompCfg.checkbox.Usedefaultcolor = Use default color
+RocketCompCfg.checkbox.Usedefaultcolor = Use default style
 RocketCompCfg.lbl.Complinestyle = Component line style:
 RocketCompCfg.but.Saveasdefstyle = Save as default style
 RocketCompCfg.lbl.Diameter = Diameter:

--- a/core/src/main/resources/l10n/messages_ar.properties
+++ b/core/src/main/resources/l10n/messages_ar.properties
@@ -1414,7 +1414,6 @@ MotorDbUpdate.Failed.title = Motor database update
 MotorDbUpdate.Failed.message = Unable to download and install the motor database update.
 
 ! AppearanceConfig
-AppearanceCfg.lbl.Appearance = مظهر
 AppearanceCfg.lbl.Usedefault = إستخدم الإفتراضي
 AppearanceCfg.but.edit = تعديل
 AppearanceCfg.but.createTexture = Create texture
@@ -1518,7 +1517,6 @@ RocketCompCfg.lbl.CDOverriddenBy.ttip = <html> %s يتم تحديد مركز ا�
 RocketCompCfg.lbl.longB1 = <html>.لا تشتمل الكتلة ومركز الجاذبية المتجاوزين على المحركات <br>
 RocketCompCfg.lbl.longB2 = يتم قياس مركز الجاذبية من الواجهة الأمامية لـ
 RocketCompCfg.lbl.Commentsonthe = تعليقات على
-RocketCompCfg.lbl.Figurestyle = :نمط الشكل
 RocketCompCfg.lbl.Componentcolor = :لون المكون
 RocketCompCfg.lbl.Choosecolor = إختر اللون
 RocketCompCfg.checkbox.Usedefaultcolor = إستخدم اللون الإفتراضي

--- a/core/src/main/resources/l10n/messages_cs.properties
+++ b/core/src/main/resources/l10n/messages_cs.properties
@@ -1414,7 +1414,6 @@ MotorDbUpdate.Failed.title = Motor database update
 MotorDbUpdate.Failed.message = Unable to download and install the motor database update.
 
 ! AppearanceConfig
-AppearanceCfg.lbl.Appearance = Appearance
 AppearanceCfg.lbl.Usedefault = Use default
 AppearanceCfg.but.edit = Edit
 AppearanceCfg.but.createTexture = Create texture
@@ -1518,7 +1517,6 @@ RocketCompCfg.lbl.CDOverriddenBy.ttip = <html>The C<sub>D</sub> of this componen
 RocketCompCfg.lbl.longB1 = <html> Zmena hmotnosti nezahrnuje motory. <br>
 RocketCompCfg.lbl.longB2 = Težište je mereno od predku
 RocketCompCfg.lbl.Commentsonthe = Komentár na
-RocketCompCfg.lbl.Figurestyle = Styl obrátku:
 RocketCompCfg.lbl.Componentcolor = Barva komponenty:
 RocketCompCfg.lbl.Choosecolor = Vyber barvu
 RocketCompCfg.checkbox.Usedefaultcolor = Použij výchozí barvu

--- a/core/src/main/resources/l10n/messages_de.properties
+++ b/core/src/main/resources/l10n/messages_de.properties
@@ -704,7 +704,6 @@ RocketCompCfg.checkbox.OverridemassandCG = Masse und Schwerpunkt für alle Unterk
 RocketCompCfg.lbl.longB1 = <html>Die überschriebene Masse enthält keine Motoren. <br>
 RocketCompCfg.lbl.longB2 = Die Messung des Schwerpunktes beginnt am Ende von
 RocketCompCfg.lbl.Commentsonthe = Kommentare zu
-RocketCompCfg.lbl.Figurestyle = Form:
 RocketCompCfg.lbl.Componentcolor = Farbe:
 RocketCompCfg.lbl.Choosecolor = Farbe auswählen
 RocketCompCfg.checkbox.Usedefaultcolor = Standardfarbe verwenden

--- a/core/src/main/resources/l10n/messages_es.properties
+++ b/core/src/main/resources/l10n/messages_es.properties
@@ -1414,7 +1414,6 @@ MotorDbUpdate.Failed.title = Motor database update
 MotorDbUpdate.Failed.message = Unable to download and install the motor database update.
 
 ! AppearanceConfig
-AppearanceCfg.lbl.Appearance = Apariencia
 AppearanceCfg.lbl.Usedefault = Usar apariencia por defecto
 AppearanceCfg.but.edit = Editar
 AppearanceCfg.but.createTexture = Create texture
@@ -1518,7 +1517,6 @@ RocketCompCfg.lbl.CDOverriddenBy.ttip = <html>The C<sub>D</sub> of this componen
 RocketCompCfg.lbl.longB1 = <html>En la masa especificada no se incluye la de los motores. <br>
 RocketCompCfg.lbl.longB2 = El CG se mide desde el extremo frontal del componente  
 RocketCompCfg.lbl.Commentsonthe = Comentarios sobre
-RocketCompCfg.lbl.Figurestyle = Estilo de dibujo:
 RocketCompCfg.lbl.Componentcolor = Color del componente:
 RocketCompCfg.lbl.Choosecolor = Elija color
 RocketCompCfg.checkbox.Usedefaultcolor = Usar color por defecto

--- a/core/src/main/resources/l10n/messages_fr.properties
+++ b/core/src/main/resources/l10n/messages_fr.properties
@@ -1414,7 +1414,6 @@ MotorDbUpdate.Failed.title = Motor database update
 MotorDbUpdate.Failed.message = Unable to download and install the motor database update.
 
 ! AppearanceConfig
-AppearanceCfg.lbl.Appearance = Apparence
 AppearanceCfg.lbl.Usedefault = Utiliser par défaut
 AppearanceCfg.but.edit = Modifier
 AppearanceCfg.but.createTexture = Create texture
@@ -1518,7 +1517,6 @@ RocketCompCfg.lbl.CDOverriddenBy.ttip = <html>The C<sub>D</sub> of this componen
 RocketCompCfg.lbl.longB1 = <html>Le forçage de la masse n'inclus pas le ou les moteurs. <br>
 RocketCompCfg.lbl.longB2 = Le centre de gravité est mesuré à partir de l'extrémité avant de la fusée
 RocketCompCfg.lbl.Commentsonthe = Commentaires à propos du 
-RocketCompCfg.lbl.Figurestyle = Modèle de forme:
 RocketCompCfg.lbl.Componentcolor = Couleur de la pièce:
 RocketCompCfg.lbl.Choosecolor = Choisir la couleur
 RocketCompCfg.checkbox.Usedefaultcolor = Utiliser la couleur par défaut

--- a/core/src/main/resources/l10n/messages_it.properties
+++ b/core/src/main/resources/l10n/messages_it.properties
@@ -1414,7 +1414,6 @@ MotorDbUpdate.Failed.title = Motor database update
 MotorDbUpdate.Failed.message = Unable to download and install the motor database update.
 
 ! AppearanceConfig
-AppearanceCfg.lbl.Appearance = Appearance
 AppearanceCfg.lbl.Usedefault = Use default
 AppearanceCfg.but.edit = Edit
 AppearanceCfg.but.createTexture = Create texture
@@ -1518,7 +1517,6 @@ RocketCompCfg.lbl.CDOverriddenBy.ttip = <html>The C<sub>D</sub> of this componen
 RocketCompCfg.lbl.longB1 = <html>La massa modificata non include i motori. <br>
 RocketCompCfg.lbl.longB2 = Il Centro di Gravita' e' misurato dall'inizio di
 RocketCompCfg.lbl.Commentsonthe = Commenti sul
-RocketCompCfg.lbl.Figurestyle = Stile del disegno:
 RocketCompCfg.lbl.Componentcolor = Colore del componente:
 RocketCompCfg.lbl.Choosecolor = Scegli il colore
 RocketCompCfg.checkbox.Usedefaultcolor = Usa il colore predefinito

--- a/core/src/main/resources/l10n/messages_ja.properties
+++ b/core/src/main/resources/l10n/messages_ja.properties
@@ -1414,7 +1414,6 @@ MotorDbUpdate.Failed.title = Motor database update
 MotorDbUpdate.Failed.message = Unable to download and install the motor database update.
 
 ! AppearanceConfig
-AppearanceCfg.lbl.Appearance = Appearance
 AppearanceCfg.lbl.Usedefault = Use default
 AppearanceCfg.but.edit = Edit
 AppearanceCfg.but.createTexture = Create texture
@@ -1518,7 +1517,6 @@ RocketCompCfg.lbl.CDOverriddenBy.ttip = <html>The C<sub>D</sub> of this componen
 RocketCompCfg.lbl.longB1 = <html>再定義された質量にはモーターは含まれない <br>
 RocketCompCfg.lbl.longB2 = 重心は部品の前方端から、部品：
 RocketCompCfg.lbl.Commentsonthe = コメント：
-RocketCompCfg.lbl.Figurestyle = スタイル：
 RocketCompCfg.lbl.Componentcolor = 部品の色：
 RocketCompCfg.lbl.Choosecolor = 色を選ぶ
 RocketCompCfg.checkbox.Usedefaultcolor = デフォルトの色を使う

--- a/core/src/main/resources/l10n/messages_nl.properties
+++ b/core/src/main/resources/l10n/messages_nl.properties
@@ -1414,7 +1414,6 @@ MotorDbUpdate.Failed.title = Motordatabase update
 MotorDbUpdate.Failed.message = Kan de update van de motordatabase niet downloaden en installeren.
 
 ! AppearanceConfig
-AppearanceCfg.lbl.Appearance = Uiterlijk
 AppearanceCfg.lbl.Usedefault = Gebruik standaard
 AppearanceCfg.but.edit = Bewerk
 AppearanceCfg.but.createTexture = Maak textuur
@@ -1518,7 +1517,6 @@ RocketCompCfg.lbl.CDOverriddenBy.ttip = <html>De C<sub>D</sub> van dit onderdeel
 RocketCompCfg.lbl.longB1 = <html>De overschreven massa omvat geen motoren. <br>
 RocketCompCfg.lbl.longB2 = Het zwaartepunt wordt gemeten vanaf de voorkant van de
 RocketCompCfg.lbl.Commentsonthe = Opmerkingen over de
-RocketCompCfg.lbl.Figurestyle = Figuurstijl:
 RocketCompCfg.lbl.Componentcolor = Onderdeelkleur:
 RocketCompCfg.lbl.Choosecolor = Kies kleur
 RocketCompCfg.checkbox.Usedefaultcolor = Gebruik standaardkleur

--- a/core/src/main/resources/l10n/messages_pl.properties
+++ b/core/src/main/resources/l10n/messages_pl.properties
@@ -1414,7 +1414,6 @@ MotorDbUpdate.Failed.title = Motor database update
 MotorDbUpdate.Failed.message = Unable to download and install the motor database update.
 
 ! AppearanceConfig
-AppearanceCfg.lbl.Appearance = Appearance
 AppearanceCfg.lbl.Usedefault = Use default
 AppearanceCfg.but.edit = Edit
 AppearanceCfg.but.createTexture = Create texture
@@ -1518,7 +1517,6 @@ RocketCompCfg.lbl.CDOverriddenBy.ttip = <html>The C<sub>D</sub> of this componen
 RocketCompCfg.lbl.longB1 = <html>Wymuszony ciężar nie uwzględnia silników. <br>
 RocketCompCfg.lbl.longB2 = Środek ciężkości jest mierzony od przodu 
 RocketCompCfg.lbl.Commentsonthe = Uwagi -
-RocketCompCfg.lbl.Figurestyle = Styl wyglądu:
 RocketCompCfg.lbl.Componentcolor = Kolor części:
 RocketCompCfg.lbl.Choosecolor = Wybierz kolor
 RocketCompCfg.checkbox.Usedefaultcolor = Ustaw kolor domyślny

--- a/core/src/main/resources/l10n/messages_pt.properties
+++ b/core/src/main/resources/l10n/messages_pt.properties
@@ -1414,7 +1414,6 @@ MotorDbUpdate.Failed.title = Motor database update
 MotorDbUpdate.Failed.message = Unable to download and install the motor database update.
 
 ! AppearanceConfig
-AppearanceCfg.lbl.Appearance = Aparência
 AppearanceCfg.lbl.Usedefault = usar padrão
 AppearanceCfg.but.edit = Editar
 AppearanceCfg.but.createTexture = Create texture
@@ -1518,7 +1517,6 @@ RocketCompCfg.lbl.CDOverriddenBy.ttip = <html>The C<sub>D</sub> of this componen
 RocketCompCfg.lbl.longB1 = <html>A massa modificada não inclui motores. <br>
 RocketCompCfg.lbl.longB2 = O centro de gravidade é medido a partir da extremidade dianteira do
 RocketCompCfg.lbl.Commentsonthe = Comentários sobre o
-RocketCompCfg.lbl.Figurestyle = Estilo da figura:
 RocketCompCfg.lbl.Componentcolor = Cor do componente:
 RocketCompCfg.lbl.Choosecolor = Escolha a cor
 RocketCompCfg.checkbox.Usedefaultcolor = Use a cor padrão

--- a/core/src/main/resources/l10n/messages_ru.properties
+++ b/core/src/main/resources/l10n/messages_ru.properties
@@ -1414,7 +1414,6 @@ MotorDbUpdate.Failed.title = Motor database update
 MotorDbUpdate.Failed.message = Unable to download and install the motor database update.
 
 ! AppearanceConfig
-AppearanceCfg.lbl.Appearance = Внешний вид
 AppearanceCfg.lbl.Usedefault = По умолчанию
 AppearanceCfg.but.edit = Изменить
 AppearanceCfg.but.createTexture = Create texture
@@ -1518,7 +1517,6 @@ RocketCompCfg.lbl.CDOverriddenBy.ttip = <html>The C<sub>D</sub> of this componen
 RocketCompCfg.lbl.longB1 = <html>Переопределенная масса не включает в себя двигатели.<br>
 RocketCompCfg.lbl.longB2 = Центр тяжести измеряется от начала
 RocketCompCfg.lbl.Commentsonthe = Примечания -
-RocketCompCfg.lbl.Figurestyle = Стиль рисунка:
 RocketCompCfg.lbl.Componentcolor = Цвет компонента:
 RocketCompCfg.lbl.Choosecolor = Выберите цвет
 RocketCompCfg.checkbox.Usedefaultcolor = Цвет по умолчанию

--- a/core/src/main/resources/l10n/messages_tr.properties
+++ b/core/src/main/resources/l10n/messages_tr.properties
@@ -1414,7 +1414,6 @@ MotorDbUpdate.Failed.title = Motor database update
 MotorDbUpdate.Failed.message = Unable to download and install the motor database update.
 
 ! AppearanceConfig
-AppearanceCfg.lbl.Appearance = Appearance
 AppearanceCfg.lbl.Usedefault = Use default
 AppearanceCfg.but.edit = Edit
 AppearanceCfg.but.createTexture = Create texture
@@ -1518,7 +1517,6 @@ RocketCompCfg.lbl.CDOverriddenBy.ttip = <html>The C<sub>D</sub> of this componen
 RocketCompCfg.lbl.longB1 = <html>The overridden mass and center of gravity does not include motors. <br>
 RocketCompCfg.lbl.longB2 = The center of gravity is measured from the front end of the
 RocketCompCfg.lbl.Commentsonthe = Comments on the
-RocketCompCfg.lbl.Figurestyle = Figure style:
 RocketCompCfg.lbl.Componentcolor = Component color:
 RocketCompCfg.lbl.Choosecolor = Choose color
 RocketCompCfg.checkbox.Usedefaultcolor = Use default color

--- a/core/src/main/resources/l10n/messages_uk.properties
+++ b/core/src/main/resources/l10n/messages_uk.properties
@@ -1414,7 +1414,6 @@ MotorDbUpdate.Failed.title = Motor database update
 MotorDbUpdate.Failed.message = Unable to download and install the motor database update.
 
 ! AppearanceConfig
-AppearanceCfg.lbl.Appearance = Зовнішній вигляд
 AppearanceCfg.lbl.Usedefault = Використовувати замовчування
 AppearanceCfg.but.edit = Змінити
 AppearanceCfg.but.createTexture = Create texture
@@ -1518,7 +1517,6 @@ RocketCompCfg.lbl.CDOverriddenBy.ttip = <html>Коефіцієнт опору (C
 RocketCompCfg.lbl.longB1 = <html>Перезаписана маса і центр ваги не включають двигуни. <br>
 RocketCompCfg.lbl.longB2 = Центр ваги вимірюється від переднього кінця
 RocketCompCfg.lbl.Commentsonthe = Коментарі до
-RocketCompCfg.lbl.Figurestyle = Стиль фігури:
 RocketCompCfg.lbl.Componentcolor = Колір компонента:
 RocketCompCfg.lbl.Choosecolor = Вибрати колір
 RocketCompCfg.checkbox.Usedefaultcolor = Використовувати замовчуваний колір

--- a/core/src/main/resources/l10n/messages_zh.properties
+++ b/core/src/main/resources/l10n/messages_zh.properties
@@ -1414,7 +1414,6 @@ MotorDbUpdate.Failed.title = 发动机数据库更新
 MotorDbUpdate.Failed.message = 无法下载并安装发动机数据库更新。
 
 ! AppearanceConfig
-AppearanceCfg.lbl.Appearance = 外观
 AppearanceCfg.lbl.Usedefault = 使用默认
 AppearanceCfg.but.edit = 编辑
 AppearanceCfg.but.createTexture = 创建纹理
@@ -1518,7 +1517,6 @@ RocketCompCfg.lbl.CDOverriddenBy.ttip = <html>此组件的 C<sub>D</sub> 由 %s 
 RocketCompCfg.lbl.longB1 = <html>覆写质量不包括发动机。<br>
 RocketCompCfg.lbl.longB2 = 重心从头部开始计算
 RocketCompCfg.lbl.Commentsonthe = 注释
-RocketCompCfg.lbl.Figurestyle = 样式:
 RocketCompCfg.lbl.Componentcolor = 组件颜色:
 RocketCompCfg.lbl.Choosecolor = 颜色选择
 RocketCompCfg.checkbox.Usedefaultcolor = 默认颜色

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/AppearancePanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/AppearancePanel.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Locale;
 
+import javax.swing.BorderFactory;
 import javax.swing.JComboBox;
 import javax.swing.JPanel;
 import javax.swing.JColorChooser;
@@ -35,6 +36,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JSpinner;
 import javax.swing.JTabbedPane;
 import javax.swing.SpinnerNumberModel;
+import javax.swing.border.TitledBorder;
 
 import info.openrocket.core.document.Attachment;
 import info.openrocket.core.util.Invalidatable;
@@ -234,7 +236,7 @@ public class AppearancePanel extends JPanel implements Invalidatable, Invalidati
 	 * @param order component traversal order object of the component config dialog
 	 */
 	public AppearancePanel(final OpenRocketDocument document, final RocketComponent c, final JDialog parent, List<Component> order) {
-		super(new MigLayout("fillx", "[150][grow][150][grow]"));
+		super(new MigLayout("fillx", "[grow]"));
 
 		this.order = order;
 		defaultAppearance = DefaultAppearance.getDefaultAppearance(c);
@@ -325,8 +327,25 @@ public class AppearancePanel extends JPanel implements Invalidatable, Invalidati
 		BooleanModel fDefault = new BooleanModel(c.getColor() == null);
 		register(fDefault);
 
+		// 2D Figure Style Section
+		add2DFigureWidgets(c, order, fDefault, figureColorHexField);
+
+		// 3D Figure Style Section
+		add3DFigureWidgets(document, c, parent, order, allInsideColor);
+	}
+
+	private void add2DFigureWidgets(RocketComponent c, List<Component> order, BooleanModel fDefault,
+									PlaceholderTextField figureColorHexField) {
 		final JButton saveAsDefault;
+
+		// 2D Figure Style Section
+		final JPanel panel = new JPanel(new MigLayout("fillx, ins unrel unrel rel unrel", "[150][grow][150][grow]"));
+		final TitledBorder border = BorderFactory.createTitledBorder(trans.get("AppearanceCfg.TitledBorder.2DFigureStyle"));
+		panel.setBorder(border);
+		add(panel, "growx, pushx, wrap");
+
 		{// Style Header Row
+			//// Use default style
 			final JCheckBox colorDefault = new JCheckBox(fDefault);
 			colorDefault.addActionListener(new ActionListener() {
 				@Override
@@ -343,11 +362,10 @@ public class AppearancePanel extends JPanel implements Invalidatable, Invalidati
 			});
 			colorDefault.setText(trans
 					.get("RocketCompCfg.checkbox.Usedefaultcolor"));
-			add(new StyledLabel(trans.get("RocketCompCfg.lbl.Figurestyle"),
-					Style.BOLD));
-			add(colorDefault);
+			panel.add(colorDefault, "spanx 2");
 			order.add(colorDefault);
 
+			//// Save as default style
 			saveAsDefault = new JButton(
 					trans.get("RocketCompCfg.but.Saveasdefstyle"));
 			saveAsDefault.addActionListener(new ActionListener() {
@@ -366,18 +384,18 @@ public class AppearancePanel extends JPanel implements Invalidatable, Invalidati
 				}
 			});
 			fDefault.addEnableComponent(saveAsDefault, false);
-			add(saveAsDefault, "span 2, align right, wrap");
+			panel.add(saveAsDefault, "spanx, wrap");
 		}
 
 		{// Figure Color
-			add(new JLabel(trans.get("RocketCompCfg.lbl.Componentcolor")));
+			panel.add(new JLabel(trans.get("RocketCompCfg.lbl.Componentcolor")));
 			JPanel colorPanel = new JPanel(new MigLayout("ins 0"));
 			colorPanel.add(figureColorButton);
 			figureColorHexField.setColumns(7);
 			colorPanel.add(figureColorHexField);
 			fDefault.addEnableComponent(figureColorButton, false);
 			fDefault.addEnableComponent(figureColorHexField, false);
-			add(colorPanel, "growx");
+			panel.add(colorPanel, "growx");
 			order.add(figureColorButton);
 			order.add(figureColorHexField);
 		}
@@ -385,7 +403,7 @@ public class AppearancePanel extends JPanel implements Invalidatable, Invalidati
 		order.add(saveAsDefault);
 
 		{// Line Style
-			add(new JLabel(trans.get("RocketCompCfg.lbl.Complinestyle")));
+			panel.add(new JLabel(trans.get("RocketCompCfg.lbl.Complinestyle")));
 
 			LineStyle[] list = new LineStyle[LineStyle.values().length + 1];
 			System.arraycopy(LineStyle.values(), 0, list, 1,
@@ -398,129 +416,141 @@ public class AppearancePanel extends JPanel implements Invalidatable, Invalidati
 
 			fDefault.addEnableComponent(combo, false);
 
-			add(combo, "growx, wrap");
+			panel.add(combo, "growx, wrap");
 			order.add(combo);
 		}
+	}
 
-		add(new JSeparator(SwingConstants.HORIZONTAL), "span, wrap, growx");
+	private void add3DFigureWidgets(OpenRocketDocument document, RocketComponent c, JDialog parent,
+									List<Component> order, boolean allInsideColor) {
+		// 3D Figure Style Section
+		final JPanel panel = new JPanel(new MigLayout("fillx, ins unrel unrel rel unrel", "[150][grow][150][grow]"));
+		final TitledBorder border = BorderFactory.createTitledBorder(trans.get("AppearanceCfg.TitledBorder.3DAppearance"));
+		panel.setBorder(border);
+		add(panel, "growx, pushx, wrap");
 
 		// Display a tabbed panel for choosing the outside and inside appearance, if the object is of type InsideColorComponent
 		if (allInsideColor) {
-			InsideColorComponentHandler handler = ((InsideColorComponent)c).getInsideColorComponentHandler();
+			add3DFigureStyleWidgetsInsideColorComponent(document, c, parent, panel, order);
+		} else {
+			appearanceSection(document, c, false, panel);
+		}
+	}
 
-			// Get translator keys
-			String tr_outside, tr_inside, tr_insideOutside, tr_insideOutside_ttip;
-			if (c instanceof FinSet) {
-				tr_outside = "RocketCompCfg.tab.LeftSide";
-				tr_inside = "RocketCompCfg.tab.RightSide";
-				tr_insideOutside = "AppearanceCfg.lbl.separateLeftSideRightSide";
-				tr_insideOutside_ttip = "AppearanceCfg.lbl.ttip.separateLeftSideRightSide";
+	private void add3DFigureStyleWidgetsInsideColorComponent(OpenRocketDocument document, RocketComponent c,
+															 JDialog parent, JPanel panel, List<Component> order) {
+		InsideColorComponentHandler handler = ((InsideColorComponent) c).getInsideColorComponentHandler();
+
+		// Get translator keys
+		String tr_outside, tr_inside, tr_insideOutside, tr_insideOutside_ttip;
+		if (c instanceof FinSet) {
+			tr_outside = "RocketCompCfg.tab.LeftSide";
+			tr_inside = "RocketCompCfg.tab.RightSide";
+			tr_insideOutside = "AppearanceCfg.lbl.separateLeftSideRightSide";
+			tr_insideOutside_ttip = "AppearanceCfg.lbl.ttip.separateLeftSideRightSide";
+		}
+		else {
+			tr_outside = "RocketCompCfg.tab.Outside";
+			tr_inside = "RocketCompCfg.tab.Inside";
+			tr_insideOutside = "AppearanceCfg.lbl.separateInsideOutside";
+			tr_insideOutside_ttip = "AppearanceCfg.lbl.ttip.separateInsideOutside";
+		}
+
+		// Use separate appearance for outside and inside (or left/right)
+		BooleanModel b_customInside = new BooleanModel(handler.isSeparateInsideOutside());
+		register(b_customInside);
+		this.customInside = new JCheckBox(b_customInside);
+		customInside.setText(trans.get(tr_insideOutside));
+		customInside.setToolTipText(trans.get(tr_insideOutside_ttip));
+		panel.add(customInside, "span 2");
+		order.add(customInside);
+
+		// Appearance for edges
+		JLabel edgesText = new JLabel(trans.get("AppearanceCfg.lbl.AppearanceEdges"));
+		panel.add(edgesText);
+		String[] options = new String[] {trans.get(tr_outside), trans.get(tr_inside)};
+		JComboBox<String> edgesComboBox = new JComboBox<>(options);
+		if (handler.isEdgesSameAsInside()) {
+			edgesComboBox.setSelectedItem(trans.get(tr_inside));
+		}
+		else {
+			edgesComboBox.setSelectedItem(trans.get(tr_outside));
+		}
+		panel.add(edgesComboBox, "growx, left, wrap");
+		order.add(edgesComboBox);
+		edgesText.setToolTipText(trans.get("AppearanceCfg.lbl.ttip.AppearanceEdges"));
+		edgesComboBox.setToolTipText(trans.get("AppearanceCfg.lbl.ttip.AppearanceEdges"));
+
+		outsideInsidePane = new JTabbedPane();
+		JPanel outsidePanel = new JPanel(new MigLayout("fill", "[150][grow][150][grow]"));
+		JPanel insidePanel = new JPanel(new MigLayout("fill", "[150][grow][150][grow]"));
+
+		appearanceSection(document, c, false, outsidePanel);
+		appearanceSection(document, c, true, insidePanel);
+
+		outsideInsidePane.addTab(trans.get(tr_outside), null, outsidePanel,
+				"Outside Tool Tip");
+		outsideInsidePane.addTab(trans.get(tr_inside), null, insidePanel,
+				"Inside Tool Tip");
+		panel.add(outsideInsidePane, "span 4, growx, wrap");
+
+		// Show the outside/inside tabbed display when customInside is selected
+		customInside.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				handler.setSeparateInsideOutside(customInside.isSelected());
+				edgesText.setEnabled(customInside.isSelected());
+				edgesComboBox.setEnabled(customInside.isSelected());
+				if (customInside.isSelected()) {
+					panel.remove(outsidePanel);
+					MigLayout layout = (MigLayout) outsidePanel.getLayout();
+					layout.setLayoutConstraints("fill");
+					outsideInsidePane.insertTab(trans.get(tr_outside), null, outsidePanel,
+							"Outside Tool Tip", 0);
+					outsideInsidePane.setSelectedIndex(0);
+					panel.add(outsideInsidePane, "span 4, growx, wrap");
+				}
+				else {
+					panel.remove(outsideInsidePane);
+					MigLayout layout = (MigLayout) outsidePanel.getLayout();
+					layout.setLayoutConstraints("fill, ins 0");
+					panel.add(outsidePanel, "span 4, growx, wrap");
+				}
+
+				// Repaint to fit to the new size
+				if (parent != null) {
+					parent.pack();
+				} else {
+					updateUI();
+				}
+
+				if (e == null) return;	// When e == null, you just want an update of the UI components, not a component change
+				c.fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 			}
-			else {
-				tr_outside = "RocketCompCfg.tab.Outside";
-				tr_inside = "RocketCompCfg.tab.Inside";
-				tr_insideOutside = "AppearanceCfg.lbl.separateInsideOutside";
-				tr_insideOutside_ttip = "AppearanceCfg.lbl.ttip.separateInsideOutside";
-			}
+		});
 
-			// Checkbox for using separate outside/inside appearance
-			BooleanModel b_customInside = new BooleanModel(handler.isSeparateInsideOutside());
-			register(b_customInside);
-			this.customInside = new JCheckBox(b_customInside);
-			customInside.setText(trans.get(tr_insideOutside));
-			customInside.setToolTipText(trans.get(tr_insideOutside_ttip));
-			add(customInside, "span 2");
-			order.add(customInside);
-
-			// Combobox for setting the edge appearance from inside/outside appearance
-			JLabel edgesText = new JLabel(trans.get("AppearanceCfg.lbl.AppearanceEdges"));
-			add(edgesText);
-			String[] options = new String[] {trans.get(tr_outside), trans.get(tr_inside)};
-			JComboBox<String> edgesComboBox = new JComboBox<>(options);
-			if (handler.isEdgesSameAsInside()) {
-				edgesComboBox.setSelectedItem(trans.get(tr_inside));
-			}
-			else {
-				edgesComboBox.setSelectedItem(trans.get(tr_outside));
-			}
-			add(edgesComboBox, "growx, left, wrap");
-			order.add(edgesComboBox);
-			edgesText.setToolTipText(trans.get("AppearanceCfg.lbl.ttip.AppearanceEdges"));
-			edgesComboBox.setToolTipText(trans.get("AppearanceCfg.lbl.ttip.AppearanceEdges"));
-
-			outsideInsidePane = new JTabbedPane();
-			JPanel outsidePanel = new JPanel(new MigLayout("fill", "[150][grow][150][grow]"));
-			JPanel insidePanel = new JPanel(new MigLayout("fill", "[150][grow][150][grow]"));
-
-			appearanceSection(document, c, false, outsidePanel);
-			appearanceSection(document, c, true, insidePanel);
-
-			outsideInsidePane.addTab(trans.get(tr_outside), null, outsidePanel,
-					"Outside Tool Tip");
-			outsideInsidePane.addTab(trans.get(tr_inside), null, insidePanel,
-					"Inside Tool Tip");
-			add(outsideInsidePane, "span 4, growx, wrap");
-
-			// Show the outside/inside tabbed display when customInside is selected
-			customInside.addActionListener(new ActionListener() {
-				@Override
-				public void actionPerformed(ActionEvent e) {
-					handler.setSeparateInsideOutside(customInside.isSelected());
-					edgesText.setEnabled(customInside.isSelected());
-					edgesComboBox.setEnabled(customInside.isSelected());
-					if (customInside.isSelected()) {
-						remove(outsidePanel);
-						MigLayout layout = (MigLayout) outsidePanel.getLayout();
-						layout.setLayoutConstraints("fill");
-						outsideInsidePane.insertTab(trans.get(tr_outside), null, outsidePanel,
-								"Outside Tool Tip", 0);
-						outsideInsidePane.setSelectedIndex(0);
-						add(outsideInsidePane, "span 4, growx, wrap");
-					}
-					else {
-						remove(outsideInsidePane);
-						MigLayout layout = (MigLayout) outsidePanel.getLayout();
-						layout.setLayoutConstraints("fill, ins 0");
-						add(outsidePanel, "span 4, growx, wrap");
-					}
-
-					// Repaint to fit to the new size
-					if (parent != null) {
-						parent.pack();
-					} else {
-						updateUI();
-					}
-
-					if (e == null) return;	// When e == null, you just want an update of the UI components, not a component change
+		// Change the edge appearance upon item selection
+		edgesComboBox.addActionListener(new ActionListener() {
+			@Override
+			public void actionPerformed(ActionEvent e) {
+				if (edgesComboBox.getSelectedItem() == null) return;
+				if (edgesComboBox.getSelectedItem().equals(trans.get(tr_outside))) {
+					handler.setEdgesSameAsInside(false);
+				}
+				else if (edgesComboBox.getSelectedItem().equals(trans.get(tr_inside))) {
+					handler.setEdgesSameAsInside(true);
+				}
+				else {
+					return;
+				}
+				if (e != null) {	// When e == null, you just want an update of the UI components, not a component change
 					c.fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
 				}
-			});
+			}
+		});
 
-			// Change the edge appearance upon item selection
-			edgesComboBox.addActionListener(new ActionListener() {
-				@Override
-				public void actionPerformed(ActionEvent e) {
-					if (edgesComboBox.getSelectedItem() == null) return;
-					if (edgesComboBox.getSelectedItem().equals(trans.get(tr_outside))) {
-						handler.setEdgesSameAsInside(false);
-					}
-					else if (edgesComboBox.getSelectedItem().equals(trans.get(tr_inside))) {
-						handler.setEdgesSameAsInside(true);
-					}
-					else {
-						return;
-					}
-					if (e != null) {	// When e == null, you just want an update of the UI components, not a component change
-						c.fireComponentChangeEvent(ComponentChangeEvent.NONFUNCTIONAL_CHANGE);
-					}
-				}
-			});
-
-			customInside.getActionListeners()[0].actionPerformed(null);
-			edgesComboBox.getActionListeners()[0].actionPerformed(null);
-		}
-		else
-			appearanceSection(document, c, false, this);
+		customInside.getActionListeners()[0].actionPerformed(null);
+		edgesComboBox.getActionListeners()[0].actionPerformed(null);
 	}
 
 	/**
@@ -571,8 +601,7 @@ public class AppearancePanel extends JPanel implements Invalidatable, Invalidati
 		colorHexField.addFocusListener(colorHexListener);
 
 		// Texture Header Row
-		panel.add(new StyledLabel(trans.get("AppearanceCfg.lbl.Appearance"),
-				Style.BOLD));
+		//// Use default appearance
 		JCheckBox materialDefault = new JCheckBox(mDefault);
 		materialDefault.addActionListener(new ActionListener() {
 			@Override
@@ -614,7 +643,7 @@ public class AppearancePanel extends JPanel implements Invalidatable, Invalidati
 			}
 		});
 		materialDefault.setText(trans.get("AppearanceCfg.lbl.Usedefault"));
-		panel.add(materialDefault, "wrap");
+		panel.add(materialDefault, "spanx, wrap");
 		order.add(materialDefault);
 
 		// Texture File


### PR DESCRIPTION
This PR fixes #2318 and puts the 2D figure style widgets and 3D appearance widgets in dedicated panels with a title border.

<img width="605" alt="image" src="https://github.com/user-attachments/assets/53bcfb1a-e1e2-4b2a-81af-31e98c3ed4c5" />
