### PR TITLE
Fix mutable coordinate operation consistency

### DIFF
--- a/core/src/main/java/info/openrocket/core/util/Coordinate.java
+++ b/core/src/main/java/info/openrocket/core/util/Coordinate.java
@@ -201,7 +201,9 @@ public final class Coordinate implements CoordinateIF {
 	}
 	
 	/**
-	 * Cross product of two Coordinates taken as vectors
+	 * Cross product of two Coordinates taken as vectors.
+	 *
+	 * @return a new unweighted cross product
 	 */
 	public static CoordinateIF cross(CoordinateIF a, CoordinateIF b) {
 		return new Coordinate(a.getY() * b.getZ() - a.getZ() * b.getY(), a.getZ() * b.getX() -

--- a/core/src/main/java/info/openrocket/core/util/CoordinateIF.java
+++ b/core/src/main/java/info/openrocket/core/util/CoordinateIF.java
@@ -7,6 +7,9 @@ import java.io.Serializable;
  *
  * The weight is a non-negative value that can be used for weighted averages
  * of coordinates.  A weight of zero indicates an unweighted coordinate.
+ * Implementations must follow the numeric behavior of {@link Coordinate}. Methods
+ * returning a coordinate may either return a new value or mutate and return the
+ * receiver, so callers must always use the returned value.
  **/
 public interface CoordinateIF extends Cloneable, Serializable {
 	/**
@@ -175,15 +178,20 @@ public interface CoordinateIF extends Cloneable, Serializable {
 	}
 
 	/**
-	 * Cross product of two Coordinates taken as vectors
+	 * Cross product of two Coordinates taken as vectors. The resulting coordinate
+	 * is unweighted, regardless of the weights of the operands.
+	 *
+	 * @param other Coordinate to take the cross product with
+	 * @return the cross product with weight zero
 	 */
 	CoordinateIF cross(CoordinateIF other);
 
 	/**
-	 * Returns a new coordinate which has the same direction from the origin as this
-	 * coordinate but is at a distance of one.  If this coordinate is the origin,
-	 * this method throws an <code>IllegalStateException</code>.  The weight of the
-	 * coordinate is unchanged.
+	 * Return a coordinate which has the same direction from the origin as this
+	 * coordinate but is at a distance of one. If this coordinate is the origin,
+	 * this method throws an <code>IllegalStateException</code>. The weight of the
+	 * coordinate is unchanged. Mutable implementations may update and return the
+	 * receiver.
 	 *
 	 * @return   the coordinate normalized to distance one of the origin.
 	 * @throws   IllegalStateException  if this coordinate is the origin.

--- a/core/src/main/java/info/openrocket/core/util/MutableCoordinate.java
+++ b/core/src/main/java/info/openrocket/core/util/MutableCoordinate.java
@@ -150,11 +150,8 @@ public final class MutableCoordinate implements CoordinateIF {
 
 	@Override
 	public CoordinateIF sub(CoordinateIF other) {
-		this.x -= other.getX();
-		this.y -= other.getY();
-		this.z -= other.getZ();
-		this.weight -= other.getWeight();
-		return this;
+		// Coordinate subtraction deliberately ignores the argument's weight.
+		return sub(other.getX(), other.getY(), other.getZ());
 	}
 
 	@Override
@@ -191,15 +188,17 @@ public final class MutableCoordinate implements CoordinateIF {
 		this.x = newX;
 		this.y = newY;
 		this.z = newZ;
-		// Weight is unchanged
+		// Cross products are unweighted, matching the legacy Coordinate behavior.
+		this.weight = 0;
 		return this;
 	}
 
 	/**
-	 * Cross product of two Coordinates taken as vectors
+	 * Calculate the cross product without mutating either argument.
+	 *
+	 * @return a new mutable, unweighted cross product
 	 */
 	public static CoordinateIF cross(CoordinateIF a, CoordinateIF b) {
-		// I know this isn't mutable, but I don't know which coordinate to modify
 		return new MutableCoordinate(a.getY() * b.getZ() - a.getZ() * b.getY(), a.getZ() * b.getX() -
 				a.getX() * b.getZ(), a.getX() * b.getY() - a.getY() * b.getX());
 	}

--- a/core/src/test/java/info/openrocket/core/util/MutableCoordinateTest.java
+++ b/core/src/test/java/info/openrocket/core/util/MutableCoordinateTest.java
@@ -1,13 +1,19 @@
 package info.openrocket.core.util;
 
+import java.util.stream.Stream;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class MutableCoordinateTest {
 
@@ -33,6 +39,22 @@ class MutableCoordinateTest {
 		assertEquals(8.0, mutable.getY(), 1e-9);
 		assertEquals(-2.0, mutable.getZ(), 1e-9);
 		assertEquals(0.5, mutable.getWeight(), 1e-9);
+	}
+
+	@Test
+	void subtractCoordinateMatchesImmutableResultAndPreservesWeight() {
+		CoordinateIF other = new Coordinate(1, 2, 3, 4);
+		CoordinateIF expected = new Coordinate(5, 7, 9, 11).sub(other);
+		MutableCoordinate mutable = new MutableCoordinate(5, 7, 9, 11);
+
+		CoordinateIF actual = mutable.sub(other);
+
+		assertSame(mutable, actual);
+		assertEquals(expected.getX(), actual.getX(), 1e-12);
+		assertEquals(expected.getY(), actual.getY(), 1e-12);
+		assertEquals(expected.getZ(), actual.getZ(), 1e-12);
+		assertEquals(expected.getWeight(), actual.getWeight(), 1e-12);
+		assertEquals(11.0, actual.getWeight(), 1e-12);
 	}
 
 	@Test
@@ -66,15 +88,17 @@ class MutableCoordinateTest {
 	}
 
 	@Test
-	void crossProductMutatesReceiver() {
-		MutableCoordinate a = new MutableCoordinate(1, 0, 0);
-		MutableCoordinate b = new MutableCoordinate(0, 1, 0);
+	void crossProductMutatesReceiverAndClearsWeight() {
+		MutableCoordinate a = new MutableCoordinate(1, 0, 0, 2);
+		MutableCoordinate b = new MutableCoordinate(0, 1, 0, 3);
 
-		a.cross(b);
+		CoordinateIF result = a.cross(b);
 
+		assertSame(a, result);
 		assertEquals(0.0, a.getX(), 1e-12);
 		assertEquals(0.0, a.getY(), 1e-12);
 		assertEquals(1.0, a.getZ(), 1e-12);
+		assertEquals(0.0, a.getWeight(), 1e-12);
 	}
 
 	@Test
@@ -83,6 +107,39 @@ class MutableCoordinateTest {
 		assertEquals(0.0, result.getX(), 1e-12);
 		assertEquals(0.0, result.getY(), 1e-12);
 		assertEquals(-1.0, result.getZ(), 1e-12);
+		assertEquals(0.0, result.getWeight(), 1e-12);
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("coordinateOperations")
+	void operationsMatchImmutableCoordinate(String name, boolean returnsReceiver, CoordinateOperation operation) {
+		CoordinateIF immutable = new Coordinate(1, 2, 3, 4);
+		MutableCoordinate mutable = new MutableCoordinate(1, 2, 3, 4);
+
+		CoordinateIF expected = operation.apply(immutable);
+		CoordinateIF actual = operation.apply(mutable);
+
+		assertCoordinateEquals(expected, actual);
+		if (returnsReceiver) {
+			assertSame(mutable, actual, name + " should return the mutable receiver");
+		} else {
+			assertNotSame(mutable, actual, name + " should return an independent value");
+		}
+	}
+
+	@Test
+	void scalarOperationsMatchImmutableCoordinate() {
+		CoordinateIF immutable = new Coordinate(1, -2, 3, 4);
+		CoordinateIF mutable = new MutableCoordinate(1, -2, 3, 4);
+		CoordinateIF other = new Coordinate(-2, 5, 7, 3);
+
+		assertEquals(immutable.isWeighted(), mutable.isWeighted());
+		assertEquals(immutable.isNaN(), mutable.isNaN());
+		assertEquals(immutable.length(), mutable.length(), 1e-12);
+		assertEquals(immutable.length2(), mutable.length2(), 1e-12);
+		assertEquals(immutable.dot(other), mutable.dot(other), 1e-12);
+		assertEquals(immutable.max(), mutable.max(), 1e-12);
+		assertEquals(immutable.toPreciseString(), mutable.toPreciseString());
 	}
 
 	@Test
@@ -157,5 +214,54 @@ class MutableCoordinateTest {
 		assertEquals(2.0, copy.getY(), 1e-12);
 		assertEquals(3.0, copy.getZ(), 1e-12);
 		assertEquals(4.0, copy.getWeight(), 1e-12);
+	}
+
+	/**
+	 * Supply every coordinate-returning interface operation with inputs that make
+	 * weight-handling differences visible.
+	 */
+	private static Stream<Arguments> coordinateOperations() {
+		CoordinateIF other = new Coordinate(-2, 5, 7, 3);
+		return Stream.of(
+				operation("setX", true, coordinate -> coordinate.setX(9)),
+				operation("setY", true, coordinate -> coordinate.setY(9)),
+				operation("setZ", true, coordinate -> coordinate.setZ(9)),
+				operation("setWeight", true, coordinate -> coordinate.setWeight(9)),
+				operation("setXYZ", true, coordinate -> coordinate.setXYZ(other)),
+				operation("add coordinate", true, coordinate -> coordinate.add(other)),
+				operation("add xyz", true, coordinate -> coordinate.add(5, 6, 7)),
+				operation("add xyz and weight", true, coordinate -> coordinate.add(5, 6, 7, 8)),
+				operation("addScaled", true, coordinate -> coordinate.addScaled(other, -0.25)),
+				operation("subtract coordinate", true, coordinate -> coordinate.sub(other)),
+				operation("subtract xyz", true, coordinate -> coordinate.sub(5, 6, 7)),
+				operation("multiply scalar", true, coordinate -> coordinate.multiply(-2)),
+				operation("multiply coordinate", true, coordinate -> coordinate.multiply(other)),
+				operation("cross", true, coordinate -> coordinate.cross(other)),
+				operation("normalize", true, CoordinateIF::normalize),
+				operation("average", true, coordinate -> coordinate.average(other)),
+				operation("average null", true, coordinate -> coordinate.average(null)),
+				operation("interpolate", true, coordinate -> coordinate.interpolate(other, 0.25)),
+				operation("toImmutable", false, CoordinateIF::toImmutable),
+				operation("toMutable", false, CoordinateIF::toMutable),
+				operation("clone", false, CoordinateIF::clone));
+	}
+
+	/** Wrap a named coordinate operation as parameterized-test arguments. */
+	private static Arguments operation(String name, boolean returnsReceiver, CoordinateOperation operation) {
+		return Arguments.of(name, returnsReceiver, operation);
+	}
+
+	/** Assert that two coordinate implementations contain the same numeric value. */
+	private static void assertCoordinateEquals(CoordinateIF expected, CoordinateIF actual) {
+		assertEquals(expected.getX(), actual.getX(), 1e-12);
+		assertEquals(expected.getY(), actual.getY(), 1e-12);
+		assertEquals(expected.getZ(), actual.getZ(), 1e-12);
+		assertEquals(expected.getWeight(), actual.getWeight(), 1e-12);
+	}
+
+	/** Operation shared by the immutable and mutable differential tests. */
+	@FunctionalInterface
+	private interface CoordinateOperation {
+		CoordinateIF apply(CoordinateIF coordinate);
 	}
 }


### PR DESCRIPTION
There were a few mistakes in the `MutableCoordinate` implementation that did not align with `Coordinate` behavior. This PR changes `MutableCoordinate` to preserve weight during subtraction and clearing it for cross products.