### PR TITLE
Fix transonic fin CNa endpoint derivative

### DIFF
--- a/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/FinSetCalc.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/FinSetCalc.java
@@ -481,7 +481,7 @@ public class FinSetCalc extends RocketComponentCalc {
 		
 		double sq = MathUtil.safeSqrt(1 + (1 - pow2(CNA_SUBSONIC)) * pow2(span * span / (finArea * cosGamma)));
 		subV = 2 * Math.PI * pow2(span) / ref / (1 + sq);
-		subD = 2 * mach * Math.PI * pow(span, 6) / (pow2(finArea * cosGamma) * ref *
+		subD = 2 * CNA_SUBSONIC * Math.PI * pow(span, 6) / (pow2(finArea * cosGamma) * ref *
 				sq * pow2(1 + sq));
 		
 		superV = finArea * (K1.getValue(CNA_SUPERSONIC) + K2.getValue(CNA_SUPERSONIC) * alpha +

--- a/core/src/test/java/info/openrocket/core/aerodynamics/FinSetCalcTest.java
+++ b/core/src/test/java/info/openrocket/core/aerodynamics/FinSetCalcTest.java
@@ -23,6 +23,7 @@ import info.openrocket.core.rocketcomponent.FlightConfiguration;
 import info.openrocket.core.rocketcomponent.Rocket;
 import info.openrocket.core.rocketcomponent.TrapezoidFinSet;
 import info.openrocket.core.startup.Application;
+import info.openrocket.core.util.PolyInterpolator;
 import info.openrocket.core.util.TestRockets;
 import info.openrocket.core.util.Transformation;
 
@@ -32,6 +33,17 @@ public class FinSetCalcTest {
 	protected final double EPSILON = 0.0001;
 
 	private static Injector injector;
+
+	/** Exposes the single-fin CNa calculation for interpolation tests. */
+	private static class TestableFinSetCalc extends FinSetCalc {
+		TestableFinSetCalc(FinSet fins) {
+			super(fins);
+		}
+
+		double calculateFinCNa(FlightConditions conditions) {
+			return calculateFinCNa1(conditions);
+		}
+	}
 
 	@BeforeAll
 	public static void setup() {
@@ -67,6 +79,48 @@ public class FinSetCalcTest {
 		}
 
 		return assemblyForces;
+	}
+
+	/**
+	 * Verify that the transonic interpolation uses the derivative of the
+	 * subsonic model at Mach 0.9, independent of the Mach being queried.
+	 */
+	@Test
+	public void testTransonicCNaUsesSubsonicEndpointDerivative() {
+		final double subsonicMach = 0.9;
+		final double supersonicMach = 1.5;
+		final double queryMach = 1.2;
+		final double derivativeStep = 0.000001;
+
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		TrapezoidFinSet fins = (TrapezoidFinSet) rocket.getChild(0).getChild(1).getChild(0);
+		FlightConditions conditions = new FlightConditions(rocket.getSelectedConfiguration());
+		conditions.setAOA(0);
+		TestableFinSetCalc calculator = new TestableFinSetCalc(fins);
+
+		conditions.setMach(subsonicMach);
+		double subsonicValue = calculator.calculateFinCNa(conditions);
+		conditions.setMach(subsonicMach - derivativeStep);
+		double belowSubsonicValue = calculator.calculateFinCNa(conditions);
+		double subsonicDerivative = (subsonicValue - belowSubsonicValue) / derivativeStep;
+
+		conditions.setMach(supersonicMach);
+		double supersonicValue = calculator.calculateFinCNa(conditions);
+		double supersonicBetaCubed = Math.pow(supersonicMach * supersonicMach - 1, 1.5);
+		double supersonicDerivative = -fins.getPlanformArea() / conditions.getRefArea()
+				* 2 * supersonicMach / supersonicBetaCubed;
+
+		PolyInterpolator interpolator = new PolyInterpolator(
+				new double[] { subsonicMach, supersonicMach },
+				new double[] { subsonicMach, supersonicMach },
+				new double[] { subsonicMach });
+		double expected = interpolator.interpolate(queryMach, subsonicValue, supersonicValue,
+				subsonicDerivative, supersonicDerivative, 0);
+
+		conditions.setMach(queryMach);
+		double actual = calculator.calculateFinCNa(conditions);
+		assertEquals(expected, actual, EPSILON,
+				"Transonic CNa should use the derivative at the Mach 0.9 endpoint");
 	}
 
 	@Test


### PR DESCRIPTION
The transonic interpolation used the queried Mach number when calculating the derivative constraint at Mach 0.9. This produced a different interpolation polynomial for each query and overestimated CNa inside the transonic region.

The interpolator interpolates like this:

```java
cnaInterpolator.interpolate(mach, subV, superV, subD, superD, 0);
```

So, from the last subsonic value (`subV`, `subD`) to the first supersonic value (`superV`, `superD`). `superV` and `superD` already correctly used a fixed mach, `CNA_SUPERSONIC`. `sq` in `subV` and `subD` also used `CNA_SUBSONIC` correctly, but `subD` still used `mach` instead of `CNA_SUBSONIC`.