### PR TITLE
[#3166] Keep material table rows stable during edits

### DIFF
--- a/core/src/test/java/info/openrocket/core/database/MaterialDatabaseTest.java
+++ b/core/src/test/java/info/openrocket/core/database/MaterialDatabaseTest.java
@@ -54,6 +54,21 @@ public class MaterialDatabaseTest {
 		assertFalse(Databases.LINE_MATERIAL.isEmpty());
 	}
 
+	/**
+	 * Verify the exact number of built-in materials so accidental removals or duplicate additions
+	 * cannot silently reduce or expand the choices presented to users.
+	 */
+	@Test
+	void testDefaultMaterialCounts() {
+		assertEquals(32, Databases.BULK_MATERIAL.size());
+		assertEquals(8, Databases.SURFACE_MATERIAL.size());
+		assertEquals(42, Databases.LINE_MATERIAL.size());
+
+		int totalMaterialCount = Databases.BULK_MATERIAL.size() + Databases.SURFACE_MATERIAL.size()
+				+ Databases.LINE_MATERIAL.size();
+		assertEquals(82, totalMaterialCount);
+	}
+
 	@Test
 	void testFindMaterialByTypeAndName() {
 		Material aluminum = Databases.findMaterial(Material.Type.BULK, "Aluminum");

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/MaterialEditPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/preferences/MaterialEditPanel.java
@@ -56,12 +56,14 @@ public class MaterialEditPanel extends JPanel {
 	private final JButton revertButton;
 	private static final Translator trans = Application.getTranslator();
 	private final OpenRocketDocument document;
+	private List<Material> materialRows;
 	
 	
 	public MaterialEditPanel(OpenRocketDocument document) {
 		super(new MigLayout("fill"));
 
 		this.document = document;
+		refreshMaterials();
 		
 
 		// TODO: LOW: Create sorter that keeps material types always in order
@@ -167,8 +169,7 @@ public class MaterialEditPanel extends JPanel {
 				) {
 					@Override
 					public int getRowCount() {
-						return Databases.BULK_MATERIAL.size() + Databases.SURFACE_MATERIAL.size() +
-								Databases.LINE_MATERIAL.size() + document.getDocumentPreferences().getTotalMaterialCount();
+						return materialRows.size();
 					}
 				};
 		
@@ -378,8 +379,25 @@ public class MaterialEditPanel extends JPanel {
 	}
 
 	private void fireChange(ColumnTableModel model) {
+		refreshMaterials();
 		model.fireTableDataChanged();
 		document.getRocket().fireComponentChangeEvent(ComponentChangeEvent.MASS_CHANGE);
+	}
+
+	/**
+	 * Rebuild the table rows as one stable snapshot of the application and document databases.
+	 * JTable row sorters cache model indices, so exposing live database sizes while a material is
+	 * removed and re-added can make the sorter request a row that no longer exists.
+	 */
+	private void refreshMaterials() {
+		List<Material> refreshedMaterials = new ArrayList<>();
+		refreshedMaterials.addAll(Databases.BULK_MATERIAL);
+		refreshedMaterials.addAll(document.getDocumentPreferences().getBulkMaterials());
+		refreshedMaterials.addAll(Databases.SURFACE_MATERIAL);
+		refreshedMaterials.addAll(document.getDocumentPreferences().getSurfaceMaterials());
+		refreshedMaterials.addAll(Databases.LINE_MATERIAL);
+		refreshedMaterials.addAll(document.getDocumentPreferences().getLineMaterials());
+		materialRows = refreshedMaterials;
 	}
 
 	private void addMaterial(Material m) {
@@ -523,51 +541,7 @@ public class MaterialEditPanel extends JPanel {
 	}
 	
 	private Material getMaterial(int origRow) {
-		int row = origRow;
-		int n;
-		
-		n = Databases.BULK_MATERIAL.size();
-		if (row < n) {
-			return Databases.BULK_MATERIAL.get(row);
-		}
-		row -= n;
-
-		n = document.getDocumentPreferences().getBulkMaterials().size();
-		if (row < n) {
-			return document.getDocumentPreferences().getBulkMaterials().get(row);
-		}
-		row -= n;
-		
-		n = Databases.SURFACE_MATERIAL.size();
-		if (row < n) {
-			return Databases.SURFACE_MATERIAL.get(row);
-		}
-		row -= n;
-
-		n = document.getDocumentPreferences().getSurfaceMaterials().size();
-		if (row < n) {
-			return document.getDocumentPreferences().getSurfaceMaterials().get(row);
-		}
-		row -= n;
-
-		n = Databases.LINE_MATERIAL.size();
-		if (row < n) {
-			return Databases.LINE_MATERIAL.get(row);
-		}
-		row -= n;
-
-		n = document.getDocumentPreferences().getLineMaterials().size();
-		if (row < n) {
-			return document.getDocumentPreferences().getLineMaterials().get(row);
-		}
-
-		throw new IndexOutOfBoundsException("row=" + origRow + " while material count" +
-				" bulk:" + Databases.BULK_MATERIAL.size() +
-				" bulk document:" + document.getDocumentPreferences().getBulkMaterials().size() +
-				" surface:" + Databases.SURFACE_MATERIAL.size() +
-				" surface document:" + document.getDocumentPreferences().getSurfaceMaterials().size() +
-				" line:" + Databases.LINE_MATERIAL.size() +
-				" line document:" + document.getDocumentPreferences().getLineMaterials().size());
+		return materialRows.get(origRow);
 	}
 	
 	

--- a/swing/src/test/java/info/openrocket/swing/gui/dialogs/preferences/MaterialEditPanelTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/dialogs/preferences/MaterialEditPanelTest.java
@@ -1,0 +1,74 @@
+package info.openrocket.swing.gui.dialogs.preferences;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.awt.Component;
+import java.awt.Container;
+
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
+
+import org.junit.jupiter.api.Test;
+
+import info.openrocket.core.document.OpenRocketDocument;
+import info.openrocket.core.document.OpenRocketDocumentFactory;
+import info.openrocket.core.material.Material;
+import info.openrocket.core.material.MaterialGroup;
+import info.openrocket.swing.util.BaseTestCase;
+
+/**
+ * Tests synchronization between the material databases and the preferences table.
+ */
+public class MaterialEditPanelTest extends BaseTestCase {
+
+	/**
+	 * A material edit temporarily removes a database row before adding its replacement. The table
+	 * must keep the old snapshot readable until it receives the completed update, because its row
+	 * sorter still maps view rows to the old model indices during that interval.
+	 */
+	@Test
+	public void materialRowsRemainReadableWhileDatabaseChanges() throws Exception {
+		SwingUtilities.invokeAndWait(() -> {
+			OpenRocketDocument document = OpenRocketDocumentFactory.createNewRocket();
+			Material material = Material.newMaterial(Material.Type.LINE, "Issue 3166 material", 0.001,
+					MaterialGroup.CUSTOM, true, true);
+			document.getDocumentPreferences().addMaterial(material);
+
+			MaterialEditPanel panel = new MaterialEditPanel(document);
+			JTable table = findTable(panel);
+			assertNotNull(table);
+
+			table.getRowSorter().toggleSortOrder(0);
+			int materialModelRow = table.getModel().getRowCount() - 1;
+			assertEquals(material.getName(), table.getModel().getValueAt(materialModelRow, 0));
+			int materialViewRow = table.convertRowIndexToView(materialModelRow);
+
+			// Simulate the remove phase of editing the material before the table change is announced.
+			document.getDocumentPreferences().removeMaterial(material);
+
+			assertEquals(materialModelRow + 1, table.getModel().getRowCount());
+			Object displayedName = assertDoesNotThrow(() -> table.getValueAt(materialViewRow, 0));
+			assertEquals(material.getName(), displayedName);
+		});
+	}
+
+	/**
+	 * Locate the table without exposing a production accessor solely for testing.
+	 */
+	private static JTable findTable(Container container) {
+		for (Component component : container.getComponents()) {
+			if (component instanceof JTable table) {
+				return table;
+			}
+			if (component instanceof Container childContainer) {
+				JTable table = findTable(childContainer);
+				if (table != null) {
+					return table;
+				}
+			}
+		}
+		return null;
+	}
+}

--- a/swing/src/test/java/info/openrocket/swing/gui/dialogs/preferences/MaterialEditPanelTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/dialogs/preferences/MaterialEditPanelTest.java
@@ -12,6 +12,7 @@ import javax.swing.SwingUtilities;
 
 import org.junit.jupiter.api.Test;
 
+import info.openrocket.core.database.Databases;
 import info.openrocket.core.document.OpenRocketDocument;
 import info.openrocket.core.document.OpenRocketDocumentFactory;
 import info.openrocket.core.material.Material;
@@ -22,6 +23,32 @@ import info.openrocket.swing.util.BaseTestCase;
  * Tests synchronization between the material databases and the preferences table.
  */
 public class MaterialEditPanelTest extends BaseTestCase {
+
+	/**
+	 * The table snapshot must include every application and document material for each material
+	 * type. This guards against omitting a database while rebuilding the snapshot.
+	 */
+	@Test
+	public void materialTableIncludesAllDatabaseMaterials() throws Exception {
+		SwingUtilities.invokeAndWait(() -> {
+			OpenRocketDocument document = OpenRocketDocumentFactory.createNewRocket();
+			document.getDocumentPreferences().addMaterial(Material.newMaterial(Material.Type.BULK,
+					"Document bulk material", 1000, MaterialGroup.CUSTOM, true, true));
+			document.getDocumentPreferences().addMaterial(Material.newMaterial(Material.Type.SURFACE,
+					"Document surface material", 0.1, MaterialGroup.CUSTOM, true, true));
+			document.getDocumentPreferences().addMaterial(Material.newMaterial(Material.Type.LINE,
+					"Document line material", 0.001, MaterialGroup.CUSTOM, true, true));
+
+			MaterialEditPanel panel = new MaterialEditPanel(document);
+			JTable table = findTable(panel);
+			assertNotNull(table);
+
+			int applicationMaterialCount = Databases.BULK_MATERIAL.size() + Databases.SURFACE_MATERIAL.size()
+					+ Databases.LINE_MATERIAL.size();
+			int documentMaterialCount = document.getDocumentPreferences().getTotalMaterialCount();
+			assertEquals(applicationMaterialCount + documentMaterialCount, table.getModel().getRowCount());
+		});
+	}
 
 	/**
 	 * A material edit temporarily removes a database row before adding its replacement. The table


### PR DESCRIPTION
Fixes #3166 by using dedicated material list refreshing, thus keeping material table rows stable while a material is removed and re-added, preventing stale row-index errors.