### PR TITLE
Export RockSim motor configurations and launch conditions

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/rocksim/RockSimCommonConstants.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/RockSimCommonConstants.java
@@ -97,6 +97,76 @@ public class RockSimCommonConstants {
     public static final String USE_SINGLE_COLOR = "UseSingleColor";
     public static final String OPACITY = "Opacity";
 
+    // Simulation and motor-configuration elements.
+    public static final String SIMULATION_RESULTS_LIST = "SimulationResultsList";
+    public static final String SIMULATION_RESULTS = "SimulationResults";
+    public static final String ENGINE_SET = "EngineSet";
+    public static final String ENGINE_COUNT = "EngineCount";
+    public static final String ENGINE_CODE = "EngineCode";
+    public static final String IGNITION_DELAY = "IgnitionDelay";
+    public static final String ENGINE_MFG = "EngineMfg";
+    public static final String CASING_CG = "CasingCG";
+    public static final String MOUNT_SERIAL_NUMBER = "MountSerialNo";
+    public static final String EJECTION_DELAY = "EjectionDelay";
+    public static final String ROTATE_X_ABOUT_Y = "RotateXaboutY";
+    public static final String ROTATE_ENGINE_AXIS_ABOUT_X = "RotateEngineAxisAboutX";
+    public static final String FINAL_STATE = "FinalState";
+    public static final String LAUNCH_GUIDE_TYPE = "LaunchGuideType";
+    public static final String LAUNCH_GUIDE_LEN = "LaunchGuideLen";
+    public static final String LAUNCH_WIND_DIRECTION = "LaunchWindDirection";
+    public static final String LAUNCH_WIND_SPEED = "LaunchWindSpeed";
+    public static final String LAUNCH_DIRECTION = "LaunchDirection";
+    public static final String LAUNCH_ANGLE = "LaunchAngle";
+    public static final String LAUNCH_GUIDE_AZIMUTH = "LaunchGuideAzimuth";
+    public static final String LAUNCH_BAROMETER = "LaunchBarometer";
+    public static final String LAUNCH_LATITUDE = "LaunchLatitude";
+    public static final String LAUNCH_LONGITUDE = "LaunchLongitude";
+    public static final String LAUNCH_HUMIDITY = "LaunchHumidity";
+    public static final String LAUNCH_TEMPERATURE = "LaunchTemperature";
+    public static final String LAUNCH_ALTITUDE = "LaunchAltitude";
+    public static final String LAUNCH_LANDING_ALTITUDE = "LaunchLandingAltitude";
+    public static final String LAUNCH_WIND_PRESET = "LaunchWindPreset";
+    public static final String LAUNCH_WIND_LOW_SPEED = "LaunchWindLowSpeed";
+    public static final String LAUNCH_WIND_HIGH_SPEED = "LaunchWindHighSpeed";
+    public static final String LAUNCH_WIND_TURBULENCE_PRESET = "LaunchWindTurbulencePreset";
+    public static final String LAUNCH_USE_RANDOM_CONDITIONS = "LaunchUseRandomConditions";
+    public static final String LAUNCH_WIND_TABLE_SIZE = "LaunchWindTableSize";
+    public static final String LAUNCH_WIND_ALT_TABLE = "LaunchWindAltTable";
+    public static final String LAUNCH_WIND_SPEED_TABLE = "LaunchWindSpeedTable";
+    public static final String LAUNCH_WIND_DIRECTION_TABLE = "LaunchWindDirectionTable";
+    public static final String CNA_MULTIPLIER = "CNaMultiplier";
+    public static final String CD_MULTIPLIER = "CdMultiplier";
+    public static final String CP_OFFSET = "CPOffset";
+    public static final String MAX_SIM_TIME = "MaxSimTim";
+    public static final String SIMULATION_NAME = "SimulationName";
+    public static final String COMMENTS = "Comments";
+    public static final String CALC_RESOLUTION = "CalcResolution";
+    public static final String SIMULATION_TYPE = "SimulationType";
+    public static final String CALCULATION_FLAGS = "CalculationFlags";
+	public static final String SIMULATION_EVENTS = "SimulationEvents";
+	public static final String SIMULATION_EVENT = "SimulationEvent";
+	public static final String PART_SERIAL_NUMBER = "PartSerialNo";
+	public static final String EVENT_TYPE = "Type";
+	public static final String DEPLOY_ALTITUDE = "DeployAltitude";
+	public static final String DEPLY_TIME = "DeplyTime";
+	public static final String HAS_DEPLOYED = "HasDeployed";
+	public static final String DEPLOYED_AT_ALTITUDE = "DeployedAt_Altitude";
+	public static final String DEPLOYED_AT_VELOCITY = "DeployedAt_Velocity";
+	public static final String DEPLOYED_AT_RANGE = "DeployedAt_Range";
+	public static final String DEPLOYED_AT_TIME = "DeployedAt_Time";
+	public static final String DEVICE_ID = "DeviceID";
+	public static final String TEST_TYPE = "TestType";
+	public static final String TEST_CONDITION = "TestCondition";
+	public static final String TEST_VALUE_ALTITUDE = "TestValueAltitude";
+	public static final String TEST_VALUE_DEGREES = "TestValueDegrees";
+	public static final String TEST_VALUE_PRESSURE = "TestValuePressure";
+	public static final String TEST_VALUE_MACH = "TestValueMach";
+	public static final String TEST_VALUE_TIME = "TestValueTime";
+	public static final String TEST_VALUE_Q = "TestValueQ";
+    public static final String STAGE_1_ENGINES = "Stage1Engines";
+    public static final String STAGE_2_ENGINES = "Stage2Engines";
+    public static final String STAGE_3_ENGINES = "Stage3Engines";
+
     /**
      * Length conversion. RockSim is in millimeters, OpenRocket in meters.
      */

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/AbstractTransitionDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/AbstractTransitionDTO.java
@@ -12,6 +12,7 @@ import info.openrocket.core.rocketcomponent.InnerTube;
 import info.openrocket.core.rocketcomponent.MassObject;
 import info.openrocket.core.rocketcomponent.Parachute;
 import info.openrocket.core.rocketcomponent.RocketComponent;
+import info.openrocket.core.rocketcomponent.Streamer;
 import info.openrocket.core.rocketcomponent.Transition;
 import info.openrocket.core.rocketcomponent.TubeCoupler;
 
@@ -65,6 +66,16 @@ public class AbstractTransitionDTO extends BasePartDTO implements AttachablePart
      * @param nc the OpenRocket component to convert
      */
     protected AbstractTransitionDTO(Transition nc) {
+        this(nc, null);
+    }
+
+    /**
+     * Conversion constructor used while exporting a complete document.
+     *
+     * @param nc      the OpenRocket component to convert
+     * @param context per-export motor-mount mapping state
+     */
+    protected AbstractTransitionDTO(Transition nc, RockSimExportContext context) {
         super(nc);
         setConstructionType(nc.isFilled() ? 0 : 1);
         setShapeCode(RockSimNoseConeCode.toCode(nc.getShapeType()));
@@ -78,31 +89,37 @@ public class AbstractTransitionDTO extends BasePartDTO implements AttachablePart
         setWallThickness(nc.getThickness() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 
         List<RocketComponent> children = nc.getChildren();
-		for (RocketComponent rocketComponents : children) {
-			if (rocketComponents instanceof InnerTube) {
-				addAttachedPart(new InnerBodyTubeDTO((InnerTube) rocketComponents, this));
-			} else if (rocketComponents instanceof BodyTube) {
-				addAttachedPart(new BodyTubeDTO((BodyTube) rocketComponents));
-			} else if (rocketComponents instanceof Transition) {
-				addAttachedPart(new TransitionDTO((Transition) rocketComponents));
-			} else if (rocketComponents instanceof EngineBlock) {
-				addAttachedPart(new EngineBlockDTO((EngineBlock) rocketComponents));
-			} else if (rocketComponents instanceof TubeCoupler) {
-				addAttachedPart(new TubeCouplerDTO((TubeCoupler) rocketComponents, this));
-			} else if (rocketComponents instanceof CenteringRing) {
-				addAttachedPart(new CenteringRingDTO((CenteringRing) rocketComponents));
-			} else if (rocketComponents instanceof Bulkhead) {
-				addAttachedPart(new BulkheadDTO((Bulkhead) rocketComponents));
-			} else if (rocketComponents instanceof Parachute) {
-				addAttachedPart(new ParachuteDTO((Parachute) rocketComponents));
-			} else if (rocketComponents instanceof MassObject) {
-				addAttachedPart(new MassObjectDTO((MassObject) rocketComponents));
-			} else if (rocketComponents instanceof FreeformFinSet) {
-				addAttachedPart(new CustomFinSetDTO((FreeformFinSet) rocketComponents));
-			} else if (rocketComponents instanceof FinSet) {
-				addAttachedPart(new FinSetDTO((FinSet) rocketComponents));
-			}
-		}
+        for (RocketComponent rocketComponents : children) {
+            if (rocketComponents instanceof InnerTube) {
+                InnerTube innerTube = (InnerTube) rocketComponents;
+                InnerBodyTubeDTO innerBodyTubeDTO = new InnerBodyTubeDTO(innerTube, this, context);
+                if (innerTube.getInstanceCount() == 1) {
+                    addAttachedPart(innerBodyTubeDTO);
+                }
+            } else if (rocketComponents instanceof BodyTube) {
+                addAttachedPart(new BodyTubeDTO((BodyTube) rocketComponents, context));
+            } else if (rocketComponents instanceof Transition) {
+                addAttachedPart(new TransitionDTO((Transition) rocketComponents, context));
+            } else if (rocketComponents instanceof EngineBlock) {
+                addAttachedPart(new EngineBlockDTO((EngineBlock) rocketComponents));
+            } else if (rocketComponents instanceof TubeCoupler) {
+                addAttachedPart(new TubeCouplerDTO((TubeCoupler) rocketComponents, this, context));
+            } else if (rocketComponents instanceof CenteringRing) {
+                addAttachedPart(new CenteringRingDTO((CenteringRing) rocketComponents));
+            } else if (rocketComponents instanceof Bulkhead) {
+                addAttachedPart(new BulkheadDTO((Bulkhead) rocketComponents));
+            } else if (rocketComponents instanceof Parachute) {
+                addAttachedPart(new ParachuteDTO((Parachute) rocketComponents, context));
+			} else if (rocketComponents instanceof Streamer) {
+				addAttachedPart(new StreamerDTO((Streamer) rocketComponents, context));
+            } else if (rocketComponents instanceof MassObject) {
+                addAttachedPart(new MassObjectDTO((MassObject) rocketComponents));
+            } else if (rocketComponents instanceof FreeformFinSet) {
+                addAttachedPart(new CustomFinSetDTO((FreeformFinSet) rocketComponents));
+            } else if (rocketComponents instanceof FinSet) {
+                addAttachedPart(new FinSetDTO((FinSet) rocketComponents));
+            }
+        }
     }
 
     public int getShapeCode() {

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/BasePartDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/BasePartDTO.java
@@ -378,6 +378,16 @@ public abstract class BasePartDTO {
         color = theColor;
     }
 
+    /**
+     * Return the serial number used to reference this component elsewhere in a
+     * RockSim file.
+     *
+     * @return the RockSim component serial number
+     */
+    public int getSerialNumber() {
+        return serialNumber;
+    }
+
     public static int getCurrentSerialNumber() {
         return currentSerialNumber - 1;
     }
@@ -386,7 +396,8 @@ public abstract class BasePartDTO {
      * Reset the serial number, which needs to happen after each file save.
      */
     public static void resetCurrentSerialNumber() {
-        currentSerialNumber = 0;
+        // Zero means "no associated component" in RockSim references.
+        currentSerialNumber = 1;
     }
 
     private static String formatRgb(ORColor color) {

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/BodyTubeDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/BodyTubeDTO.java
@@ -76,6 +76,16 @@ public class BodyTubeDTO extends BasePartDTO implements AttachableParts {
      * @param theORInnerTube an OR inner tube; used by subclasses
      */
     protected BodyTubeDTO(InnerTube theORInnerTube) {
+        this(theORInnerTube, null);
+    }
+
+    /**
+     * Copy constructor used while exporting a complete document.
+     *
+     * @param theORInnerTube an OR inner tube; used by subclasses
+     * @param context        per-export motor-mount mapping state
+     */
+    protected BodyTubeDTO(InnerTube theORInnerTube, RockSimExportContext context) {
         super(theORInnerTube);
     }
 
@@ -85,6 +95,16 @@ public class BodyTubeDTO extends BasePartDTO implements AttachableParts {
      * @param theORBodyTube an OR body tube
      */
     protected BodyTubeDTO(BodyTube theORBodyTube) {
+        this(theORBodyTube, null);
+    }
+
+    /**
+     * Copy constructor used while exporting a complete document.
+     *
+     * @param theORBodyTube an OR body tube
+     * @param context       per-export motor-mount mapping state
+     */
+    protected BodyTubeDTO(BodyTube theORBodyTube, RockSimExportContext context) {
         super(theORBodyTube);
 
         setEngineOverhang(theORBodyTube.getMotorOverhang() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
@@ -93,23 +113,27 @@ public class BodyTubeDTO extends BasePartDTO implements AttachableParts {
         setMotorDia((theORBodyTube.getMotorMountDiameter() / 2) * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
         setMotorMount(theORBodyTube.isMotorMount());
 
+        if (context != null && theORBodyTube.isMotorMount()) {
+            context.registerMotorMount(theORBodyTube, getSerialNumber());
+        }
+
         List<RocketComponent> children = theORBodyTube.getChildren();
 		for (RocketComponent rocketComponent : children) {
 			if (rocketComponent instanceof InnerTube) {
 				final InnerTube innerTube = (InnerTube) rocketComponent;
-				final InnerBodyTubeDTO innerBodyTubeDTO = new InnerBodyTubeDTO(innerTube, this);
+				final InnerBodyTubeDTO innerBodyTubeDTO = new InnerBodyTubeDTO(innerTube, this, context);
 				//Only add the inner tube if it is NOT a cluster.
 				if (innerTube.getInstanceCount() == 1) {
 					addAttachedPart(innerBodyTubeDTO);
 				}
 			} else if (rocketComponent instanceof BodyTube) {
-				addAttachedPart(new BodyTubeDTO((BodyTube) rocketComponent));
+				addAttachedPart(new BodyTubeDTO((BodyTube) rocketComponent, context));
 			} else if (rocketComponent instanceof Transition) {
-				addAttachedPart(new TransitionDTO((Transition) rocketComponent));
+				addAttachedPart(new TransitionDTO((Transition) rocketComponent, context));
 			} else if (rocketComponent instanceof EngineBlock) {
 				addAttachedPart(new EngineBlockDTO((EngineBlock) rocketComponent));
 			} else if (rocketComponent instanceof TubeCoupler) {
-				addAttachedPart(new TubeCouplerDTO((TubeCoupler) rocketComponent, this));
+				addAttachedPart(new TubeCouplerDTO((TubeCoupler) rocketComponent, this, context));
 			} else if (rocketComponent instanceof CenteringRing) {
 				addAttachedPart(new CenteringRingDTO((CenteringRing) rocketComponent));
 			} else if (rocketComponent instanceof Bulkhead) {
@@ -117,9 +141,9 @@ public class BodyTubeDTO extends BasePartDTO implements AttachableParts {
 			} else if (rocketComponent instanceof LaunchLug) {
 				addAttachedPart(new LaunchLugDTO((LaunchLug) rocketComponent));
 			} else if (rocketComponent instanceof Streamer) {
-				addAttachedPart(new StreamerDTO((Streamer) rocketComponent));
+				addAttachedPart(new StreamerDTO((Streamer) rocketComponent, context));
 			} else if (rocketComponent instanceof Parachute) {
-				addAttachedPart(new ParachuteDTO((Parachute) rocketComponent));
+				addAttachedPart(new ParachuteDTO((Parachute) rocketComponent, context));
 			} else if (rocketComponent instanceof MassObject) {
 				addAttachedPart(new MassObjectDTO((MassObject) rocketComponent));
 			} else if (rocketComponent instanceof FreeformFinSet) {
@@ -129,11 +153,12 @@ public class BodyTubeDTO extends BasePartDTO implements AttachableParts {
 			} else if (rocketComponent instanceof TubeFinSet) {
 				addAttachedPart(new TubeFinSetDTO((TubeFinSet) rocketComponent));
 			} else if (rocketComponent instanceof PodSet) {
-				for (PodSetDTO podSetDTO : PodSetDTO.generatePodSetDTOs((PodSet) rocketComponent)) {
+				for (PodSetDTO podSetDTO : PodSetDTO.generatePodSetDTOs((PodSet) rocketComponent, context)) {
 					addAttachedPart(podSetDTO);
 				}
 			} else if (rocketComponent instanceof ParallelStage) {
-				for (ParallelStageDTO parallelStageDTO : ParallelStageDTO.generateParallelStageDTOs((ParallelStage) rocketComponent)) {
+				for (ParallelStageDTO parallelStageDTO :
+						ParallelStageDTO.generateParallelStageDTOs((ParallelStage) rocketComponent, context)) {
 					addAttachedPart(parallelStageDTO);
 				}
 			}

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/EngineSetDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/EngineSetDTO.java
@@ -1,0 +1,148 @@
+package info.openrocket.core.file.rocksim.export;
+
+import info.openrocket.core.file.rocksim.RockSimCommonConstants;
+import info.openrocket.core.motor.Motor;
+import info.openrocket.core.motor.MotorConfiguration;
+import info.openrocket.core.motor.ThrustCurveMotor;
+
+import java.util.Locale;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+
+/**
+ * A motor installed in one physical RockSim motor mount.
+ * <p>
+ * RockSim requires clustered motors to be represented by repeated EngineSet
+ * entries, each with {@code EngineCount} equal to one and its own mount serial
+ * number.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+public class EngineSetDTO {
+
+	private static final double ROCKSIM_NO_EJECTION_CHARGE = -2.0;
+
+	@XmlElement(name = RockSimCommonConstants.ENGINE_COUNT)
+	private final int engineCount = 1;
+	@XmlElement(name = RockSimCommonConstants.ENGINE_CODE)
+	private String engineCode = "";
+	@XmlElement(name = RockSimCommonConstants.IGNITION_DELAY)
+	private double ignitionDelay;
+	@XmlElement(name = RockSimCommonConstants.ENGINE_MFG)
+	private String engineManufacturer = "";
+	@XmlElement(name = RockSimCommonConstants.ENGINE_OVERHANG)
+	private double engineOverhang;
+	@XmlElement(name = RockSimCommonConstants.CASING_CG)
+	private final double casingCG = 0.0;
+	@XmlElement(name = RockSimCommonConstants.MOUNT_SERIAL_NUMBER)
+	private int mountSerialNumber;
+	@XmlElement(name = RockSimCommonConstants.EJECTION_DELAY)
+	private double ejectionDelay;
+	@XmlElement(name = RockSimCommonConstants.ROTATE_X_ABOUT_Y)
+	private final double rotateXAboutY = 0.0;
+	@XmlElement(name = RockSimCommonConstants.ROTATE_ENGINE_AXIS_ABOUT_X)
+	private final double rotateEngineAxisAboutX = 0.0;
+
+	/**
+	 * Constructor required by JAXB.
+	 */
+	public EngineSetDTO() {
+	}
+
+	/**
+	 * Convert one OpenRocket motor configuration for one exported physical mount.
+	 *
+	 * @param motorConfiguration the configured OpenRocket motor
+	 * @param serialNumber       the exported RockSim mount serial number
+	 */
+	public EngineSetDTO(MotorConfiguration motorConfiguration, int serialNumber) {
+		this(motorConfiguration, serialNumber, motorConfiguration.getIgnitionDelay(),
+				motorConfiguration.getEjectionDelay());
+	}
+
+	/**
+	 * Convert one motor while applying RockSim-compatible staging timings.
+	 *
+	 * @param motorConfiguration the configured OpenRocket motor
+	 * @param serialNumber       the exported RockSim mount serial number
+	 * @param exportedIgnitionDelay delay after RockSim stage separation
+	 * @param exportedEjectionDelay delay used by RockSim for ejection/staging
+	 */
+	public EngineSetDTO(MotorConfiguration motorConfiguration, int serialNumber, double exportedIgnitionDelay,
+			double exportedEjectionDelay) {
+		Motor motor = motorConfiguration.getMotor();
+		String code = motor.getCode();
+		engineCode = code == null || code.isBlank() ? motor.getDesignation() : code;
+		ignitionDelay = exportedIgnitionDelay;
+		engineOverhang = motorConfiguration.getMount().getMotorOverhang()
+				* RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
+		mountSerialNumber = serialNumber;
+
+		if (exportedEjectionDelay == Motor.PLUGGED_DELAY) {
+			ejectionDelay = ROCKSIM_NO_EJECTION_CHARGE;
+		} else {
+			ejectionDelay = exportedEjectionDelay;
+		}
+
+		if (motor instanceof ThrustCurveMotor) {
+			ThrustCurveMotor thrustCurveMotor = (ThrustCurveMotor) motor;
+			// The display name is generally the canonical vendor name expected by
+			// RockSim's engine database (for example, "Cesaroni Technology Inc.").
+			engineManufacturer = thrustCurveMotor.getManufacturer().getDisplayName();
+		}
+	}
+
+	public int getEngineCount() {
+		return engineCount;
+	}
+
+	public String getEngineCode() {
+		return engineCode;
+	}
+
+	public double getIgnitionDelay() {
+		return ignitionDelay;
+	}
+
+	public String getEngineManufacturer() {
+		return engineManufacturer;
+	}
+
+	public double getEngineOverhang() {
+		return engineOverhang;
+	}
+
+	public int getMountSerialNumber() {
+		return mountSerialNumber;
+	}
+
+	public double getEjectionDelay() {
+		return ejectionDelay;
+	}
+
+	/**
+	 * Format this motor as RockSim displays it in the simulation list.
+	 *
+	 * @return the motor code, ejection delay, and optional ignition delay
+	 */
+	public String getDisplayName() {
+		StringBuilder result = new StringBuilder(engineCode);
+		if (ejectionDelay == ROCKSIM_NO_EJECTION_CHARGE) {
+			result.append("-Plugged");
+		} else {
+			result.append('-').append(formatNumber(ejectionDelay));
+		}
+		if (ignitionDelay > 0.0) {
+			result.append('-').append(String.format(Locale.ROOT, "%.2f", ignitionDelay));
+		}
+		return result.toString();
+	}
+
+	private static String formatNumber(double value) {
+		if (value == Math.rint(value)) {
+			return Long.toString((long) value);
+		}
+		return Double.toString(value);
+	}
+}

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/InnerBodyTubeDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/InnerBodyTubeDTO.java
@@ -47,7 +47,18 @@ public class InnerBodyTubeDTO extends BodyTubeDTO implements AttachableParts {
 	 *               individual instances for each cluster member will be added.
 	 */
 	public InnerBodyTubeDTO(InnerTube bt, AttachableParts parent) {
-		super(bt);
+		this(bt, parent, null);
+	}
+
+	/**
+	 * Full copy constructor used while exporting a complete document.
+	 *
+	 * @param bt      the corresponding OR inner body tube
+	 * @param parent  the RockSim attached-parts container
+	 * @param context per-export motor-mount mapping state
+	 */
+	public InnerBodyTubeDTO(InnerTube bt, AttachableParts parent, RockSimExportContext context) {
+		super(bt, context);
 		setEngineOverhang(bt.getMotorOverhang() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 		setID(bt.getInnerRadius() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
 		setOD(bt.getOuterRadius() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
@@ -57,46 +68,46 @@ public class InnerBodyTubeDTO extends BodyTubeDTO implements AttachableParts {
 		setRadialAngle(bt.getRadialDirection());
 		setRadialLoc(bt.getRadialPosition() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
 
+		// RockSim represents each cluster member as a separate tube.  Expand the
+		// cluster before converting children so no references are recorded for the
+		// temporary aggregate DTO that is discarded.
+		if (bt.getClusterConfiguration().getClusterCount() > 1) {
+			handleCluster(bt, parent, context);
+			parent.removeAttachedPart(this);
+			return;
+		}
+
 		List<RocketComponent> children = bt.getChildren();
 		for (RocketComponent rocketComponents : children) {
 			if (rocketComponents instanceof InnerTube) {
 				final InnerTube innerTube = (InnerTube) rocketComponents;
-				// Only if the inner tube is NOT a cluster, then create the corresponding
-				// Rocksim DTO and add it
-				// to the list of attached parts. If it is a cluster, then it is handled
-				// specially outside of this
-				// loop.
+				InnerBodyTubeDTO innerBodyTubeDTO = new InnerBodyTubeDTO(innerTube, this, context);
+				// Cluster members add themselves to this container while being split.
 				if (innerTube.getInstanceCount() == 1) {
-					addAttachedPart(new InnerBodyTubeDTO(innerTube, this));
+					addAttachedPart(innerBodyTubeDTO);
 				}
 			} else if (rocketComponents instanceof BodyTube) {
-				addAttachedPart(new BodyTubeDTO((BodyTube) rocketComponents));
+				addAttachedPart(new BodyTubeDTO((BodyTube) rocketComponents, context));
 			} else if (rocketComponents instanceof Transition) {
-				addAttachedPart(new TransitionDTO((Transition) rocketComponents));
+				addAttachedPart(new TransitionDTO((Transition) rocketComponents, context));
 			} else if (rocketComponents instanceof EngineBlock) {
 				addAttachedPart(new EngineBlockDTO((EngineBlock) rocketComponents));
 			} else if (rocketComponents instanceof TubeCoupler) {
-				addAttachedPart(new TubeCouplerDTO((TubeCoupler) rocketComponents));
+				addAttachedPart(new TubeCouplerDTO((TubeCoupler) rocketComponents, this, context));
 			} else if (rocketComponents instanceof CenteringRing) {
 				addAttachedPart(new CenteringRingDTO((CenteringRing) rocketComponents));
 			} else if (rocketComponents instanceof Bulkhead) {
 				addAttachedPart(new BulkheadDTO((Bulkhead) rocketComponents));
 			} else if (rocketComponents instanceof Streamer) {
-				addAttachedPart(new StreamerDTO((Streamer) rocketComponents));
+				addAttachedPart(new StreamerDTO((Streamer) rocketComponents, context));
 			} else if (rocketComponents instanceof Parachute) {
-				addAttachedPart(new ParachuteDTO((Parachute) rocketComponents));
+				addAttachedPart(new ParachuteDTO((Parachute) rocketComponents, context));
 			} else if (rocketComponents instanceof MassObject) {
 				addAttachedPart(new MassObjectDTO((MassObject) rocketComponents));
 			}
 		}
-		// Do the cluster. For now this splits the cluster into separate tubes, which is
-		// how Rocksim represents it.
-		// The import (from Rocksim to OR) could be augmented to be more intelligent and
-		// try to determine if the
-		// co-located tubes are a cluster.
-		if (bt.getClusterConfiguration().getClusterCount() > 1) {
-			handleCluster(bt, parent);
-			parent.removeAttachedPart(this);
+		if (context != null && bt.isMotorMount()) {
+			context.registerMotorMount(bt, getSerialNumber());
 		}
 	}
 
@@ -109,7 +120,7 @@ public class InnerBodyTubeDTO extends BodyTubeDTO implements AttachableParts {
 	 * @param p  the collection (parent's attached parts really) to which all
 	 *           cluster tubes will be added
 	 */
-	private void handleCluster(InnerTube it, AttachableParts p) {
+	private void handleCluster(InnerTube it, AttachableParts p, RockSimExportContext context) {
 
 		// old version - Oct, 19 2015
 		// Coordinate[] coords = { Coordinate.NUL };
@@ -121,7 +132,10 @@ public class InnerBodyTubeDTO extends BodyTubeDTO implements AttachableParts {
 		for (int x = 0; x < coords.length; x++) {
 			InnerTube partialClone = InnerTube.makeIndividualClusterComponent(coords[x], it.getName() + " #" + (x + 1),
 					it);
-			p.addAttachedPart(new InnerBodyTubeDTO(partialClone, p));
+			if (context != null) {
+				context.registerSplitComponentTree(it, partialClone);
+			}
+			p.addAttachedPart(new InnerBodyTubeDTO(partialClone, p, context));
 		}
 	}
 

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/NoseConeDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/NoseConeDTO.java
@@ -35,7 +35,17 @@ public class NoseConeDTO extends AbstractTransitionDTO {
      * @param nc the OR nose cone
      */
     public NoseConeDTO(NoseCone nc) {
-        super(nc);
+        this(nc, null);
+    }
+
+    /**
+     * Full copy constructor used while exporting a complete document.
+     *
+     * @param nc      the OR nose cone
+     * @param context per-export motor-mount mapping state
+     */
+    public NoseConeDTO(NoseCone nc, RockSimExportContext context) {
+        super(nc, context);
         setBaseDia(nc.getAftRadius() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
         setShoulderLen(nc.getAftShoulderLength() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
         setShoulderOD(nc.getAftShoulderRadius() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/ParachuteDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/ParachuteDTO.java
@@ -45,7 +45,20 @@ public class ParachuteDTO extends BasePartDTO {
      * @param theORParachute the OR Parachute instance
      */
     public ParachuteDTO(Parachute theORParachute) {
+		this(theORParachute, null);
+	}
+
+	/**
+	 * Copy constructor used while exporting simulations with deployment events.
+	 *
+	 * @param theORParachute the OR Parachute instance
+	 * @param context        per-export component serial mapping
+	 */
+	public ParachuteDTO(Parachute theORParachute, RockSimExportContext context) {
         super(theORParachute);
+		if (context != null) {
+			context.registerRecoveryDevice(theORParachute, getSerialNumber());
+		}
 
         setChuteCount(1);
         setDia(theORParachute.getDiameter() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/ParallelStageDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/ParallelStageDTO.java
@@ -18,7 +18,17 @@ public class ParallelStageDTO extends PodSetDTO {
 	 * @param theORParallelStage the single-instance OR ParallelStage
 	 */
 	protected ParallelStageDTO(ParallelStage theORParallelStage) {
-		super(theORParallelStage);
+		this(theORParallelStage, null);
+	}
+
+	/**
+	 * Copy constructor used while exporting a complete document.
+	 *
+	 * @param theORParallelStage the single-instance OR ParallelStage
+	 * @param context            per-export motor-mount mapping state
+	 */
+	protected ParallelStageDTO(ParallelStage theORParallelStage, RockSimExportContext context) {
+		super(theORParallelStage, context);
 		setDetachable(1);
 		setEjected(0);
 	}
@@ -30,10 +40,26 @@ public class ParallelStageDTO extends PodSetDTO {
 	 * @return the set of ParallelStageDTOs
 	 */
 	public static ParallelStageDTO[] generateParallelStageDTOs(ParallelStage theORParallelStage) {
+		return generateParallelStageDTOs(theORParallelStage, null);
+	}
+
+	/**
+	 * Generate physical RockSim parallel stages while retaining links to their
+	 * source components for motor-mount references.
+	 *
+	 * @param theORParallelStage the OR ParallelStage
+	 * @param context            per-export motor-mount mapping state
+	 * @return the set of ParallelStageDTOs
+	 */
+	public static ParallelStageDTO[] generateParallelStageDTOs(ParallelStage theORParallelStage,
+			RockSimExportContext context) {
 		ParallelStageDTO[] set = new ParallelStageDTO[theORParallelStage.getInstanceCount()];
 		int i = 0;
 		for (RocketComponent stageInstance : theORParallelStage.splitInstances(false)) {
-			set[i] = new ParallelStageDTO((ParallelStage) stageInstance);
+			if (context != null) {
+				context.registerSplitComponentTree(theORParallelStage, stageInstance);
+			}
+			set[i] = new ParallelStageDTO((ParallelStage) stageInstance, context);
 			i++;
 		}
 		return set;

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/PodSetDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/PodSetDTO.java
@@ -54,10 +54,25 @@ public class PodSetDTO extends BasePartDTO implements AttachableParts {
      * @return the set of PodSetDTOs
      */
     public static PodSetDTO[] generatePodSetDTOs(ComponentAssembly theORPodSet) {
+        return generatePodSetDTOs(theORPodSet, null);
+    }
+
+    /**
+     * Generate physical RockSim pods while retaining links to their source
+     * components for motor-mount references.
+     *
+     * @param theORPodSet the OR PodSet
+     * @param context     per-export motor-mount mapping state
+     * @return the set of PodSetDTOs
+     */
+    public static PodSetDTO[] generatePodSetDTOs(ComponentAssembly theORPodSet, RockSimExportContext context) {
         PodSetDTO[] set = new PodSetDTO[theORPodSet.getInstanceCount()];
         int i = 0;
         for (RocketComponent podInstance : theORPodSet.splitInstances()) {
-            set[i] = new PodSetDTO((PodSet) podInstance);
+            if (context != null) {
+                context.registerSplitComponentTree(theORPodSet, podInstance);
+            }
+            set[i] = new PodSetDTO((PodSet) podInstance, context);
             i++;
         }
         return set;
@@ -69,6 +84,16 @@ public class PodSetDTO extends BasePartDTO implements AttachableParts {
      * @param theORPodSet the single-instance OR PodSet
      */
     protected PodSetDTO(ComponentAssembly theORPodSet) {
+        this(theORPodSet, null);
+    }
+
+    /**
+     * Copy constructor used while exporting a complete document.
+     *
+     * @param theORPodSet the single-instance OR PodSet
+     * @param context     per-export motor-mount mapping state
+     */
+    protected PodSetDTO(ComponentAssembly theORPodSet, RockSimExportContext context) {
         super(theORPodSet);
         // OR should always override the radial angle and distance
         setAutoCalcRadialDistance(false);
@@ -88,15 +113,15 @@ public class PodSetDTO extends BasePartDTO implements AttachableParts {
 
         for (RocketComponent child : theORPodSet.getChildren()) {
             if (child instanceof BodyTube) {
-                addAttachedPart(new BodyTubeDTO((BodyTube) child));
+                addAttachedPart(new BodyTubeDTO((BodyTube) child, context));
             } else if (child instanceof NoseCone) {
                 if (((NoseCone) child).isFlipped()) {
-                    addAttachedPart(new TransitionDTO((NoseCone) child));
+                    addAttachedPart(new TransitionDTO((NoseCone) child, context));
                 } else {
-                    addAttachedPart(new NoseConeDTO((NoseCone) child));
+                    addAttachedPart(new NoseConeDTO((NoseCone) child, context));
                 }
             } else if (child instanceof Transition) {
-                addAttachedPart(new TransitionDTO((Transition) child));
+                addAttachedPart(new TransitionDTO((Transition) child, context));
             }
         }
     }

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/RockSimDocumentDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/RockSimDocumentDTO.java
@@ -20,6 +20,9 @@ public class RockSimDocumentDTO {
     @XmlElement(name = RockSimCommonConstants.DESIGN_INFORMATION)
     private RockSimDesignDTO design;
 
+    @XmlElement(name = RockSimCommonConstants.SIMULATION_RESULTS_LIST)
+    private SimulationResultsListDTO simulationResultsList;
+
     /**
      * Constructor.
      */
@@ -42,6 +45,24 @@ public class RockSimDocumentDTO {
      */
     public void setDesign(RockSimDesignDTO theDesign) {
         this.design = theDesign;
+    }
+
+    /**
+     * Return the simulations and their motor configurations.
+     *
+     * @return the RockSim simulation list
+     */
+    public SimulationResultsListDTO getSimulationResultsList() {
+        return simulationResultsList;
+    }
+
+    /**
+     * Set the simulations and their motor configurations.
+     *
+     * @param theSimulationResultsList the RockSim simulation list
+     */
+    public void setSimulationResultsList(SimulationResultsListDTO theSimulationResultsList) {
+        simulationResultsList = theSimulationResultsList;
     }
 
     /**

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/RockSimExportContext.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/RockSimExportContext.java
@@ -1,0 +1,100 @@
+package info.openrocket.core.file.rocksim.export;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import info.openrocket.core.rocketcomponent.MotorMount;
+import info.openrocket.core.rocketcomponent.RocketComponent;
+
+/**
+ * Holds per-export state that links OpenRocket motor mounts to the serial
+ * numbers assigned to their physical RockSim components.
+ * <p>
+ * RockSim represents each member of a cluster or component assembly as a
+ * separate component.  Consequently, one OpenRocket motor mount can map to
+ * several RockSim serial numbers.
+ */
+final class RockSimExportContext {
+
+	private final Map<UUID, UUID> sourceComponentIds = new HashMap<>();
+	private final Map<UUID, List<Integer>> motorMountSerialNumbers = new HashMap<>();
+	private final Map<UUID, List<Integer>> recoveryDeviceSerialNumbers = new HashMap<>();
+
+	/**
+	 * Record a physical motor mount emitted by the component exporter.
+	 *
+	 * @param mount        the component used to create the exported mount
+	 * @param serialNumber the RockSim component serial number
+	 */
+	void registerMotorMount(MotorMount mount, int serialNumber) {
+		RocketComponent component = (RocketComponent) mount;
+		UUID sourceId = resolveSourceComponentId(component.getID());
+		motorMountSerialNumbers.computeIfAbsent(sourceId, ignored -> new ArrayList<>()).add(serialNumber);
+	}
+
+	/**
+	 * Return every physical RockSim mount created for an OpenRocket mount.
+	 *
+	 * @param mount the original OpenRocket motor mount
+	 * @return an immutable, serial-number-ordered list
+	 */
+	List<Integer> getMotorMountSerialNumbers(MotorMount mount) {
+		RocketComponent component = (RocketComponent) mount;
+		List<Integer> serialNumbers = motorMountSerialNumbers.get(component.getID());
+		if (serialNumbers == null) {
+			return Collections.emptyList();
+		}
+		return List.copyOf(serialNumbers);
+	}
+
+	/**
+	 * Record a physical recovery device emitted by the component exporter.
+	 *
+	 * @param component    the recovery device used to create the DTO
+	 * @param serialNumber the RockSim component serial number
+	 */
+	void registerRecoveryDevice(RocketComponent component, int serialNumber) {
+		UUID sourceId = resolveSourceComponentId(component.getID());
+		recoveryDeviceSerialNumbers.computeIfAbsent(sourceId, ignored -> new ArrayList<>()).add(serialNumber);
+	}
+
+	/**
+	 * Return every physical RockSim component created for a recovery device.
+	 *
+	 * @param component the original OpenRocket recovery device
+	 * @return an immutable, serial-number-ordered list
+	 */
+	List<Integer> getRecoveryDeviceSerialNumbers(RocketComponent component) {
+		List<Integer> serialNumbers = recoveryDeviceSerialNumbers.get(component.getID());
+		if (serialNumbers == null) {
+			return Collections.emptyList();
+		}
+		return List.copyOf(serialNumbers);
+	}
+
+	/**
+	 * Associate a temporary split component tree with the source tree from which
+	 * it was copied.  The exporter uses this for clustered mounts, pods, and
+	 * parallel stages, all of which RockSim expands into physical components.
+	 *
+	 * @param source the source component tree
+	 * @param copy   the temporary split copy
+	 */
+	void registerSplitComponentTree(RocketComponent source, RocketComponent copy) {
+		sourceComponentIds.put(copy.getID(), resolveSourceComponentId(source.getID()));
+
+		int childCount = Math.min(source.getChildCount(), copy.getChildCount());
+		for (int i = 0; i < childCount; i++) {
+			registerSplitComponentTree(source.getChild(i), copy.getChild(i));
+		}
+	}
+
+	private UUID resolveSourceComponentId(UUID componentId) {
+		UUID sourceId = sourceComponentIds.get(componentId);
+		return sourceId == null ? componentId : sourceId;
+	}
+}

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/RockSimSaver.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/RockSimSaver.java
@@ -6,26 +6,28 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
-
-import info.openrocket.core.util.BugException;
-import info.openrocket.core.util.MemoryManagement;
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.Marshaller;
-
-import info.openrocket.core.logging.ErrorSet;
-import info.openrocket.core.logging.WarningSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.ArrayList;
+import java.util.List;
 
 import info.openrocket.core.document.OpenRocketDocument;
 import info.openrocket.core.document.StorageOptions;
 import info.openrocket.core.file.RocketSaver;
 import info.openrocket.core.file.rocksim.RockSimCommonConstants;
+import info.openrocket.core.logging.ErrorSet;
+import info.openrocket.core.logging.WarningSet;
 import info.openrocket.core.masscalc.MassCalculator;
 import info.openrocket.core.masscalc.RigidBody;
 import info.openrocket.core.rocketcomponent.AxialStage;
 import info.openrocket.core.rocketcomponent.FlightConfiguration;
 import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.rocketcomponent.RocketComponent;
+import info.openrocket.core.util.BugException;
+import info.openrocket.core.util.MemoryManagement;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Marshaller;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class is responsible for converting an OpenRocket design to a Rocksim design.
@@ -95,28 +97,40 @@ public class RockSimSaver extends RocketSaver {
 	 * @return a corresponding Rocksim representation
 	 */
 	private RockSimDocumentDTO toRockSimDocumentDTO(OpenRocketDocument doc) {
-		RockSimDocumentDTO rsd = new RockSimDocumentDTO();
-
-		rsd.setDesign(toRockSimDesignDTO(doc.getRocket()));
-
-		return rsd;
+		Rocket exportRocket = doc.getRocket().copyWithOriginalID();
+		// Component serials are references shared by the design, motors, and
+		// deployment events.  Serialize their allocation so separate exports cannot
+		// interleave the static sequence used by the existing DTO hierarchy.
+		synchronized (BasePartDTO.class) {
+			BasePartDTO.resetCurrentSerialNumber();
+			try {
+				RockSimDocumentDTO result = new RockSimDocumentDTO();
+				RockSimExportContext context = new RockSimExportContext();
+				result.setDesign(toRockSimDesignDTO(exportRocket, context));
+				result.setSimulationResultsList(new SimulationResultsListDTO(doc, context));
+				return result;
+			} finally {
+				BasePartDTO.resetCurrentSerialNumber();
+				MemoryManagement.collectable(exportRocket);
+			}
+		}
 	}
 
-	private RockSimDesignDTO toRockSimDesignDTO(Rocket rocket) {
+	private RockSimDesignDTO toRockSimDesignDTO(Rocket rocket, RockSimExportContext context) {
 		RockSimDesignDTO result = new RockSimDesignDTO();
-		result.setDesign(toRocketDesignDTO(rocket));
+		result.setDesign(toRocketDesignDTO(rocket, context));
 		return result;
 	}
 
-	private RocketDesignDTO toRocketDesignDTO(Rocket rocket) {
-		rocket = rocket.copyWithOriginalID();		// Make sure we don't change the original design.
+	private RocketDesignDTO toRocketDesignDTO(Rocket rocket, RockSimExportContext context) {
 		RocketDesignDTO result = new RocketDesignDTO();
+		List<AxialStage> axialStages = getAxialStages(rocket);
 
 		final FlightConfiguration configuration = rocket.getEmptyConfiguration();
 		final RigidBody spentData = MassCalculator.calculateStructure(configuration);
 		final double cg = spentData.cm.getX() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
 
-		int stageCount = rocket.getChildCount();
+		int stageCount = axialStages.size();
 		if (stageCount == 3) {
 			result.setStage321CG(cg);
 		} else if (stageCount == 2) {
@@ -128,26 +142,33 @@ public class RockSimSaver extends RocketSaver {
 		result.setName(rocket.getName());
 		result.setStageCount(stageCount);
 		if (stageCount > 0) {
-			result.setStage3(toStageDTO(rocket.getChild(0).getStage(), result, 3));
+			result.setStage3(toStageDTO(axialStages.get(0), result, 3, context));
 		}
 		if (stageCount > 1) {
-			result.setStage2(toStageDTO(rocket.getChild(1).getStage(), result, 2));
+			result.setStage2(toStageDTO(axialStages.get(1), result, 2, context));
 		}
 		if (stageCount > 2) {
-			result.setStage1(toStageDTO(rocket.getChild(2).getStage(), result, 1));
+			result.setStage1(toStageDTO(axialStages.get(2), result, 1, context));
 		}
-		// Set the last serial number element and reset it.
+		// Record the final component serial number in the RockSim design.
 		result.setLastSerialNumber(BasePartDTO.getCurrentSerialNumber());
-		BasePartDTO.resetCurrentSerialNumber();
-
-		// Clean up
-		MemoryManagement.collectable(rocket);
 
 		return result;
 	}
 
-	private StageDTO toStageDTO(AxialStage stage, RocketDesignDTO designDTO, int stageNumber) {
-		return new StageDTO(stage, designDTO, stageNumber);
+	private List<AxialStage> getAxialStages(Rocket rocket) {
+		List<AxialStage> stages = new ArrayList<>();
+		for (RocketComponent child : rocket.getChildren()) {
+			if (child instanceof AxialStage) {
+				stages.add((AxialStage) child);
+			}
+		}
+		return stages;
+	}
+
+	private StageDTO toStageDTO(AxialStage stage, RocketDesignDTO designDTO, int stageNumber,
+			RockSimExportContext context) {
+		return new StageDTO(stage, designDTO, stageNumber, context);
 	}
 
 }

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/SimulationEventDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/SimulationEventDTO.java
@@ -1,0 +1,128 @@
+package info.openrocket.core.file.rocksim.export;
+
+import info.openrocket.core.file.rocksim.RockSimCommonConstants;
+import info.openrocket.core.rocketcomponent.DeploymentConfiguration;
+import info.openrocket.core.rocketcomponent.DeploymentConfiguration.DeployEvent;
+import info.openrocket.core.rocketcomponent.RecoveryDevice;
+import info.openrocket.core.rocketcomponent.Streamer;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+
+/**
+ * A RockSim recovery-device deployment event.
+ * <p>
+ * RockSim misspells {@code DeplyTime} in its file format; that spelling must be
+ * retained for compatibility.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+public class SimulationEventDTO {
+
+	private static final int NO_EVENT = 0;
+	private static final int AT_MAX_EJECTION = 1;
+	private static final int AT_TIME_AFTER_IGNITION = 2;
+	private static final int AT_TIME_AFTER_APOGEE = 3;
+	private static final int AT_APOGEE = 4;
+	private static final int AT_ALTITUDE = 5;
+	private static final int PARACHUTE_DEVICE = 128;
+	private static final int STREAMER_DEVICE = 256;
+	private static final String UNUSED_TEST_VALUES = "0,0,0";
+	private static final String STANDARD_TEST_TYPES = "28,28,28";
+
+	@XmlElement(name = RockSimCommonConstants.PART_SERIAL_NUMBER)
+	private int partSerialNumber;
+	@XmlElement(name = RockSimCommonConstants.EVENT_TYPE)
+	private int type;
+	@XmlElement(name = RockSimCommonConstants.DEPLOY_ALTITUDE)
+	private double deployAltitude;
+	@XmlElement(name = RockSimCommonConstants.DEPLY_TIME)
+	private double deployTime;
+	@XmlElement(name = RockSimCommonConstants.HAS_DEPLOYED)
+	private final int hasDeployed = 0;
+	@XmlElement(name = RockSimCommonConstants.DEPLOYED_AT_ALTITUDE)
+	private final double deployedAtAltitude = 0.0;
+	@XmlElement(name = RockSimCommonConstants.DEPLOYED_AT_VELOCITY)
+	private final double deployedAtVelocity = 0.0;
+	@XmlElement(name = RockSimCommonConstants.DEPLOYED_AT_RANGE)
+	private final double deployedAtRange = 0.0;
+	@XmlElement(name = RockSimCommonConstants.DEPLOYED_AT_TIME)
+	private final double deployedAtTime = 0.0;
+	@XmlElement(name = RockSimCommonConstants.DEVICE_ID)
+	private int deviceId;
+	@XmlElement(name = RockSimCommonConstants.TEST_TYPE)
+	private final String testType = STANDARD_TEST_TYPES;
+	@XmlElement(name = RockSimCommonConstants.TEST_CONDITION)
+	private final String testCondition = UNUSED_TEST_VALUES;
+	@XmlElement(name = RockSimCommonConstants.TEST_VALUE_ALTITUDE)
+	private final String testValueAltitude = UNUSED_TEST_VALUES;
+	@XmlElement(name = RockSimCommonConstants.TEST_VALUE_DEGREES)
+	private final String testValueDegrees = UNUSED_TEST_VALUES;
+	@XmlElement(name = RockSimCommonConstants.TEST_VALUE_PRESSURE)
+	private final String testValuePressure = UNUSED_TEST_VALUES;
+	@XmlElement(name = RockSimCommonConstants.TEST_VALUE_MACH)
+	private final String testValueMach = UNUSED_TEST_VALUES;
+	@XmlElement(name = RockSimCommonConstants.TEST_VALUE_TIME)
+	private final String testValueTime = UNUSED_TEST_VALUES;
+	@XmlElement(name = RockSimCommonConstants.TEST_VALUE_Q)
+	private final String testValueQ = UNUSED_TEST_VALUES;
+
+	/** Constructor required by JAXB. */
+	public SimulationEventDTO() {
+	}
+
+	/**
+	 * Convert an OpenRocket recovery-device configuration.
+	 *
+	 * @param device       the configured recovery device
+	 * @param configuration its configuration for this simulation
+	 * @param serialNumber  the exported component serial number
+	 */
+	public SimulationEventDTO(RecoveryDevice device, DeploymentConfiguration configuration, int serialNumber) {
+		partSerialNumber = serialNumber;
+		deviceId = device instanceof Streamer ? STREAMER_DEVICE : PARACHUTE_DEVICE;
+		type = toRockSimType(configuration.getDeployEvent(), configuration.getDeployDelay());
+		deployTime = configuration.getDeployDelay();
+		deployAltitude = configuration.getDeployAltitude();
+
+		if (configuration.getDeployEvent() == DeployEvent.EJECTION) {
+			// RockSim's max-ejection mode has no separate post-ejection delay.  Preserve
+			// the trigger; a nonzero OpenRocket delay cannot be represented exactly.
+			deployTime = 0.0;
+		}
+		if (configuration.getDeployEvent() != DeployEvent.ALTITUDE) {
+			deployAltitude = 0.0;
+		}
+	}
+
+	private static int toRockSimType(DeployEvent event, double delay) {
+		return switch (event) {
+			case NEVER -> NO_EVENT;
+			case EJECTION -> AT_MAX_EJECTION;
+			case LAUNCH -> AT_TIME_AFTER_IGNITION;
+			case APOGEE -> delay > 0.0 ? AT_TIME_AFTER_APOGEE : AT_APOGEE;
+			case ALTITUDE -> AT_ALTITUDE;
+			// RockSim Standard cannot trigger a sustainer device from lower-stage
+			// separation.  "Time after ignition" is measured from launch for that
+			// device, so using it here could deploy recovery while still ascending.
+			case LOWER_STAGE_SEPARATION -> NO_EVENT;
+		};
+	}
+
+	public int getPartSerialNumber() {
+		return partSerialNumber;
+	}
+
+	public int getType() {
+		return type;
+	}
+
+	public double getDeployAltitude() {
+		return deployAltitude;
+	}
+
+	public double getDeployTime() {
+		return deployTime;
+	}
+
+}

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/SimulationResultsDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/SimulationResultsDTO.java
@@ -1,0 +1,452 @@
+package info.openrocket.core.file.rocksim.export;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.StringJoiner;
+
+import info.openrocket.core.document.Simulation;
+import info.openrocket.core.file.rocksim.RockSimCommonConstants;
+import info.openrocket.core.models.wind.MultiLevelPinkNoiseWindModel;
+import info.openrocket.core.models.wind.MultiLevelPinkNoiseWindModel.LevelWindModel;
+import info.openrocket.core.models.wind.PinkNoiseWindModel;
+import info.openrocket.core.models.wind.WindModel.AltitudeReference;
+import info.openrocket.core.models.wind.WindModelType;
+import info.openrocket.core.motor.IgnitionEvent;
+import info.openrocket.core.motor.Motor;
+import info.openrocket.core.motor.MotorConfiguration;
+import info.openrocket.core.rocketcomponent.AxialStage;
+import info.openrocket.core.rocketcomponent.DeploymentConfiguration;
+import info.openrocket.core.rocketcomponent.FlightConfiguration;
+import info.openrocket.core.rocketcomponent.FlightConfigurationId;
+import info.openrocket.core.rocketcomponent.RecoveryDevice;
+import info.openrocket.core.rocketcomponent.RocketComponent;
+import info.openrocket.core.rocketcomponent.StageSeparationConfiguration;
+import info.openrocket.core.rocketcomponent.StageSeparationConfiguration.SeparationEvent;
+import info.openrocket.core.simulation.SimulationOptions;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElementWrapper;
+
+/**
+ * RockSim's combined simulation-input and simulation-results record.
+ * <p>
+ * OpenRocket exports the inputs that RockSim can recalculate: motor selections,
+ * launch conditions, and basic simulation controls.  Result fields are left at
+ * their unevaluated values because results produced by a different simulator
+ * should not be presented as RockSim results.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+public class SimulationResultsDTO {
+
+	private static final int ROCKSIM_CUSTOM_PRESET = 99;
+	private static final int ROCKSIM_NOT_SIMULATED = 5;
+	private static final int ROCKSIM_RUNGE_KUTTA = 1;
+	private static final int MAX_WIND_LEVELS = 25;
+	private static final double STANDARD_TEMPERATURE_OFFSET = 273.15;
+	private static final double PASCALS_PER_MMHG = 101325.0 / 760.0;
+
+	@XmlElement(name = RockSimCommonConstants.FINAL_STATE)
+	private final int finalState = ROCKSIM_NOT_SIMULATED;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_GUIDE_TYPE)
+	private final int launchGuideType = 0;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_GUIDE_LEN)
+	private double launchGuideLength;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_WIND_DIRECTION)
+	private final int launchWindDirection = 0;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_WIND_SPEED)
+	private final double launchWindSpeed = 0.0;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_DIRECTION)
+	private final int launchDirection = 0;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_ANGLE)
+	private double launchAngle;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_GUIDE_AZIMUTH)
+	private double launchGuideAzimuth;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_BAROMETER)
+	private double launchBarometer;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_LATITUDE)
+	private double launchLatitude;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_LONGITUDE)
+	private double launchLongitude;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_HUMIDITY)
+	private double launchHumidity;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_TEMPERATURE)
+	private double launchTemperature;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_ALTITUDE)
+	private double launchAltitude;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_LANDING_ALTITUDE)
+	private double launchLandingAltitude;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_WIND_PRESET)
+	private final int launchWindPreset = ROCKSIM_CUSTOM_PRESET;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_WIND_LOW_SPEED)
+	private double launchWindLowSpeed;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_WIND_HIGH_SPEED)
+	private double launchWindHighSpeed;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_WIND_TURBULENCE_PRESET)
+	private final int launchWindTurbulencePreset = ROCKSIM_CUSTOM_PRESET;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_USE_RANDOM_CONDITIONS)
+	private final int launchUseRandomConditions = 0;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_WIND_TABLE_SIZE)
+	private int launchWindTableSize;
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_WIND_ALT_TABLE)
+	private String launchWindAltitudeTable = zeroWindTable();
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_WIND_SPEED_TABLE)
+	private String launchWindSpeedTable = zeroWindTable();
+	@XmlElement(name = RockSimCommonConstants.LAUNCH_WIND_DIRECTION_TABLE)
+	private String launchWindDirectionTable = zeroWindTable();
+	@XmlElement(name = RockSimCommonConstants.CNA_MULTIPLIER)
+	private final double cnaMultiplier = 1.0;
+	@XmlElement(name = RockSimCommonConstants.CD_MULTIPLIER)
+	private final double cdMultiplier = 1.0;
+	@XmlElement(name = RockSimCommonConstants.CP_OFFSET)
+	private final double cpOffset = 0.0;
+	@XmlElement(name = RockSimCommonConstants.MAX_SIM_TIME)
+	private double maxSimulationTime;
+	@XmlElement(name = RockSimCommonConstants.SIMULATION_NAME)
+	private String simulationName = "";
+	@XmlElement(name = RockSimCommonConstants.COMMENTS)
+	private String comments = "";
+	@XmlElement(name = RockSimCommonConstants.CALC_RESOLUTION)
+	private final int calculateResolution = 1;
+	@XmlElement(name = RockSimCommonConstants.SIMULATION_TYPE)
+	private final int simulationType = ROCKSIM_RUNGE_KUTTA;
+	@XmlElement(name = RockSimCommonConstants.CALCULATION_FLAGS)
+	private final int calculationFlags = 1;
+	@XmlElementWrapper(name = RockSimCommonConstants.SIMULATION_EVENTS)
+	@XmlElement(name = RockSimCommonConstants.SIMULATION_EVENT)
+	private final List<SimulationEventDTO> simulationEvents = new ArrayList<>();
+
+	@XmlElementWrapper(name = RockSimCommonConstants.STAGE_1_ENGINES)
+	@XmlElement(name = RockSimCommonConstants.ENGINE_SET)
+	private final List<EngineSetDTO> stage1Engines = new ArrayList<>();
+	@XmlElementWrapper(name = RockSimCommonConstants.STAGE_2_ENGINES)
+	@XmlElement(name = RockSimCommonConstants.ENGINE_SET)
+	private final List<EngineSetDTO> stage2Engines = new ArrayList<>();
+	@XmlElementWrapper(name = RockSimCommonConstants.STAGE_3_ENGINES)
+	@XmlElement(name = RockSimCommonConstants.ENGINE_SET)
+	private final List<EngineSetDTO> stage3Engines = new ArrayList<>();
+
+	/**
+	 * Constructor required by JAXB.
+	 */
+	public SimulationResultsDTO() {
+	}
+
+	/**
+	 * Convert an OpenRocket simulation into inputs RockSim can recalculate.
+	 *
+	 * @param simulation the OpenRocket simulation
+	 * @param context    the component-to-mount-serial mapping for this export
+	 */
+	public SimulationResultsDTO(Simulation simulation, RockSimExportContext context) {
+		comments = simulation.getName();
+		copyLaunchConditions(simulation.getOptions());
+		copyMotors(simulation, context);
+		copyRecoveryEvents(simulation, context);
+		simulationName = formatMotorSummary();
+	}
+
+	private void copyLaunchConditions(SimulationOptions options) {
+		launchGuideLength = options.getLaunchRodLength() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH;
+		launchAngle = options.getLaunchRodAngle();
+		// RockSim-written RKT files store compass azimuths in degrees.
+		launchGuideAzimuth = Math.toDegrees(options.getLaunchRodDirection());
+		launchBarometer = options.getLaunchPressure() / PASCALS_PER_MMHG;
+		launchLatitude = options.getLaunchLatitude();
+		launchLongitude = options.getLaunchLongitude();
+		launchHumidity = options.getLaunchRelativeHumidity() * 100.0;
+		launchTemperature = options.getLaunchTemperature() - STANDARD_TEMPERATURE_OFFSET;
+		launchAltitude = options.getLaunchAltitude();
+		launchLandingAltitude = options.getLaunchAltitude();
+		maxSimulationTime = options.getMaxSimulationTime();
+
+		if (options.getWindModelType() == WindModelType.MULTI_LEVEL) {
+			copyMultiLevelWind(options);
+		} else {
+			copyAverageWind(options.getAverageWindModel());
+		}
+	}
+
+	private void copyAverageWind(PinkNoiseWindModel windModel) {
+		// RockSim's fixed custom-wind range preserves the OpenRocket mean.  The two
+		// applications do not expose equivalent pink-noise turbulence parameters.
+		launchWindLowSpeed = windModel.getAverage();
+		launchWindHighSpeed = windModel.getAverage();
+	}
+
+	private void copyMultiLevelWind(SimulationOptions options) {
+		MultiLevelPinkNoiseWindModel windModel = options.getMultiLevelWindModel();
+		List<LevelWindModel> levels = windModel.getLevels();
+		launchWindTableSize = Math.min(levels.size(), MAX_WIND_LEVELS);
+
+		if (!levels.isEmpty()) {
+			launchWindLowSpeed = levels.get(0).getSpeed();
+			launchWindHighSpeed = levels.get(0).getSpeed();
+		}
+
+		double[] altitudes = new double[MAX_WIND_LEVELS];
+		double[] speeds = new double[MAX_WIND_LEVELS];
+		double[] directions = new double[MAX_WIND_LEVELS];
+		for (int i = 0; i < launchWindTableSize; i++) {
+			LevelWindModel level = levels.get(i);
+			double altitude = level.getAltitude();
+			if (windModel.getAltitudeReference() == AltitudeReference.AGL) {
+				// RockSim wind-table altitudes are above sea level (ASL).
+				altitude += options.getLaunchAltitude();
+			}
+			altitudes[i] = altitude;
+			speeds[i] = level.getSpeed();
+			// RockSim-written wind tables use compass degrees, despite older format
+			// documentation describing this value as radians.
+			directions[i] = Math.toDegrees(level.getDirection());
+		}
+
+		launchWindAltitudeTable = formatWindTable(altitudes);
+		launchWindSpeedTable = formatWindTable(speeds);
+		launchWindDirectionTable = formatWindTable(directions);
+	}
+
+	private void copyMotors(Simulation simulation, RockSimExportContext context) {
+		FlightConfiguration flightConfiguration = simulation.getActiveConfiguration();
+		for (MotorConfiguration motorConfiguration : flightConfiguration.getActiveMotors()) {
+			if (motorConfiguration.getIgnitionEvent() == IgnitionEvent.NEVER) {
+				// RockSim has no never-ignite flag.  Omitting the motor is safer than
+				// turning a deliberately disabled motor into an automatically staged one.
+				continue;
+			}
+			RocketComponent mount = (RocketComponent) motorConfiguration.getMount();
+			double ignitionDelay = getRockSimIgnitionDelay(motorConfiguration, simulation);
+			double ejectionDelay = getRockSimEjectionDelay(motorConfiguration, simulation);
+			for (int serialNumber : context.getMotorMountSerialNumbers(motorConfiguration.getMount())) {
+				EngineSetDTO engine = new EngineSetDTO(motorConfiguration, serialNumber, ignitionDelay, ejectionDelay);
+				switch (mount.getStage().getStageNumber()) {
+					case 0:
+						stage3Engines.add(engine);
+						break;
+					case 1:
+						stage2Engines.add(engine);
+						break;
+					case 2:
+						stage1Engines.add(engine);
+						break;
+					default:
+						// RockSim supports at most three axial stages.
+						break;
+				}
+			}
+		}
+
+		Comparator<EngineSetDTO> byMountSerial = Comparator.comparingInt(EngineSetDTO::getMountSerialNumber);
+		stage1Engines.sort(byMountSerial);
+		stage2Engines.sort(byMountSerial);
+		stage3Engines.sort(byMountSerial);
+	}
+
+	private double getRockSimEjectionDelay(MotorConfiguration motorConfiguration, Simulation simulation) {
+		RocketComponent mount = (RocketComponent) motorConfiguration.getMount();
+		AxialStage stage = mount.getStage();
+		if (stage.getUpperStage() == null) {
+			return motorConfiguration.getEjectionDelay();
+		}
+
+		StageSeparationConfiguration separation = stage.getSeparationConfigurations()
+				.get(simulation.getFlightConfigurationId());
+		SeparationEvent event = separation.getSeparationEvent();
+		if (event == SeparationEvent.NEVER) {
+			return Motor.PLUGGED_DELAY;
+		}
+		if (event == SeparationEvent.EJECTION) {
+			if (motorConfiguration.getEjectionDelay() == Motor.PLUGGED_DELAY) {
+				return Motor.PLUGGED_DELAY;
+			}
+			return motorConfiguration.getEjectionDelay() + separation.getSeparationDelay();
+		}
+		if (event == SeparationEvent.BURNOUT) {
+			// RockSim stages a booster when its ejection delay expires.  A zero
+			// ejection delay therefore reproduces burnout staging.
+			return separation.getSeparationDelay();
+		}
+		if (event == SeparationEvent.UPPER_IGNITION) {
+			// RockSim couples upper-stage ignition and separation.  The exported
+			// upper-stage ignition delay therefore also supplies the separation time.
+			return separation.getSeparationDelay();
+		}
+
+		// RockSim Standard cannot stage on altitude, apogee, launch, or ignition.
+		// Keep those stages attached instead of inventing a potentially unsafe time.
+		return Motor.PLUGGED_DELAY;
+	}
+
+	private double getRockSimIgnitionDelay(MotorConfiguration motorConfiguration, Simulation simulation) {
+		RocketComponent mount = (RocketComponent) motorConfiguration.getMount();
+		AxialStage stage = mount.getStage();
+		AxialStage lowerStage = getLowerActiveStage(stage, simulation.getActiveConfiguration());
+		if (lowerStage == null) {
+			return motorConfiguration.getIgnitionDelay();
+		}
+
+		StageSeparationConfiguration separation = lowerStage.getSeparationConfigurations()
+				.get(simulation.getFlightConfigurationId());
+		double separationDelay = separation.getSeparationDelay();
+		IgnitionEvent ignitionEvent = motorConfiguration.getIgnitionEvent();
+		if (separation.getSeparationEvent() == SeparationEvent.UPPER_IGNITION) {
+			return motorConfiguration.getIgnitionDelay();
+		}
+		if (ignitionEvent == IgnitionEvent.BURNOUT && separation.getSeparationEvent() == SeparationEvent.BURNOUT) {
+			return Math.max(0.0, motorConfiguration.getIgnitionDelay() - separationDelay);
+		}
+		if ((ignitionEvent == IgnitionEvent.EJECTION_CHARGE || ignitionEvent == IgnitionEvent.AUTOMATIC)
+				&& separation.getSeparationEvent() == SeparationEvent.EJECTION) {
+			return Math.max(0.0, motorConfiguration.getIgnitionDelay() - separationDelay);
+		}
+
+		// RockSim cannot ignite an upper-stage motor before the stage separates.
+		return 0.0;
+	}
+
+	private AxialStage getLowerActiveStage(AxialStage stage, FlightConfiguration configuration) {
+		AxialStage lowerStage = null;
+		for (AxialStage candidate : configuration.getActiveStages()) {
+			if (candidate.getStageNumber() > stage.getStageNumber()
+					&& (lowerStage == null || candidate.getStageNumber() < lowerStage.getStageNumber())) {
+				lowerStage = candidate;
+			}
+		}
+		return lowerStage;
+	}
+
+	private void copyRecoveryEvents(Simulation simulation, RockSimExportContext context) {
+		FlightConfigurationId configurationId = simulation.getFlightConfigurationId();
+		for (RocketComponent component : simulation.getRocket()) {
+			if (!(component instanceof RecoveryDevice)) {
+				continue;
+			}
+			RecoveryDevice device = (RecoveryDevice) component;
+			if (!simulation.getActiveConfiguration().isComponentActive(device)) {
+				continue;
+			}
+			DeploymentConfiguration configuration = device.getDeploymentConfigurations().get(configurationId);
+			for (int serialNumber : context.getRecoveryDeviceSerialNumbers(device)) {
+				simulationEvents.add(new SimulationEventDTO(device, configuration, serialNumber));
+			}
+		}
+	}
+
+	private String formatMotorSummary() {
+		StringBuilder result = new StringBuilder();
+		appendMotorGroup(result, stage1Engines);
+		appendMotorGroup(result, stage2Engines);
+		appendMotorGroup(result, stage3Engines);
+		return result.toString();
+	}
+
+	private void appendMotorGroup(StringBuilder result, List<EngineSetDTO> engines) {
+		if (engines.isEmpty()) {
+			return;
+		}
+
+		StringJoiner group = new StringJoiner(", ", "[", "] ");
+		for (EngineSetDTO engine : engines) {
+			group.add(engine.getDisplayName());
+		}
+		result.append(group);
+	}
+
+	private static String zeroWindTable() {
+		return formatWindTable(new double[MAX_WIND_LEVELS]);
+	}
+
+	private static String formatWindTable(double[] values) {
+		StringJoiner result = new StringJoiner(",");
+		for (double value : values) {
+			result.add(Double.toString(value));
+		}
+		return result.toString();
+	}
+
+	public String getSimulationName() {
+		return simulationName;
+	}
+
+	public String getComments() {
+		return comments;
+	}
+
+	public List<SimulationEventDTO> getSimulationEvents() {
+		return simulationEvents;
+	}
+
+	public double getLaunchGuideLength() {
+		return launchGuideLength;
+	}
+
+	public double getLaunchAngle() {
+		return launchAngle;
+	}
+
+	public double getLaunchGuideAzimuth() {
+		return launchGuideAzimuth;
+	}
+
+	public double getLaunchBarometer() {
+		return launchBarometer;
+	}
+
+	public double getLaunchLatitude() {
+		return launchLatitude;
+	}
+
+	public double getLaunchLongitude() {
+		return launchLongitude;
+	}
+
+	public double getLaunchHumidity() {
+		return launchHumidity;
+	}
+
+	public double getLaunchTemperature() {
+		return launchTemperature;
+	}
+
+	public double getLaunchAltitude() {
+		return launchAltitude;
+	}
+
+	public double getLaunchWindLowSpeed() {
+		return launchWindLowSpeed;
+	}
+
+	public double getLaunchWindHighSpeed() {
+		return launchWindHighSpeed;
+	}
+
+	public int getLaunchWindTableSize() {
+		return launchWindTableSize;
+	}
+
+	public String getLaunchWindAltitudeTable() {
+		return launchWindAltitudeTable;
+	}
+
+	public String getLaunchWindSpeedTable() {
+		return launchWindSpeedTable;
+	}
+
+	public String getLaunchWindDirectionTable() {
+		return launchWindDirectionTable;
+	}
+
+	public List<EngineSetDTO> getStage1Engines() {
+		return stage1Engines;
+	}
+
+	public List<EngineSetDTO> getStage2Engines() {
+		return stage2Engines;
+	}
+
+	public List<EngineSetDTO> getStage3Engines() {
+		return stage3Engines;
+	}
+}

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/SimulationResultsListDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/SimulationResultsListDTO.java
@@ -1,0 +1,44 @@
+package info.openrocket.core.file.rocksim.export;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import info.openrocket.core.document.OpenRocketDocument;
+import info.openrocket.core.document.Simulation;
+import info.openrocket.core.file.rocksim.RockSimCommonConstants;
+
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+
+/**
+ * Container for the simulations exported at the root of a RockSim document.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+public class SimulationResultsListDTO {
+
+	@XmlElement(name = RockSimCommonConstants.SIMULATION_RESULTS)
+	private final List<SimulationResultsDTO> simulations = new ArrayList<>();
+
+	/**
+	 * Constructor required by JAXB.
+	 */
+	public SimulationResultsListDTO() {
+	}
+
+	/**
+	 * Convert every OpenRocket simulation in document order.
+	 *
+	 * @param document the source OpenRocket document
+	 * @param context  the component-to-mount-serial mapping for this export
+	 */
+	public SimulationResultsListDTO(OpenRocketDocument document, RockSimExportContext context) {
+		for (Simulation simulation : document.getSimulations()) {
+			simulations.add(new SimulationResultsDTO(simulation, context));
+		}
+	}
+
+	public List<SimulationResultsDTO> getSimulations() {
+		return simulations;
+	}
+}

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/StageDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/StageDTO.java
@@ -42,6 +42,19 @@ public class StageDTO {
      *                    only one)
      */
     public StageDTO(AxialStage theORStage, RocketDesignDTO design, int stageNumber) {
+        this(theORStage, design, stageNumber, null);
+    }
+
+    /**
+     * Copy constructor used while exporting a complete document.
+     *
+     * @param theORStage  the OR stage
+     * @param design      the encompassing container DTO
+     * @param stageNumber the RockSim stage number
+     * @param context     per-export motor-mount mapping state
+     */
+    public StageDTO(AxialStage theORStage, RocketDesignDTO design, int stageNumber,
+            RockSimExportContext context) {
 
         if (stageNumber == 3) {
             if (theORStage.isMassOverridden()) {
@@ -78,11 +91,11 @@ public class StageDTO {
         List<RocketComponent> children = theORStage.getChildren();
 		for (RocketComponent rocketComponents : children) {
 			if (rocketComponents instanceof NoseCone) {
-				addExternalPart(toNoseConeDTO((NoseCone) rocketComponents));
+				addExternalPart(toNoseConeDTO((NoseCone) rocketComponents, context));
 			} else if (rocketComponents instanceof BodyTube) {
-				addExternalPart(toBodyTubeDTO((BodyTube) rocketComponents));
+				addExternalPart(toBodyTubeDTO((BodyTube) rocketComponents, context));
 			} else if (rocketComponents instanceof Transition) {
-				addExternalPart(toTransitionDTO((Transition) rocketComponents));
+				addExternalPart(toTransitionDTO((Transition) rocketComponents, context));
 			}
 		}
     }
@@ -95,19 +108,19 @@ public class StageDTO {
         externalPart.add(theExternalPartDTO);
     }
 
-    private AbstractTransitionDTO toNoseConeDTO(NoseCone nc) {
+    private AbstractTransitionDTO toNoseConeDTO(NoseCone nc, RockSimExportContext context) {
         if (nc.isFlipped()) {
-            return new TransitionDTO(nc);
+            return new TransitionDTO(nc, context);
         } else {
-            return new NoseConeDTO(nc);
+            return new NoseConeDTO(nc, context);
         }
     }
 
-    private BodyTubeDTO toBodyTubeDTO(BodyTube bt) {
-        return new BodyTubeDTO(bt);
+    private BodyTubeDTO toBodyTubeDTO(BodyTube bt, RockSimExportContext context) {
+        return new BodyTubeDTO(bt, context);
     }
 
-    private TransitionDTO toTransitionDTO(Transition tran) {
-        return new TransitionDTO(tran);
+    private TransitionDTO toTransitionDTO(Transition tran, RockSimExportContext context) {
+        return new TransitionDTO(tran, context);
     }
 }

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/StreamerDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/StreamerDTO.java
@@ -33,7 +33,20 @@ public class StreamerDTO extends BasePartDTO {
      * @param theORStreamer the OR streamer component
      */
     public StreamerDTO(Streamer theORStreamer) {
+		this(theORStreamer, null);
+	}
+
+	/**
+	 * Copy constructor used while exporting simulations with deployment events.
+	 *
+	 * @param theORStreamer the OR streamer component
+	 * @param context       per-export component serial mapping
+	 */
+	public StreamerDTO(Streamer theORStreamer, RockSimExportContext context) {
         super(theORStreamer);
+		if (context != null) {
+			context.registerRecoveryDevice(theORStreamer, getSerialNumber());
+		}
         setWidth(theORStreamer.getStripWidth() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_LENGTH);
         setDragCoefficient(theORStreamer.getCD());
     }

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/TransitionDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/TransitionDTO.java
@@ -43,7 +43,17 @@ public class TransitionDTO extends AbstractTransitionDTO {
      * @param theORTransition the OR transition
      */
     public TransitionDTO(Transition theORTransition) {
-        super(theORTransition);
+        this(theORTransition, null);
+    }
+
+    /**
+     * Copy constructor used while exporting a complete document.
+     *
+     * @param theORTransition the OR transition
+     * @param context         per-export motor-mount mapping state
+     */
+    public TransitionDTO(Transition theORTransition, RockSimExportContext context) {
+        super(theORTransition, context);
         setFrontDia(theORTransition.getForeRadius() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
         setRearDia(theORTransition.getAftRadius() * RockSimCommonConstants.ROCKSIM_TO_OPENROCKET_RADIUS);
         setFrontShoulderDia(

--- a/core/src/main/java/info/openrocket/core/file/rocksim/export/TubeCouplerDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rocksim/export/TubeCouplerDTO.java
@@ -47,6 +47,17 @@ public class TubeCouplerDTO extends CenteringRingDTO {
      *               individual instances for each cluster member will be added.
      */
     public TubeCouplerDTO(TubeCoupler tc, AttachableParts parent) {
+        this(tc, parent, null);
+    }
+
+    /**
+     * Full copy constructor used while exporting a complete document.
+     *
+     * @param tc      the corresponding OR tube coupler
+     * @param parent  the RockSim attached-parts container
+     * @param context per-export motor-mount mapping state
+     */
+    public TubeCouplerDTO(TubeCoupler tc, AttachableParts parent, RockSimExportContext context) {
         super(tc);
         setUsageCode(UsageCode.TubeCoupler);
 
@@ -56,19 +67,23 @@ public class TubeCouplerDTO extends CenteringRingDTO {
         for (RocketComponent component : tc.getChildren()) {
             component.setAxialMethod(AxialMethod.ABSOLUTE);
             if (component instanceof InnerTube) {
-                parent.addAttachedPart(new InnerBodyTubeDTO((InnerTube) component, parent));
+                InnerTube innerTube = (InnerTube) component;
+                InnerBodyTubeDTO innerBodyTubeDTO = new InnerBodyTubeDTO(innerTube, parent, context);
+                if (innerTube.getInstanceCount() == 1) {
+                    parent.addAttachedPart(innerBodyTubeDTO);
+                }
             } else if (component instanceof EngineBlock) {
                 parent.addAttachedPart(new EngineBlockDTO((EngineBlock) component));
             } else if (component instanceof TubeCoupler) {
-                new TubeCouplerDTO((TubeCoupler) component, parent);
+                new TubeCouplerDTO((TubeCoupler) component, parent, context);
             } else if (component instanceof CenteringRing) {
                 parent.addAttachedPart(new CenteringRingDTO((CenteringRing) component));
             } else if (component instanceof Bulkhead) {
                 parent.addAttachedPart(new BulkheadDTO((Bulkhead) component));
             } else if (component instanceof Parachute) {
-                parent.addAttachedPart(new ParachuteDTO((Parachute) component));
+                parent.addAttachedPart(new ParachuteDTO((Parachute) component, context));
             } else if (component instanceof Streamer) {
-                parent.addAttachedPart(new StreamerDTO((Streamer) component));
+                parent.addAttachedPart(new StreamerDTO((Streamer) component, context));
             } else if (component instanceof MassObject) {
                 parent.addAttachedPart(new MassObjectDTO((MassObject) component));
             }

--- a/core/src/test/java/info/openrocket/core/file/rocksim/export/RockSimSimulationExportTest.java
+++ b/core/src/test/java/info/openrocket/core/file/rocksim/export/RockSimSimulationExportTest.java
@@ -1,0 +1,389 @@
+package info.openrocket.core.file.rocksim.export;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import info.openrocket.core.document.OpenRocketDocument;
+import info.openrocket.core.document.OpenRocketDocumentFactory;
+import info.openrocket.core.document.Simulation;
+import info.openrocket.core.file.rocksim.importt.RockSimTestBase;
+import info.openrocket.core.models.wind.MultiLevelPinkNoiseWindModel;
+import info.openrocket.core.models.wind.WindModel.AltitudeReference;
+import info.openrocket.core.models.wind.WindModelType;
+import info.openrocket.core.motor.IgnitionEvent;
+import info.openrocket.core.motor.Manufacturer;
+import info.openrocket.core.motor.Motor;
+import info.openrocket.core.motor.MotorConfiguration;
+import info.openrocket.core.motor.ThrustCurveMotor;
+import info.openrocket.core.rocketcomponent.AxialStage;
+import info.openrocket.core.rocketcomponent.BodyTube;
+import info.openrocket.core.rocketcomponent.ClusterConfiguration;
+import info.openrocket.core.rocketcomponent.DeploymentConfiguration;
+import info.openrocket.core.rocketcomponent.DeploymentConfiguration.DeployEvent;
+import info.openrocket.core.rocketcomponent.FlightConfigurationId;
+import info.openrocket.core.rocketcomponent.InnerTube;
+import info.openrocket.core.rocketcomponent.Parachute;
+import info.openrocket.core.rocketcomponent.RecoveryDevice;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.rocketcomponent.StageSeparationConfiguration;
+import info.openrocket.core.rocketcomponent.StageSeparationConfiguration.SeparationEvent;
+import info.openrocket.core.rocketcomponent.Streamer;
+import info.openrocket.core.simulation.SimulationOptions;
+import info.openrocket.core.util.Coordinate;
+import info.openrocket.core.util.CoordinateIF;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.Unmarshaller;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests RockSim simulation, motor-configuration, and launch-condition export.
+ */
+public class RockSimSimulationExportTest extends RockSimTestBase {
+
+	private static final double EPSILON = 1.0e-9;
+
+	@Test
+	public void exportsPhysicalMotorMountsAndLaunchConditionsForEachSimulation() throws Exception {
+		OpenRocketDocument document = OpenRocketDocumentFactory.createNewRocket();
+		Rocket rocket = document.getRocket();
+		AxialStage sustainer = rocket.getStage(0);
+
+		BodyTube sustainerBody = makeBodyTube("Sustainer body");
+		sustainer.addChild(sustainerBody);
+		InnerTube clusteredMount = makeMotorMount("Cluster mount", 0.012);
+		clusteredMount.setClusterConfiguration(ClusterConfiguration.CONFIGURATIONS[1]);
+		sustainerBody.addChild(clusteredMount);
+		InnerTube auxiliaryMount = makeMotorMount("Auxiliary mount", 0.004);
+		sustainerBody.addChild(auxiliaryMount);
+		Parachute main = new Parachute();
+		main.setName("Main");
+		sustainerBody.addChild(main);
+		Streamer drogue = new Streamer();
+		drogue.setName("Drogue");
+		sustainerBody.addChild(drogue);
+
+		AxialStage booster = new AxialStage();
+		booster.setName("Booster");
+		rocket.addChild(booster);
+		BodyTube boosterBody = makeBodyTube("Booster body");
+		booster.addChild(boosterBody);
+		InnerTube boosterMount = makeMotorMount("Booster mount", 0.008);
+		boosterBody.addChild(boosterMount);
+
+		FlightConfigurationId firstConfiguration = new FlightConfigurationId();
+		rocket.createFlightConfiguration(firstConfiguration).setAllStages();
+		configureMotor(clusteredMount, firstConfiguration, makeMotor("AeroTech", "H148R"),
+				Motor.PLUGGED_DELAY, 1.25, IgnitionEvent.BURNOUT);
+		configureMotor(auxiliaryMount, firstConfiguration, makeMotor("Estes", "C6"),
+				5.0, 0.0, IgnitionEvent.LAUNCH);
+		configureMotor(boosterMount, firstConfiguration, makeMotor("Estes", "D12"),
+				7.0, 0.3, IgnitionEvent.AUTOMATIC);
+		configureSeparation(booster, firstConfiguration, SeparationEvent.BURNOUT, 0.5);
+		configureDeployment(main, firstConfiguration, DeployEvent.ALTITUDE, 0.0, 250.0);
+		configureDeployment(drogue, firstConfiguration, DeployEvent.APOGEE, 2.0, 0.0);
+		rocket.getFlightConfiguration(firstConfiguration).setAllStages();
+
+		FlightConfigurationId secondConfiguration = new FlightConfigurationId();
+		rocket.createFlightConfiguration(secondConfiguration).setAllStages();
+		configureMotor(clusteredMount, secondConfiguration, makeMotor("AeroTech", "I59WN"),
+				Motor.PLUGGED_DELAY, 0.4, IgnitionEvent.BURNOUT);
+		configureMotor(boosterMount, secondConfiguration, makeMotor("AeroTech", "I357T"),
+				14.0, 0.0, IgnitionEvent.AUTOMATIC);
+		configureSeparation(booster, secondConfiguration, SeparationEvent.UPPER_IGNITION, 0.0);
+		configureDeployment(main, secondConfiguration, DeployEvent.LOWER_STAGE_SEPARATION, 0.0, 0.0);
+		configureDeployment(drogue, secondConfiguration, DeployEvent.LAUNCH, 1.5, 0.0);
+		rocket.getFlightConfiguration(secondConfiguration).setAllStages();
+
+		Simulation averageWindSimulation = new Simulation(document, rocket);
+		averageWindSimulation.setName("Average wind configuration");
+		averageWindSimulation.setFlightConfigurationId(firstConfiguration);
+		setAverageWindLaunchConditions(averageWindSimulation.getOptions());
+		document.addSimulation(averageWindSimulation);
+
+		Simulation multiLevelWindSimulation = new Simulation(document, rocket);
+		multiLevelWindSimulation.setName("Multi-level wind configuration");
+		multiLevelWindSimulation.setFlightConfigurationId(secondConfiguration);
+		setMultiLevelWindLaunchConditions(multiLevelWindSimulation.getOptions());
+		document.addSimulation(multiLevelWindSimulation);
+
+		// Export twice because save dialogs commonly estimate size before writing the
+		// file.  The second document must retain valid, repeatable component references.
+		RockSimDocumentDTO firstExport = marshalAndRead(document);
+		RockSimDocumentDTO exported = marshalAndRead(document);
+		List<SimulationResultsDTO> simulations = exported.getSimulationResultsList().getSimulations();
+		assertEquals(2, simulations.size());
+		int firstComponentSerial = firstExport.getDesign().getDesign().getStage3().getExternalPart().get(0)
+				.getSerialNumber();
+		int repeatedComponentSerial = exported.getDesign().getDesign().getStage3().getExternalPart().get(0)
+				.getSerialNumber();
+		assertEquals(firstComponentSerial, repeatedComponentSerial,
+				"Repeated exports must assign the same component serials.");
+		assertTrue(repeatedComponentSerial > 0,
+				"RockSim reserves component serial zero for an absent component reference.");
+
+		Set<Integer> clusteredMountSerials = findMountSerials(exported, "Cluster mount");
+		Set<Integer> auxiliaryMountSerials = findMountSerials(exported, "Auxiliary mount");
+		Set<Integer> boosterMountSerials = findMountSerials(exported, "Booster mount");
+		assertEquals(2, clusteredMountSerials.size(), "A two-motor cluster must export two physical mounts.");
+		assertEquals(1, auxiliaryMountSerials.size());
+		assertEquals(1, boosterMountSerials.size());
+
+		SimulationResultsDTO first = simulations.get(0);
+		assertEquals("[D12-0.5-0.30] [H148R-Plugged-0.75, H148R-Plugged-0.75, C6-5] ",
+				first.getSimulationName());
+		assertEquals("Average wind configuration", first.getComments());
+		assertEquals(3, first.getStage3Engines().size());
+		assertEquals(1, first.getStage2Engines().size());
+		assertEquals(clusteredMountSerials, serialsForMotor(first.getStage3Engines(), "H148R"));
+		assertEquals(auxiliaryMountSerials, serialsForMotor(first.getStage3Engines(), "C6"));
+		assertEquals(boosterMountSerials, serialsForMotor(first.getStage2Engines(), "D12"));
+		assertEngine(first.getStage3Engines(), "H148R", "AeroTech", 0.75, -2.0, 12.0);
+		assertEngine(first.getStage2Engines(), "D12", "Estes", 0.3, 0.5, 8.0);
+		assertRecoveryEvent(exported, first, "Main", 5, 250.0, 0.0);
+		assertRecoveryEvent(exported, first, "Drogue", 3, 0.0, 2.0);
+		assertAverageWindLaunchConditions(first);
+
+		SimulationResultsDTO second = simulations.get(1);
+		assertEquals("[I357T-0] [I59WN-Plugged-0.40, I59WN-Plugged-0.40] ", second.getSimulationName());
+		assertEquals("Multi-level wind configuration", second.getComments());
+		assertEquals(2, second.getStage3Engines().size());
+		assertEquals(1, second.getStage2Engines().size());
+		assertEquals(clusteredMountSerials, serialsForMotor(second.getStage3Engines(), "I59WN"));
+		assertEquals(boosterMountSerials, serialsForMotor(second.getStage2Engines(), "I357T"));
+		assertEngine(second.getStage2Engines(), "I357T", "AeroTech", 0.0, 0.0, 8.0);
+		assertRecoveryEvent(exported, second, "Main", 0, 0.0, 0.0);
+		assertRecoveryEvent(exported, second, "Drogue", 2, 0.0, 1.5);
+		assertMultiLevelWindLaunchConditions(second);
+	}
+
+	private RockSimDocumentDTO marshalAndRead(OpenRocketDocument document) throws Exception {
+		String result = new RockSimSaver().marshalToRockSim(document);
+		assertNotNull(result);
+		assertTrue(result.contains("<SimulationResultsList>"));
+
+		JAXBContext binder = JAXBContext.newInstance(RockSimDocumentDTO.class);
+		Unmarshaller unmarshaller = binder.createUnmarshaller();
+		return (RockSimDocumentDTO) unmarshaller.unmarshal(new StringReader(result));
+	}
+
+	private BodyTube makeBodyTube(String name) {
+		BodyTube tube = new BodyTube();
+		tube.setName(name);
+		tube.setLength(0.5);
+		tube.setOuterRadius(0.04);
+		tube.setThickness(0.002);
+		return tube;
+	}
+
+	private InnerTube makeMotorMount(String name, double overhang) {
+		InnerTube mount = new InnerTube();
+		mount.setName(name);
+		mount.setLength(0.15);
+		mount.setOuterRadius(0.015);
+		mount.setThickness(0.001);
+		mount.setMotorMount(true);
+		mount.setMotorOverhang(overhang);
+		return mount;
+	}
+
+	private void configureMotor(InnerTube mount, FlightConfigurationId configurationId, ThrustCurveMotor motor,
+			double ejectionDelay, double ignitionDelay, IgnitionEvent ignitionEvent) {
+		MotorConfiguration configuration = new MotorConfiguration(mount, configurationId);
+		configuration.setMotor(motor);
+		configuration.setEjectionDelay(ejectionDelay);
+		configuration.setIgnitionDelay(ignitionDelay);
+		configuration.setIgnitionEvent(ignitionEvent);
+		mount.setMotorConfig(configuration, configurationId);
+	}
+
+	private void configureSeparation(AxialStage stage, FlightConfigurationId configurationId,
+			SeparationEvent event, double delay) {
+		StageSeparationConfiguration configuration = new StageSeparationConfiguration();
+		configuration.setSeparationEvent(event);
+		configuration.setSeparationDelay(delay);
+		stage.getSeparationConfigurations().set(configurationId, configuration);
+	}
+
+	private void configureDeployment(RecoveryDevice device, FlightConfigurationId configurationId,
+			DeployEvent event, double delay, double altitude) {
+		DeploymentConfiguration configuration = new DeploymentConfiguration();
+		configuration.setDeployEvent(event);
+		configuration.setDeployDelay(delay);
+		configuration.setDeployAltitude(altitude);
+		device.getDeploymentConfigurations().set(configurationId, configuration);
+	}
+
+	private ThrustCurveMotor makeMotor(String manufacturer, String designation) {
+		return new ThrustCurveMotor.Builder()
+				.setManufacturer(Manufacturer.getManufacturer(manufacturer))
+				.setDesignation(designation)
+				.setCommonName(designation)
+				.setMotorType(Motor.Type.RELOAD)
+				.setStandardDelays(new double[] { 0.0, 5.0, Motor.PLUGGED_DELAY })
+				.setDiameter(0.029)
+				.setLength(0.12)
+				.setTimePoints(new double[] { 0.0, 0.5, 1.0 })
+				.setThrustPoints(new double[] { 0.0, 100.0, 0.0 })
+				.setCGPoints(new CoordinateIF[] {
+						new Coordinate(0.06, 0.0, 0.0, 0.1),
+						new Coordinate(0.06, 0.0, 0.0, 0.08),
+						new Coordinate(0.06, 0.0, 0.0, 0.06) })
+				.setDigest(manufacturer + "-" + designation)
+				.build();
+	}
+
+	private void setAverageWindLaunchConditions(SimulationOptions options) {
+		options.setLaunchRodLength(3.048);
+		options.setLaunchRodAngle(Math.toRadians(5.0));
+		options.setLaunchIntoWind(false);
+		options.setLaunchRodDirection(Math.toRadians(123.0));
+		options.setLaunchAltitude(350.0);
+		options.setISAAtmosphere(false);
+		options.setLaunchTemperature(285.15);
+		options.setLaunchPressure(95000.0);
+		options.setLaunchRelativeHumidity(0.65);
+		options.setLaunchLatitude(50.9);
+		options.setLaunchLongitude(4.4);
+		options.getAverageWindModel().setAverage(7.5);
+		options.getAverageWindModel().setStandardDeviation(1.2);
+		options.getAverageWindModel().setDirection(Math.toRadians(210.0));
+		options.setMaxSimulationTime(600.0);
+	}
+
+	private void setMultiLevelWindLaunchConditions(SimulationOptions options) {
+		options.setLaunchAltitude(100.0);
+		options.setLaunchIntoWind(false);
+		options.setLaunchRodDirection(Math.toRadians(10.0));
+		options.setWindModelType(WindModelType.MULTI_LEVEL);
+		MultiLevelPinkNoiseWindModel wind = options.getMultiLevelWindModel();
+		wind.clearLevels();
+		wind.setAltitudeReference(AltitudeReference.AGL);
+		wind.addWindLevel(0.0, 3.0, Math.toRadians(45.0), 0.3);
+		wind.addWindLevel(1000.0, 9.0, Math.toRadians(270.0), 0.9);
+	}
+
+	private Set<Integer> findMountSerials(RockSimDocumentDTO document, String namePrefix) {
+		Set<Integer> serialNumbers = new HashSet<>();
+		RocketDesignDTO design = document.getDesign().getDesign();
+		collectMountSerials(design.getStage3().getExternalPart(), namePrefix, serialNumbers);
+		collectMountSerials(design.getStage2().getExternalPart(), namePrefix, serialNumbers);
+		collectMountSerials(design.getStage1().getExternalPart(), namePrefix, serialNumbers);
+		return serialNumbers;
+	}
+
+	private void collectMountSerials(List<BasePartDTO> parts, String namePrefix, Set<Integer> serialNumbers) {
+		for (BasePartDTO part : parts) {
+			if (part instanceof BodyTubeDTO) {
+				BodyTubeDTO tube = (BodyTubeDTO) part;
+				if (tube.getMotorMount() == 1 && tube.getName().startsWith(namePrefix)) {
+					serialNumbers.add(tube.getSerialNumber());
+				}
+				collectMountSerials(tube.getAttachedParts(), namePrefix, serialNumbers);
+			}
+		}
+	}
+
+	private Set<Integer> serialsForMotor(List<EngineSetDTO> engines, String designation) {
+		Set<Integer> serialNumbers = new HashSet<>();
+		for (EngineSetDTO engine : engines) {
+			if (designation.equals(engine.getEngineCode())) {
+				serialNumbers.add(engine.getMountSerialNumber());
+			}
+		}
+		return serialNumbers;
+	}
+
+	private void assertRecoveryEvent(RockSimDocumentDTO document, SimulationResultsDTO simulation,
+			String deviceName, int type,
+			double altitude, double time) {
+		Set<Integer> serials = findRecoverySerials(document, deviceName);
+		List<SimulationEventDTO> matching = new ArrayList<>();
+		for (SimulationEventDTO event : simulation.getSimulationEvents()) {
+			if (serials.contains(event.getPartSerialNumber())) {
+				matching.add(event);
+			}
+		}
+		assertEquals(1, matching.size());
+		SimulationEventDTO event = matching.get(0);
+		assertEquals(type, event.getType());
+		assertEquals(altitude, event.getDeployAltitude(), EPSILON);
+		assertEquals(time, event.getDeployTime(), EPSILON);
+	}
+
+	private Set<Integer> findRecoverySerials(RockSimDocumentDTO document, String name) {
+		Set<Integer> serialNumbers = new HashSet<>();
+		RocketDesignDTO design = document.getDesign().getDesign();
+		collectRecoverySerials(design.getStage3().getExternalPart(), name, serialNumbers);
+		collectRecoverySerials(design.getStage2().getExternalPart(), name, serialNumbers);
+		collectRecoverySerials(design.getStage1().getExternalPart(), name, serialNumbers);
+		return serialNumbers;
+	}
+
+	private void collectRecoverySerials(List<BasePartDTO> parts, String name, Set<Integer> serialNumbers) {
+		for (BasePartDTO part : parts) {
+			if ((part instanceof ParachuteDTO || part instanceof StreamerDTO) && name.equals(part.getName())) {
+				serialNumbers.add(part.getSerialNumber());
+			}
+			if (part instanceof BodyTubeDTO) {
+				collectRecoverySerials(((BodyTubeDTO) part).getAttachedParts(), name, serialNumbers);
+			}
+		}
+	}
+
+	private void assertEngine(List<EngineSetDTO> engines, String designation, String manufacturer,
+			double ignitionDelay, double ejectionDelay, double overhang) {
+		List<EngineSetDTO> matching = new ArrayList<>();
+		for (EngineSetDTO engine : engines) {
+			if (designation.equals(engine.getEngineCode())) {
+				matching.add(engine);
+			}
+		}
+		assertNotEquals(0, matching.size());
+		for (EngineSetDTO engine : matching) {
+			assertEquals(1, engine.getEngineCount());
+			assertEquals(manufacturer, engine.getEngineManufacturer());
+			assertEquals(ignitionDelay, engine.getIgnitionDelay(), EPSILON);
+			assertEquals(ejectionDelay, engine.getEjectionDelay(), EPSILON);
+			assertEquals(overhang, engine.getEngineOverhang(), EPSILON);
+		}
+	}
+
+	private void assertAverageWindLaunchConditions(SimulationResultsDTO simulation) {
+		assertEquals(3048.0, simulation.getLaunchGuideLength(), EPSILON);
+		assertEquals(Math.toRadians(5.0), simulation.getLaunchAngle(), EPSILON);
+		assertEquals(123.0, simulation.getLaunchGuideAzimuth(), EPSILON);
+		assertEquals(95000.0 / (101325.0 / 760.0), simulation.getLaunchBarometer(), EPSILON);
+		assertEquals(50.9, simulation.getLaunchLatitude(), EPSILON);
+		assertEquals(4.4, simulation.getLaunchLongitude(), EPSILON);
+		assertEquals(65.0, simulation.getLaunchHumidity(), EPSILON);
+		assertEquals(12.0, simulation.getLaunchTemperature(), EPSILON);
+		assertEquals(350.0, simulation.getLaunchAltitude(), EPSILON);
+		assertEquals(7.5, simulation.getLaunchWindLowSpeed(), EPSILON);
+		assertEquals(7.5, simulation.getLaunchWindHighSpeed(), EPSILON);
+		assertEquals(0, simulation.getLaunchWindTableSize());
+	}
+
+	private void assertMultiLevelWindLaunchConditions(SimulationResultsDTO simulation) {
+		assertEquals(10.0, simulation.getLaunchGuideAzimuth(), EPSILON);
+		assertEquals(2, simulation.getLaunchWindTableSize());
+		assertTableStartsWith(simulation.getLaunchWindAltitudeTable(), 100.0, 1100.0);
+		assertTableStartsWith(simulation.getLaunchWindSpeedTable(), 3.0, 9.0);
+		assertTableStartsWith(simulation.getLaunchWindDirectionTable(), 45.0, 270.0);
+	}
+
+	private void assertTableStartsWith(String table, double first, double second) {
+		String[] values = table.split(",");
+		assertEquals(25, values.length);
+		assertEquals(first, Double.parseDouble(values[0]), EPSILON);
+		assertEquals(second, Double.parseDouble(values[1]), EPSILON);
+	}
+}


### PR DESCRIPTION
RockSim exports contained the rocket geometry but omitted motor configurations and launch conditions. RockSim therefore showed no loaded motors and could not reproduce the OpenRocket simulations correctly. This is quite annoying when attempting to do quick comparisons between OR and RockSim...

The exporter now:

- Exports each simulation and its configured motors.
- Supports clustered and multi-stage motor mounts.
- Translates staging and recovery events to RockSim-compatible settings.
- Exports launch rod, atmosphere, altitude, humidity, and wind conditions.
- Maintains stable component references across repeated exports.

Unsupported RockSim event types are disabled safely instead of being converted to incorrect timing.

Tested with multi-stage and clustered configurations and verified directly in RockSim.