### PR TITLE
Fix tube-fin CP interpolation initialization

### DIFF
--- a/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/TubeFinSetCalc.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/TubeFinSetCalc.java
@@ -80,7 +80,8 @@ public class TubeFinSetCalc extends TubeCalc {
 
 		// aspect ratio.
 		ar = 2 * innerRadius / chord;
-
+		// The transonic CP polynomial depends on the tube-fin aspect ratio.
+		calculatePoly();
 
 		// Some trigonometry...
 		// We need a triangle with the following three sides:

--- a/core/src/test/java/info/openrocket/core/aerodynamics/TubeFinSetCalcTest.java
+++ b/core/src/test/java/info/openrocket/core/aerodynamics/TubeFinSetCalcTest.java
@@ -1,0 +1,51 @@
+package info.openrocket.core.aerodynamics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import info.openrocket.core.aerodynamics.barrowman.TubeFinSetCalc;
+import info.openrocket.core.logging.WarningSet;
+import info.openrocket.core.rocketcomponent.BodyTube;
+import info.openrocket.core.rocketcomponent.FlightConfiguration;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.rocketcomponent.TubeFinSet;
+import info.openrocket.core.util.BaseTestCase;
+import info.openrocket.core.util.TestRockets;
+import info.openrocket.core.util.Transformation;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for tube-fin aerodynamic calculations.
+ */
+public class TubeFinSetCalcTest extends BaseTestCase {
+	private static final double EPSILON = 0.000001;
+
+	/**
+	 * Verify that tube fins use their geometry-dependent transonic interpolation
+	 * polynomial instead of its zero-initialized coefficient array.
+	 */
+	@Test
+	public void testTransonicCPUsesInterpolationPolynomial() {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		BodyTube body = (BodyTube) rocket.getChild(0).getChild(1);
+		TubeFinSet tubeFins = new TubeFinSet();
+		tubeFins.setOuterRadius(0.027);
+		tubeFins.setThickness(0.002);
+		tubeFins.setLength(0.05);
+		body.addChild(tubeFins);
+
+		// AR = 2 * innerRadius / chord = 1, for which p(1) is about 0.32124.
+		FlightConfiguration configuration = rocket.getSelectedConfiguration();
+		FlightConditions conditions = new FlightConditions(configuration);
+		conditions.setMach(1.0);
+		AerodynamicForces forces = new AerodynamicForces();
+		TubeFinSetCalc calculator = new TubeFinSetCalc(tubeFins);
+		calculator.calculateNonaxialForces(conditions, Transformation.IDENTITY, forces, new WarningSet());
+
+		double relativeCP = forces.getCP().getX() / tubeFins.getLength();
+		assertEquals(0.3212417255, relativeCP, EPSILON,
+				"Tube-fin CP should follow the transonic interpolation polynomial");
+		assertTrue(relativeCP > 0.25, "The initialized polynomial must move this tube-fin CP aft");
+	}
+}


### PR DESCRIPTION
There is a bug in the current tube fin calculation where the CP is zero between Mach 0.5 and 2.0. The interpolation array is initialized to zero, but `calculatePoly()` is never called. Consequently, the CP jumps from 25% chord at Mach 0.5 to the leading edge immediately above it, remaining there until Mach 2

You can see the effect here (the pole is probably related to #3196):
 
<img width="600" alt="image" src="https://github.com/user-attachments/assets/7cd3b5da-370c-4b02-84cd-e746463e8d39" />

Fix from this PR:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/42c4c065-0418-41d5-872e-f0b01d4851a3" />
