### PR TITLE
Apply humidity-only atmospheric changes

### DIFF
--- a/core/src/main/java/info/openrocket/core/models/atmosphere/AtmosphericConditions.java
+++ b/core/src/main/java/info/openrocket/core/models/atmosphere/AtmosphericConditions.java
@@ -208,12 +208,15 @@ public class AtmosphericConditions implements Cloneable, Monitorable {
 		if (!(other instanceof AtmosphericConditions))
 			return false;
 		AtmosphericConditions o = (AtmosphericConditions) other;
-		return MathUtil.equals(this.pressure, o.pressure) && MathUtil.equals(this.temperature, o.temperature);
+		return MathUtil.equals(this.pressure, o.pressure) &&
+				MathUtil.equals(this.temperature, o.temperature) &&
+				MathUtil.equals(this.relativeHumidity, o.relativeHumidity);
 	}
 
 	@Override
 	public int hashCode() {
-		return (int) (this.pressure + this.temperature * 1000);
+		return (int) (this.pressure + this.temperature * 1000 +
+				this.relativeHumidity * 1000000);
 	}
 
 	@Override

--- a/core/src/test/java/info/openrocket/core/aerodynamics/FlightConditionsTest.java
+++ b/core/src/test/java/info/openrocket/core/aerodynamics/FlightConditionsTest.java
@@ -1,6 +1,9 @@
 package info.openrocket.core.aerodynamics;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -192,6 +195,23 @@ class FlightConditionsTest {
 
 		assertEquals(280, conditions.getAtmosphericConditions().getTemperature(), EPSILON);
 		assertEquals(90000, conditions.getAtmosphericConditions().getPressure(), EPSILON);
+	}
+
+	@Test
+	void testHumidityOnlyAtmosphericChangeIsApplied() {
+		double dryDensity = conditions.getAtmosphericConditions().getDensity();
+		AtmosphericConditions humid = new AtmosphericConditions(
+				AtmosphericConditions.STANDARD_TEMPERATURE,
+				AtmosphericConditions.STANDARD_PRESSURE, 1.0);
+		int[] changeCount = { 0 };
+		conditions.addChangeListener(event -> changeCount[0]++);
+
+		conditions.setAtmosphericConditions(humid);
+
+		assertEquals(1.0, conditions.getAtmosphericConditions().getRelativeHumidity(), EPSILON);
+		assertTrue(conditions.getAtmosphericConditions().getDensity() < dryDensity,
+				"Applying humid conditions should reduce density at fixed pressure and temperature");
+		assertEquals(1, changeCount[0], "A humidity-only atmospheric change should fire a change event");
 	}
 
 	@Test

--- a/core/src/test/java/info/openrocket/core/models/atmosphere/AtmosphericConditionsTest.java
+++ b/core/src/test/java/info/openrocket/core/models/atmosphere/AtmosphericConditionsTest.java
@@ -1,12 +1,16 @@
 package info.openrocket.core.models.atmosphere;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import static org.junit.jupiter.api.Assertions.*;
-
 
 public class AtmosphericConditionsTest {
 	private AtmosphericConditions conditions;
@@ -75,6 +79,21 @@ public class AtmosphericConditionsTest {
 		AtmosphericConditions dry = new AtmosphericConditions(288.15, 101325.0, 0.0);
 		AtmosphericConditions wet = new AtmosphericConditions(288.15, 101325.0, 1.0);
 		assertTrue(wet.getDensity() < dry.getDensity());
+	}
+
+	@Test
+	@DisplayName("Humidity should be part of atmospheric equality and hashing")
+	void testHumidityAffectsEqualityAndHashCode() {
+		AtmosphericConditions dry = new AtmosphericConditions(288.15, 101325.0, 0.0);
+		AtmosphericConditions dryCopy = new AtmosphericConditions(288.15, 101325.0, 0.0);
+		AtmosphericConditions humid = new AtmosphericConditions(288.15, 101325.0, 1.0);
+
+		assertTrue(dry.equals(dryCopy));
+		assertEquals(dry.hashCode(), dryCopy.hashCode());
+		assertFalse(dry.equals(humid),
+				"Atmospheric conditions with different humidity should not compare equal");
+		assertNotEquals(dry.hashCode(), humid.hashCode(),
+				"Relative humidity should contribute to the atmospheric hash code");
 	}
 
 	@Test


### PR DESCRIPTION
`AtmosphericConditions.equals()` compared only pressure and temperature, ignoring relative humidity.

As a result, `FlightConditions.setAtmosphericConditions()` considered two atmospheric states equal when only their humidity differed and returned without applying the new conditions or firing a change event.

This could leave the simulation using stale humidity-dependent properties, including air density and kinematic viscosity.

This PR include relative humidity in `AtmosphericConditions.equals()` and `hashCode()`.
