### PR TITLE
Use flight configuration recovery settings in RASAero export

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/rasaero/export/RecoveryDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rasaero/export/RecoveryDTO.java
@@ -9,6 +9,7 @@ import info.openrocket.core.logging.WarningSet;
 import info.openrocket.core.rocketcomponent.AxialStage;
 import info.openrocket.core.rocketcomponent.BodyTube;
 import info.openrocket.core.rocketcomponent.DeploymentConfiguration;
+import info.openrocket.core.rocketcomponent.FlightConfigurationId;
 import info.openrocket.core.rocketcomponent.Parachute;
 import info.openrocket.core.rocketcomponent.Rocket;
 import info.openrocket.core.rocketcomponent.RocketComponent;
@@ -74,17 +75,18 @@ public class RecoveryDTO {
 
     public RecoveryDTO(Rocket rocket, WarningSet warnings, ErrorSet errors) {
         List<Parachute> parachutes = getParachutesFromRocket(rocket);
+        FlightConfigurationId configurationId = rocket.getSelectedConfiguration().getId();
 
         switch (parachutes.size()) {
             case 0:
                 log.debug("No parachutes present");
                 break;
             case 1:
-                configureRecoveryDevice1(parachutes.get(0), errors);
+                configureRecoveryDevice1(parachutes.get(0), configurationId, errors);
                 break;
             case 2:
-                configureRecoveryDevice1(parachutes.get(0), errors);
-                configureRecoveryDevice2(parachutes.get(1), errors);
+                configureRecoveryDevice1(parachutes.get(0), configurationId, errors);
+                configureRecoveryDevice2(parachutes.get(1), configurationId, errors);
                 break;
         }
     }
@@ -112,10 +114,11 @@ public class RecoveryDTO {
         return parachutes;
     }
 
-    private void configureRecoveryDevice1(Parachute device1, ErrorSet errors) {
+    private void configureRecoveryDevice1(Parachute device1, FlightConfigurationId configurationId,
+            ErrorSet errors) {
         setCD1(device1.getCD());
         setDeviceType1("Parachute");
-        DeploymentConfiguration deployConfig = device1.getDeploymentConfigurations().getDefault();
+        DeploymentConfiguration deployConfig = device1.getDeploymentConfigurations().get(configurationId);
         setAltitude1(deployConfig.getDeployAltitude() * RASAeroCommonConstants.OPENROCKET_TO_RASAERO_ALTITUDE);
         if (deployConfig.getDeployEvent() == DeploymentConfiguration.DeployEvent.APOGEE) {
             setEventType1(RASAeroCommonConstants.DEPLOYMENT_APOGEE);
@@ -129,10 +132,11 @@ public class RecoveryDTO {
         setSize1(device1.getDiameter() * RASAeroCommonConstants.OPENROCKET_TO_RASAERO_LENGTH);
     }
 
-    private void configureRecoveryDevice2(Parachute device2, ErrorSet errors) {
+    private void configureRecoveryDevice2(Parachute device2, FlightConfigurationId configurationId,
+            ErrorSet errors) {
         setCD1(device2.getCD());
         setDeviceType2("Parachute");
-        DeploymentConfiguration deployConfig = device2.getDeploymentConfigurations().getDefault();
+        DeploymentConfiguration deployConfig = device2.getDeploymentConfigurations().get(configurationId);
         setAltitude2(deployConfig.getDeployAltitude() * RASAeroCommonConstants.OPENROCKET_TO_RASAERO_ALTITUDE);
         if (deployConfig.getDeployEvent() == DeploymentConfiguration.DeployEvent.APOGEE) {
             setEventType2(RASAeroCommonConstants.DEPLOYMENT_APOGEE);

--- a/core/src/test/java/info/openrocket/core/file/rasaero/export/RecoveryDTOTest.java
+++ b/core/src/test/java/info/openrocket/core/file/rasaero/export/RecoveryDTOTest.java
@@ -1,0 +1,57 @@
+package info.openrocket.core.file.rasaero.export;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import info.openrocket.core.file.rasaero.RASAeroCommonConstants;
+import info.openrocket.core.logging.ErrorSet;
+import info.openrocket.core.logging.WarningSet;
+import info.openrocket.core.rocketcomponent.AxialStage;
+import info.openrocket.core.rocketcomponent.BodyTube;
+import info.openrocket.core.rocketcomponent.DeploymentConfiguration;
+import info.openrocket.core.rocketcomponent.FlightConfigurationId;
+import info.openrocket.core.rocketcomponent.Parachute;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.util.BaseTestCase;
+
+/**
+ * Tests conversion of OpenRocket recovery settings to RASAero recovery settings.
+ */
+public class RecoveryDTOTest extends BaseTestCase {
+
+	/**
+	 * A flight configuration override must take precedence over the recovery component's default
+	 * deployment configuration during export.
+	 */
+	@Test
+	public void usesSelectedFlightConfigurationDeploymentOverride() {
+		Rocket rocket = new Rocket();
+		AxialStage stage = new AxialStage();
+		BodyTube bodyTube = new BodyTube();
+		Parachute parachute = new Parachute();
+		rocket.addChild(stage);
+		stage.addChild(bodyTube);
+		bodyTube.addChild(parachute);
+
+		// The component default is incompatible with RASAero.
+		parachute.getDeploymentConfigurations().getDefault()
+				.setDeployEvent(DeploymentConfiguration.DeployEvent.EJECTION);
+
+		FlightConfigurationId configurationId = new FlightConfigurationId();
+		rocket.createFlightConfiguration(configurationId);
+		DeploymentConfiguration override = new DeploymentConfiguration();
+		override.setDeployEvent(DeploymentConfiguration.DeployEvent.ALTITUDE);
+		override.setDeployAltitude(350);
+		parachute.getDeploymentConfigurations().set(configurationId, override);
+		rocket.setSelectedConfiguration(configurationId);
+
+		ErrorSet errors = new ErrorSet();
+		RecoveryDTO recovery = new RecoveryDTO(rocket, new WarningSet(), errors);
+
+		assertEquals(0, errors.size());
+		assertEquals(RASAeroCommonConstants.RECOVERY_ALTITUDE, recovery.getEventType1());
+		assertEquals(350 * RASAeroCommonConstants.OPENROCKET_TO_RASAERO_ALTITUDE,
+				recovery.getAltitude1());
+	}
+}


### PR DESCRIPTION
When you export an OpenRocket design to RASAero, it will give you export error messages, such as when the recovery device uses an incompatible deployment setting. However, this setting was derived from the recovery device's deployment config, instead of from the currently selected flight config. This PR fixes that.