### PR TITLE
Fix body friction fineness ratio

### DIFF
--- a/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanDragCalculator.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanDragCalculator.java
@@ -163,8 +163,8 @@ public class BarrowmanDragCalculator implements DragCalculator {
 			}
 		}
 
-		double fB = (maxX - minX + 0.0001) / maxR;
-		double correction = (1 + 1.0 / (2 * fB));
+		double bodyLength = maxX - minX + 0.0001;
+		double correction = calculateBodyFrictionCorrection(bodyLength, maxR);
 
 		if (forceMap != null) {
 			for (Map.Entry<RocketComponent, AerodynamicForces> entry : forceMap.entrySet()) {
@@ -175,6 +175,21 @@ public class BarrowmanDragCalculator implements DragCalculator {
 		}
 
 		return otherFrictionCD + correction * bodyFrictionCD;
+	}
+
+	/**
+	 * Calculate the cylindrical-body wetted-area correction from OpenRocket
+	 * technical documentation equation (3.85). The body fineness ratio is the
+	 * body length divided by its maximum diameter, not its maximum radius.
+	 *
+	 * @param bodyLength aerodynamic body length
+	 * @param maxRadius maximum body radius
+	 * @return body skin-friction correction multiplier
+	 */
+	static double calculateBodyFrictionCorrection(double bodyLength, double maxRadius) {
+		double bodyDiameter = 2 * maxRadius;
+		double finenessRatio = bodyLength / bodyDiameter;
+		return 1 + 1.0 / (2 * finenessRatio);
 	}
 
 	private double calculateReynoldsNumber(FlightConfiguration configuration, FlightConditions conditions) {

--- a/core/src/test/java/info/openrocket/core/aerodynamics/BarrowmanDragCalculatorTest.java
+++ b/core/src/test/java/info/openrocket/core/aerodynamics/BarrowmanDragCalculatorTest.java
@@ -1,0 +1,25 @@
+package info.openrocket.core.aerodynamics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the extended Barrowman drag calculations.
+ */
+public class BarrowmanDragCalculatorTest {
+	private static final double EPSILON = 0.000001;
+
+	/**
+	 * Verify that body fineness is based on maximum diameter. A one-meter body
+	 * with a 0.1-meter diameter has a fineness ratio of 10, giving a correction
+	 * of 1 + 1 / (2 * 10) = 1.05.
+	 */
+	@Test
+	public void testBodyFrictionCorrectionUsesDiameter() {
+		double correction = BarrowmanDragCalculator.calculateBodyFrictionCorrection(1.0, 0.05);
+
+		assertEquals(1.05, correction, EPSILON,
+				"Body skin-friction correction should use length divided by diameter");
+	}
+}


### PR DESCRIPTION
OR's tech docs Equation (3.85) applies the cylindrical-body skin-friction correction

$$
1+\frac{1}{2f_B},
$$

where the body fineness ratio is defined as

$$
f_B=\frac{L}{D}.
$$

However, in out code, we calculated `fB` using the maximum radius:

```java
double fB = (maxX - minX + 0.0001) / maxR;
double correction = (1 + 1.0 / (2 * fB));
```

which doubled the fineness ratio and halved the correction above 1. For example, a body with a true fineness ratio of 10 received a correction of 1.025 instead of 1.05.

This PR replaced R by D...