### PR TITLE
Rename DataBranch get/getClone methods to revert to old API

### DIFF
--- a/core/src/main/java/info/openrocket/core/componentanalysis/CADataBranch.java
+++ b/core/src/main/java/info/openrocket/core/componentanalysis/CADataBranch.java
@@ -123,7 +123,7 @@ public class CADataBranch extends DataBranch<CADataType> {
 
 	public List<Double> getClone(CADataType type, RocketComponent component) {
 		if (type instanceof CADomainDataType) {
-			return super.getClone(type);
+			return super.get(type);
 		}
 
 		Map<RocketComponent, ArrayList<Double>> typeMap = componentValues.get(type);
@@ -137,7 +137,7 @@ public class CADataBranch extends DataBranch<CADataType> {
 
 	public List<Double> get(CADataType type, RocketComponent component) {
 		if (type instanceof CADomainDataType) {
-			return super.get(type);
+			return super.getView(type);
 		}
 
 		Map<RocketComponent, ArrayList<Double>> typeMap = componentValues.get(type);

--- a/core/src/main/java/info/openrocket/core/file/CSVExport.java
+++ b/core/src/main/java/info/openrocket/core/file/CSVExport.java
@@ -156,7 +156,7 @@ public class CSVExport {
 								  String fieldSeparator, int decimalPlaces, boolean isExponentialNotation,
 								  boolean eventComments, String commentStarter) {
 		// Time variable
-		final List<Double> time = branch.get(FlightDataType.TYPE_TIME);
+		final List<Double> time = branch.getView(FlightDataType.TYPE_TIME);
 
 		// Number of data points
 		int n = time != null ? time.size() : branch.getLength();
@@ -169,7 +169,7 @@ public class CSVExport {
 		// List of field values
 		List<List<Double>> fieldValues = new ArrayList<>();
 		for (FlightDataType t : fields) {
-			final List<Double> values = branch.get(t);
+			final List<Double> values = branch.getView(t);
 			fieldValues.add(values);
 		}
 
@@ -218,7 +218,7 @@ public class CSVExport {
 	private static void writeData(PrintWriter writer, CADataBranch branch, CADomainDataType domainDataType,
 								  CADataType[] fields, Map<CADataType, List<RocketComponent>> components, Unit[] units,
 								  String fieldSeparator, int decimalPlaces, boolean isExponentialNotation) {
-		final List<Double> domainValues = branch.get(domainDataType);
+		final List<Double> domainValues = branch.getView(domainDataType);
 
 		int n = domainValues != null ? domainValues.size() : branch.getLength();
 

--- a/core/src/main/java/info/openrocket/core/file/openrocket/OpenRocketSaver.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/OpenRocketSaver.java
@@ -647,7 +647,7 @@ public class OpenRocketSaver extends RocketSaver {
 		// Retrieve the data from the branch
 		List<List<Double>> data = new ArrayList<>(types.length);
 		for (FlightDataType type : types) {
-			data.add(branch.getClone(type));
+			data.add(branch.get(type));
 		}
 		
 		// Build the <databranch> tag
@@ -739,7 +739,7 @@ public class OpenRocketSaver extends RocketSaver {
 		if (types.length == 0)
 			return 0;
 		
-		final List<Double> timeData = branch.get(FlightDataType.TYPE_TIME);
+		final List<Double> timeData = branch.getView(FlightDataType.TYPE_TIME);
 		if (timeData == null) {
 			// If time data not available, store all points
 			return branch.getLength();

--- a/core/src/main/java/info/openrocket/core/file/openrocket/importt/OpenRocketLoader.java
+++ b/core/src/main/java/info/openrocket/core/file/openrocket/importt/OpenRocketLoader.java
@@ -73,7 +73,7 @@ public class OpenRocketLoader extends AbstractRocketLoader {
 			FlightDataBranch branch = s.getSimulatedData().getBranch(0);
 			if (branch == null)
 				continue;
-			List<Double> list = branch.getClone(FlightDataType.TYPE_TIME);
+			List<Double> list = branch.get(FlightDataType.TYPE_TIME);
 			if (list == null)
 				continue;
 

--- a/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
+++ b/core/src/main/java/info/openrocket/core/simulation/AbstractSimulationStepper.java
@@ -605,8 +605,8 @@ public abstract class AbstractSimulationStepper implements SimulationStepper {
 		 * @return the motor mass time-derivative, or NaN if it cannot be computed
 		 */
 		private static double computeMotorMassDerivative(FlightDataBranch dataBranch) {
-			List<Double> motorMass = dataBranch.get(FlightDataType.TYPE_MOTOR_MASS);
-			List<Double> time = dataBranch.get(FlightDataType.TYPE_TIME);
+			List<Double> motorMass = dataBranch.getView(FlightDataType.TYPE_MOTOR_MASS);
+			List<Double> time = dataBranch.getView(FlightDataType.TYPE_TIME);
 			if (motorMass == null || time == null) {
 				return Double.NaN;
 			}

--- a/core/src/main/java/info/openrocket/core/simulation/DataBranch.java
+++ b/core/src/main/java/info/openrocket/core/simulation/DataBranch.java
@@ -119,7 +119,7 @@ public abstract class DataBranch<T extends DataType> implements Monitorable {
 	 * @return		a list of the variable values, or <code>null</code> if
 	 * 				the variable type hasn't been added to this branch.
 	 */
-	public List<Double> getClone(T type) {
+	public List<Double> get(T type) {
 		ArrayList<Double> list = values.get(type);
 		if (list == null)
 			return null;
@@ -133,7 +133,7 @@ public abstract class DataBranch<T extends DataType> implements Monitorable {
 	 * @return		an unmodifiable list backed by the internal storage, or null if
 	 * 				the variable type hasn't been added to this branch.
 	 */
-	public List<Double> get(T type) {
+	public List<Double> getView(T type) {
 		ArrayList<Double> list = values.get(type);
 		if (list == null) {
 			return null;

--- a/core/src/main/java/info/openrocket/core/simulation/FlightData.java
+++ b/core/src/main/java/info/openrocket/core/simulation/FlightData.java
@@ -207,8 +207,8 @@ public class FlightData {
 		flightTime = branch.getLast(FlightDataType.TYPE_TIME);
 		
 		// Time to apogee
-		final List<Double> time = branch.get(FlightDataType.TYPE_TIME);
-		final List<Double> altitude = branch.get(FlightDataType.TYPE_ALTITUDE);
+		final List<Double> time = branch.getView(FlightDataType.TYPE_TIME);
+		final List<Double> altitude = branch.getView(FlightDataType.TYPE_ALTITUDE);
 		
 		if (time == null || altitude == null) {
 			timeToApogee = Double.NaN;
@@ -235,21 +235,21 @@ public class FlightData {
 		for (FlightEvent event : branch.getEvents()) {
 			if (event.getType() == FlightEvent.Type.LAUNCHROD) {
 				double t = event.getTime();
-				final List<Double> velocity = branch.get(FlightDataType.TYPE_VELOCITY_TOTAL);
+				final List<Double> velocity = branch.getView(FlightDataType.TYPE_VELOCITY_TOTAL);
 				launchRodVelocity = MathUtil.interpolate( time, velocity, t);
 			} else if ( event.getType() == FlightEvent.Type.RECOVERY_DEVICE_DEPLOYMENT) {
 				double t = event.getTime();
-				final List<Double> velocity = branch.get(FlightDataType.TYPE_VELOCITY_TOTAL);
+				final List<Double> velocity = branch.getView(FlightDataType.TYPE_VELOCITY_TOTAL);
 				deploymentVelocity = MathUtil.interpolate( time, velocity, t);
 			} else if (event.getType() == FlightEvent.Type.GROUND_HIT) {
 				double t = event.getTime();
-				final List<Double> velocity = branch.get(FlightDataType.TYPE_VELOCITY_TOTAL);
+				final List<Double> velocity = branch.getView(FlightDataType.TYPE_VELOCITY_TOTAL);
 				groundHitVelocity = MathUtil.interpolate( time,  velocity, t);
 			}
 		}
 		
 		// Max. acceleration (must be after apogee time)
-		if (branch.get(FlightDataType.TYPE_ACCELERATION_TOTAL) != null) {
+		if (branch.getView(FlightDataType.TYPE_ACCELERATION_TOTAL) != null) {
 			maxAcceleration = calculateMaxAcceleration();
 		} else {
 			maxAcceleration = Double.NaN;
@@ -316,8 +316,8 @@ public class FlightData {
 			}
 		}
 		
-		final List<Double> time = branch.get(FlightDataType.TYPE_TIME);
-		final List<Double> acceleration = branch.get(FlightDataType.TYPE_ACCELERATION_TOTAL);
+		final List<Double> time = branch.getView(FlightDataType.TYPE_TIME);
+		final List<Double> acceleration = branch.getView(FlightDataType.TYPE_ACCELERATION_TOTAL);
 		
 		if (time == null || acceleration == null) {
 			return Double.NaN;

--- a/core/src/main/java/info/openrocket/core/simulation/FlightDataBranch.java
+++ b/core/src/main/java/info/openrocket/core/simulation/FlightDataBranch.java
@@ -262,7 +262,7 @@ public class FlightDataBranch extends DataBranch<FlightDataType> {
 		if (Double.isNaN(time)) {
 			return -1;
 		}
-		List<Double> times = get(FlightDataType.TYPE_TIME);
+		List<Double> times = getView(FlightDataType.TYPE_TIME);
 		if (times == null) {
 			return -1;
 		}

--- a/core/src/main/java/info/openrocket/core/simulation/customexpression/IndexExpression.java
+++ b/core/src/main/java/info/openrocket/core/simulation/customexpression/IndexExpression.java
@@ -42,8 +42,8 @@ public class IndexExpression extends CustomExpression {
 		FlightDataType myType = FlightDataType.getType(null, getSymbol(), null);
 
 		FlightDataBranch dataBranch = status.getFlightDataBranch();
-		List<Double> data = dataBranch.getClone(myType);
-		List<Double> time = dataBranch.getClone(FlightDataType.TYPE_TIME);
+		List<Double> data = dataBranch.get(myType);
+		List<Double> time = dataBranch.get(FlightDataType.TYPE_TIME);
 		LinearInterpolator interp = new LinearInterpolator(time, data);
 
 		// Set the variables in the expression to evaluate

--- a/core/src/main/java/info/openrocket/core/simulation/customexpression/RangeExpression.java
+++ b/core/src/main/java/info/openrocket/core/simulation/customexpression/RangeExpression.java
@@ -82,8 +82,8 @@ public class RangeExpression extends CustomExpression {
 		// Otherwise there will be a type conflict when we get the new data.
 		FlightDataType type = FlightDataType.getType(null, getSymbol(), null);
 
-		List<Double> data = dataBranch.getClone(type);
-		List<Double> time = dataBranch.getClone(FlightDataType.TYPE_TIME);
+		List<Double> data = dataBranch.get(type);
+		List<Double> time = dataBranch.get(FlightDataType.TYPE_TIME);
 		if (data == null || time == null || time.isEmpty()) {
 			return new Variable("Unknown");
 		}

--- a/core/src/test/java/info/openrocket/core/componentanalysis/CADataBranchTest.java
+++ b/core/src/test/java/info/openrocket/core/componentanalysis/CADataBranchTest.java
@@ -98,8 +98,8 @@ class CADataBranchTest {
 		sweep.setValue(CADataType.CP_X, component, 2.0);
 
 		assertEquals(2, sweep.getLength());
-		assertEquals(sweep.getLength(), sweep.get(CADomainDataType.MACH).size());
-		assertEquals(sweep.getLength(), sweep.get(CADataType.CP_X).size());
+		assertEquals(sweep.getLength(), sweep.getView(CADomainDataType.MACH).size());
+		assertEquals(sweep.getLength(), sweep.getView(CADataType.CP_X).size());
 		assertEquals(sweep.getLength(), sweep.get(CADataType.CP_X, component).size());
 	}
 

--- a/core/src/test/java/info/openrocket/core/componentanalysis/CADataBranchViewTest.java
+++ b/core/src/test/java/info/openrocket/core/componentanalysis/CADataBranchViewTest.java
@@ -20,7 +20,7 @@ class CADataBranchViewTest extends BaseTestCase {
 		branch.setDomainValue(CADomainDataType.MACH, 0.1);
 		branch.setValue(CADataType.TOTAL_CD, component, 0.4);
 
-		List<Double> domainView = branch.get(CADomainDataType.MACH);
+		List<Double> domainView = branch.getView(CADomainDataType.MACH);
 		List<Double> componentView = branch.get(CADataType.TOTAL_CD, component);
 
 		assertEquals(0.1, domainView.get(0));

--- a/core/src/test/java/info/openrocket/core/componentanalysis/CAParameterSweepTest.java
+++ b/core/src/test/java/info/openrocket/core/componentanalysis/CAParameterSweepTest.java
@@ -68,7 +68,7 @@ class CAParameterSweepTest extends ComponentAnalysisTestBase {
 		double initialMach = parameters.getMach();
 		CADataBranch branch = sweep.sweep(CADomainDataType.MACH, 0.5, 0.6, 0.1, initialMach);
 
-		List<Double> machDomain = branch.get(CADomainDataType.MACH);
+		List<Double> machDomain = branch.getView(CADomainDataType.MACH);
 		assertNotNull(machDomain);
 		assertEquals(List.of(0.5, 0.6), machDomain);
 
@@ -126,7 +126,7 @@ class CAParameterSweepTest extends ComponentAnalysisTestBase {
 		double delta = Math.PI / 1800;
 		CADataBranch branch = sweep.sweep(CADomainDataType.WIND_DIRECTION, 6.0, 2 * Math.PI, delta, 0.15);
 
-		List<Double> direction = branch.get(CADomainDataType.WIND_DIRECTION);
+		List<Double> direction = branch.getView(CADomainDataType.WIND_DIRECTION);
 		assertEquals(branch.getLength(), direction.size());
 		for (int i = 1; i < direction.size(); i++) {
 			assertEquals(delta, direction.get(i) - direction.get(i - 1), 1e-6,

--- a/core/src/test/java/info/openrocket/core/document/SimulationTest.java
+++ b/core/src/test/java/info/openrocket/core/document/SimulationTest.java
@@ -188,8 +188,8 @@ public class SimulationTest extends BaseTestCase {
 		FlightData flightData =  simulation.getSimulatedData();
 		FlightDataBranch branch = flightData.getBranch(0);
 
-		List<Double> altitudeData = branch.get(FlightDataType.TYPE_ALTITUDE);
-		List<Double> altitudeASLData = branch.get(FlightDataType.TYPE_ALTITUDE_ABOVE_SEA);
+		List<Double> altitudeData = branch.getView(FlightDataType.TYPE_ALTITUDE);
+		List<Double> altitudeASLData = branch.getView(FlightDataType.TYPE_ALTITUDE_ABOVE_SEA);
 
 		assertNotNull(altitudeData);
 		assertNotNull(altitudeASLData);
@@ -221,8 +221,8 @@ public class SimulationTest extends BaseTestCase {
 		FlightData flightData =  simulation.getSimulatedData();
 		FlightDataBranch branch = flightData.getBranch(0);
 
-		List<Double> altitudeData = branch.get(FlightDataType.TYPE_ALTITUDE);
-		List<Double> altitudeASLData = branch.get(FlightDataType.TYPE_ALTITUDE_ABOVE_SEA);
+		List<Double> altitudeData = branch.getView(FlightDataType.TYPE_ALTITUDE);
+		List<Double> altitudeASLData = branch.getView(FlightDataType.TYPE_ALTITUDE_ABOVE_SEA);
 
 		assertNotNull(altitudeData);
 		assertNotNull(altitudeASLData);

--- a/core/src/test/java/info/openrocket/core/file/openrocket/OpenRocketSaverTest.java
+++ b/core/src/test/java/info/openrocket/core/file/openrocket/OpenRocketSaverTest.java
@@ -55,7 +55,6 @@ import info.openrocket.core.rocketcomponent.FlightConfigurationId;
 import info.openrocket.core.rocketcomponent.InnerTube;
 import info.openrocket.core.rocketcomponent.MotorMount;
 import info.openrocket.core.rocketcomponent.Rocket;
-import info.openrocket.core.simulation.FlightDataType;
 import info.openrocket.core.simulation.extension.impl.ScriptingExtension;
 import info.openrocket.core.simulation.extension.impl.ScriptingUtil;
 import info.openrocket.core.startup.Application;
@@ -671,7 +670,7 @@ public class OpenRocketSaverTest {
 		FlightDataBranch loadedBranch = loadedData.getBranch(0);
 		assertNotNull(loadedBranch);
 
-		List<Double> times = loadedBranch.get(FlightDataType.TYPE_TIME);
+		List<Double> times = loadedBranch.getView(FlightDataType.TYPE_TIME);
 		assertNotNull(times);
 		assertFalse(times.isEmpty());
 

--- a/core/src/test/java/info/openrocket/core/simulation/CorrectiveMomentCoefficientTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/CorrectiveMomentCoefficientTest.java
@@ -50,8 +50,8 @@ public class CorrectiveMomentCoefficientTest extends BaseTestCase {
 		FlightDataBranch branch = simulation.getSimulatedData().getBranch(0);
 		assertNotNull(branch);
 
-		List<Double> time = branch.get(FlightDataType.TYPE_TIME);
-		List<Double> ccm = branch.get(FlightDataType.TYPE_CORRECTIVE_MOMENT_COEFF);
+		List<Double> time = branch.getView(FlightDataType.TYPE_TIME);
+		List<Double> ccm = branch.getView(FlightDataType.TYPE_CORRECTIVE_MOMENT_COEFF);
 		assertNotNull(time);
 		assertNotNull(ccm);
 		assertFalse(ccm.isEmpty());

--- a/core/src/test/java/info/openrocket/core/simulation/DampingMomentCoefficientTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/DampingMomentCoefficientTest.java
@@ -60,9 +60,9 @@ public class DampingMomentCoefficientTest extends BaseTestCase {
 		FlightDataBranch branch = simulation.getSimulatedData().getBranch(0);
 		assertNotNull(branch);
 
-		List<Double> total = branch.get(FlightDataType.TYPE_DAMPING_MOMENT_COEFF);
-		List<Double> aerodynamic = branch.get(FlightDataType.TYPE_DAMPING_MOMENT_COEFF_AERODYNAMIC);
-		List<Double> propulsive = branch.get(FlightDataType.TYPE_DAMPING_MOMENT_COEFF_PROPULSIVE);
+		List<Double> total = branch.getView(FlightDataType.TYPE_DAMPING_MOMENT_COEFF);
+		List<Double> aerodynamic = branch.getView(FlightDataType.TYPE_DAMPING_MOMENT_COEFF_AERODYNAMIC);
+		List<Double> propulsive = branch.getView(FlightDataType.TYPE_DAMPING_MOMENT_COEFF_PROPULSIVE);
 
 		assertNotNull(total);
 		assertNotNull(aerodynamic);

--- a/core/src/test/java/info/openrocket/core/simulation/DampingRatioTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/DampingRatioTest.java
@@ -50,8 +50,8 @@ public class DampingRatioTest extends BaseTestCase {
 		FlightDataBranch branch = simulation.getSimulatedData().getBranch(0);
 		assertNotNull(branch);
 
-		List<Double> zeta = branch.get(FlightDataType.TYPE_DAMPING_RATIO);
-		List<Double> time = branch.get(FlightDataType.TYPE_TIME);
+		List<Double> zeta = branch.getView(FlightDataType.TYPE_DAMPING_RATIO);
+		List<Double> time = branch.getView(FlightDataType.TYPE_TIME);
 
 		assertNotNull(zeta);
 		assertNotNull(time);

--- a/core/src/test/java/info/openrocket/core/simulation/DataBranchViewTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/DataBranchViewTest.java
@@ -16,7 +16,7 @@ class DataBranchViewTest extends BaseTestCase {
 		branch.addPoint();
 		branch.setValue(FlightDataType.TYPE_TIME, 0.1);
 
-		List<Double> view = branch.get(FlightDataType.TYPE_TIME);
+		List<Double> view = branch.getView(FlightDataType.TYPE_TIME);
 		assertEquals(1, view.size());
 		assertEquals(0.1, view.get(0));
 
@@ -33,7 +33,7 @@ class DataBranchViewTest extends BaseTestCase {
 		branch.addPoint();
 		branch.setValue(FlightDataType.TYPE_TIME, 1.0);
 
-		List<Double> view = branch.get(FlightDataType.TYPE_TIME);
+		List<Double> view = branch.getView(FlightDataType.TYPE_TIME);
 
 		assertThrows(UnsupportedOperationException.class, () -> view.add(2.0));
 	}
@@ -42,7 +42,7 @@ class DataBranchViewTest extends BaseTestCase {
 	void valuesViewForMissingTypeIsEmptyAndUnmodifiable() {
 		FlightDataBranch branch = new FlightDataBranch("test", FlightDataType.TYPE_TIME);
 
-		List<Double> view = branch.get(FlightDataType.TYPE_VELOCITY_TOTAL);
+		List<Double> view = branch.getView(FlightDataType.TYPE_VELOCITY_TOTAL);
 		assertNull(view);
 	}
 }

--- a/core/src/test/java/info/openrocket/core/simulation/NaturalFrequencyTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/NaturalFrequencyTest.java
@@ -50,8 +50,8 @@ public class NaturalFrequencyTest extends BaseTestCase {
 		FlightDataBranch branch = simulation.getSimulatedData().getBranch(0);
 		assertNotNull(branch);
 
-		List<Double> omegaN = branch.get(FlightDataType.TYPE_NATURAL_FREQUENCY);
-		List<Double> time = branch.get(FlightDataType.TYPE_TIME);
+		List<Double> omegaN = branch.getView(FlightDataType.TYPE_NATURAL_FREQUENCY);
+		List<Double> time = branch.getView(FlightDataType.TYPE_TIME);
 
 		assertNotNull(omegaN);
 		assertNotNull(time);

--- a/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/CAPlot.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/dialogs/componentanalysis/CAPlot.java
@@ -49,7 +49,7 @@ public class CAPlot extends Plot<CADataType, CADataBranch, CAPlotConfiguration> 
 		series.setBaseName(newBaseName);
 		series.updateDescription();
 
-		List<Double> plotx = branch.get(filledConfig.getDomainAxisType());
+		List<Double> plotx = branch.getView(filledConfig.getDomainAxisType());
 		List<Double> ploty = branch.get(type, component);
 
 		int pointCount = plotx.size();

--- a/swing/src/main/java/info/openrocket/swing/gui/plot/Plot.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/Plot.java
@@ -222,7 +222,7 @@ public abstract class Plot<T extends DataType, B extends DataBranch<T>, C extend
 
 						String nameT = FlightDataType.TYPE_TIME.getName();
 						double dataT = Double.NaN;
-						final List<Double> time = allBranches.get(ser.getBranchIdx()).get((T)FlightDataType.TYPE_TIME);
+						final List<Double> time = allBranches.get(ser.getBranchIdx()).getView((T)FlightDataType.TYPE_TIME);
 						if (time != null) {
 							dataT = time.get(item);
 						}
@@ -324,8 +324,8 @@ public abstract class Plot<T extends DataType, B extends DataBranch<T>, C extend
 		// Default implementation for regular DataBranch
 		MetadataXYSeries series = new MetadataXYSeries(startIndex, false, true, branchIdx, dataIndex, unit.getUnit(), branchName, baseName);
 
-		List<Double> plotx = branch.get(filledConfig.getDomainAxisType());
-		List<Double> ploty = branch.get(type);
+		List<Double> plotx = branch.getView(filledConfig.getDomainAxisType());
+		List<Double> ploty = branch.getView(type);
 
 		int pointCount = plotx.size();
 		for (int j = 0; j < pointCount; j++) {

--- a/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationPlot.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/SimulationPlot.java
@@ -1,7 +1,6 @@
 package info.openrocket.swing.gui.plot;
 
 import java.awt.Color;
-import java.awt.Font;
 import java.awt.Image;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -255,9 +254,9 @@ public class SimulationPlot extends Plot<FlightDataType, FlightDataBranch, Simul
 
 		FlightDataBranch dataBranch = simulation.getSimulatedData().getBranch(branch);
 
-		final List<Double> time = dataBranch.get(FlightDataType.TYPE_TIME);
+		final List<Double> time = dataBranch.getView(FlightDataType.TYPE_TIME);
 		String tName = FlightDataType.TYPE_TIME.getName();
-		final List<Double> domain = dataBranch.get(config.getDomainAxisType());
+		final List<Double> domain = dataBranch.getView(config.getDomainAxisType());
 		LinearInterpolator domainInterpolator = new LinearInterpolator(time, domain);
 		String xName = config.getDomainAxisType().getName();
 
@@ -287,7 +286,7 @@ public class SimulationPlot extends Plot<FlightDataType, FlightDataBranch, Simul
 				int dataTypeIdx = series.getDataIdx();
 				FlightDataType type = config.getType(dataTypeIdx);
 				String yName = type.toString();
-				final List<Double> range = dataBranch.get(type);
+				final List<Double> range = dataBranch.getView(type);
 				LinearInterpolator rangeInterpolator = new LinearInterpolator(time, range);
 				
 				for (int i = 0; i < eventSets.size(); i++) {


### PR DESCRIPTION
#2909 changed the API of the `DataBranch` from `get` returning a mutable clone to returning an unmodifiable live view. This can be problematic for other applications which used the `DataBranch.get` API. For example:

```java
List<Double> values = branch.get(type);
values.replaceAll(...);
```

This would throw an `UnsupportedOperationException`.

This PR renames the `get`/`getClone` methods in `DataBranch` to `getView`/ `get` respectively. So, the old API remains the same.