### PR TITLE
Fix component analysis legend series highlighting

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/CAPlot.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/CAPlot.java
@@ -26,7 +26,8 @@ public class CAPlot extends Plot<CADataType, CADataBranch, CAPlotConfiguration> 
 		// Create the series for each component
 		List<XYSeries> allSeries = new ArrayList<>();
 		for (int i = 0; i < components.size(); i++) {
-			XYSeries series = createSingleSeries(startIndex*1000 + i, type, unit, branch, branchIdx, branchName, dataIndex, baseName,
+			XYSeries series = createSingleSeries(startIndex*1000 + i, type, unit, branch, branchIdx, branchName,
+					dataIndex, i, baseName,
 					components.get(i), componentNames.get(i));
 			allSeries.add(series);
 		}
@@ -35,7 +36,8 @@ public class CAPlot extends Plot<CADataType, CADataBranch, CAPlotConfiguration> 
 	}
 
 	private XYSeries createSingleSeries(int key, CADataType type, Unit unit,
-										CADataBranch branch, int branchIdx, String branchName, int dataIndex, String baseName,
+										CADataBranch branch, int branchIdx, String branchName, int dataIndex,
+										int componentIndex, String baseName,
 										RocketComponent component, String componentName) {
 		// Default implementation for regular DataBranch
 		MetadataXYSeries series = new MetadataXYSeries(key, false, true, branchIdx, dataIndex, unit.getUnit(),
@@ -47,6 +49,9 @@ public class CAPlot extends Plot<CADataType, CADataBranch, CAPlotConfiguration> 
 			newBaseName += " (" + componentName + ")";
 		}
 		series.setBaseName(newBaseName);
+		// Component names are not guaranteed to be unique, so use the component's position
+		// within this data type as its legend identity.
+		series.setLegendKey(dataIndex + ":" + componentIndex);
 		series.updateDescription();
 
 		List<Double> plotx = branch.get(filledConfig.getDomainAxisType());

--- a/swing/src/main/java/info/openrocket/swing/gui/plot/Plot.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/Plot.java
@@ -279,8 +279,10 @@ public abstract class Plot<T extends DataType, B extends DataBranch<T>, C extend
 
 				// Use a thick line in the legend so the color block is still obvious with styled strokes.
 				for (int j = 0; j < data[axisno].getSeriesCount(); j += branchCount) {
-					String name = data[axisno].getSeries(j).getDescription();
+					MetadataXYSeries series = (MetadataXYSeries) data[axisno].getSeries(j);
+					String name = series.getDescription();
 					this.legendItems.lineLabels.add(name);
+					this.legendItems.seriesKeys.add(series.getLegendKey());
 					Paint linePaint = r.lookupSeriesPaint(j);
 					this.legendItems.linePaints.add(linePaint);
 					Shape itemShape = r.lookupSeriesShape(j);
@@ -406,6 +408,7 @@ public abstract class Plot<T extends DataType, B extends DataBranch<T>, C extend
 
 	protected static class LegendItems implements LegendItemSource {
 		protected final List<String> lineLabels = new ArrayList<>();
+		protected final List<Comparable<?>> seriesKeys = new ArrayList<>();
 		protected final List<Paint> linePaints = new ArrayList<>();
 		protected final List<Stroke> lineStrokes = new ArrayList<>();
 		protected final List<Shape> pointShapes = new ArrayList<>();
@@ -437,6 +440,7 @@ public abstract class Plot<T extends DataType, B extends DataBranch<T>, C extend
 						urlText, shapeIsVisible, shape, shapeIsFilled, fillPaint,
 						shapeOutlineVisible, outlinePaint, outlineStroke, lineVisible,
 						legendLine, lineStroke, linePaint);
+				result.setSeriesKey(seriesKeys.get(i));
 
 				c.add(result);
 				i++;
@@ -607,6 +611,7 @@ public abstract class Plot<T extends DataType, B extends DataBranch<T>, C extend
 		private final String unit;
 		private final String branchName;
 		private String baseName;
+		private Comparable<?> legendKey;
 
 		public MetadataXYSeries(Comparable key, boolean autoSort, boolean allowDuplicateXValues, int branchIdx, int dataIdx, String unit,
 								String branchName, String baseName) {
@@ -616,6 +621,7 @@ public abstract class Plot<T extends DataType, B extends DataBranch<T>, C extend
 			this.unit = unit;
 			this.branchName = branchName;
 			this.baseName = baseName;
+			this.legendKey = dataIdx >= 0 ? dataIdx : baseName;
 			updateDescription();
 		}
 
@@ -646,6 +652,20 @@ public abstract class Plot<T extends DataType, B extends DataBranch<T>, C extend
 
 		public void setBaseName(String baseName) {
 			this.baseName = baseName;
+		}
+
+		/**
+		 * Returns the stable identity used to associate this series with its legend item.
+		 */
+		public Comparable<?> getLegendKey() {
+			return legendKey;
+		}
+
+		/**
+		 * Sets the stable identity used to associate this series with its legend item.
+		 */
+		public void setLegendKey(Comparable<?> legendKey) {
+			this.legendKey = legendKey;
 		}
 
 		public void updateDescription() {

--- a/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationChart.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationChart.java
@@ -64,9 +64,9 @@ public class SimulationChart extends ChartPanel {
 	
 	private MouseWheelHandler mouseWheelHandler = null;
 
-    private String hoveredLegendLabel = null;
+    private Comparable<?> hoveredLegendKey = null;
 
-    private final Set<String> selectedLegendLabels = new HashSet<>();
+    private final Set<Comparable<?>> selectedLegendKeys = new HashSet<>();
 
     private final Map<String, Stroke> baseStrokes = new HashMap<>();
 	
@@ -189,15 +189,16 @@ public class SimulationChart extends ChartPanel {
     @Override
     public void mouseMoved(MouseEvent e) {
         super.mouseMoved(e);
-        String legendLabel = null;
+        Comparable<?> legendKey = null;
         ChartEntity entity = getChartRenderingInfo().getEntityCollection().getEntity(e.getX(), e.getY());
 
-        if (entity instanceof LegendItemEntity) {
-            legendLabel = entity.getToolTipText();
+        if (entity instanceof LegendItemEntity legendItemEntity) {
+            legendKey = getLegendKey(legendItemEntity);
         }
 
-        if ((legendLabel == null && hoveredLegendLabel != null)||(legendLabel != null && !legendLabel.equals(hoveredLegendLabel))) {
-            hoveredLegendLabel = legendLabel;
+        if ((legendKey == null && hoveredLegendKey != null) ||
+                (legendKey != null && !legendKey.equals(hoveredLegendKey))) {
+            hoveredLegendKey = legendKey;
             updateHighlightingSet();
         }
     }
@@ -211,12 +212,13 @@ public class SimulationChart extends ChartPanel {
         if (e.getButton() != MouseEvent.BUTTON1) return;
         ChartEntity entity = getChartRenderingInfo().getEntityCollection().getEntity(e.getX(), e.getY());
 
-        if (entity instanceof LegendItemEntity) {
-            String label = entity.getToolTipText();
-            if (selectedLegendLabels.contains(label)) {
-                selectedLegendLabels.remove(label);
+        if (entity instanceof LegendItemEntity legendItemEntity) {
+            Comparable<?> legendKey = getLegendKey(legendItemEntity);
+            if (legendKey == null) return;
+            if (selectedLegendKeys.contains(legendKey)) {
+                selectedLegendKeys.remove(legendKey);
             }
-            else selectedLegendLabels.add(label);
+            else selectedLegendKeys.add(legendKey);
             updateHighlightingSet();
         }
     }
@@ -226,7 +228,7 @@ public class SimulationChart extends ChartPanel {
     @Override
     public void paintComponent(Graphics g) {
         super.paintComponent(g);
-        Set<String> labelsToHighlight = new HashSet<>(selectedLegendLabels);
+        Set<Comparable<?>> keysToHighlight = new HashSet<>(selectedLegendKeys);
         EntityCollection entities = getChartRenderingInfo().getEntityCollection();
         Graphics2D g2 = (Graphics2D) g.create();
         try {
@@ -234,9 +236,9 @@ public class SimulationChart extends ChartPanel {
             g2.setStroke(new BasicStroke(4.0f));
             for (int i = 0; i < entities.getEntityCount(); i++) {
                 ChartEntity entity = entities.getEntity(i);
-                if (entity instanceof LegendItemEntity) {
-                    String label = entity.getToolTipText();
-                    if (label != null && labelsToHighlight.contains(label)) {
+                if (entity instanceof LegendItemEntity legendItemEntity) {
+                    Comparable<?> legendKey = getLegendKey(legendItemEntity);
+                    if (legendKey != null && keysToHighlight.contains(legendKey)) {
                         Rectangle2D swatchBorder = getRectangle2D(entity);
                         g2.draw(swatchBorder);
                     }
@@ -264,17 +266,26 @@ public class SimulationChart extends ChartPanel {
         );
     }
 
-    private void updateHighlightingSet() {
-        Set<String> labelsToHighlight = new HashSet<>(selectedLegendLabels);
-        if (hoveredLegendLabel != null) {
-            labelsToHighlight.add(hoveredLegendLabel);
-        }
-        applyLegendHighlight(labelsToHighlight);
+    /**
+     * Returns the stable series identity attached to a legend item. The tooltip fallback supports charts
+     * whose legend items do not yet provide an explicit series key.
+     */
+    private static Comparable<?> getLegendKey(LegendItemEntity entity) {
+        Comparable<?> seriesKey = entity.getSeriesKey();
+        return seriesKey != null ? seriesKey : entity.getToolTipText();
     }
 
-    private void applyLegendHighlight(Set<String> labelsToHighlight) {
+    private void updateHighlightingSet() {
+        Set<Comparable<?>> keysToHighlight = new HashSet<>(selectedLegendKeys);
+        if (hoveredLegendKey != null) {
+            keysToHighlight.add(hoveredLegendKey);
+        }
+        applyLegendHighlight(keysToHighlight);
+    }
+
+    void applyLegendHighlight(Set<Comparable<?>> keysToHighlight) {
         XYPlot plot = getChart().getXYPlot();
-        boolean hasHighlight = labelsToHighlight != null;
+        boolean hasHighlight = keysToHighlight != null && !keysToHighlight.isEmpty();
 
         for (int r = 0; r < plot.getRendererCount(); r++) {
             XYItemRenderer renderer = plot.getRenderer(r);
@@ -288,14 +299,13 @@ public class SimulationChart extends ChartPanel {
                 BasicStroke base = (BasicStroke) baseStrokes.computeIfAbsent(key, k -> renderer.getSeriesStroke(finalS));
 
                 BasicStroke stroke = base;
-                // Match by base name so all branches of a variable are highlighted together.
-                // For MetadataXYSeries, the legend label equals the base name (branch 0 has no prefix),
-                // so checking baseName works for every branch regardless of which stage is selected.
-                String matchKey = dataset.getSeries(s).getDescription();
+                // Match by stable identity instead of display text because component names can be duplicated.
+                // Regular simulation branches deliberately share one key for each configured data series.
+                Comparable<?> matchKey = dataset.getSeries(s).getDescription();
                 if (dataset.getSeries(s) instanceof MetadataXYSeries) {
-                    matchKey = ((MetadataXYSeries) dataset.getSeries(s)).getBaseName();
+                    matchKey = ((MetadataXYSeries) dataset.getSeries(s)).getLegendKey();
                 }
-                if (hasHighlight && labelsToHighlight.contains(matchKey)) {
+                if (hasHighlight && keysToHighlight.contains(matchKey)) {
                     stroke = new BasicStroke(base.getLineWidth() * 3.0f, base.getEndCap(), base.getLineJoin(), base.getMiterLimit(), base.getDashArray(), base.getDashPhase());
                 }
 

--- a/swing/src/test/java/info/openrocket/swing/gui/plot/SimulationChartTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/plot/SimulationChartTest.java
@@ -1,0 +1,132 @@
+package info.openrocket.swing.gui.plot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.awt.BasicStroke;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.jfree.chart.LegendItemCollection;
+import org.jfree.chart.plot.XYPlot;
+import org.jfree.chart.renderer.xy.XYItemRenderer;
+import org.jfree.chart.title.LegendTitle;
+import org.jfree.data.xy.XYSeriesCollection;
+import org.junit.jupiter.api.Test;
+
+import info.openrocket.core.componentanalysis.CADataBranch;
+import info.openrocket.core.componentanalysis.CADataType;
+import info.openrocket.core.componentanalysis.CADomainDataType;
+import info.openrocket.core.rocketcomponent.BodyTube;
+import info.openrocket.core.simulation.FlightDataBranch;
+import info.openrocket.core.simulation.FlightDataType;
+import info.openrocket.swing.gui.dialogs.componentanalysis.CAPlot;
+import info.openrocket.swing.gui.dialogs.componentanalysis.CAPlotConfiguration;
+import info.openrocket.swing.util.BaseTestCase;
+
+/**
+ * Tests interactions with data series in simulation and component-analysis charts.
+ */
+public class SimulationChartTest extends BaseTestCase {
+
+	/**
+	 * Highlighting one component-analysis legend item must only widen that component's series.
+	 */
+	@Test
+	public void componentAnalysisLegendHighlightsOnlyMatchingSeries() {
+		BodyTube firstComponent = new BodyTube();
+		firstComponent.setName("Body Tube");
+		BodyTube secondComponent = new BodyTube();
+		secondComponent.setName("Body Tube");
+
+		CADataBranch branch = new CADataBranch("Analysis", CADomainDataType.MACH, CADataType.TOTAL_CD);
+		addAnalysisPoint(branch, firstComponent, secondComponent, 0.1, 0.2, 0.3);
+		addAnalysisPoint(branch, firstComponent, secondComponent, 0.2, 0.25, 0.35);
+
+		CAPlotConfiguration configuration = new CAPlotConfiguration("Test", CADomainDataType.MACH);
+		configuration.addPlotDataType(CADataType.TOTAL_CD, 0);
+		configuration.setPlotDataComponents(0, List.of(firstComponent, secondComponent));
+		CAPlot componentAnalysisPlot = new CAPlot("Test", branch, configuration,
+				Collections.singletonList(branch), false);
+		SimulationChart chart = new SimulationChart(componentAnalysisPlot.getJFreeChart());
+
+		XYPlot plot = chart.getChart().getXYPlot();
+		XYSeriesCollection dataset = (XYSeriesCollection) plot.getDataset(0);
+		XYItemRenderer renderer = plot.getRenderer(0);
+		float firstBaseWidth = ((BasicStroke) renderer.getSeriesStroke(0)).getLineWidth();
+		float secondBaseWidth = ((BasicStroke) renderer.getSeriesStroke(1)).getLineWidth();
+
+		LegendTitle legend = chart.getChart().getLegend();
+		LegendItemCollection legendItems = legend.getSources()[0].getLegendItems();
+		Comparable<?> firstLegendKey = legendItems.get(0).getSeriesKey();
+		Comparable<?> secondLegendKey = legendItems.get(1).getSeriesKey();
+		assertEquals(legendItems.get(0).getLabel(), legendItems.get(1).getLabel());
+		assertNotEquals(firstLegendKey, secondLegendKey);
+
+		chart.applyLegendHighlight(Set.of(firstLegendKey));
+
+		assertEquals(firstBaseWidth * 3.0f,
+				((BasicStroke) renderer.getSeriesStroke(0)).getLineWidth());
+		assertEquals(secondBaseWidth,
+				((BasicStroke) renderer.getSeriesStroke(1)).getLineWidth());
+	}
+
+	/**
+	 * Simulation branches for different stages share one legend item and must continue to highlight together.
+	 */
+	@Test
+	public void simulationLegendHighlightsAllBranchesOfMatchingDataSeries() {
+		FlightDataBranch firstBranch = createFlightDataBranch("Sustainer", 100);
+		FlightDataBranch secondBranch = createFlightDataBranch("Booster", 50);
+		SimulationPlotConfiguration configuration = new SimulationPlotConfiguration("Test", FlightDataType.TYPE_TIME);
+		configuration.addPlotDataType(FlightDataType.TYPE_ALTITUDE, 0);
+		TestPlot simulationPlot = new TestPlot(firstBranch, configuration,
+				List.of(firstBranch, secondBranch));
+		SimulationChart chart = new SimulationChart(simulationPlot.getJFreeChart());
+
+		XYPlot plot = chart.getChart().getXYPlot();
+		XYItemRenderer renderer = plot.getRenderer(0);
+		float firstBaseWidth = ((BasicStroke) renderer.getSeriesStroke(0)).getLineWidth();
+		float secondBaseWidth = ((BasicStroke) renderer.getSeriesStroke(1)).getLineWidth();
+		Comparable<?> legendKey = chart.getChart().getLegend().getSources()[0].getLegendItems()
+				.get(0).getSeriesKey();
+
+		chart.applyLegendHighlight(Set.of(legendKey));
+
+		assertEquals(firstBaseWidth * 3.0f,
+				((BasicStroke) renderer.getSeriesStroke(0)).getLineWidth());
+		assertEquals(secondBaseWidth * 3.0f,
+				((BasicStroke) renderer.getSeriesStroke(1)).getLineWidth());
+	}
+
+	private static void addAnalysisPoint(CADataBranch branch, BodyTube firstComponent,
+			BodyTube secondComponent, double mach, double firstValue, double secondValue) {
+		branch.addPoint();
+		branch.setDomainValue(CADomainDataType.MACH, mach);
+		branch.setValue(CADataType.TOTAL_CD, firstComponent, firstValue);
+		branch.setValue(CADataType.TOTAL_CD, secondComponent, secondValue);
+	}
+
+	private static FlightDataBranch createFlightDataBranch(String name, double altitude) {
+		FlightDataBranch branch = new FlightDataBranch(name, FlightDataType.TYPE_TIME,
+				FlightDataType.TYPE_ALTITUDE);
+		branch.addPoint();
+		branch.setValue(FlightDataType.TYPE_TIME, 0);
+		branch.setValue(FlightDataType.TYPE_ALTITUDE, altitude);
+		branch.addPoint();
+		branch.setValue(FlightDataType.TYPE_TIME, 1);
+		branch.setValue(FlightDataType.TYPE_ALTITUDE, altitude + 10);
+		return branch;
+	}
+
+	/**
+	 * Minimal concrete plot used to exercise the shared simulation-series behavior.
+	 */
+	private static class TestPlot extends Plot<FlightDataType, FlightDataBranch, SimulationPlotConfiguration> {
+		TestPlot(FlightDataBranch mainBranch, SimulationPlotConfiguration configuration,
+				List<FlightDataBranch> allBranches) {
+			super("Test", mainBranch, configuration, allBranches, false);
+		}
+	}
+}


### PR DESCRIPTION
When hovering over the legend items in a plot, the corresponding series should be highlighted in the plot. In the Component Analysis plots however, for data series with the same CA data type, but different components, it highlighted all series simultaneously. Legend entries now use unique series keys, so only the corresponding series is highlighted.