### PR TITLE
Account for body-in-fin interference in CNa

### DIFF
--- a/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/FinSetCalc.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/FinSetCalc.java
@@ -147,13 +147,13 @@ public class FinSetCalc extends RocketComponentCalc {
 			break;
 		}
 				
-		// Body-fin interference effect
+		// Combined body-fin interference effect on the normal force
 		double r = bodyRadius;
 		double tau = r / (span + r);
-		if (Double.isNaN(tau) || Double.isInfinite(tau))
+		if (Double.isNaN(tau) || Double.isInfinite(tau)) {
 			tau = 0;
-		cna *= 1 + tau; // Classical Barrowman
-		//		cna *= pow2(1 + tau);	// Barrowman thesis (too optimistic??)
+		}
+		cna *= calculateBodyFinInterferenceFactor(tau, conditions.getMach());
 		//		logger.debug("Component cna = {}", cna);
 		
 		// TODO: LOW: check for fin tip mach cone interference
@@ -169,7 +169,8 @@ public class FinSetCalc extends RocketComponentCalc {
 		// Without body-fin interference effect:
 		//		forces.CrollForce = fins * (macSpan+r) * cna1 * component.getCantAngle() / 
 		//			conditions.getRefLength();
-		// With body-fin interference effect:
+		// The body-in-fin lift does not act through the canted fin surface, so
+		// roll forcing retains only the classical fin-in-body correction.
 		forces.setCrollForce((macSpan + r) * cna1 * (1 + tau) * cantAngle / conditions.getRefLength());
 		
 		if (conditions.getAOA() > STALL_ANGLE) {
@@ -412,6 +413,34 @@ public class FinSetCalc extends RocketComponentCalc {
 		K1 = new LinearInterpolator(x, k1);
 		K2 = new LinearInterpolator(x, k2);
 		K3 = new LinearInterpolator(x, k3);
+	}
+
+	/**
+	 * Calculate the combined fin-in-body and body-in-fin normal-force multiplier.
+	 *
+	 * <p>For slender configurations, equations 14 and 21 of NACA Report 1307
+	 * combine to {@code (1 + tau)^2}.  OpenRocket does not yet model the
+	 * supersonic Mach-cone geometry needed for the body contribution, so that
+	 * additional term is blended out over the existing transonic CNa interval.
+	 * The classical fin-in-body term remains at all Mach numbers.</p>
+	 *
+	 * @param tau body radius divided by the fin semispan measured from the rocket axis
+	 * @param mach flight Mach number
+	 * @return total body-fin interference multiplier
+	 * @see <a href="https://ntrs.nasa.gov/citations/19930091008">NACA Report 1307</a>
+	 */
+	static double calculateBodyFinInterferenceFactor(double tau, double mach) {
+		double finInBodyFactor = 1 + tau;
+		if (mach <= CNA_SUBSONIC) {
+			return pow2(finInBodyFactor);
+		}
+		if (mach >= CNA_SUPERSONIC) {
+			return finInBodyFactor;
+		}
+
+		double bodyInFinFactor = tau * finInBodyFactor;
+		double bodyContributionWeight = (CNA_SUPERSONIC - mach) / (CNA_SUPERSONIC - CNA_SUBSONIC);
+		return finInBodyFactor + bodyContributionWeight * bodyInFinFactor;
 	}
 	
 	protected double calculateFinCNa1(FlightConditions conditions) {

--- a/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/FinSetCalc.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/FinSetCalc.java
@@ -153,6 +153,16 @@ public class FinSetCalc extends RocketComponentCalc {
 		if (Double.isNaN(tau) || Double.isInfinite(tau)) {
 			tau = 0;
 		}
+		/*
+		 * TODO: Replace this scalar approximation with the complete fin/body
+		 * method from NACA Report 1307. Calculate fin-in-body and body-in-fin
+		 * CNa and CP separately (equations 13-34 and 58-71; charts 1-5 and
+		 * 10-16), then combine their moments. The report's two-panel,
+		 * constant-radius model must first be generalized and validated for
+		 * radial fin sets; preserve this approximation as the fallback outside
+		 * the full method's applicability range. See the technical documentation
+		 * subsection "Future complete NACA implementation" for the full roadmap.
+		 */
 		cna *= calculateBodyFinInterferenceFactor(tau, conditions.getMach());
 		//		logger.debug("Component cna = {}", cna);
 		

--- a/core/src/test/java/info/openrocket/core/aerodynamics/BarrowmanCalculatorTest.java
+++ b/core/src/test/java/info/openrocket/core/aerodynamics/BarrowmanCalculatorTest.java
@@ -101,7 +101,7 @@ public class BarrowmanCalculatorTest {
 			double cna_body = 0; // equal-to-zero, see [Barrowman66] p15.
 			double cpx_body = 0;
 
-			double cna_3fin = 24.146933;
+			double cna_3fin = 28.82053382;
 			double cpx_3fin = 0.0193484;
 			double fin_x = 0.22;
 			cpx_3fin += fin_x;
@@ -132,8 +132,8 @@ public class BarrowmanCalculatorTest {
 		// calculated from OpenRocket 15.03:
 		// double expCPx = 0.225;
 		// verified from the equations:
-		double expCPx = 0.2235154;
-		double exp_cna = 26.146933;
+		double expCPx = 0.22591627;
+		double exp_cna = 30.82053382;
 		CoordinateIF calcCP = calc.getCP(config, conditions, warnings);
 
 		assertEquals(expCPx, calcCP.getX(), EPSILON, " Estes Alpha III cp x value is incorrect:");
@@ -155,8 +155,8 @@ public class BarrowmanCalculatorTest {
 		{
 			boosterFins.setFinCount(3);
 			final CoordinateIF cp_3fin = calc.getCP(config, conditions, warnings);
-			assertEquals(16.51651439, cp_3fin.getWeight(), EPSILON, " Falcon 9 Heavy CNa value is incorrect:");
-			assertEquals(1.00667319, cp_3fin.getX(), EPSILON, " Falcon 9 Heavy CP x value is incorrect:");
+			assertEquals(20.19347236, cp_3fin.getWeight(), EPSILON, " Falcon 9 Heavy CNa value is incorrect:");
+			assertEquals(1.03800258, cp_3fin.getX(), EPSILON, " Falcon 9 Heavy CP x value is incorrect:");
 			assertEquals(0.0, cp_3fin.getY(), EPSILON, " Falcon 9 Heavy CP y value is incorrect:");
 			assertEquals(0.0, cp_3fin.getZ(), EPSILON, " Falcon 9 Heavy CP z value is incorrect:");
 		}
@@ -164,16 +164,16 @@ public class BarrowmanCalculatorTest {
 			boosterFins.setFinCount(2);
 			boosterFins.setAngleOffset(Math.PI / 4);
 			final CoordinateIF cp_2fin = calc.getCP(config, conditions, warnings);
-			assertEquals(12.1073483560, cp_2fin.getWeight(), EPSILON, " Falcon 9 Heavy CNa value is incorrect:");
-			assertEquals(0.9440139181, cp_2fin.getX(), EPSILON, " Falcon 9 Heavy CP x value is incorrect:");
+			assertEquals(14.55865366, cp_2fin.getWeight(), EPSILON, " Falcon 9 Heavy CNa value is incorrect:");
+			assertEquals(0.98353414, cp_2fin.getX(), EPSILON, " Falcon 9 Heavy CP x value is incorrect:");
 			assertEquals(0.0, cp_2fin.getY(), EPSILON, " Falcon 9 Heavy CP y value is incorrect:");
 			assertEquals(0.0, cp_2fin.getZ(), EPSILON, " Falcon 9 Heavy CP z value is incorrect:");
 		}
 		{
 			boosterFins.setFinCount(1);
 			final CoordinateIF cp_1fin = calc.getCP(config, conditions, warnings);
-			assertEquals(7.6981823141, cp_1fin.getWeight(), EPSILON, " Falcon 9 Heavy CNa value is incorrect:");
-			assertEquals(0.8095779106, cp_1fin.getX(), EPSILON, " Falcon 9 Heavy CP x value is incorrect:");
+			assertEquals(8.92383497, cp_1fin.getWeight(), EPSILON, " Falcon 9 Heavy CNa value is incorrect:");
+			assertEquals(0.86027918, cp_1fin.getX(), EPSILON, " Falcon 9 Heavy CP x value is incorrect:");
 			assertEquals(0.0f, cp_1fin.getY(), EPSILON, " Falcon 9 Heavy CP y value is incorrect:");
 			assertEquals(0.0f, cp_1fin.getZ(), EPSILON, " Falcon 9 Heavy CP z value is incorrect:");
 		}
@@ -190,14 +190,14 @@ public class BarrowmanCalculatorTest {
 		{
 			((FinSet) rocket.getChild(0).getChild(1).getChild(0)).setFinCount(4);
 			final CoordinateIF wholeRocketCP = calc.getCP(config, conditions, warnings);
-			assertEquals(34.19591165, wholeRocketCP.getWeight(), EPSILON, "Split-Fin Rocket CNa value is incorrect:");
-			assertEquals(0.22724216, wholeRocketCP.getX(), EPSILON, "Split-Fin Rocket CP x value is incorrect:");
+			assertEquals(40.42737843, wholeRocketCP.getWeight(), EPSILON, "Split-Fin Rocket CNa value is incorrect:");
+			assertEquals(0.22910818, wholeRocketCP.getX(), EPSILON, "Split-Fin Rocket CP x value is incorrect:");
 		}
 		{
 			((FinSet) rocket.getChild(0).getChild(1).getChild(0)).setFinCount(3);
 			final CoordinateIF wholeRocketCP = calc.getCP(config, conditions, warnings);
-			assertEquals(26.14693374, wholeRocketCP.getWeight(), EPSILON, "Split-Fin Rocket CNa value is incorrect:");
-			assertEquals(0.22351541, wholeRocketCP.getX(), EPSILON, "Split-Fin Rocket CP x value is incorrect:");
+			assertEquals(30.82053382, wholeRocketCP.getWeight(), EPSILON, "Split-Fin Rocket CNa value is incorrect:");
+			assertEquals(0.22591627, wholeRocketCP.getX(), EPSILON, "Split-Fin Rocket CP x value is incorrect:");
 		}
 		{
 			((FinSet) rocket.getChild(0).getChild(1).getChild(0)).setFinCount(2);
@@ -224,8 +224,8 @@ public class BarrowmanCalculatorTest {
 
 		{
 			final CoordinateIF wholeRocketCP = calc.getCP(config, conditions, warnings);
-			assertEquals(26.14693374, wholeRocketCP.getWeight(), EPSILON, "Split-Fin Rocket CNa value is incorrect:");
-			assertEquals(0.22351541, wholeRocketCP.getX(), EPSILON, "Split-Fin Rocket CP x value is incorrect:");
+			assertEquals(30.82053382, wholeRocketCP.getWeight(), EPSILON, "Split-Fin Rocket CNa value is incorrect:");
+			assertEquals(0.22591627, wholeRocketCP.getX(), EPSILON, "Split-Fin Rocket CP x value is incorrect:");
 		}
 		{
 			final BodyTube body = (BodyTube) rocket.getChild(0).getChild(1);
@@ -234,8 +234,8 @@ public class BarrowmanCalculatorTest {
 			TestRockets.splitRocketFins(body, fins, 3);
 
 			final CoordinateIF wholeRocketCP = calc.getCP(config, conditions, warnings);
-			assertEquals(26.14693374, wholeRocketCP.getWeight(), EPSILON, "Split-Fin Rocket CNa value is incorrect:");
-			assertEquals(0.22351541, wholeRocketCP.getX(), EPSILON, "Split-Fin Rocket CP x value is incorrect:");
+			assertEquals(30.82053382, wholeRocketCP.getWeight(), EPSILON, "Split-Fin Rocket CNa value is incorrect:");
+			assertEquals(0.22591627, wholeRocketCP.getX(), EPSILON, "Split-Fin Rocket CP x value is incorrect:");
 		}
 	}
 
@@ -251,8 +251,8 @@ public class BarrowmanCalculatorTest {
 		{
 			((FinSet) rocket.getChild(0).getChild(1).getChild(0)).setFinCount(4);
 			final CoordinateIF wholeRocketCP = calc.getCP(config, conditions, warnings);
-			assertEquals(34.19591165, wholeRocketCP.getWeight(), EPSILON, "Split-Fin Rocket CNa value is incorrect:");
-			assertEquals(0.22724, wholeRocketCP.getX(), EPSILON, "Split-Fin Rocket CP x value is incorrect:");
+			assertEquals(40.42737843, wholeRocketCP.getWeight(), EPSILON, "Split-Fin Rocket CNa value is incorrect:");
+			assertEquals(0.22910818, wholeRocketCP.getX(), EPSILON, "Split-Fin Rocket CP x value is incorrect:");
 		}
 		{
 			final BodyTube body = (BodyTube) rocket.getChild(0).getChild(1);
@@ -260,8 +260,8 @@ public class BarrowmanCalculatorTest {
 			TestRockets.splitRocketFins(body, fins, 4);
 
 			final CoordinateIF wholeRocketCP = calc.getCP(config, conditions, warnings);
-			assertEquals(34.19591165, wholeRocketCP.getWeight(), EPSILON, "Split-Fin Rocket CNa value is incorrect:");
-			assertEquals(0.22724, wholeRocketCP.getX(), EPSILON, "Split-Fin Rocket CP x value is incorrect:");
+			assertEquals(40.42737843, wholeRocketCP.getWeight(), EPSILON, "Split-Fin Rocket CNa value is incorrect:");
+			assertEquals(0.22910818, wholeRocketCP.getX(), EPSILON, "Split-Fin Rocket CP x value is incorrect:");
 		}
 	}
 
@@ -278,10 +278,10 @@ public class BarrowmanCalculatorTest {
 		final WarningSet warnings = new WarningSet();
 
 		final CoordinateIF cp = calc.getCP(config, conditions, warnings);
-		assertEquals(0.25461, cp.getX(), EPSILON, " Endplate rocket cp x value is incorrect:");
+		assertEquals(0.25575683, cp.getX(), EPSILON, " Endplate rocket cp x value is incorrect:");
 		assertEquals(0.0, cp.getY(), EPSILON, " Endplate rocket cp y value is incorrect:");
 		assertEquals(0.0, cp.getZ(), EPSILON, " Endplate rocket cp z value is incorrect:");
-		assertEquals(40.96857, cp.getWeight(), EPSILON, " Endplate rocket CNa value is incorrect:");
+		assertEquals(45.32530223, cp.getWeight(), EPSILON, " Endplate rocket CNa value is incorrect:");
 	}
 
 	@Test
@@ -388,21 +388,17 @@ public class BarrowmanCalculatorTest {
 
 		// The "with pods" version has no way of seeing the fins are
 		// on the actual body tube rather than the phantom tubes,
-		// so CD won't take fin-body interference into consideration.
-		// So we'll adjust our CD in these tests. The magic numbers
-		// in x and w come from temporarily disabling the
-		// interference calculation in FinSetCalc and comparing
-		// results with and without it
-		// cpNoPods (0.34125,0.00000,0.00000,w=16.20502) -- interference disabled
-		// cpNoPods (0.34797,0.00000,0.00000,w=19.34773) -- interference enabled
+		// so its fin normal force won't include body interference.
+		// The deltas below come from comparing the same design with the
+		// interference calculation in FinSetCalc disabled and enabled.
 
 		final CoordinateIF cpNoPods = calcNoPods.getCP(configNoPods, conditionsNoPods, warningsNoPods);
 		final CoordinateIF cpPods = calcPods.getCP(configPods, conditionsPods, warningsPods);
-		assertEquals(cpNoPods.getX() - 0.002788761352, cpPods.getX(),
+		assertEquals(cpNoPods.getX() - 0.005189678651, cpPods.getX(),
 				EPSILON, " Alpha III With Pods rocket cp x value is incorrect:");
 		assertEquals(cpNoPods.getY(), cpPods.getY(), EPSILON, " Alpha III With Pods rocket cp y value is incorrect:");
 		assertEquals(cpNoPods.getZ(), cpPods.getZ(), EPSILON, " Alpha III With Pods rocket cp z value is incorrect:");
-		assertEquals(cpPods.getWeight(), cpNoPods.getWeight() - 3.91572,
+		assertEquals(cpPods.getWeight(), cpNoPods.getWeight() - 8.589319064,
 				EPSILON, " Alpha III With Pods rocket CNa value is incorrect:");
 	}
 

--- a/core/src/test/java/info/openrocket/core/aerodynamics/FinSetCalcTest.java
+++ b/core/src/test/java/info/openrocket/core/aerodynamics/FinSetCalcTest.java
@@ -84,7 +84,7 @@ public class FinSetCalcTest {
 		// get the forces for the three fins
 		AerodynamicForces forces = sumFins(fins, rocket);
 
-		double exp_cna_fins = 24.146933;
+		double exp_cna_fins = 28.82053382;
 		double exp_cpx_fins = 0.0193484;
 
 		assertEquals(exp_cna_fins, forces.getCP().getWeight(), EPSILON, " FinSetCalc produces bad CNa: ");
@@ -109,7 +109,7 @@ public class FinSetCalcTest {
 		// get the forces for the four fins
 		AerodynamicForces forces = sumFins(fins, rocket);
 
-		double exp_cna_fins = 32.195911;
+		double exp_cna_fins = 38.42737843;
 		double exp_cpx_fins = 0.0193484;
 
 		assertEquals(exp_cna_fins, forces.getCP().getWeight(), EPSILON, " FinSetCalc produces bad CNa: ");

--- a/core/src/test/java/info/openrocket/core/aerodynamics/barrowman/FinBodyInterferenceTest.java
+++ b/core/src/test/java/info/openrocket/core/aerodynamics/barrowman/FinBodyInterferenceTest.java
@@ -1,0 +1,36 @@
+package info.openrocket.core.aerodynamics.barrowman;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class FinBodyInterferenceTest {
+	private static final double EPSILON = 1.0e-12;
+	private static final double TAU = 0.25;
+
+	/**
+	 * The subsonic multiplier includes both the fin-in-body and body-in-fin terms.
+	 */
+	@Test
+	public void includesBodyContributionAtSubsonicSpeeds() {
+		assertEquals(1.5625, FinSetCalc.calculateBodyFinInterferenceFactor(TAU, 0.5), EPSILON);
+		assertEquals(1.5625, FinSetCalc.calculateBodyFinInterferenceFactor(TAU, 0.9), EPSILON);
+	}
+
+	/**
+	 * The unmodeled body term is smoothly removed through the transonic interval.
+	 */
+	@Test
+	public void blendsBodyContributionThroughTransonicSpeeds() {
+		assertEquals(1.40625, FinSetCalc.calculateBodyFinInterferenceFactor(TAU, 1.2), EPSILON);
+	}
+
+	/**
+	 * The established fin-in-body correction remains unchanged at supersonic speeds.
+	 */
+	@Test
+	public void retainsClassicalCorrectionAtSupersonicSpeeds() {
+		assertEquals(1.25, FinSetCalc.calculateBodyFinInterferenceFactor(TAU, 1.5), EPSILON);
+		assertEquals(1.25, FinSetCalc.calculateBodyFinInterferenceFactor(TAU, 3.0), EPSILON);
+	}
+}

--- a/doc/techdoc/chapter-aerodynamic-properties.tex
+++ b/doc/techdoc/chapter-aerodynamic-properties.tex
@@ -1147,11 +1147,57 @@ pressure would require the full NACA method.  Since the additional
 normal force acts on the body, it is not included in the fin-cant roll
 forcing term.
 
-% TODO: FUTURE: supersonic interference effects, MIL-HDBK page 5-25 or B'man
-
-
-
 \pagebreak[4]
+\paragraph{Future complete NACA implementation.}
+Here ``complete'' refers to the fin--body portions of Report 1307, not
+to its separate wing--tail vortex-interference model.  The scalar
+correction above is intentionally an interim model.  A future
+implementation should perform the following work, mapping the report's
+wing notation to the rocket fins:
+
+\begin{enumerate}
+\item Keep the fin-in-body and body-in-fin loads separate,
+\begin{align}
+\del{\CNa}_{F(B)} &= K_{F(B)}\;\del{\CNa}_F, \\
+\del{\CNa}_{B(F)} &= K_{B(F)}\;\del{\CNa}_F.
+\end{align}
+Determine both factors from equations 13--34 and charts 1--5 of
+Report 1307.  The calculation needs the body-radius/total-semispan
+ratio $r/s$ (the report measures $s$ from the axis to the fin tip),
+$\beta A$ with $\beta=\sqrt{|M_\infty^2-1|}$, taper ratio, and edge
+sweep.  It must apply the report's slender-body/planar-model selection
+rule derived from the restriction in equation 22.  The planar model of
+equations 23--31 distinguishes subsonic and supersonic fin edges and
+configurations with and without an afterbody.  All terms must use a
+consistent OpenRocket reference area when they are combined.
+
+\item Calculate the two centers of pressure independently.  Use
+equations 58--65 and charts 10--13 for the fins in the presence of the
+body.  Use equations 66--71 and charts 14--16 for the force transferred
+to the body: the image-vortex lifting-line model of figure 15 and
+Appendix D for subsonic flow, and the Mach-line planar model of figure 4
+for supersonic flow.  Combine the two normal forces and their moments,
+following the force-weighted procedure of equation 82.  Only the force
+on the fin surface should contribute to cant-driven roll.
+
+\item Generalize and validate the report's unbanked two-panel wing
+model before using it for radial fin sets.  The implementation must
+define how the loads from each fin orientation are projected and
+superposed without counting the shared body response more than once.
+It must also define an explicit fallback to the present approximation
+for geometries outside the method's assumptions, including large
+angles of attack, strongly varying body radius, forward-swept leading
+edges, and swept-back trailing edges.
+
+\item Implement closed-form equations directly and store any digitized
+chart data with source and interpolation metadata.  Regression tests
+should reproduce the fin/body entries of the computing example in
+table I, exercise the chart boundaries and afterbody alternatives, and
+verify finite, continuous behavior through the transonic range.
+\end{enumerate}
+
+
+
 \subsection{Pitch damping moment}
 
 So far the effect of the current pitch angular velocity has been

--- a/doc/techdoc/chapter-aerodynamic-properties.tex
+++ b/doc/techdoc/chapter-aerodynamic-properties.tex
@@ -1113,79 +1113,39 @@ case.
 \subsubsection{Fin--body interference}
 
 The normal force coefficient must still be corrected for fin--body
-interference, which increases the overall produced normal force.  Here
-two distinct effects can be identified: the normal force on the fins
-due to the presence of the body and the normal force on the body due
-to the presence of fins.  Of these the former is significantly larger;
-the latter is therefore ignored.  The effect of the extra fin lift is
-taken into account using a correction term
+interference, which increases the overall produced normal force.  Two
+distinct effects are included: the normal force on the fins due to the
+presence of the body and the normal force on the body due to the
+presence of the fins.  Define
 %
 \begin{equation}
-\del{\CNa}_{T(B)} = K_{T(B)}\;\del{\CNa}_N
+\tau = \frac{r_t}{s+r_t},
 \end{equation}
 %
-where $\del{\CNa}_{T(B)}$ is the normal force coefficient derivative
-of the tail in the presence of the body.  The term $K_{T(B)}$ can be
-approximated by~\cite{barrowman-rd}
+where $s$ is the exposed fin span from root to tip and $r_t$ is the
+body radius at the fin position.  The classical Barrowman correction
+for the fins in the presence of the body is~\cite{barrowman-rd}
 %
 \begin{equation}
-K_{T(B)} = 1 + \frac{r_t}{s + r_t},
+K_{T(B)} = 1 + \tau.
 \end{equation}
 %
-where $s$ is the fin span from root to tip and $r_t$ is the body
-radius at the fin position.  The value $\del{\CNa}_{T(B)}$ is then
-used as the final normal force coefficient derivative of the fins.
-
-
-%The normal force coefficient must still be corrected for fin--body
-%interference, which increases the produced normal force.  The effect
-%of the interference can be split into two components, the normal force
-%of the fins in the presence of the body $\del{\CNa}_{T(B)}$ and of the
-%body in the presence of the fins $\del{\CNa}_{B(T)}$.  (The subscript
-%$T$ refers to {\it tail}.)  The interference is taken into account
-%using the correction factors
-%%
-%\begin{align}
-%\del{\CNa}_{T(B)} &= K_{T(B)}\;\del{\CNa}_N \\
-%\del{\CNa}_{B(T)} &= K_{B(T)}\;\del{\CNa}_N.
-%\end{align}
-%%
-%In his original report, Barrowman simplified the factor $K_{T(B)}$ to
-%%
-%\begin{equation}
-%K_{T(B)} = 1 + \frac{r_t}{s + r_t},
-%\end{equation}
-%%
-%where $s$ is the fin span from root to tip and $r_t$ is the body
-%radius at the fin position, and ignored the effect of $K_{B(T)}$ as
-%small compared to $K_{T(B)}$ for typical fin dimensions.  However,
-%$K_{T(B)}$ may be significant for fins with a span short compared to
-%the body radius.  In his thesis, a more accurate equation for
-%$K_{T(B)}$ is provided, and $K_{B(T)}$ is given
-%as~\cite[p.~31]{barrowman-thesis}
-%%
-%\begin{equation}
-%K_{B(T)} = \del{1 + \frac{r_t}{s + r_t}}^2 - K_{T(B)}.
-%\end{equation}
-%%
-%Therefore the total interference effect can be accounted for by a
-%factor
-%%
-%\begin{equation}
-%K_T = K_{T(B)} + K_{B(T)} = \del{1 + \frac{r_t}{s + r_t}}^2
-%\end{equation}
-%%
-%and
-%%
-%\begin{equation}
-%\del{\CNa}_{\rm fins} = K_T\; (\CNa)_N.
-%\end{equation}
-
-%This equation takes the increase on body lift and adds it as an
-%additional force on the fins.  The equation holds at subsonic speeds
-%and also at supersonic speeds until the fin tip Mach cone intersects
-%the body.  In the latter case more complex interference factors would
-%be required, which have been ignored in the current software.
+The slender-body expressions for the two interference effects in
+NACA Report 1307, equations 14 and 21, combine to~\cite{naca-1307}
+%
+\begin{equation}
+K_T = K_{T(B)} + K_{B(T)} = (1+\tau)^2.
+\end{equation}
+%
+This combined factor is used through Mach 0.9.  OpenRocket does not
+yet model the fin-tip Mach-cone geometry needed for the body term at
+supersonic speeds, so $K_{B(T)}=\tau(1+\tau)$ is linearly blended to
+zero between Mach 0.9 and Mach 1.5.  Above Mach 1.5 only the established
+$K_{T(B)}$ correction is retained.  The body contribution is lumped at
+the fin-set center of pressure; calculating its separate center of
+pressure would require the full NACA method.  Since the additional
+normal force acts on the body, it is not included in the fin-cant roll
+forcing term.
 
 % TODO: FUTURE: supersonic interference effects, MIL-HDBK page 5-25 or B'man
 
@@ -2373,4 +2333,3 @@ of fins & factor     \\
 \end{tabular}
 \end{center}
 \end{table}
-

--- a/doc/techdoc/techdoc.tex
+++ b/doc/techdoc/techdoc.tex
@@ -332,6 +332,11 @@ understanding for my passion towards rocketry.
   calculation of the aerodynamic characteristics of slender finned
   vehicles}, M.Sc. thesis, The Catholic University of America, 1967.
 
+\bibitem{naca-1307} Pitts, W., Nielsen, J., Kaattari, G., {\it Lift
+  and center of pressure of wing-body-tail combinations at subsonic,
+  transonic, and supersonic speeds}, NACA Report 1307, 1959.  Available
+  at \url{https://ntrs.nasa.gov/citations/19930091008}.
+
 \bibitem{rocksim} van Milligan, T., RockSim Model Rocket Design and
   Simulation Software, \url{http://www.apogeerockets.com/RockSim.asp},
   retrieved 14.5.2009.

--- a/swing/src/test/java/info/openrocket/swing/IntegrationTest.java
+++ b/swing/src/test/java/info/openrocket/swing/IntegrationTest.java
@@ -118,7 +118,7 @@ public class IntegrationTest {
 		 
 		// Compute cg+cp + altitude
 	    //   double cgx, double mass, double cpx, double cna)
-		checkCgCp(0.248, 0.0645, 0.320, 12.0);
+		checkCgCp(0.248, 0.0645, 0.331, 14.88);
 		checkAlt(48.8);
 		
 		// Mass modification
@@ -128,7 +128,7 @@ public class IntegrationTest {
 		checkUndoState("Modify mass", null);
 		
 		// Check cg+cp + altitude
-		checkCgCp(0.230, 0.0745, 0.320, 12.0);
+		checkCgCp(0.230, 0.0745, 0.331, 14.88);
 		checkAlt(37.4);
 		
 		// Non-change
@@ -142,7 +142,7 @@ public class IntegrationTest {
 		checkUndoState("Name change", null);
 		
 		// Check cg+cp
-		checkCgCp(0.230, 0.0745, 0.320, 12.0);
+		checkCgCp(0.230, 0.0745, 0.331, 14.88);
 		
 		// Aerodynamic modification
 		document.addUndoPosition("Remove component");
@@ -151,7 +151,7 @@ public class IntegrationTest {
 		checkUndoState("Remove component", null);
 		
 		// Check cg+cp + altitude
-		checkCgCp(0.163, 0.0613, 0.275, 9.95);
+		checkCgCp(0.163, 0.0613, 0.275, 12.88);
 		checkAlt(45.6);
 		
 		// Undo "Remove component" change
@@ -160,7 +160,7 @@ public class IntegrationTest {
 		checkUndoState("Name change", "Remove component");
 		
 		// Check cg+cp + altitude
-		checkCgCp(0.230, 0.0745, 0.320, 12.0);
+		checkCgCp(0.230, 0.0745, 0.331, 14.88);
 		checkAlt(37.4);
 		
 		// Undo "Name change" change
@@ -169,7 +169,7 @@ public class IntegrationTest {
 		checkUndoState("Modify mass", "Name change");
 		
 		// Check cg+cp
-		checkCgCp(0.230, 0.0745, 0.320, 12.0);
+		checkCgCp(0.230, 0.0745, 0.331, 14.88);
 		
 		// Undo "Modify mass" change
 		undoAction.actionPerformed(new ActionEvent(this, 0, "foo"));
@@ -177,7 +177,7 @@ public class IntegrationTest {
 		checkUndoState(null, "Modify mass");
 		
 		// Check cg+cp + altitude
-		checkCgCp(0.248, 0.0645, 0.320, 12.0);
+		checkCgCp(0.248, 0.0645, 0.331, 14.88);
 		checkAlt(48.87);
 		
 		// Redo "Modify mass" change
@@ -186,7 +186,7 @@ public class IntegrationTest {
 		checkUndoState("Modify mass", "Name change");
 		
 		// Check cg+cp + altitude
-		checkCgCp(0.230, 0.0745, 0.320, 12.0);
+		checkCgCp(0.230, 0.0745, 0.331, 14.88);
 		checkAlt(37.4);
 		
 		// Mass modification
@@ -196,7 +196,7 @@ public class IntegrationTest {
 		checkUndoState("Modify mass2", null);
 		
 		// Check cg+cp + altitude
-		checkCgCp(0.223, 0.0795, 0.320, 12.0);
+		checkCgCp(0.223, 0.0795, 0.331, 14.88);
 		checkAlt(33);
 		
 		// Perform component movement
@@ -213,7 +213,7 @@ public class IntegrationTest {
 		document.stopUndo();
 		
 		// Check cg+cp + altitude
-		checkCgCp(0.221, 0.0797, 0.320, 12.0);
+		checkCgCp(0.221, 0.0797, 0.331, 14.88);
 		checkAlt(33);
 		
 		// Modify mass without setting undo description
@@ -221,7 +221,7 @@ public class IntegrationTest {
 		checkUndoState("Modify mass2", null);
 		
 		// Check cg+cp + altitude
-		checkCgCp(0.215, 0.0847, 0.320, 12.0);
+		checkCgCp(0.215, 0.0847, 0.331, 14.88);
 		checkAlt(29.0);
 		
 		// Undo "Modify mass2" change
@@ -230,7 +230,7 @@ public class IntegrationTest {
 		checkUndoState("Move component", "Modify mass2");
 		
 		// Check cg+cp + altitude
-		checkCgCp(0.221, 0.0797, 0.320, 12.0);
+		checkCgCp(0.221, 0.0797, 0.331, 14.88);
 		checkAlt(33);
 		
 		// Undo "Move component" change
@@ -239,7 +239,7 @@ public class IntegrationTest {
 		checkUndoState("Modify mass2", "Move component");
 		
 		// Check cg+cp + altitude
-		checkCgCp(0.223, 0.0795, 0.320, 12.0);
+		checkCgCp(0.223, 0.0795, 0.331, 14.88);
 		checkAlt(33);
 		
 		// Redo "Move component" change
@@ -248,7 +248,7 @@ public class IntegrationTest {
 		checkUndoState("Move component", "Modify mass2");
 		
 		// Check cg+cp + altitude
-		checkCgCp(0.221, 0.0797, 0.320, 12.0);
+		checkCgCp(0.221, 0.0797, 0.331, 14.88);
 		checkAlt(33);
 		
 	}


### PR DESCRIPTION
## Problem

As reported in #2489, OpenRocket predicts noticeably less weathercocking than RASAero II and RockSim for the tested rocket.

One likely contributor is that OpenRocket currently underestimates the fin-set normal-force slope, CNa. It accounts for the increased force on the fins caused by the body, but omits the corresponding force induced on the body by the fins. This missing contribution is most noticeable for relatively short fins mounted on a large-diameter body.

A lower CNa produces less aerodynamic normal force for a given angle of attack. It also reduces the aerodynamic weighting of the aft fin section, moving the calculated total CP forward. Together, these effects produce a weaker restoring moment in a crosswind, so the simulated rocket turns into the wind less strongly.

## What changed

OpenRocket previously used the classical Barrowman fin-in-body correction

`K_F(B) = 1 + τ`

where

`τ = r_t / (s + r_t)`,

`r_t` is the body radius and `s` is the exposed fin span.

This PR adds the omitted body contribution so that the combined subsonic correction becomes

`K_total = (1 + τ)²`.

The extra contribution used by the implementation is therefore

`K_body,effective = (1 + τ)² - (1 + τ) = τ(1 + τ)`.

The combined factor is applied through Mach 0.9. Between Mach 0.9 and 1.5, the additional body contribution is linearly reduced to zero. Above Mach 1.5, OpenRocket retains the existing `1 + τ` correction because calculating the body contribution there requires the fin-tip Mach-cone geometry from the full NACA method.

The additional force is currently assigned to the fin-set center of pressure. It is not included in cant-driven roll forcing because it represents force on the body rather than on the canted fin surface.

## Formula derivation and references

The existing `1 + τ` correction is the simplified fin-body interference factor from [Barrowman’s original NARAM-8 report](https://www.nakka-rocketry.net/articles/Barrowman.NARAM-8.pdf).

The combined square follows from the slender-body factors in [NACA Report 1307, equation 14](https://ntrs.nasa.gov/api/citations/19930091008/downloads/19930091008.pdf#page=8) and [equation 21](https://ntrs.nasa.gov/api/citations/19930091008/downloads/19930091008.pdf#page=10). If their long shared numerator is written as `Q(x)`, the equations reduce to

`K_F(B) = Q(x) / (1 - x)²`
<img height="150" alt="Screenshot 2026-08-10 at 01 36 22" src="https://github.com/user-attachments/assets/fc7a0816-2b5f-4a8f-8b20-83f41d6fb870" />

with `x = r/8`. I won't try to type out `Q(x)`... but it's the entire numerator, including 2/PI

and

`K_B(F) = [(1 - x²)² - Q(x)] / (1 - x)²`.

<img height="100" alt="Screenshot 2026-08-10 at 01 36 38" src="https://github.com/user-attachments/assets/733f7acc-c2ca-45a4-bc6a-2e19da7a6d4d" />


Their sum is therefore

`K_F(B) + K_B(F) = (1 - x²)² / (1 - x)² = (1 + x)²`.

NACA uses `x = r/s`, with `s` measured from the body axis to the fin tip. In OpenRocket notation this is `x = r_t / (s + r_t) = τ`.

The same decomposition, along with the supersonic fin-tip Mach-cone limitation, appears in [Barrowman’s 1967 thesis, sections 3.31–3.32 and equations 3-96–3-99](https://ntrs.nasa.gov/api/citations/20010047838/downloads/20010047838.pdf#page=41).

This PR only uses the combined slender-body identity. It does not yet implement NACA’s separate geometry-dependent fin and body factors or their separate centers of pressure. A roadmap for that fuller implementation has been added to the technical documentation.

## CNa comparison to RASAero II

Old OpenRocket CNa plot of 'Two Stage High Power' example rocket for the two fin sets (blue = in Sustainer, red = booster):
<img width="700" alt="Old" src="https://github.com/user-attachments/assets/ae2fb0cb-7914-4af7-9565-cee70ae7d53c" />

New CNa plot:
<img width="700" alt="New" src="https://github.com/user-attachments/assets/befebabd-d269-4423-9533-1c54069e7742" />

Rocket design exported to RASAero II and CNa plot of the sustainer (equivalent of the blue line in the OR plots):
<img width="1590" height="474" alt="Screenshot 2026-08-09 at 17 14 53" src="https://github.com/user-attachments/assets/20d2f5dc-c8f8-4b18-8119-415fb8f05a7b" />

OR still underestimates CNa, but it's already closer to what RASAero calculates.

**EDIT**: I forgot that the nose cone still adds '2' to CNa of the sustainer. So, you need to shift the blue curves above upwards by '2'.

## Weathercocking comparison to RASAero II and RockSim

Unfortunately, I'm not knowledgeable enough to make a reliable comparison of weathercocking between OR, RASAero, and RockSim. It would be great if someone could chip in on this!

I also don't know how to reliably plot CNa in terms of Mach in RockSim.

---

Related to #2489, but I don't want to close it yet. Let's first implement the complete CNa implementation.