### PR TITLE
Harden jar migration

### DIFF
--- a/core/src/main/java/info/openrocket/core/plugin/JarMigrationHelper.java
+++ b/core/src/main/java/info/openrocket/core/plugin/JarMigrationHelper.java
@@ -6,15 +6,18 @@ import org.objectweb.asm.commons.ClassRemapper;
 import org.objectweb.asm.commons.Remapper;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
-import java.util.jar.JarInputStream;
 import java.util.jar.JarOutputStream;
 
 /**
@@ -26,11 +29,24 @@ import java.util.jar.JarOutputStream;
  * @author Sibo Van Gool <sibo.vangool@hotmail.com>
  */
 public class JarMigrationHelper {
-	private static final String OLD_PACKAGE_PREFIX = "net.sf.openrocket";
+	private static final String OLD_PACKAGE_PATH_PREFIX = "net/sf/openrocket/";
 	public static final String MIGRATION_SUFFIX = "-migrated";
-	// We first save the migrated plugin with this suffix so SwingStartup can check later that it has been migrated.
-	// It is then renamed to the final name (without this suffix).
+	// Legacy suffix. Older versions saved the migrated plugin with this extra suffix and renamed it later during
+	// startup. That rename could silently fail (e.g. on Windows, where the JAR is locked once it is on the classpath),
+	// so such files may still be present and must be recognized as already migrated.
 	public static final String NEW_MIGRATION_SUFFIX = "-new";
+	// System property under which the JAR files that were migrated during this startup are stored
+	// (absolute paths, separated by File.pathSeparator), so the UI can inform the user about the migration.
+	public static final String MIGRATED_JARS_PROPERTY = "openrocket.plugins.migrated";
+
+	/**
+	 * Describes how a plugin JAR should be handled while building the plugin classpath.
+	 */
+	public enum MigrationStatus {
+		COMPATIBLE,
+		NEEDS_MIGRATION,
+		SUPERSEDED
+	}
 
 	/**
 	 * Exception thrown when an error occurs while migrating a JAR file.
@@ -38,6 +54,10 @@ public class JarMigrationHelper {
 	public static class JarMigrationException extends Exception {
 		public JarMigrationException(String message) {
 			super(message);
+		}
+
+		public JarMigrationException(String message, Throwable cause) {
+			super(message, cause);
 		}
 	}
 
@@ -50,30 +70,96 @@ public class JarMigrationHelper {
 	 * @throws JarMigrationException If an error occurs while checking the JAR file.
 	 */
 	public static boolean shouldMigrate(File jarFile, List<File> allJars) throws JarMigrationException {
-		return containsOldPackage(jarFile) && !isMigrated(jarFile, allJars);
+		return getMigrationStatus(jarFile, allJars) == MigrationStatus.NEEDS_MIGRATION;
 	}
 
 	/**
-	 * Check if the JAR file has already been migrated.
+	 * Determine how a plugin JAR should be handled. An original JAR is superseded only when a readable migrated
+	 * companion exists; a corrupt or incomplete companion therefore does not suppress a new migration attempt.
+	 *
 	 * @param jarFile The JAR file to check.
 	 * @param allJars All JAR files in the plugin directory.
-	 * @return True if the JAR file has already been migrated.
+	 * @return The migration status of the JAR file.
+	 * @throws JarMigrationException If the JAR itself cannot be read.
 	 */
-	private static boolean isMigrated(File jarFile, List<File> allJars) {
-		if (jarFile.getName().contains(MIGRATION_SUFFIX)) {
-			return true;
+	public static MigrationStatus getMigrationStatus(File jarFile, List<File> allJars)
+			throws JarMigrationException {
+		if (isMigratedJar(jarFile)) {
+			if (containsOldPackage(jarFile)) {
+				throw new JarMigrationException("Migrated JAR still contains old OpenRocket packages: "
+						+ jarFile.getName());
+			}
+			return MigrationStatus.COMPATIBLE;
 		}
 
-		// Check if another JAR in the list is the migrated version of this JAR
-		String migratedName = getMigratedName(jarFile, false);
+		if (!containsOldPackage(jarFile)) {
+			return MigrationStatus.COMPATIBLE;
+		}
 
+		String migratedName = getMigratedName(jarFile, false);
+		String legacyMigratedName = getMigratedName(jarFile, true);
 		for (File f : allJars) {
-			if (f.getName().equals(migratedName)) {
-				return true;
+			if ((f.getName().equals(migratedName) || f.getName().equals(legacyMigratedName))
+					&& isReadableMigratedJar(f)) {
+				return MigrationStatus.SUPERSEDED;
 			}
 		}
 
-		return false;
+		return MigrationStatus.NEEDS_MIGRATION;
+	}
+
+	/**
+	 * Check whether a JAR uses either the current or legacy migrated filename.
+	 *
+	 * @param jarFile The JAR file to check.
+	 * @return True when the filename identifies a migrated plugin JAR.
+	 */
+	public static boolean isMigratedJar(File jarFile) {
+		String lowerName = jarFile.getName().toLowerCase(Locale.ROOT);
+		return lowerName.endsWith(MIGRATION_SUFFIX + ".jar") || isLegacyMigratedJar(jarFile);
+	}
+
+	/**
+	 * Check whether a JAR uses the legacy temporary migrated filename.
+	 *
+	 * @param jarFile The JAR file to check.
+	 * @return True when the filename ends in {@code -migrated-new.jar}.
+	 */
+	public static boolean isLegacyMigratedJar(File jarFile) {
+		String lowerName = jarFile.getName().toLowerCase(Locale.ROOT);
+		return lowerName.endsWith(MIGRATION_SUFFIX + NEW_MIGRATION_SUFFIX + ".jar");
+	}
+
+	/**
+	 * Rename a legacy migrated JAR to its final name before it is added to the classpath. If a readable final JAR
+	 * already exists, that file is preferred and the legacy file is left untouched.
+	 *
+	 * @param legacyJar A JAR named with the legacy {@code -migrated-new.jar} suffix.
+	 * @return The final JAR, or the original file when it does not use the legacy name.
+	 * @throws JarMigrationException If the legacy file cannot be normalized.
+	 */
+	public static File normalizeLegacyMigratedJar(File legacyJar) throws JarMigrationException {
+		if (!isLegacyMigratedJar(legacyJar)) {
+			return legacyJar;
+		}
+
+		File finalJar = new File(legacyJar.getParentFile(), getFinalNameForLegacyJar(legacyJar));
+		if (finalJar.isFile() && isReadableMigratedJar(finalJar)) {
+			return finalJar;
+		}
+		if (containsOldPackage(legacyJar)) {
+			throw new JarMigrationException("Legacy migrated JAR still contains old OpenRocket packages: "
+					+ legacyJar.getName());
+		}
+
+		try {
+			moveReplacing(legacyJar.toPath(), finalJar.toPath());
+			return finalJar;
+		} catch (IOException e) {
+			String message = String.format("Error renaming legacy migrated JAR %s: %s",
+					legacyJar.getName(), e.getMessage());
+			throw new JarMigrationException(message, e);
+		}
 	}
 
 	/**
@@ -81,12 +167,25 @@ public class JarMigrationHelper {
 	 * @param jarFile The original JAR file.
 	 * @return The name of the migrated JAR file.
 	 */
-	private static String getMigratedName(File jarFile, boolean includeNewSuffix) {
-		return jarFile.getName().replaceFirst("\\.jar$", MIGRATION_SUFFIX + (includeNewSuffix ? NEW_MIGRATION_SUFFIX : "") + ".jar");
+	private static String getMigratedName(File jarFile, boolean includeLegacySuffix) {
+		String name = jarFile.getName();
+		String baseName = name.toLowerCase(Locale.ROOT).endsWith(".jar")
+				? name.substring(0, name.length() - ".jar".length()) : name;
+		return baseName + MIGRATION_SUFFIX + (includeLegacySuffix ? NEW_MIGRATION_SUFFIX : "") + ".jar";
 	}
 
-	private static String getMigratedName(File jarFile) {
-		return getMigratedName(jarFile, true);
+	private static String getFinalNameForLegacyJar(File legacyJar) {
+		String name = legacyJar.getName();
+		int legacySuffixLength = (MIGRATION_SUFFIX + NEW_MIGRATION_SUFFIX + ".jar").length();
+		return name.substring(0, name.length() - legacySuffixLength) + MIGRATION_SUFFIX + ".jar";
+	}
+
+	private static boolean isReadableMigratedJar(File jarFile) {
+		try {
+			return jarFile.isFile() && !containsOldPackage(jarFile);
+		} catch (JarMigrationException e) {
+			return false;
+		}
 	}
 
 	/**
@@ -96,19 +195,12 @@ public class JarMigrationHelper {
 	 * @throws JarMigrationException If an error occurs while checking the JAR file.
 	 */
 	private static boolean containsOldPackage(File jarFile) throws JarMigrationException {
-		try (JarInputStream jin = new JarInputStream(new FileInputStream(jarFile))) {
-			JarEntry entry;
-			while ((entry = jin.getNextJarEntry()) != null) {
-				String name = entry.getName();
-				if (name.replace('/', '.').startsWith(OLD_PACKAGE_PREFIX)) {
-					return true;
-				}
-			}
+		try (JarFile jar = new JarFile(jarFile)) {
+			return jar.stream().anyMatch(entry -> entry.getName().startsWith(OLD_PACKAGE_PATH_PREFIX));
 		} catch (IOException e) {
 			String msg = String.format("Error checking JAR file %s: %s", jarFile.getName(), e.getMessage());
-			throw new JarMigrationException(msg);
+			throw new JarMigrationException(msg, e);
 		}
-		return false;
 	}
 
 	/**
@@ -118,57 +210,80 @@ public class JarMigrationHelper {
 	 * @throws JarMigrationException If an error occurs while migrating the JAR file.
 	 */
 	public static File migrateJarFile(File inputJar) throws JarMigrationException {
-		final String migratedName = getMigratedName(inputJar);
+		final String migratedName = getMigratedName(inputJar, false);
 		final File migratedJar = new File(inputJar.getParent(), migratedName);
+		Path temporaryJar = null;
 
 		CustomRemapper remapper = new CustomRemapper();
 
-		try (JarFile jar = new JarFile(inputJar);
-			 JarOutputStream jos = new JarOutputStream(new FileOutputStream(migratedJar))) {
+		try {
+			temporaryJar = Files.createTempFile(inputJar.getParentFile().toPath(), migratedName + "-", ".tmp");
+			try (JarFile jar = new JarFile(inputJar);
+				 JarOutputStream jos = new JarOutputStream(new FileOutputStream(temporaryJar.toFile()))) {
 
-			jar.stream().forEach(entry -> {
-				try (InputStream is = jar.getInputStream(entry)) {
-					String name = entry.getName();
-					String newName = name;
-					// Only remap entries in net/sf/openrocket
-					if (name.startsWith("net/sf/openrocket/")) {
-						newName = remapper.map(name);
-					}
-					// Skip leftover net/sf entries.
-					if (newName.startsWith("net/sf/") || newName.startsWith("net")) {
-						return;
-					}
-					JarEntry newEntry = new JarEntry(newName);
-					jos.putNextEntry(newEntry);
-					if (!entry.isDirectory()) {
-						byte[] data;
-						if (name.endsWith(".class")) {
-							// Remap class files using ASM.
-							ClassReader reader = new ClassReader(is);
-							ClassWriter writer = new ClassWriter(reader, 0);
-							ClassRemapper classRemapper = new ClassRemapper(writer, remapper);
-							reader.accept(classRemapper, 0);
-							data = writer.toByteArray();
-						} else {
-							// Copy other resources as is.
-							data = is.readAllBytes();
+				jar.stream().forEach(entry -> {
+					try (InputStream is = jar.getInputStream(entry)) {
+						String name = entry.getName();
+						String newName = name;
+						// Only remap entries in net/sf/openrocket
+						if (name.startsWith(OLD_PACKAGE_PATH_PREFIX)) {
+							newName = remapper.map(name);
 						}
-						jos.write(data);
+						// Skip leftover net/sf entries.
+						if (newName.startsWith("net/sf/") || newName.startsWith("net")) {
+							return;
+						}
+						JarEntry newEntry = new JarEntry(newName);
+						jos.putNextEntry(newEntry);
+						if (!entry.isDirectory()) {
+							byte[] data;
+							if (name.endsWith(".class")) {
+								// Remap class files using ASM.
+								ClassReader reader = new ClassReader(is);
+								ClassWriter writer = new ClassWriter(reader, 0);
+								ClassRemapper classRemapper = new ClassRemapper(writer, remapper);
+								reader.accept(classRemapper, 0);
+								data = writer.toByteArray();
+							} else {
+								// Copy other resources as is.
+								data = is.readAllBytes();
+							}
+							jos.write(data);
+						}
+						jos.closeEntry();
+					} catch (IOException e) {
+						throw new RuntimeException(e);
 					}
-					jos.closeEntry();
-				} catch (IOException e) {
-					throw new RuntimeException(e.getMessage());
-				}
-			});
-		} catch (IOException | RuntimeException e) {
-			if (migratedJar.exists()) {
-				migratedJar.delete();
+				});
 			}
+
+			if (containsOldPackage(temporaryJar.toFile())) {
+				throw new JarMigrationException("Migrated JAR still contains old OpenRocket packages: "
+						+ migratedJar.getName());
+			}
+			moveReplacing(temporaryJar, migratedJar.toPath());
+		} catch (IOException | RuntimeException e) {
 			String msg = String.format("Error migrating JAR file %s: %s", migratedJar.getName(), e.getMessage());
-			throw new JarMigrationException(e.getMessage());
+			throw new JarMigrationException(msg, e);
+		} finally {
+			if (temporaryJar != null) {
+				try {
+					Files.deleteIfExists(temporaryJar);
+				} catch (IOException ignored) {
+					// The incomplete temporary file is not used for migration detection or classpath construction.
+				}
+			}
 		}
 
 		return migratedJar;
+	}
+
+	private static void moveReplacing(Path source, Path destination) throws IOException {
+		try {
+			Files.move(source, destination, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+		} catch (AtomicMoveNotSupportedException e) {
+			Files.move(source, destination, StandardCopyOption.REPLACE_EXISTING);
+		}
 	}
 
 	/**

--- a/core/src/main/java/info/openrocket/core/startup/jij/PluginClasspathProvider.java
+++ b/core/src/main/java/info/openrocket/core/startup/jij/PluginClasspathProvider.java
@@ -3,8 +3,11 @@ package info.openrocket.core.startup.jij;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import info.openrocket.core.plugin.JarMigrationHelper;
 import info.openrocket.core.plugin.PluginHelper;
@@ -46,22 +49,71 @@ public class PluginClasspathProvider implements ClasspathProvider {
 	 * @param files List of JAR files to check.
 	 * @return List of JAR files that are compatible with the new package structure.
 	 */
-	private static List<File> getCompatibleFiles(List<File> files) {
-		List<File> migratedFiles = new ArrayList<>();
-		for (File f : files) {
+	static List<File> getCompatibleFiles(List<File> files) {
+		List<File> normalizedFiles = normalizeLegacyMigratedFiles(files);
+		List<File> compatibleFiles = new ArrayList<>();
+		Set<Path> compatiblePaths = new HashSet<>();
+		List<String> migratedThisRun = new ArrayList<>();
+		System.clearProperty(JarMigrationHelper.MIGRATED_JARS_PROPERTY);
+
+		for (File f : normalizedFiles) {
 			try {
-				if (JarMigrationHelper.shouldMigrate(f, files)) {
-					File migratedJar = JarMigrationHelper.migrateJarFile(f);
-					migratedFiles.add(migratedJar);
-				} else {
-					migratedFiles.add(f);
+				JarMigrationHelper.MigrationStatus status =
+						JarMigrationHelper.getMigrationStatus(f, normalizedFiles);
+				switch (status) {
+					case COMPATIBLE -> addCompatibleFile(compatibleFiles, compatiblePaths, f);
+					case NEEDS_MIGRATION -> {
+						File migratedJar = JarMigrationHelper.migrateJarFile(f);
+						addCompatibleFile(compatibleFiles, compatiblePaths, migratedJar);
+						migratedThisRun.add(migratedJar.getAbsolutePath());
+					}
+					case SUPERSEDED -> {
+						// The migrated companion is processed separately; do not put the old source JAR on the classpath.
+					}
 				}
 			} catch (JarMigrationHelper.JarMigrationException e) {
-				// Ignore the exception, the JAR file is not migrated
+				// Exclude unreadable or unsuccessfully migrated JARs from the plugin classpath.
 				System.err.println(e.getMessage());
 			}
 		}
-		return migratedFiles;
+
+		// Record the migrations so the UI can later inform the user (only for migrations performed during
+		// this startup, to avoid repeating the message on every startup)
+		if (!migratedThisRun.isEmpty()) {
+			System.setProperty(JarMigrationHelper.MIGRATED_JARS_PROPERTY,
+					String.join(File.pathSeparator, migratedThisRun));
+		}
+
+		return compatibleFiles;
+	}
+
+	/**
+	 * Rename legacy migrated JARs before the plugin classloader is created. The returned list is de-duplicated because
+	 * both the legacy and final name can be present in the directory during recovery from older migrations.
+	 */
+	private static List<File> normalizeLegacyMigratedFiles(List<File> files) {
+		List<File> normalizedFiles = new ArrayList<>();
+		Set<Path> normalizedPaths = new HashSet<>();
+		for (File file : files) {
+			File normalizedFile = file;
+			if (JarMigrationHelper.isLegacyMigratedJar(file)) {
+				try {
+					normalizedFile = JarMigrationHelper.normalizeLegacyMigratedJar(file);
+				} catch (JarMigrationHelper.JarMigrationException e) {
+					// Keep the legacy path as a fallback; its validity is checked before it is added to the classpath.
+					System.err.println(e.getMessage());
+				}
+			}
+			addCompatibleFile(normalizedFiles, normalizedPaths, normalizedFile);
+		}
+		return normalizedFiles;
+	}
+
+	private static void addCompatibleFile(List<File> files, Set<Path> paths, File file) {
+		Path path = file.toPath().toAbsolutePath().normalize();
+		if (paths.add(path)) {
+			files.add(file);
+		}
 	}
 
 	private void findCustomPlugins(List<URL> urls) {

--- a/core/src/test/java/info/openrocket/core/plugin/JarMigrationHelperTest.java
+++ b/core/src/test/java/info/openrocket/core/plugin/JarMigrationHelperTest.java
@@ -1,0 +1,102 @@
+package info.openrocket.core.plugin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests migration detection and validation for original, current, and legacy plugin JARs.
+ */
+public class JarMigrationHelperTest {
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	public void testShouldMigrateOldPackageJar() throws Exception {
+		File plugin = createJar("MyPlugin.jar", "net/sf/openrocket/util/MyClass.class");
+
+		assertTrue(JarMigrationHelper.shouldMigrate(plugin, List.of(plugin)));
+	}
+
+	@Test
+	public void testShouldNotMigrateNewPackageJar() throws Exception {
+		File plugin = createJar("MyPlugin.jar", "info/openrocket/core/util/MyClass.class");
+
+		assertFalse(JarMigrationHelper.shouldMigrate(plugin, List.of(plugin)));
+	}
+
+	@Test
+	public void testShouldNotMigrateWhenMigratedVersionExists() throws Exception {
+		File plugin = createJar("MyPlugin.jar", "net/sf/openrocket/util/MyClass.class");
+		File migrated = createJar("MyPlugin" + JarMigrationHelper.MIGRATION_SUFFIX + ".jar",
+				"info/openrocket/core/util/MyClass.class");
+
+		assertFalse(JarMigrationHelper.shouldMigrate(plugin, List.of(plugin, migrated)));
+		assertEquals(JarMigrationHelper.MigrationStatus.SUPERSEDED,
+				JarMigrationHelper.getMigrationStatus(plugin, List.of(plugin, migrated)));
+	}
+
+	@Test
+	public void testShouldNotMigrateWhenLegacyMigratedVersionExists() throws Exception {
+		// Older versions left the migrated JAR with an extra "-new" suffix when the rename during startup
+		// failed; such a file must still count as an already performed migration.
+		File plugin = createJar("MyPlugin.jar", "net/sf/openrocket/util/MyClass.class");
+		File legacyMigrated = createJar(
+				"MyPlugin" + JarMigrationHelper.MIGRATION_SUFFIX + JarMigrationHelper.NEW_MIGRATION_SUFFIX + ".jar",
+				"info/openrocket/core/util/MyClass.class");
+
+		assertFalse(JarMigrationHelper.shouldMigrate(plugin, List.of(plugin, legacyMigrated)));
+	}
+
+	@Test
+	public void testShouldNotMigrateMigratedJarItself() throws Exception {
+		File migrated = createJar("MyPlugin" + JarMigrationHelper.MIGRATION_SUFFIX + ".jar",
+				"info/openrocket/core/util/MyClass.class");
+
+		assertFalse(JarMigrationHelper.shouldMigrate(migrated, List.of(migrated)));
+	}
+
+	@Test
+	public void testCorruptMigratedVersionDoesNotSuppressMigration() throws Exception {
+		File plugin = createJar("MyPlugin.jar", "net/sf/openrocket/util/MyClass.class");
+		File migrated = tempDir.resolve("MyPlugin" + JarMigrationHelper.MIGRATION_SUFFIX + ".jar").toFile();
+		Files.writeString(migrated.toPath(), "not a JAR");
+
+		assertTrue(JarMigrationHelper.shouldMigrate(plugin, List.of(plugin, migrated)));
+	}
+
+	@Test
+	public void testUnreadableMigratedJarIsRejected() throws Exception {
+		File migrated = tempDir.resolve("MyPlugin" + JarMigrationHelper.MIGRATION_SUFFIX + ".jar").toFile();
+		Files.writeString(migrated.toPath(), "not a JAR");
+
+		assertThrows(JarMigrationHelper.JarMigrationException.class,
+				() -> JarMigrationHelper.getMigrationStatus(migrated, List.of(migrated)));
+	}
+
+	/**
+	 * Create a JAR file containing a single (empty) entry with the given name.
+	 * Only the entry name matters for the migration checks.
+	 */
+	private File createJar(String jarName, String entryName) throws IOException {
+		File jar = tempDir.resolve(jarName).toFile();
+		try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(jar))) {
+			jos.putNextEntry(new JarEntry(entryName));
+			jos.closeEntry();
+		}
+		return jar;
+	}
+}

--- a/core/src/test/java/info/openrocket/core/startup/jij/PluginClasspathProviderTest.java
+++ b/core/src/test/java/info/openrocket/core/startup/jij/PluginClasspathProviderTest.java
@@ -1,0 +1,122 @@
+package info.openrocket.core.startup.jij;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarOutputStream;
+
+import info.openrocket.core.plugin.JarMigrationHelper;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests migration filtering performed before plugin JARs are added to the application classpath.
+ */
+public class PluginClasspathProviderTest {
+	@TempDir
+	private Path tempDir;
+
+	@AfterEach
+	public void clearMigrationProperty() {
+		System.clearProperty(JarMigrationHelper.MIGRATED_JARS_PROPERTY);
+	}
+
+	@Test
+	public void testOriginalJarIsExcludedWhenMigratedCompanionExists() throws Exception {
+		File original = createJar("MyPlugin.jar", "net/sf/openrocket/plugin.txt");
+		File migrated = createJar("MyPlugin-migrated.jar", "info/openrocket/core/plugin.txt");
+
+		List<File> compatibleFiles = PluginClasspathProvider.getCompatibleFiles(List.of(original, migrated));
+
+		assertEquals(List.of(migrated), compatibleFiles);
+		assertNull(System.getProperty(JarMigrationHelper.MIGRATED_JARS_PROPERTY));
+	}
+
+	@Test
+	public void testLegacyMigratedJarIsNormalizedBeforeClasspathUse() throws Exception {
+		File original = createJar("MyPlugin.jar", "net/sf/openrocket/plugin.txt");
+		File legacyMigrated = createJar("MyPlugin-migrated-new.jar", "info/openrocket/core/plugin.txt");
+		File finalMigrated = tempDir.resolve("MyPlugin-migrated.jar").toFile();
+
+		List<File> compatibleFiles = PluginClasspathProvider.getCompatibleFiles(List.of(original, legacyMigrated));
+
+		assertEquals(List.of(finalMigrated), compatibleFiles);
+		assertTrue(finalMigrated.isFile());
+		assertFalse(legacyMigrated.exists());
+		assertNull(System.getProperty(JarMigrationHelper.MIGRATED_JARS_PROPERTY));
+	}
+
+	@Test
+	public void testExistingFinalMigratedJarIsPreferredOverLegacyJar() throws Exception {
+		File legacyMigrated = createJar("MyPlugin-migrated-new.jar", "info/openrocket/core/legacy.txt");
+		File finalMigrated = createJar("MyPlugin-migrated.jar", "info/openrocket/core/final.txt");
+
+		List<File> compatibleFiles = PluginClasspathProvider.getCompatibleFiles(
+				List.of(legacyMigrated, finalMigrated));
+
+		assertEquals(List.of(finalMigrated), compatibleFiles);
+		assertTrue(legacyMigrated.isFile());
+		assertTrue(finalMigrated.isFile());
+	}
+
+	@Test
+	public void testCorruptMigratedCompanionIsReplaced() throws Exception {
+		File original = createJar("MyPlugin.jar", "net/sf/openrocket/plugin.txt");
+		File corruptMigrated = tempDir.resolve("MyPlugin-migrated.jar").toFile();
+		Files.writeString(corruptMigrated.toPath(), "not a JAR");
+
+		List<File> compatibleFiles = PluginClasspathProvider.getCompatibleFiles(List.of(original, corruptMigrated));
+
+		assertEquals(List.of(corruptMigrated), compatibleFiles);
+		assertTrue(isJarReadable(corruptMigrated));
+		assertEquals(corruptMigrated.getAbsolutePath(),
+				System.getProperty(JarMigrationHelper.MIGRATED_JARS_PROPERTY));
+	}
+
+	@Test
+	public void testCompletedMigrationIsNotReportedAgain() throws Exception {
+		File original = createJar("MyPlugin.jar", "net/sf/openrocket/plugin.txt");
+
+		List<File> firstRun = PluginClasspathProvider.getCompatibleFiles(List.of(original));
+		File migrated = tempDir.resolve("MyPlugin-migrated.jar").toFile();
+
+		assertEquals(List.of(migrated), firstRun);
+		assertEquals(migrated.getAbsolutePath(),
+				System.getProperty(JarMigrationHelper.MIGRATED_JARS_PROPERTY));
+
+		List<File> secondRun = PluginClasspathProvider.getCompatibleFiles(List.of(original, migrated));
+
+		assertEquals(List.of(migrated), secondRun);
+		assertNull(System.getProperty(JarMigrationHelper.MIGRATED_JARS_PROPERTY));
+	}
+
+	private File createJar(String jarName, String entryName) throws IOException {
+		File jar = tempDir.resolve(jarName).toFile();
+		try (JarOutputStream output = new JarOutputStream(new FileOutputStream(jar))) {
+			output.putNextEntry(new JarEntry(entryName));
+			output.write(new byte[] { 1 });
+			output.closeEntry();
+		}
+		return jar;
+	}
+
+	private boolean isJarReadable(File jarFile) {
+		try (JarFile ignored = new JarFile(jarFile)) {
+			return true;
+		} catch (IOException e) {
+			return false;
+		}
+	}
+}

--- a/swing/src/main/java/info/openrocket/swing/startup/OpenRocket.java
+++ b/swing/src/main/java/info/openrocket/swing/startup/OpenRocket.java
@@ -16,7 +16,7 @@ import info.openrocket.core.arch.SystemInfo.Platform;
  * classpath setup.
  * 
  * The startup class sequence is the following:
- *   1. Startup
+ *   1. OpenRocket
  *   2. SwingStartup
  * 
  * This class changes the current classpath to contain the jar-in-jar
@@ -26,9 +26,9 @@ import info.openrocket.core.arch.SystemInfo.Platform;
  * @author Sampo Niskanen <sampo.niskanen@iki.fi>
  */
 public class OpenRocket {
-	
+	static final String CLASSPATH_READY_PROPERTY = "openrocket.startup.classpath-ready";
 	private static final String STARTUP_CLASS = "info.openrocket.swing.startup.SwingStartup";
-	
+
 	public static void main(String[] args) {
 		// Set OSX-specific properties
 		if (SystemInfo.getPlatform() == Platform.MAC_OS) {
@@ -40,8 +40,32 @@ public class OpenRocket {
 		// by designation.
 		System.setProperty("java.util.Arrays.useLegacyMergeSort","true");
 		addClasspathUrlHandler();
-		JarInJarStarter.runMain(STARTUP_CLASS, args, new CurrentClasspathProvider(),
-				new ManifestClasspathProvider(), new PluginClasspathProvider());
+
+		String previousClasspathReady = System.getProperty(CLASSPATH_READY_PROPERTY);
+		System.setProperty(CLASSPATH_READY_PROPERTY, Boolean.TRUE.toString());
+		try {
+			JarInJarStarter.runMain(STARTUP_CLASS, args, new CurrentClasspathProvider(),
+					new ManifestClasspathProvider(), new PluginClasspathProvider());
+		} finally {
+			restoreClasspathReadyProperty(previousClasspathReady);
+		}
+	}
+
+	/**
+	 * Check whether the first startup stage has prepared the application and plugin classpath.
+	 *
+	 * @return True when {@link SwingStartup} is running through the bootstrap classloader.
+	 */
+	static boolean isClasspathReady() {
+		return Boolean.parseBoolean(System.getProperty(CLASSPATH_READY_PROPERTY));
+	}
+
+	private static void restoreClasspathReadyProperty(String previousValue) {
+		if (previousValue == null) {
+			System.clearProperty(CLASSPATH_READY_PROPERTY);
+		} else {
+			System.setProperty(CLASSPATH_READY_PROPERTY, previousValue);
+		}
 	}
 	
 	private static void addClasspathUrlHandler() {

--- a/swing/src/main/java/info/openrocket/swing/startup/SwingStartup.java
+++ b/swing/src/main/java/info/openrocket/swing/startup/SwingStartup.java
@@ -60,6 +60,12 @@ public class SwingStartup {
 	 * OpenRocket startup main method.
 	 */
 	public static void main(final String[] args) throws Exception {
+		// IDEs can launch this second-stage class directly. Route that invocation through the first-stage bootstrap so
+		// plugin migration and classpath setup are performed before any plugin classes are scanned.
+		if (!OpenRocket.isClasspathReady()) {
+			OpenRocket.main(args);
+			return;
+		}
 
 		// Check for "openrocket.debug" property before anything else
 		checkDebugStatus();

--- a/swing/src/main/java/info/openrocket/swing/startup/SwingStartup.java
+++ b/swing/src/main/java/info/openrocket/swing/startup/SwingStartup.java
@@ -7,7 +7,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Arrays;
-import java.util.List;
 import java.util.stream.IntStream;
 
 import javax.swing.JOptionPane;
@@ -17,7 +16,6 @@ import javax.swing.ToolTipManager;
 
 import info.openrocket.core.l10n.Translator;
 import info.openrocket.core.plugin.JarMigrationHelper;
-import info.openrocket.core.plugin.PluginHelper;
 import info.openrocket.core.preferences.ApplicationPreferences;
 import info.openrocket.core.startup.Application;
 import net.miginfocom.layout.LayoutUtil;
@@ -249,22 +247,23 @@ public class SwingStartup {
 		log.info("Checking update status");
 		checkUpdateStatus(updateRetriever);
 
-		// Check if plugins were migrated, if so, display a message
-		final List<File> files = PluginHelper.getPluginJars();
-		final Translator trans = Application.getTranslator();
-		files.stream()
-				.filter(f -> f.getName().contains(JarMigrationHelper.MIGRATION_SUFFIX + JarMigrationHelper.NEW_MIGRATION_SUFFIX))
-				.forEach(f -> displayPluginMigratedMessage(f, trans));
+		// Check if plugins were migrated during this startup, if so, display a message
+		final String migratedJars = System.getProperty(JarMigrationHelper.MIGRATED_JARS_PROPERTY);
+		if (migratedJars != null) {
+			System.clearProperty(JarMigrationHelper.MIGRATED_JARS_PROPERTY);
+			final Translator trans = Application.getTranslator();
+			for (String path : migratedJars.split(File.pathSeparator)) {
+				displayPluginMigratedMessage(new File(path), trans);
+			}
+		}
 	}
 
 	private static void displayPluginMigratedMessage(File f, Translator trans) {
-		File newFile = new File(f.getAbsolutePath().replace(JarMigrationHelper.NEW_MIGRATION_SUFFIX, ""));
-		f.renameTo(newFile);
 		String message = String.format(trans.get("SwingStartup.pluginMigrated"),
-				newFile.getName().replace(JarMigrationHelper.MIGRATION_SUFFIX, ""), newFile);
+				f.getName().replace(JarMigrationHelper.MIGRATION_SUFFIX, ""), f);
 		JOptionPane.showMessageDialog(null, message, "Plugin migrated", JOptionPane.INFORMATION_MESSAGE);
 	}
-	
+
 	/**
 	 * Check that the JRE is not running headless.
 	 */


### PR DESCRIPTION
Migrated plugins could be migrated and reported repeatedly because legacy `-migrated-new.jar` files were not reliably recognized. Launching `SwingStartup` directly also skipped plugin migration entirely (not an issue for users, but for devs).

This PR validates and safely publishes migrated JARs, excludes superseded originals from the classpath, and only reports migrations performed during the current startup. Direct `SwingStartup` launches now pass through the normal classpath bootstrap so plugin migration always runs.