### PR TITLE
Fix/rasaero sustainer motor export

### DIFF
--- a/core/src/main/java/info/openrocket/core/file/rasaero/RASAeroCommonConstants.java
+++ b/core/src/main/java/info/openrocket/core/file/rasaero/RASAeroCommonConstants.java
@@ -1,6 +1,7 @@
 package info.openrocket.core.file.rasaero;
 
 import info.openrocket.core.file.motor.AbstractMotorLoader;
+import info.openrocket.core.file.rasaero.RASAeroMotorsLoader.RASAeroMotor;
 import info.openrocket.core.logging.WarningSet;
 import info.openrocket.core.motor.Manufacturer;
 import info.openrocket.core.motor.Motor;
@@ -12,8 +13,10 @@ import info.openrocket.core.rocketcomponent.Transition;
 import info.openrocket.core.util.ORColor;
 import info.openrocket.core.util.MathUtil;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import info.openrocket.core.file.rasaero.export.RASAeroSaver.RASAeroExportException;
@@ -389,31 +392,147 @@ public class RASAeroCommonConstants {
 
     /**
      * Format an OpenRocket motor as a RASAero motor.
-     * @param RASAeroMotors list of available RASAero motors
-     * @param ORMotor OpenRocket motor
+     *
+     * @param rasaeroMotors motors present in RASAero's {@code rasp.eng}
+     * @param openRocketMotor OpenRocket motor to export
+     * @param warnings warning set for unavailable or ambiguous motors
      * @return a RASAero String representation of a motor
      */
-    public static String OPENROCKET_TO_RASAERO_MOTOR(List<ThrustCurveMotor> RASAeroMotors, Motor ORMotor,
+    public static String OPENROCKET_TO_RASAERO_MOTOR(List<RASAeroMotor> rasaeroMotors, Motor openRocketMotor,
                                                      WarningSet warnings) {
-        if (!(ORMotor instanceof ThrustCurveMotor)) {
-            log.debug("RASAero motor not found: not a thrust curve motor");
+        if (openRocketMotor == null) {
+            return null;
+        }
+        if (!(openRocketMotor instanceof ThrustCurveMotor)) {
+            String msg = String.format("Motor '%s' cannot be exported to RASAero because it is not a thrust-curve "
+                    + "motor.", openRocketMotor.getDesignation());
+            addMotorWarning(warnings, msg);
+            log.debug(msg);
+            return null;
+        }
+        if (rasaeroMotors == null || rasaeroMotors.isEmpty()) {
             return null;
         }
 
-        for (ThrustCurveMotor RASAeroMotor : RASAeroMotors) {
-            String RASAeroDesignation = AbstractMotorLoader.removeDelay(RASAeroMotor.getDesignation());
-            if (ORMotor.getDesignation().equals(RASAeroDesignation) &&
-                    ((ThrustCurveMotor) ORMotor).getManufacturer().matches(RASAeroMotor.getManufacturer().getDisplayName())) {
-                String motorName = RASAeroMotor.getDesignation();
-                log.debug(String.format("RASAero RASAeroMotor found: %s", motorName));
-                return motorName + "  (" + OPENROCKET_TO_RASAERO_MANUFACTURER(RASAeroMotor.getManufacturer()) + ")";
-            }
+        ThrustCurveMotor thrustCurveMotor = (ThrustCurveMotor) openRocketMotor;
+        List<RASAeroMotor> candidates = findDesignationMatches(rasaeroMotors, thrustCurveMotor);
+        RASAeroMotor match = selectUniqueMotor(candidates, thrustCurveMotor);
+
+        if (match == null && candidates.isEmpty()) {
+            // Some databases use a propellant suffix while others only retain the
+            // impulse class and average thrust. Physical dimensions keep this fallback
+            // conservative and prevent similarly named motors from being confused.
+            candidates = findCommonNameMatches(rasaeroMotors, thrustCurveMotor);
+            match = selectUniqueMotor(candidates, thrustCurveMotor);
         }
 
-        String msg = String.format("Could not find RASAero motor for '%s'", ORMotor.getDesignation());
-        warnings.add(msg);
-        log.debug(msg);
+        if (match != null) {
+            String motorName = match.getDesignation();
+            log.debug("RASAero motor found: {}", motorName);
+            return motorName + "  (" + match.getManufacturer() + ")";
+        }
+
+        String message;
+        if (candidates.isEmpty()) {
+            message = String.format("Motor '%s' by %s is not available in RASAero II's rasp.eng catalog; "
+                            + "the motor field was omitted.",
+                    openRocketMotor.getDesignation(), thrustCurveMotor.getManufacturer().getDisplayName());
+        } else {
+            message = String.format("Motor '%s' by %s matches multiple entries in RASAero II's rasp.eng catalog; "
+                            + "the motor field was omitted.",
+                    openRocketMotor.getDesignation(), thrustCurveMotor.getManufacturer().getDisplayName());
+        }
+        addMotorWarning(warnings, message);
+        log.debug(message);
         return null;
+    }
+
+    /**
+     * Finds catalog entries whose full designation matches after removing a
+     * RASP delay suffix. Matching is case-insensitive, so an OpenRocket
+     * {@code I59WN} can match RASAero's {@code I59WN-P}.
+     */
+    private static List<RASAeroMotor> findDesignationMatches(List<RASAeroMotor> rasaeroMotors,
+                                                              ThrustCurveMotor openRocketMotor) {
+        List<RASAeroMotor> matches = new ArrayList<>();
+        String designation = normalizeMotorDesignation(openRocketMotor.getDesignation());
+        for (RASAeroMotor rasaeroMotor : rasaeroMotors) {
+            if (sameManufacturer(openRocketMotor, rasaeroMotor)
+                    && designation.equals(normalizeMotorDesignation(rasaeroMotor.getDesignation()))) {
+                matches.add(rasaeroMotor);
+            }
+        }
+        return matches;
+    }
+
+    /**
+     * Finds a conservative fallback match using the simplified designation and
+     * motor case dimensions.
+     */
+    private static List<RASAeroMotor> findCommonNameMatches(List<RASAeroMotor> rasaeroMotors,
+                                                             ThrustCurveMotor openRocketMotor) {
+        List<RASAeroMotor> matches = new ArrayList<>();
+        String designation = commonMotorDesignation(openRocketMotor.getDesignation());
+        for (RASAeroMotor rasaeroMotor : rasaeroMotors) {
+            if (sameManufacturer(openRocketMotor, rasaeroMotor)
+                    && designation.equals(commonMotorDesignation(rasaeroMotor.getDesignation()))
+                    && motorDimensionsMatch(openRocketMotor, rasaeroMotor)) {
+                matches.add(rasaeroMotor);
+            }
+        }
+        return matches;
+    }
+
+    /**
+     * Selects a single catalog entry. If a designation maps to more than one
+     * entry, dimensions may disambiguate it; otherwise the exporter warns instead
+     * of guessing.
+     */
+    private static RASAeroMotor selectUniqueMotor(List<RASAeroMotor> candidates,
+                                                   ThrustCurveMotor openRocketMotor) {
+        if (candidates.size() == 1) {
+            return candidates.get(0);
+        }
+        if (candidates.size() > 1) {
+            List<RASAeroMotor> dimensionMatches = new ArrayList<>();
+            for (RASAeroMotor candidate : candidates) {
+                if (motorDimensionsMatch(openRocketMotor, candidate)) {
+                    dimensionMatches.add(candidate);
+                }
+            }
+            if (dimensionMatches.size() == 1) {
+                return dimensionMatches.get(0);
+            }
+        }
+        return null;
+    }
+
+    private static boolean sameManufacturer(ThrustCurveMotor openRocketMotor, RASAeroMotor rasaeroMotor) {
+        String manufacturer = OPENROCKET_TO_RASAERO_MANUFACTURER(openRocketMotor.getManufacturer());
+        return manufacturer.equalsIgnoreCase(rasaeroMotor.getManufacturer());
+    }
+
+    private static String normalizeMotorDesignation(String designation) {
+        String withoutDelay = AbstractMotorLoader.removeDelay(designation.trim());
+        return withoutDelay.replaceAll("\\s+", "").toUpperCase(Locale.ROOT);
+    }
+
+    private static String commonMotorDesignation(String designation) {
+        return ThrustCurveMotor.Builder.simplifyDesignation(normalizeMotorDesignation(designation));
+    }
+
+    private static boolean motorDimensionsMatch(Motor first, RASAeroMotor second) {
+        // Motor data sources commonly differ by rounding a metric case dimension.
+        double diameterTolerance = Math.max(0.001, first.getDiameter() * 0.02);
+        double lengthTolerance = Math.max(0.003, first.getLength() * 0.02);
+        return Math.abs(first.getDiameter() - second.getDiameter()) <= diameterTolerance
+                && Math.abs(first.getLength() - second.getLength()) <= lengthTolerance;
+    }
+
+    private static void addMotorWarning(WarningSet warnings, String message) {
+        if (warnings != null) {
+            warnings.add(message);
+        }
     }
 
     public static String OPENROCKET_TO_RASAERO_MANUFACTURER(Manufacturer manufacturer) {

--- a/core/src/main/java/info/openrocket/core/file/rasaero/RASAeroMotorsLoader.java
+++ b/core/src/main/java/info/openrocket/core/file/rasaero/RASAeroMotorsLoader.java
@@ -6,10 +6,19 @@ import info.openrocket.core.file.motor.AbstractMotorLoader;
 import info.openrocket.core.motor.ThrustCurveMotor;
 import info.openrocket.core.startup.Application;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
 public abstract class RASAeroMotorsLoader {
+    private static final String RASAERO_MOTOR_FILE = "rasp.eng";
+    private static final String RASAERO_MOTOR_RESOURCE =
+            "datafiles/thrustcurves/RASAero/" + RASAERO_MOTOR_FILE;
+
     private static List<ThrustCurveMotor> allMotors = null;
 
     /**
@@ -63,22 +72,85 @@ public abstract class RASAeroMotorsLoader {
         }
     }
 
-    // Not currently used for importing, because it causes some compatibility issues
-    // when e.g. wanting to open the RASAero motor
-    // in the motor selection table (because it is not present there).
-    // It's probably also better to load OR-native motors.
-    // But I'll leave this in, in case it's needed in the future.
     /**
-     * Loads all motors available for RASAero export.
+     * Loads the motor catalog distributed with RASAero II for export validation.
      * <p>
-     * Historically this loaded motors from a bundled {@code RASAero_Motors.eng} file. That file is no longer shipped;
-     * these motors are now part of the normal OpenRocket motor database.
+     * The RASAero designation is retained exactly, including delays such as
+     * {@code -P}, because that is the spelling RASAero expects in a CDX1 file.
      * 
-     * @param warnings The warning set to add import warnings to.
-     * @return the loaded motors
+     * @param warnings the warning set to add loading warnings to
+     * @return the motors available in RASAero's {@code rasp.eng}
      */
-    public static List<ThrustCurveMotor> loadAllRASAeroMotors(WarningSet warnings) {
-        return loadMotorsFromOpenRocketDatabase(warnings);
+    public static List<RASAeroMotor> loadAllRASAeroMotors(WarningSet warnings) {
+        List<RASAeroMotor> motors = new ArrayList<>();
+
+        try (InputStream stream = openRASAeroMotorResource()) {
+            if (stream == null) {
+                addWarning(warnings, "Unable to load RASAero motor catalog '" + RASAERO_MOTOR_FILE + "'.");
+                return motors;
+            }
+
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(stream, StandardCharsets.ISO_8859_1))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    RASAeroMotor motor = parseMotorHeader(line);
+                    if (motor != null) {
+                        motors.add(motor);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            addWarning(warnings, "Unable to load RASAero motor catalog '" + RASAERO_MOTOR_FILE
+                    + "': " + e.getMessage());
+            return motors;
+        }
+
+        if (motors.isEmpty()) {
+            addWarning(warnings, "RASAero motor catalog '" + RASAERO_MOTOR_FILE + "' contains no motors.");
+        }
+
+        return motors;
+    }
+
+    private static InputStream openRASAeroMotorResource() {
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        InputStream stream = contextClassLoader != null
+                ? contextClassLoader.getResourceAsStream(RASAERO_MOTOR_RESOURCE)
+                : null;
+        if (stream == null) {
+            stream = RASAeroMotorsLoader.class.getResourceAsStream("/" + RASAERO_MOTOR_RESOURCE);
+        }
+        return stream;
+    }
+
+    /**
+     * Parses only RASP motor header records. Export validation needs the exact
+     * name, manufacturer, and case dimensions, not the thrust-curve samples.
+     */
+    private static RASAeroMotor parseMotorHeader(String line) {
+        String trimmedLine = line.trim();
+        if (trimmedLine.isEmpty() || trimmedLine.startsWith(";")) {
+            return null;
+        }
+
+        String[] fields = trimmedLine.split("\\s+");
+        if (fields.length != 7) {
+            return null;
+        }
+
+        try {
+            double diameter = Double.parseDouble(fields[1]) / 1000.0;
+            double length = Double.parseDouble(fields[2]) / 1000.0;
+            double propellantMass = Double.parseDouble(fields[4]);
+            double totalMass = Double.parseDouble(fields[5]);
+            if (diameter <= 0 || length <= 0 || propellantMass < 0 || totalMass < propellantMass) {
+                return null;
+            }
+            return new RASAeroMotor(fields[0], fields[6], diameter, length);
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
     /**
@@ -101,6 +173,45 @@ public abstract class RASAeroMotorsLoader {
             }
         }
         return motors;
+    }
+
+    private static void addWarning(WarningSet warnings, String message) {
+        if (warnings != null) {
+            warnings.add(message);
+        }
+    }
+
+    /**
+     * A motor entry from RASAero's bundled {@code rasp.eng} catalog.
+     */
+    public static final class RASAeroMotor {
+        private final String designation;
+        private final String manufacturer;
+        private final double diameter;
+        private final double length;
+
+        private RASAeroMotor(String designation, String manufacturer, double diameter, double length) {
+            this.designation = designation;
+            this.manufacturer = manufacturer;
+            this.diameter = diameter;
+            this.length = length;
+        }
+
+        public String getDesignation() {
+            return designation;
+        }
+
+        public String getManufacturer() {
+            return manufacturer;
+        }
+
+        public double getDiameter() {
+            return diameter;
+        }
+
+        public double getLength() {
+            return length;
+        }
     }
 
 }

--- a/core/src/main/java/info/openrocket/core/file/rasaero/export/SimulationDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rasaero/export/SimulationDTO.java
@@ -4,6 +4,7 @@ import info.openrocket.core.document.Simulation;
 import info.openrocket.core.file.rasaero.CustomBooleanAdapter;
 import info.openrocket.core.file.rasaero.CustomDoubleAdapter;
 import info.openrocket.core.file.rasaero.RASAeroCommonConstants;
+import info.openrocket.core.file.rasaero.RASAeroMotorsLoader.RASAeroMotor;
 import info.openrocket.core.l10n.Translator;
 import info.openrocket.core.logging.ErrorSet;
 import info.openrocket.core.logging.WarningSet;
@@ -128,7 +129,7 @@ public class SimulationDTO {
      * @param errors     a list to add export errors to
      */
     public SimulationDTO(Rocket rocket, Simulation simulation, Map<AxialStage, MotorMount> mounts,
-            List<ThrustCurveMotor> motors,
+            List<RASAeroMotor> motors,
             WarningSet warnings, ErrorSet errors) {
         String simulationName = simulation != null ? simulation.getName() : "DEFAULT";
         FlightConfigurationId fcid = simulation != null ? simulation.getFlightConfigurationId() : null;

--- a/core/src/main/java/info/openrocket/core/file/rasaero/export/SimulationListDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rasaero/export/SimulationListDTO.java
@@ -38,42 +38,11 @@ public class SimulationListDTO {
         Map<AxialStage, MotorMount> mounts = new HashMap<>();
         Rocket rocket = document.getRocket();
 
-        // Fetch all the motor mounts from the design
+        // RASAero supports one motor per stage, so retain the first populated mount
+        // found in each core stage.
         for (RocketComponent child : rocket.getChildren()) {
             AxialStage stage = (AxialStage) child;
-            if (mounts.containsKey(stage)) {
-                continue;
-            }
-            for (RocketComponent stageChild : stage.getChildren()) {
-                if (stageChild instanceof BodyTube) {
-                    // First check if the body tube itself has a motor
-                    if (((BodyTube) stageChild).hasMotor()) {
-                        mounts.put(stage, (BodyTube) stageChild);
-                        break;
-                    }
-                    // Then check if it has an inner tube with a motor
-                    else {
-                        boolean addedMount = false;
-                        for (RocketComponent tubeChild : stageChild.getChildren()) {
-                            if (tubeChild instanceof MotorMount && ((MotorMount) tubeChild).hasMotor()) {
-                                mounts.put(stage, (MotorMount) tubeChild);
-                                addedMount = true;
-                                break;
-                            }
-                        }
-                        if (addedMount) {
-                            break;
-                        }
-                    }
-                }
-            }
-
-            // If at this point, we still don't have a mount, there is probably a mount
-            // without a motor.
-            // In that case, add a null mount, so that mass/CG export happens.
-            if (!mounts.containsKey(stage)) {
-                mounts.put(stage, null);
-            }
+            mounts.put(stage, findMotorMount(stage));
         }
 
         // Load all RASAero motors
@@ -91,6 +60,27 @@ public class SimulationListDTO {
         }
 
         motors.clear();
+    }
+
+    /**
+     * Finds the first populated motor mount anywhere within a core stage.
+     * Structural inner tubes may contain another inner tube that acts as the actual
+     * motor mount, so checking only direct body-tube children is insufficient.
+     *
+     * @param stage the core stage whose component subtree is searched
+     * @return the first populated mount in the stage, or {@code null} when absent
+     */
+    static MotorMount findMotorMount(AxialStage stage) {
+        for (RocketComponent component : stage.getAllChildren()) {
+            if (component instanceof MotorMount) {
+                MotorMount mount = (MotorMount) component;
+                // Exclude mounts belonging to nested parallel stages.
+                if (component.getStage() == stage && mount.hasMotor()) {
+                    return mount;
+                }
+            }
+        }
+        return null;
     }
 
     public List<SimulationDTO> getSimulations() {

--- a/core/src/main/java/info/openrocket/core/file/rasaero/export/SimulationListDTO.java
+++ b/core/src/main/java/info/openrocket/core/file/rasaero/export/SimulationListDTO.java
@@ -4,11 +4,10 @@ import info.openrocket.core.document.OpenRocketDocument;
 import info.openrocket.core.document.Simulation;
 import info.openrocket.core.file.rasaero.RASAeroCommonConstants;
 import info.openrocket.core.file.rasaero.RASAeroMotorsLoader;
+import info.openrocket.core.file.rasaero.RASAeroMotorsLoader.RASAeroMotor;
 import info.openrocket.core.logging.ErrorSet;
 import info.openrocket.core.logging.WarningSet;
-import info.openrocket.core.motor.ThrustCurveMotor;
 import info.openrocket.core.rocketcomponent.AxialStage;
-import info.openrocket.core.rocketcomponent.BodyTube;
 import info.openrocket.core.rocketcomponent.MotorMount;
 import info.openrocket.core.rocketcomponent.Rocket;
 import info.openrocket.core.rocketcomponent.RocketComponent;
@@ -46,7 +45,7 @@ public class SimulationListDTO {
         }
 
         // Load all RASAero motors
-        List<ThrustCurveMotor> motors = RASAeroMotorsLoader.loadAllRASAeroMotors(warnings);
+        List<RASAeroMotor> motors = RASAeroMotorsLoader.loadAllRASAeroMotors(warnings);
 
         // Add all the simulations
         for (Simulation simulation : document.getSimulations()) {

--- a/core/src/main/resources/datafiles/thrustcurves/RASAero/.gitattributes
+++ b/core/src/main/resources/datafiles/thrustcurves/RASAero/.gitattributes
@@ -1,0 +1,1 @@
+rasp.eng binary

--- a/core/src/main/resources/datafiles/thrustcurves/RASAero/README.md
+++ b/core/src/main/resources/datafiles/thrustcurves/RASAero/README.md
@@ -1,0 +1,9 @@
+# RASAero II motor catalog
+
+`rasp.eng` is the motor catalog distributed with the official RASAero II
+1.0.2.0 installer.  The exporter uses this snapshot to validate motor names and
+to emit the exact designation that RASAero recognizes.
+
+Source: https://www.rasaero.com/dl_software_ii.htm
+
+SHA-256: `64560042f3cf9938492f9f94bb04dace61422ae2c1c5449cb0576d4090ef4c41`

--- a/core/src/main/resources/datafiles/thrustcurves/RASAero/rasp.eng
+++ b/core/src/main/resources/datafiles/thrustcurves/RASAero/rasp.eng
@@ -1,0 +1,21689 @@
+;Aerotech D9 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;Submitted to ThrustCurve.org by Chris Kobel (3/29/07)
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+D9W 24 70 4-7 0.0101001 0.045 AT 
+0.1 13.7
+0.15 15.4
+0.2 16.3
+0.25 16.8
+0.35 17.2
+0.4 17.2
+0.5 16.8
+0.65 15.9
+0.8 14.5
+1.1 9.2
+1.25 7
+1.4 4.8
+1.6 2.5
+1.9 0
+;
+;Aerotech D13 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;Submitted to ThrustCurve.org by Chris Kobel (3/29/07)
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+D13W 18 70 4-7-10 0.0098 0.0326 AT 
+0.03 13.462
+0.061 21.171
+0.085 20.618
+0.127 21.605
+0.158 21.042
+0.182 22.306
+0.217 22.592
+0.227 23.61
+0.248 21.891
+0.279 23.155
+0.317 22.039
+0.366 21.338
+0.383 21.901
+0.449 20.648
+0.462 21.486
+0.48 19.947
+0.507 19.947
+0.521 20.509
+0.559 18.693
+0.58 19.118
+0.66 17.578
+0.743 15.337
+0.861 12.406
+0.947 9.329
+1.068 5.834
+1.155 4.158
+1.172 4.72
+1.231 2.762
+1.328 1.928
+1.404 1.093
+1.52 0
+;
+;Aerotech D15 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;Submitted to ThrustCurve.org by Chris Kobel (3/29/07)
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+D15T 24 70 4-6-8 0.0089 0.044 AT 
+0.014 11.48
+0.049 26.272
+0.081 30.087
+0.107 31.261
+0.121 31.249
+0.159 31.36
+0.208 31.249
+0.283 29.583
+0.439 23.353
+0.551 18.484
+0.675 13.43
+0.863 6.422
+0.938 3.892
+1.01 2.335
+1.085 0.778
+1.142 0.389
+1.15 0
+;
+;Aerotech D21 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;Submitted to ThrustCurve.org by Chris Kobel (3/29/07)
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+D21T 18 70 4-7 0.0096 0.025 AT 
+0.01 1.367
+0.021 19.367
+0.029 32.12
+0.037 31.667
+0.051 30.528
+0.094 30.074
+0.115 31.213
+0.133 30.074
+0.177 30.76
+0.189 29.842
+0.203 30.528
+0.226 29.842
+0.275 28.935
+0.296 29.389
+0.331 28.027
+0.421 25.971
+0.478 24.146
+0.579 20.728
+0.659 17.774
+0.739 14.356
+0.799 9.569
+0.852 4.557
+0.899 1.139
+0.94 0
+;
+;Aerotech D7 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+D7RC 24 70 1000 0.0105002 0.0422 AT
+0.036 3.336
+0.084 9.326
+0.101 10.281
+0.143 10.827
+0.213 10.99
+0.271 10.887
+0.359 10.685
+0.471 10.13
+0.506 10.342
+0.535 9.929
+0.81 8.697
+1.226 6.713
+1.589 5.138
+1.8 4.861
+2.151 4.581
+2.649 4.57
+2.696 3.887
+2.748 2.388
+2.807 0.889
+2.842 0.207
+2.87 0
+;
+;AeroTech D24T (Blue Thunder) RASP.ENG file made from
+;manufacturers published data.
+;File was produced May 07, 2004 by Stanley_Hemphill@Hotmail.com.
+;The motor is listed in the www.thrustcurve.org database as an
+;engine certified by NAR, but there is "no data" at the weblink
+;to the NAR file database.
+;The author has created this file by extracting the manufacturers
+;Thrust-Time curve from The AeroTech-2002 Catalog, and then deploting
+;32 points using the distance measuring tools in Paint Shop Pro 8.
+;The file was then created in RockSim 7 and the motor and static values
+;were read from the RockSim Engine Editor.
+;Motor Dia Len Delay Propellant Total Manufacturer
+D24BT_CO_SU 18 70 4-7-10 0.0087 0.032 AT
+0.038 39.6
+0.055 36.5
+0.076 34.4
+0.122 32.4
+0.164 31.1
+0.219 30.3
+0.261 29.3
+0.308 28.7
+0.329 27.9
+0.358 26.9
+0.392 25.8
+0.434 25
+0.485 24
+0.539 23.2
+0.577 22.3
+0.62 20.9
+0.666 19.6
+0.695 18
+0.721 16.5
+0.75 15.5
+0.754 14.3
+0.759 12.4
+0.76 11
+0.763 9.1
+0.7634 7.5
+0.771 5.9
+0.792 4
+0.83 2.6
+0.868 1.8
+0.9 1.1
+0.94 0
+;
+;Aerotech E15 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+E15 24 70 4-7 0.0201 0.0501 AT 
+0.02 23.33
+0.036 27.318
+0.058 28.84
+0.079 27.171
+0.139 25.638
+0.183 24.263
+0.237 24.106
+0.297 22.426
+0.373 21.964
+0.4 20.894
+0.443 21.355
+0.487 20.442
+0.617 19.833
+0.742 18.457
+0.812 20
+0.85 18.006
+0.899 18.467
+1.035 17.711
+1.1 16.945
+1.16 16.945
+1.377 15.736
+1.426 14.656
+1.436 16.198
+1.463 14.813
+1.55 14.361
+1.572 15.432
+1.61 13.752
+1.827 12.839
+2.126 10.098
+2.337 6.116
+2.538 1.369
+2.64 0
+;
+;Aerotech E6T single use from NAR cert data
+E6T 24 70 2-4-8-0 0.0215 0.0463 AT 
+0.011 18.085
+0.109 19.681
+0.217 16.312
+0.315 13.475
+0.457 11.348
+0.63 9.043
+0.804 7.801
+0.989 6.738
+1.272 6.028
+2 5.851
+3 5.496
+4 5.496
+4.446 4.965
+5.011 4.965
+5.533 4.787
+5.609 6.56
+5.707 4.255
+6.033 0
+;
+;Based On NAR Test Data
+;12/23/93
+E11J 24 70 4 0.025 0.0624 AT 
+0.0725446 14.3704
+0.16183 17.6296
+0.206473 18.3704
+0.418527 19.2593
+0.731027 18.3704
+1.31696 14.2222
+1.91964 9.03704
+2.51116 2.22222
+2.83 0
+;
+;E15W-4,7,P from NAR data
+E15W 24 70 4-7-0 0.0201 0.0502 AT 
+0.012 9.918
+0.018 20.205
+0.027 25.257
+0.039 28.152
+0.055 28.768
+0.088 27.29
+0.197 24.517
+0.297 22.977
+0.467 20.945
+0.561 19.959
+0.679 20.021
+0.722 19.22
+0.761 18.789
+0.807 20.021
+0.84 18.234
+0.904 18.727
+0.995 17.926
+1.034 18.172
+1.104 16.756
+1.147 17.248
+1.256 16.386
+1.377 15.77
+1.411 14.846
+1.426 16.324
+1.45 15.031
+1.547 14.353
+1.559 16.016
+1.589 13.86
+1.62 14.23
+1.693 13.121
+1.72 13.429
+1.829 12.936
+1.866 11.951
+1.944 11.951
+2.005 10.965
+2.093 10.472
+2.236 8.316
+2.26 9.055
+2.278 7.207
+2.378 4.99
+2.442 2.71
+2.499 1.602
+2.548 1.047
+2.618 0
+;
+;Aerotech E16 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;Submitted to ThrustCurve.org by Chris Kobel (3/30/07)
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+E16W 29 124 4-7-10 0.019 0.107 AT 
+0.132 32.223
+0.221 37.2
+0.255 36.699
+0.306 36.699
+0.371 35.357
+0.414 33.785
+0.437 34.906
+0.472 33.785
+0.53 32.894
+0.553 31.772
+0.576 32.443
+0.638 29.309
+0.72 27.296
+0.867 23.942
+1.083 19.245
+1.273 14.319
+1.458 9.397
+1.513 8.055
+1.524 8.279
+1.555 6.936
+1.656 4.474
+1.814 1.79
+2 0
+;
+;Aerotech E18 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;Submitted to ThrustCurve.org by Chris Kobel (3/29/07)
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+E18W 24 70 4-8-10 0.0207 0.057 AT 
+0.016 6.586
+0.042 18.004
+0.073 27.138
+0.098 29.815
+0.134 30.357
+0.17 30.347
+0.195 31.08
+0.236 30.347
+0.287 30.878
+0.338 30.337
+0.368 30.878
+0.404 29.795
+0.424 30.688
+0.465 29.976
+0.526 29.785
+0.592 29.063
+0.669 28.341
+0.786 26.908
+0.908 23.85
+1.025 21.163
+1.157 17.905
+1.284 14.857
+1.462 11.338
+1.66 7.106
+1.838 3.47
+2.006 1.309
+2.083 0.588
+2.14 0
+;
+;Aerotech E23 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;Submitted to ThrustCurve.org by Chris Kobel (3/30/07)
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+E23T 29 124 5-8 0.0174 0.1039 AT 
+0.024 16.299
+0.035 21.959
+0.067 30.785
+0.09 35.774
+0.153 37.577
+0.2 38.22
+0.24 37.357
+0.322 37.577
+0.393 35.093
+0.534 32.378
+0.727 27.168
+0.766 26.938
+0.798 25.125
+0.908 21.729
+1.057 16.98
+1.187 12.682
+1.336 7.471
+1.45 3.169
+1.497 1.584
+1.532 0.679
+1.57 0
+;
+;Aerotech E28 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;Submitted to ThrustCurve.org by Chris Kobel (3/29/07)
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+E28T 24 70 2-5-8 0.0184 0.0545 AT 
+0.01 29.862
+0.018 45.139
+0.038 47.562
+0.081 50.52
+0.106 48.953
+0.146 48.263
+0.161 48.953
+0.197 48.953
+0.242 47.562
+0.313 46.18
+0.411 43.057
+0.494 40.624
+0.527 39.583
+0.542 40.274
+0.562 38.542
+0.633 36.46
+0.683 34.377
+0.743 31.244
+0.799 29.162
+0.877 26.038
+0.97 20.832
+1.006 17.359
+1.046 11.462
+1.089 6.943
+1.132 3.819
+1.172 1.735
+1.22 0
+;
+;Aerotech E30 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;Submitted to ThrustCurve.org by Chris Kobel (3/30/07)
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+E30T 24 70 4-7 0.0193 0.0433 AT 
+0.013 38.847
+0.02 45.621
+0.041 48.27
+0.059 46.502
+0.11 46.502
+0.166 45.912
+0.184 46.792
+0.217 45.912
+0.265 45.912
+0.319 45.031
+0.383 44.15
+0.482 42.089
+0.594 38.847
+0.615 39.437
+0.628 37.376
+0.684 35.314
+0.742 33.263
+0.804 30.021
+0.88 25.607
+0.962 20.014
+1.038 12.949
+1.089 7.358
+1.151 3.237
+1.186 1.176
+1.2 0
+;
+;Aerotech E7TRC RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+E7RC 24 70 1000 0.0171 0.0484 AT 
+0.038 6.636
+0.063 10.056
+0.087 11.019
+0.134 11.42
+0.206 11.58
+0.312 11.149
+0.466 10.738
+0.667 9.777
+0.94 8.132
+1.223 6.281
+1.484 5.182
+1.709 4.701
+2.112 4.423
+2.776 4.279
+3.31 4.205
+3.926 4.266
+4.401 4.192
+4.638 4.258
+4.744 4.119
+5.124 3.979
+5.219 3.977
+5.266 3.156
+5.313 1.992
+5.36 0.965
+5.43 0
+;
+;Aerotech E6TRC RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+E6-RC 24 70 1000 0.0215 0.0527 AT 
+0.047 10.866
+0.127 11.693
+0.19 11.9
+0.316 11.622
+0.522 10.593
+0.743 9.287
+0.996 7.842
+1.249 6.19
+1.47 5.296
+1.787 4.747
+2.372 4.471
+3.02 4.403
+3.747 4.264
+4.49 4.403
+5.375 4.333
+6.087 4.264
+6.719 4.264
+6.877 4.196
+6.957 3.783
+7.004 2.614
+7.036 1.513
+7.083 0.55
+7.12 0
+;
+;Aerotech E12JRC RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+E12JRC 24 70 1000 0.0303 0.0594 AT 
+0.054 16.764
+0.095 18.33
+0.197 16.545
+0.313 16.654
+0.36 17.211
+0.401 16.316
+0.442 17.55
+0.476 16.206
+0.578 16.316
+0.666 16.764
+0.7 15.649
+0.768 16.316
+0.89 16.097
+1.019 15.649
+1.162 14.983
+1.23 14.983
+1.25 13.968
+1.291 14.754
+1.332 13.749
+1.373 14.197
+1.434 13.53
+1.488 13.749
+1.597 12.635
+1.726 11.401
+1.828 10.615
+1.889 9.613
+1.957 9.613
+1.998 8.495
+2.093 8.607
+2.277 7.042
+2.487 5.813
+3.05 0
+;
+;
+F10 29 92 4-6-8 0.04 0.083 AT 
+0.01 16.81
+0.03 22.34
+0.11 22.23
+0.26 21.49
+0.37 20
+0.47 20.21
+0.67 18.09
+0.99 15.74
+1.31 13.4
+1.81 10.85
+2.49 10.21
+3.13 8.94
+3.6 8.83
+4.11 8.62
+4.95 8.62
+5.45 8.62
+5.58 8.51
+5.88 8.72
+6.22 8.51
+6.46 8.51
+6.6 7.77
+6.71 7.02
+6.79 5.64
+6.91 3.83
+6.95 2.23
+7 0.96
+7.05 0
+;
+;Aerotech F22 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+F22 29 125 4-7 0.0463 0.1342 AT 
+0.014 11.527
+0.075 20.126
+0.157 26.572
+0.293 29.113
+0.382 30.278
+0.45 29.69
+0.539 30.667
+0.614 30.089
+0.662 31.15
+0.771 30.478
+0.948 29.89
+0.996 28.714
+1.078 28.136
+1.187 27.738
+1.289 26.761
+1.337 26.96
+1.412 25.984
+1.474 25.008
+1.515 26.173
+1.542 24.808
+1.706 22.856
+1.938 20.903
+2.101 18.173
+2.129 19.338
+2.251 16.21
+2.402 13.48
+2.64 8.791
+2.961 3.32
+3.31 0
+;
+;F25 Motor Thrust Curve created by Tim Van Milligan
+;for RockSim Users - www.rocksim.com
+;file produced March 2, 2005
+;Based on data supplied by Aerotech for the newer molded case F25.
+F25 29 98 4-6-9 0.0388 0.0972 AT 
+0.039 57.631
+0.187 53.491
+0.342 51.239
+0.5 47.86
+1 33.806
+1.5 22.94
+2 10.135
+2.207 4.504
+2.69 0
+;
+;Exported using ThrustCurveTool, www.ThrustGear.com
+;@File: 060603WF27Composite.txt, @Pts-I: 1001, @Pts-O: 32, @Sm: 5, @CO: 5%
+;@TI: 49.5446, @TIa: 49.299, @TIe: 0.0%, @ThMax: 36.2491, @ThAvg: 24.1799, @Tb: 2.049
+F27 29 83 4-8 0.0284 0.08 AT 
+0 4.84718
+0.0125 15.5374
+0.0175 18.8183
+0.025 22.5311
+0.0325 25.2547
+0.04 27.3204
+0.0575 30.3657
+0.0725 31.4597
+0.0975 32.2507
+0.265 35.0238
+0.295 35.9203
+0.4675 35.9684
+0.59 35.065
+0.8 32.0145
+0.825 31.2773
+0.8575 31.1102
+0.9025 29.9308
+0.955 29.7244
+1.045 27.2951
+1.085 27.2663
+1.1175 25.9881
+1.1475 26.0014
+1.235 23.2853
+1.28 22.9001
+1.3425 21.0771
+1.52 17.256
+1.8075 6.85478
+1.9175 4.16387
+2.05 1.78386
+2.1775 0.488016
+2.4225 0.44385
+2.425 0
+;
+;Aerotech F32 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+F32 24 124 5-10-15 0.0377 0.0814 AT 
+0.025 46.699
+0.031 51.846
+0.061 55.64
+0.085 52.868
+0.126 47.37
+0.245 45.637
+0.34 44.946
+0.394 42.873
+0.447 42.873
+0.572 41.14
+0.72 39.408
+0.744 40.78
+0.786 38.026
+1.041 35.592
+1.136 33.179
+1.177 34.541
+1.225 32.818
+1.379 31.436
+1.474 30.394
+1.635 28.311
+1.676 27.28
+1.694 29.683
+1.712 26.929
+1.854 25.537
+1.943 23.815
+2.092 21.051
+2.187 18.287
+2.276 13.82
+2.382 7.281
+2.525 2.457
+2.72 0
+;
+;Aerotech F37 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+F37 29 99 6-10-14 0.0282 0.1086 AT 
+0.018 7.251
+0.053 13.626
+0.088 22.331
+0.106 25.227
+0.141 26.385
+0.183 28.411
+0.26 37.685
+0.31 41.449
+0.422 44.035
+0.524 45.183
+0.59 46.47
+0.682 45.153
+0.864 43.386
+0.934 40.471
+1.042 35.23
+1.151 29.699
+1.246 25.037
+1.354 19.796
+1.445 13.397
+1.498 7.586
+1.54 3.226
+1.6 0
+;
+;Aerotech F40 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+F40 29 124 4-7-10 0.04 0.126 AT 
+0.015 17.776
+0.049 41.016
+0.089 58.793
+0.124 62.9
+0.148 65.173
+0.183 62.442
+0.242 68.07
+0.292 60.617
+0.321 61.524
+0.415 60.617
+0.524 58.334
+0.741 52.412
+0.87 48.314
+0.889 49.221
+0.914 47.397
+1.102 40.109
+1.285 33.728
+1.492 25.064
+1.665 15.952
+1.808 8.659
+1.942 3.19
+2.06 0
+;
+;Aerotech F52 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+F52 29 124 5-8-11 0.0366 0.1214 AT 
+0.012 46.899
+0.033 61.778
+0.056 69.441
+0.097 73.483
+0.115 76.636
+0.13 74.381
+0.153 74.82
+0.168 78.422
+0.182 78.95
+0.206 77.963
+0.238 77.504
+0.258 73.892
+0.314 72.974
+0.39 72.046
+0.428 70.679
+0.501 65.699
+0.565 62.975
+0.688 58.874
+0.749 56.15
+0.837 52.517
+0.901 49.793
+0.971 46.161
+1.088 39.365
+1.144 34.386
+1.173 29.417
+1.222 20.376
+1.275 13.151
+1.339 5.461
+1.389 1.838
+1.42 0
+;
+;Aerotech F72 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+F72 24 124 5-10-15 0.0368 0.0742 AT 
+0.012 62.586
+0.017 84.986
+0.02 98.78
+0.03 94.748
+0.05 90.152
+0.069 82.688
+0.089 85.556
+0.104 80.39
+0.136 83.255
+0.146 80.96
+0.176 82.688
+0.198 78.672
+0.213 80.96
+0.253 80.39
+0.315 80.96
+0.38 79.821
+0.429 79.241
+0.489 78.092
+0.523 78.672
+0.536 75.225
+0.675 73.496
+0.699 67.182
+0.719 68.331
+0.747 64.884
+0.769 66.033
+0.858 60.867
+0.923 52.824
+0.98 40.195
+1.012 29.864
+1.034 20.092
+1.089 11.48
+1.21 0
+;
+;Aerotech F12 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;Submitted to ThrustCurve.org by Chris Kobel (4/6/07)
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+F12J 24 70 2-5 0.0303 0.0667 AT 
+0.037 20.894
+0.054 22.152
+0.101 22.152
+0.148 22.571
+0.165 23.409
+0.2 22.421
+0.281 22.142
+0.369 22.132
+0.474 22.271
+0.526 23.54
+0.549 21.982
+0.637 22.122
+0.724 21.842
+0.8 21.413
+0.823 22.251
+0.846 20.714
+0.881 21.553
+0.945 21.123
+1.021 20.704
+1.114 20.554
+1.213 19.296
+1.382 18.298
+1.481 18.019
+1.737 15.343
+1.79 17.3
+1.883 13.936
+2.051 11.26
+2.22 7.468
+2.447 3.671
+2.709 1.135
+2.93 0
+;
+;Aerotech F24 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;Submitted to ThrustCurve.org by Chris Kobel (4/6/07)
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+F24W 24 70 4-7-10 0.0253 0.062 AT 
+0.033 16.442
+0.112 40.646
+0.125 41.45
+0.18 40.927
+0.245 40.626
+0.281 41.017
+0.355 40.024
+0.438 39.713
+0.543 38.227
+0.603 37.032
+0.658 33.779
+0.685 34.663
+0.726 29.934
+0.772 30.216
+0.951 26.953
+1.071 25.166
+1.107 23.088
+1.185 21.311
+1.383 17.144
+1.649 10.91
+1.828 5.869
+1.938 2.903
+1.988 2.306
+2.048 1.412
+2.13 0
+;
+;Aerotech F39 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;Submitted to ThrustCurve.org by Chris Kobel (4/6/07)
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+F39T 24 70 3-6-9 0.0227 0.059 AT 
+0.01 45.057
+0.016 54.131
+0.046 58.321
+0.079 59.47
+0.103 58.311
+0.13 57.253
+0.172 55.491
+0.235 53.738
+0.321 51.271
+0.363 50.566
+0.387 49.509
+0.408 50.203
+0.426 48.804
+0.453 47.746
+0.48 47.041
+0.68 41.059
+0.716 39.649
+0.752 38.944
+0.809 36.487
+0.86 34.382
+0.893 33.324
+0.917 32.619
+1 28.752
+1.075 25.247
+1.105 22.095
+1.126 17.201
+1.144 13.001
+1.174 8.109
+1.219 4.606
+1.261 2.5
+1.33 0
+;
+;F42T Motor Thrust Curve created by Tim Van Milligan
+;for RockSim Users - www.rocksim.com
+;Based on data supplied by Aerotech prior to NAR certification.
+F42T 29 83 4-8 0.027 0.076 AT 
+0.01 68.694
+0.029 65.879
+0.202 62.5
+0.511 51.802
+0.739 43.356
+0.993 31.532
+1.02 29.279
+1.072 23.086
+1.199 9.572
+1.262 4.505
+1.319 2.815
+1.47 0
+;
+;Aerotech F62T (Blue Thunder)
+;AeroTech RMS-29/60 Easy Access Reloadable Motor Hardware.
+;RASP.ENG file made from manufacturers catalog data.
+;File produced May, 17 2004.
+;The file was produced by scaling 16 data points off
+;the thrust curves in the manufacturers catalog.
+;The F62T cannot be found on thrustcurve.org.
+;Hence the amateur file production.
+;The file was created by Stan Hemphill.
+;Contact at stanley_hemphill@hotmail.com.
+;Motor Dia Len Delay Prop Gross Mfg
+F62T 29 99 6-8-9-10-11-13-14-16-18 0.025 0.109 AT 
+0.0046 53.6364
+0.0416 55.2727
+0.0909 58.3636
+0.1356 61.6364
+0.1649 64.9091
+0.1864 67.6364
+0.5085 67.6364
+0.5701 64.7273
+0.6687 60
+0.7427 55.0909
+0.7982 49.6364
+0.9029 48.7273
+0.9492 24.7273
+0.9661 20.1818
+0.9985 0
+;
+;
+F20EJ 29 83 4-7 0.03 0.0746 AT 
+0.01 52.08
+0.03 49.81
+0.06 46.98
+0.1 45.56
+0.15 44.49
+0.18 45.55
+0.21 43.42
+0.24 43.78
+0.32 43.77
+0.36 44.11
+0.44 43.04
+0.45 40.58
+0.53 39.86
+0.62 38.08
+0.76 36.3
+0.8 37.35
+0.84 34.88
+0.89 36.99
+0.9 33.46
+1.03 30.61
+1.06 32.02
+1.09 29.55
+1.23 26
+1.32 22.45
+1.35 23.16
+1.36 21.39
+1.58 16.42
+1.8 11.1
+2.01 6.48
+2.19 3.63
+2.39 1.13
+2.68 0
+;
+;F26FJ Motor Thrust Curve created by Tim Van Milligan
+;for RockSim Users - www.rocksim.com
+;File created March 2, 2005
+;Based on data supplied by Aerotech prior to NAR certification.
+F26FJ 29 98 6-9 0.0431 0.1007 AT 
+0.041 38.289
+0.114 36.318
+0.293 34.347
+0.497 32.939
+0.774 32.376
+1 31.25
+1.254 28.716
+1.498 25.338
+1.743 22.241
+2.003 17.737
+2.077 15.484
+2.304 5.349
+2.484 1.689
+2.61 0
+;
+;Aerotech F13RCJ RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+F13RCJ 32 107 1000 0.0323 0.1105 AT 
+0.048 15.309
+0.084 18.629
+0.143 19.98
+0.311 18.968
+0.538 18.172
+0.729 17.138
+0.992 15.428
+1.279 13.828
+1.673 12.456
+1.984 11.879
+2.044 12.227
+2.139 11.313
+2.378 11.193
+2.51 11.084
+2.558 12.108
+2.641 10.855
+2.976 10.736
+3.49 10.627
+3.873 10.507
+3.992 10.965
+4.028 10.627
+4.41 10.507
+4.625 10.736
+4.769 9.941
+4.829 8.684
+4.865 6.742
+4.96 3.199
+5.02 1.485
+5.1 0
+;
+;Aerotech F16RCJ RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+F16RCJ 32 107 1000 0.0625 0.1404 AT 
+0.046 26.35
+0.116 22.388
+0.139 21.374
+0.185 21.886
+0.22 20.54
+0.301 19.696
+0.498 18.35
+0.579 19.194
+0.637 16.492
+0.718 18.35
+0.834 18.35
+0.95 18.35
+1.054 19.194
+1.147 17.848
+1.181 18.853
+1.263 17.336
+1.436 18.009
+1.633 17.165
+1.784 17.336
+1.865 18.682
+1.934 16.834
+1.981 17.336
+2.178 16.332
+2.375 16.332
+2.502 18.18
+2.664 15.659
+2.896 15.488
+3.29 13.8
+3.718 11.611
+4.181 9.426
+4.888 5.891
+5.69 0
+;
+;Aerotech F21W (White Lightning) RASP.ENG file.
+;File produced Jun 22 2004.
+;The file was produced by scaling data points off the
+;thrust curve in the Tripoli.org motor pdf file.
+;The F21W cannot be found on thrustcurve.org.
+;Hence the amateur file production.
+;The file was created by Stan Hemphill
+;Contact at stanley_hemphill@hotmail.com
+;Motor ## Dia Len Delays Prop Motor Company
+F21WL_CO_SU 24 96 6-8 0.03 0.064 AT 
+0.0045 37.2266
+0.009 42.1474
+0.018 42.504
+0.027 40.5071
+0.0337 38.8669
+0.0427 38.225
+0.0517 37.7258
+0.0607 36.87
+0.072 36.4422
+0.0877 36.4422
+0.1102 35.3724
+0.135 35.8716
+0.1552 35.4437
+0.1732 36.2282
+0.2025 35.6577
+0.2452 37.2979
+0.2835 36.5848
+0.3195 38.0111
+0.3375 37.4406
+0.3757 38.5816
+0.396 38.225
+0.4297 39.3661
+0.4454 38.0111
+0.4747 38.7242
+0.4882 37.7971
+0.5084 38.1537
+0.5354 38.5103
+0.5647 37.9398
+0.5849 37.2266
+0.6007 37.8685
+0.6389 36.87
+0.6704 37.1553
+0.7649 35.9429
+0.9201 32.9477
+1.0056 30.309
+1.0709 29.7385
+1.2643 24.0333
+1.2868 24.0333
+1.3723 20.8241
+1.3926 20.8241
+1.5883 15.4754
+1.6108 15.4754
+2.0112 5.0634
+2.1192 3.4231
+2.2407 2.4247
+2.378 1.4976
+2.4927 0.9271
+2.5152 0
+;
+;Aerotech F23RCWSK RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+F23-RC-SK 32 107 1000 0.0378 0.1287 AT 
+0.042 22.644
+0.133 28.191
+0.161 27.261
+0.189 29.57
+0.252 31.419
+0.343 32.578
+0.399 32.348
+0.441 33.737
+0.476 30.729
+0.539 33.507
+0.609 34.197
+0.777 34.886
+0.826 34.656
+0.896 36
+0.938 34.656
+1.015 34.656
+1.071 34.197
+1.12 33.038
+1.218 32.578
+1.267 29.81
+1.351 29.34
+1.393 27.731
+1.54 26.802
+1.645 24.263
+1.799 21.255
+1.862 19.866
+2.051 15.479
+2.317 11.552
+2.618 6.7
+2.884 3.234
+3.185 1.386
+3.47 0
+;
+;Aerotech G25 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+G25 29 124 5-10-15 0.0625 0.1197 AT 
+0.035 30.499
+0.047 36.712
+0.059 41.18
+0.13 40.669
+0.177 38.969
+0.295 38.969
+0.343 40.947
+0.413 40.38
+0.437 38.69
+0.484 39.824
+0.532 37.845
+0.65 37.557
+0.721 38.969
+0.803 38.69
+0.85 37.279
+0.98 39.535
+1.063 36.434
+1.098 38.124
+1.252 37.845
+1.37 37.279
+1.583 37
+1.819 35.3
+1.984 33.61
+2.185 31.344
+2.315 28.809
+2.622 24.286
+3.024 18.917
+3.39 13.838
+3.839 7.624
+4.323 4.518
+4.783 2.541
+5.3 0
+;
+;Aerotech G33 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+G33 29 124 5-7 0.0722 0.1593 AT 
+0.027 22.642
+0.061 42.201
+0.117 47.354
+0.243 46.678
+0.34 46.339
+0.438 47.384
+0.48 50.92
+0.508 46.359
+0.543 47.732
+0.662 45.693
+0.851 42.28
+1.039 41.266
+1.116 42.987
+1.193 39.226
+1.221 42.31
+1.312 38.888
+1.326 40.609
+1.479 38.221
+1.675 35.157
+1.843 32.77
+1.878 36.888
+1.899 32.093
+1.997 30.382
+2.13 26.622
+2.263 23.547
+2.444 19.11
+2.591 13.977
+2.752 8.502
+2.892 4.743
+3.053 2.014
+3.27 0
+;
+;Aerotech G54 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+G54 29 124 6-10-14 0.046 0.1365 AT 
+0.018 10.953
+0.042 39.215
+0.083 66.888
+0.14 72.075
+0.223 74.958
+0.25 76.694
+0.282 80.156
+0.315 79.577
+0.336 79.577
+0.354 81.64
+0.365 77.841
+0.374 80.724
+0.389 76.694
+0.455 76.116
+0.523 74.39
+0.639 70.928
+0.722 67.467
+0.82 64.005
+0.897 58.817
+0.992 51.894
+1.084 43.824
+1.197 34.017
+1.268 28.251
+1.283 29.987
+1.295 27.104
+1.328 23.642
+1.366 16.719
+1.399 9.803
+1.435 4.612
+1.51 0
+;
+;Aerotech G55 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+G55 24 117 5-10-15 0.0625 0.1148 AT 
+0.009 81.136
+0.014 84.65
+0.034 80.557
+0.084 77.064
+0.13 71.823
+0.18 72.422
+0.206 68.919
+0.342 69.538
+0.483 68.989
+0.513 66.663
+0.543 68.42
+0.664 66.114
+0.876 66.164
+0.901 64.418
+0.997 65.026
+1.062 66.793
+1.088 63.879
+1.148 63.889
+1.158 66.813
+1.173 63.31
+1.209 62.741
+1.325 61.593
+1.395 59.277
+1.456 57.541
+1.486 58.129
+1.587 52.32
+1.708 40.094
+1.824 26.11
+1.95 15.63
+2.112 7.498
+2.258 3.446
+2.44 0
+;
+;Aerotech G64 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+G64 29 124 4-8-10 0.0625 0.1512 AT 
+0.014 54.325
+0.032 81.488
+0.059 98.31
+0.101 85.021
+0.165 83.847
+0.274 85.614
+0.37 87.39
+0.476 86.798
+0.503 91.516
+0.517 85.614
+0.585 83.847
+0.723 80.896
+0.745 82.07
+0.773 77.945
+0.883 75.576
+0.988 74.401
+1.093 69.673
+1.262 61.412
+1.28 61.994
+1.326 58.451
+1.372 54.907
+1.422 47.238
+1.505 34.841
+1.591 23.027
+1.701 13.581
+1.829 7.085
+1.902 4.133
+1.966 1.771
+2.09 0
+;
+;Exported using ThrustCurveTool, www.ThrustGear.com
+;NAR S&T Data, contributed by John DeMar
+G72 29 124 4-7-10 0.06 0.144 AT 
+0.004 4.2403
+0.006 9.6831
+0.016 54.397
+0.03 98.17
+0.034 108.509
+0.04 121.159
+0.048 133.047
+0.058 142.348
+0.068 147.209
+0.082 149.393
+0.112 146.89
+0.15 138.783
+0.17 136.039
+0.376 112.222
+0.466 103.079
+0.482 104.438
+0.56 92.6523
+0.606 92.8669
+0.644 84.2058
+0.748 73.9389
+0.76 74.2841
+0.79 69.704
+0.804 70.6
+0.822 66.7591
+0.856 62.6853
+1.154 39.9972
+1.374 19.9105
+1.474 12.5198
+1.574 7.41771
+1.78 1.19026
+2 0
+;
+;Aerotech G80 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;Note: This is for the 116N-sec G80T produced before Sept. 2006
+G80 29 124 4-7-10 0.0574 0.1049 AT 
+0.006 101.291
+0.013 105.18
+0.031 103.473
+0.038 104.069
+0.067 99.803
+0.103 96.906
+0.181 94.733
+0.271 94.039
+0.303 96.985
+0.367 95.547
+0.428 94.842
+0.456 97.055
+0.463 92.65
+0.51 94.872
+0.596 93.444
+0.606 95.646
+0.624 91.985
+0.635 95.656
+0.646 91.995
+0.696 90.547
+0.846 85.477
+0.96 80.388
+1.071 74.564
+1.207 62.878
+1.296 52.639
+1.35 37.252
+1.382 20.397
+1.418 10.139
+1.457 4.281
+1.5 0
+;
+;Aerotech G40W RASP.ENG file made by Tim Van Milligan
+;For RockSim www.RockSim.com
+;File Created March 2, 2005
+;Thrust curve supplied by Aerotech for the molded case G40W motors.
+G40W 29 124 4-7-10 0.0538 0.123 AT 
+0.024 74.325
+0.057 67.005
+0.252 65.879
+0.5 63.063
+0.765 60.248
+1 54.054
+1.25 47.298
+1.502 36.599
+1.751 25.338
+1.999 12.951
+2.121 3.941
+2.3 0
+;
+;G61W Data Entered by Tim Van Milligan
+;For RockSim: www.RockSim.com
+;Based on TRA Certification Test date: June 13, 2004
+;Not Approved by TRA or Aerotech
+G61W 38 106.7 6-10-14 0.0613 0.1904 AT 
+0.008 3.083
+0.054 71.348
+0.089 72.229
+0.174 75.312
+0.216 78.394
+0.247 79.716
+0.502 81.037
+0.753 77.073
+1.001 72.669
+1.132 66.944
+1.252 55.933
+1.503 38.316
+1.754 10.13
+1.905 3.523
+2.04 0
+;
+;Aerotech G67R (Redline)
+;AeroTech RMS-38/120 EZ Access Reloadable Motors (New! Hardware).
+;New AeroTech Redline Motor. Just announced on AeroTech's Website!
+;File produced 28 Feb 2005.
+;The file was produced by scaling data points off the
+;thrust curve in the manufacturers catalog sheet.
+;The motor is not yet on www.thrustcurve.org.
+;Hence the amateur file production.
+;The file was created by Stan Hemphill.
+;Contact at stanley_hemphill@hotmail.com.
+;Motor Dia Len Delay Prop Gross Mfg
+G67R 38 106 4-6-8-9-10-12-13-15-17 0.0576 0.191 AT 
+0.04 4.92
+0.05 6.56
+0.06 9.84
+0.07 16.41
+0.08 32.81
+0.1 49.22
+0.13 68.08
+0.15 76.29
+0.18 80.39
+0.24 82.85
+0.26 85.31
+0.31 87.77
+0.51 89.41
+0.53 91.05
+0.56 87.77
+0.6 86.95
+0.61 88.59
+0.67 86.95
+0.69 85.31
+0.71 86.95
+0.72 85.31
+0.74 86.13
+0.77 85.31
+0.81 82.03
+0.95 78.75
+1.05 73.82
+1.43 53.32
+1.5 52.5
+1.52 50.86
+1.54 45.94
+1.62 11.48
+1.64 0
+;
+;Submitted to ThrustCurve.org by Chris Kobel (4/13/07)
+;G69N based on Aerotech instruction sheet by C. Kobel 3/29/07
+G69N 38 106 0 0.0622 0.195 AT 
+0.02 51.972
+0.05 75.574
+0.1 76.709
+0.2 77.617
+0.3 79.206
+0.4 81.475
+0.5 84.425
+0.6 86.922
+0.7 88.737
+0.8 89.645
+0.9 91.688
+1 93.503
+1.1 94.411
+1.2 94.638
+1.3 93.957
+1.35 93.05
+1.4 89.418
+1.5 62.865
+1.6 33.362
+1.65 19.518
+1.7 12.028
+1.75 7.489
+1.8 4.539
+1.9 1.816
+2 0
+;
+;G71R based on Aerotech instruction sheet by C. Kobel 3/29/07
+G71R 29 124 4-7-10 0.0569 0.147 AT 
+0 0.389
+0.05 109.714
+0.1 117.884
+0.2 113.216
+0.3 109.714
+0.4 105.045
+0.5 99.21
+0.6 92.207
+0.7 83.258
+0.8 75.477
+0.9 68.085
+1 57.97
+1.1 47.465
+1.2 33.848
+1.3 21.009
+1.4 11.283
+1.5 5.447
+1.6 2.334
+1.7 0
+;
+;Aerotech G75J (Black Jack)
+;AeroTech RMS-29/180 Easy Access Reloadable Motor Hardware.
+;RASP.ENG file made from made from NAR or TMT published data.
+;File produced May, 17 2004.
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data from NAR or TMT files.
+;The curve drawn with these data points is as accurate as could
+;could be made scaling the data from the curve on the TMT html
+;page. The file is 63 data points. NOT wRASP v1.6 compatible.
+;The file was created by Stan Hemphill.
+;Contact at stanley_hemphill@hotmail.com.
+;Motor Dia Len Delay Prop Gross Mfg
+G75J 29 194 1-3-4-6-7-9-10 0.114 0.236 AT 
+0.0281 68.8604
+0.038 78.6517
+0.0561 75.923
+0.066 73.0337
+0.0776 70.4655
+0.1139 69.3419
+0.1403 68.6998
+0.1667 67.5762
+0.1881 70.305
+0.2013 69.0209
+0.2294 72.5522
+0.2541 76.4045
+0.2723 71.4286
+0.3102 76.244
+0.335 71.9101
+0.4208 75.6019
+0.4604 72.3917
+0.5215 79.2937
+0.5941 73.3547
+0.6436 80.0963
+0.7013 73.8363
+0.7393 76.4045
+0.7541 74.6388
+0.7657 77.3676
+0.7937 78.6517
+0.8036 77.0465
+0.8168 80.2568
+0.8267 75.2809
+0.8383 81.5409
+0.8581 75.7624
+0.8795 77.8491
+0.934 74.1573
+0.9868 79.9358
+1.038 76.7255
+1.0561 72.2311
+1.0941 78.8122
+1.1221 75.6019
+1.1502 80.8989
+1.1617 76.886
+1.1848 80.0963
+1.1997 76.7255
+1.2327 78.8122
+1.2508 76.4045
+1.2871 82.504
+1.3102 77.5281
+1.3267 81.862
+1.3564 75.2809
+1.3729 80.0963
+1.4076 75.7624
+1.4884 79.9358
+1.5116 73.6758
+1.5297 81.0594
+1.5512 74.6388
+1.5611 80.8989
+1.604 72.8732
+1.7211 75.6019
+1.7607 68.6998
+1.7789 70.1445
+1.8119 66.9342
+1.8267 70.7865
+1.8482 70.7865
+2.3878 0
+;
+;Aerotech G77R (Redline)
+;AeroTech RMS-29/120 EZ Access Reloadable Motors (New! Hardware).
+;New AeroTech Redline Motor. Just announced on AeroTech's Website!
+;File produced 28 Feb 2005.
+;The file was produced by scaling data points off the
+;thrust curve in the manufacturers catalog sheet.
+;The motor is not yet on www.thrustcurve.org.
+;Hence the amateur file production.
+;The file was created by Stan Hemphill.
+;Contact at stanley_hemphill@hotmail.com.
+;Motor Dia Len Delay Prop Gross Mfg
+G77R 29 150 4-6-8-9-10-12-13-15-17 0.0554 0.155 AT 
+0.0132 14.8333
+0.0243 32.4479
+0.0331 46.3542
+0.0375 52.8438
+0.0463 56.5521
+0.0617 59.3333
+0.258 73.2396
+0.6548 87.1458
+0.8709 89
+0.8885 85.2917
+1.0252 86.2188
+1.0472 84.3646
+1.0715 86.2188
+1.1002 84.3646
+1.1332 85.2917
+1.195 76.9479
+1.2104 76.0208
+1.2369 65.8229
+1.2611 43.5729
+1.2898 27.8125
+1.3317 12.0521
+1.3625 4.6354
+1.4 0
+;
+;@File: G78G_Typ.txt, @Pts-I: 1001, @Pts-O: 31, @Sm: 0, @CO: 5%
+;@TI: 109.776, @TIa: 109.5639, @TIe: 0.0%, @ThMax: 102.242, @ThAvg: 79.5671, @Tb: 1.377
+;Exported using ThrustCurveTool, www.ThrustGear.com
+G78G 29 146 4-7-10 0.0597 0.125 AT
+0.004 2.76203
+0.006 34.7707
+0.008 44.326
+0.01 41.2789
+0.012 28.5933
+0.014 27.3926
+0.016 38.0574
+0.02 47.7036
+0.022 48.2012
+0.03 56.4344
+0.042 61.4034
+0.06 65.883
+0.212 84.526
+0.266 88.9218
+0.404 95.5932
+0.43 98.9746
+0.466 100.536
+0.58 102.242
+0.694 101.319
+0.86 95.4526
+1.1 90.4186
+1.132 82.5618
+1.156 72.6383
+1.168 64.903
+1.194 42.3389
+1.216 28.3424
+1.226 24.9802
+1.2559 17.4005
+1.2859 13.0465
+1.3819 5.05295
+1.4719 0
+;
+;G79W Data Entered by Tim Van Milligan
+;For RockSim: www.RockSim.com
+;Based on TRA Certification Test date: June 13, 2004
+;Not Approved by TRA or Aerotech
+G79W 29 149.86 6-10-14 0.0609 0.154 AT 
+0.015 7.157
+0.074 91.937
+0.09 91.387
+0.114 84.781
+0.145 84.23
+0.201 89.185
+0.291 94.69
+0.4 98.544
+0.6 99.645
+0.708 96.892
+0.8 93.038
+0.915 85.331
+1 77.624
+1.085 71.017
+1.175 68.265
+1.199 44.59
+1.28 22.021
+1.36 4.955
+1.42 0
+;
+;Aerotech G80T RASP.ENG file made by Tim Van Milligan
+;For RockSim www.RockSim.com
+;File Created March 2, 2005
+;Thrust curve supplied by Aerotech for the molded case G80T motors.
+G80T 29 124 4-7-10 0.0479 0.1161 AT 
+0.016 110.761
+0.049 100.648
+0.195 98.537
+0.472 96.425
+0.635 90.091
+0.798 82.348
+0.99 63.345
+1.121 38.711
+1.215 18.3
+1.287 5.56
+1.41 0
+;
+;
+G101T 29 114.3 5-8-12 0.046 0.136 AT 
+0.01 35.29
+0.02 63.97
+0.02 78.09
+0.03 84.71
+0.04 89.96
+0.06 93.96
+0.12 97.26
+0.17 99.14
+0.21 101.73
+0.27 104.09
+0.31 104.56
+0.36 103.62
+0.4 103.38
+0.45 101.03
+0.51 99.27
+0.53 94.41
+0.56 93.09
+0.64 87.35
+0.76 78.53
+0.8 75.88
+0.88 68.82
+0.89 65.73
+0.9 61.32
+0.91 55.15
+0.93 35.73
+0.94 32.65
+0.95 22.5
+0.98 10.59
+1 5.29
+1.05 0
+;
+;Aerotech G104T (Blue Thunder)
+;AeroTech RMS-29/100 EZ Access Reloadable Motors.
+;File produced 28 Feb 2005.
+;The file was produced by scaling data points off the
+;thrust curve in the manufacturers catalog sheet.
+;The motor is not yet on www.thrustcurve.org.
+;Hence the amateur file production.
+;The file was created by Stan Hemphill.
+;Contact at stanley_hemphill@hotmail.com.
+;Motor Dia Len Delay Prop Gross Mfg
+G104T 29 124 6-8-9-10-11-13-14-16-18 0.0408 0.136 AT 
+0.0067 125.343
+0.0471 123.542
+0.0856 121.967
+0.1019 121.405
+0.1462 121.18
+0.1837 120.842
+0.2029 120.504
+0.2385 118.817
+0.2644 117.242
+0.2798 116.904
+0.3279 116.679
+0.3923 116.679
+0.4298 116.116
+0.4615 114.091
+0.5067 110.153
+0.5404 104.64
+0.576 96.201
+0.6067 89.5626
+0.6817 78.8736
+0.7692 67.9595
+0.7865 64.9216
+0.799 62.5588
+0.8058 58.0582
+0.8192 50.5196
+0.8385 39.043
+0.8625 27.5664
+0.8769 16.6523
+0.9019 0
+;
+;Aerotech G12RC RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+G12RC 32 107 1000 0.0511 0.131 AT 
+0.03 18.549
+0.117 19.96
+0.239 20.64
+0.362 20.111
+0.519 18.982
+0.694 17.138
+0.886 15.02
+1.131 13.186
+1.375 11.915
+1.689 11.069
+2.021 10.363
+2.422 10.232
+3.172 9.677
+4.114 9.267
+5.039 8.857
+6.137 8.733
+7.132 8.607
+7.795 8.335
+7.952 8.196
+8.074 8.055
+8.179 6.924
+8.319 4.661
+8.476 1.973
+8.55 0
+;
+;38-120
+;Created from TRA Certification Record issued 23 Nov 2006
+;Bill Wagstaff - 04/30/07
+G339N 38 97 0 0.049 0.19 AT 
+0.009 371
+0.05 375
+0.1 375
+0.15 364
+0.2 349
+0.25 310
+0.3 264
+0.324 257
+0.342 39
+0.359 0
+;
+;
+G35EJ 29 98 4-7 0.05 0.1005 AT 
+0.01 39.14
+0.02 76.22
+0.05 64.46
+0.13 57.54
+0.21 57.53
+0.24 64.43
+0.25 57.06
+0.35 56.12
+0.43 55.2
+0.48 57.49
+0.51 52.41
+0.55 53.33
+0.76 50.54
+0.91 50.06
+1.11 44.96
+1.32 41.24
+1.55 35.68
+1.6 36.13
+1.63 33.36
+1.67 34.28
+1.8 30.12
+2 25.02
+2.14 21.32
+2.23 19.46
+2.3 15.77
+2.41 9.76
+2.53 6.52
+2.65 3.74
+2.74 1.88
+2.91 0
+;
+;Aerotech G38FJ RASP.ENG file made by Tim Van Milligan
+;For RockSim www.RockSim.com
+;File Created March 2, 2005
+;Thrust curve supplied by Aerotech for the molded case G38FJ motors.
+G38FJ 29 124 4-7 0.0597 0.1264 AT 
+0.024 52.928
+0.171 48.424
+0.497 45.045
+1 42.23
+1.279 39.978
+1.498 36.599
+1.783 30.406
+2.011 23.086
+2.272 10.135
+2.467 3.941
+2.64 0
+;
+;G53FJ based on Aerotech instruction sheet by C. Kobel 12/9/07
+G53FJ 29 124 5-7-10 0.06 0.152 AT 
+0.012 44.898
+0.031 71.504
+0.064 80.234
+0.081 83.976
+0.1 86.47
+0.15 84.599
+0.2 81.897
+0.3 78.571
+0.4 76.493
+0.5 73.583
+0.6 70.881
+0.7 67.347
+0.8 63.813
+0.9 60.072
+1 54.667
+1.1 47.392
+1.2 39.909
+1.3 32.426
+1.4 25.983
+1.5 20.578
+1.6 10.601
+1.7 3.949
+1.8 1.247
+1.85 0
+;
+;AeroTech H45W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+H45W 38 194 0 0.193984 0.294784 AT 
+0.141 62.554
+0.424 63.504
+0.707 65.913
+0.992 68.37
+1.276 69.315
+1.559 68.523
+1.843 67.231
+2.127 65.705
+2.411 63.154
+2.695 59.21
+2.979 55.6
+3.264 50.79
+3.547 45.237
+3.83 39.835
+4.115 34.562
+4.399 29.213
+4.682 24.72
+4.967 20.616
+5.251 17.475
+5.534 14.498
+5.818 12.697
+6.102 10.792
+6.386 9.229
+6.67 7.754
+6.954 6.075
+7.239 0
+;
+;AeroTech H55W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+H55W 29 191 0 0.09856 0.18816 AT 
+0.052 92.752
+0.159 98.019
+0.268 95.821
+0.375 96.162
+0.482 97.146
+0.591 96.927
+0.699 95.915
+0.806 94.447
+0.914 92.001
+1.022 88.756
+1.129 86.97
+1.236 84.072
+1.345 80.172
+1.453 74.343
+1.56 64.99
+1.668 46.38
+1.776 32.835
+1.883 25.734
+1.991 19.92
+2.099 16.229
+2.207 13.059
+2.315 10.451
+2.422 7.7
+2.53 5.696
+2.639 3.979
+2.747 0
+;
+;AeroTech H70W
+;Copyright Tripoli Motor Testing 1997 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+H70W 29 229 0 0.11648 0.224 AT 
+0.055 114.847
+0.169 131.427
+0.283 126.879
+0.397 127.136
+0.51 127.254
+0.625 125.894
+0.739 124.917
+0.852 122.031
+0.967 119.032
+1.08 115.071
+1.194 108.446
+1.308 102.273
+1.422 96.098
+1.535 86.953
+1.65 75.702
+1.764 62.402
+1.877 48.132
+1.992 36.862
+2.105 28.065
+2.219 21.592
+2.333 16.894
+2.447 12.686
+2.56 9.681
+2.675 6.818
+2.79 4.488
+2.904 0
+;
+;AeroTech H73J
+;Copyright Tripoli Motor Testing 1997 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+H73J 38 152 6 0.14784 0.30912 AT 
+0.056 49.252
+0.172 82.004
+0.287 82.13
+0.403 84.596
+0.52 86.883
+0.635 88.888
+0.751 89.652
+0.867 91.342
+0.982 92.98
+1.099 94.571
+1.215 94.641
+1.33 93.549
+1.446 91.447
+1.561 88.189
+1.678 82.436
+1.794 77.397
+1.909 70.772
+2.025 61.173
+2.141 51.161
+2.257 38.54
+2.373 21.562
+2.489 12.213
+2.604 7.327
+2.72 3.706
+2.836 1.777
+2.953 0
+;
+;AeroTech H97J
+;Copyright Tripoli Motor Testing 1997 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+H97J 29 238 6 0.1344 0.27776 AT 
+0.045 89.405
+0.136 100.289
+0.228 100.463
+0.32 102.019
+0.411 102.813
+0.503 103.55
+0.595 101.701
+0.686 103.056
+0.778 103.331
+0.87 102.613
+0.961 103.394
+1.053 100.963
+1.145 101.226
+1.236 99.864
+1.328 98.42
+1.42 96.827
+1.511 95.034
+1.603 93.241
+1.695 93.485
+1.786 88.068
+1.878 64.358
+1.97 30.264
+2.061 8.691
+2.153 1.399
+2.245 0.525
+2.336 0
+;
+;AeroTech H112J
+;Copyright Tripoli Motor Testing 1999 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+H112J 38 202 0 0.187712 0.379456 AT 
+0.064 85.431
+0.194 101.938
+0.324 101.897
+0.454 102.839
+0.584 104.479
+0.715 103.845
+0.845 103.439
+0.975 104.286
+1.106 104.922
+1.236 104.39
+1.367 102.768
+1.497 102.237
+1.627 100.032
+1.757 98.345
+1.888 94.56
+2.018 89.018
+2.148 82.857
+2.279 77.685
+2.409 72.373
+2.54 67.041
+2.67 59.764
+2.8 37.616
+2.93 14.457
+3.06 4.642
+3.192 1.818
+3.323 0
+;
+;AeroTech H123W
+;Copyright Tripoli Motor Testing 1999 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+H123W 38 154 0 0.126336 0.278656 AT 
+0.047 96.764
+0.143 146.256
+0.239 150.699
+0.334 152.496
+0.43 151.248
+0.526 149.875
+0.622 150.2
+0.718 149.176
+0.814 144.858
+0.909 143.536
+1.005 141.414
+1.101 135.125
+1.198 125.288
+1.295 114.035
+1.391 101.556
+1.486 90.175
+1.582 78.694
+1.678 66.364
+1.774 54.26
+1.87 46.872
+1.966 38.186
+2.061 22.737
+2.157 13.478
+2.253 7.587
+2.35 5.252
+2.447 0
+;
+;AeroTech H125W
+;Copyright Tripoli Motor Testing 1997 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+H125W-29mm 29 330 14 0.18816 0.32256 AT 
+0.053 275.994
+0.161 241.473
+0.27 216.283
+0.378 199.482
+0.488 188.758
+0.597 182.349
+0.705 175.862
+0.814 169.365
+0.922 162.281
+1.031 154.276
+1.141 143.915
+1.249 133.48
+1.357 123.007
+1.466 113.058
+1.575 101.801
+1.684 88.423
+1.793 73.53
+1.901 60.425
+2.009 46.643
+2.119 36.785
+2.228 29.546
+2.336 23.641
+2.445 18.794
+2.553 14.728
+2.663 10.97
+2.772 0
+;
+;
+H125W-38mm 38 191 6-10-14 0.1462 0.225 AT 
+0.05 100
+0.5 167
+1.53 129
+2 145
+2.56 0
+;
+;
+H128W 29 195 6-10-14 0.0922 0.2145 AT 
+0 0.62
+0.1 157.28
+0.2 129.75
+0.3 129.75
+0.4 125.26
+0.5 125.26
+0.9 125.26
+1 120.81
+1.2 102.93
+1.3 44.75
+1.4 8.94
+1.5 0
+;
+;AeroTech H148R
+;provided by ThrustCurve.org (www.thrustcurve.org)
+H148R 38 152 0 0.14784 0.30912 AT 
+0.027 77.232
+0.088 174.296
+0.148 185.046
+0.208 190.458
+0.268 192.497
+0.327 191.996
+0.388 188.79
+0.448 187.548
+0.509 182.697
+0.57 178.151
+0.63 172.906
+0.69 169.607
+0.75 164.51
+0.81 158.375
+0.87 153.019
+0.93 146.81
+0.991 139.443
+1.053 132.001
+1.112 123.271
+1.173 112.559
+1.233 104.737
+1.292 97.657
+1.353 94.932
+1.413 60.644
+1.474 13.007
+1.535 0
+;
+;AeroTech H165R
+;provided by ThrustCurve.org (www.thrustcurve.org)
+H165R 29 194 0 0.0896 0.2016 AT 
+0.018 55.047
+0.059 157.258
+0.101 168.509
+0.144 173.219
+0.186 179.237
+0.229 183.947
+0.271 187.872
+0.314 188.134
+0.356 188.919
+0.399 190.488
+0.441 187.349
+0.484 189.18
+0.525 186.547
+0.566 185.517
+0.609 180.807
+0.651 177.667
+0.694 170.602
+0.736 167.201
+0.779 158.828
+0.821 155.688
+0.864 153.333
+0.906 136.325
+0.949 73.526
+0.991 20.671
+1.034 4.448
+1.076 0
+;
+;AeroTech H180W
+;Copyright Tripoli Motor Testing 1997 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+H180W 29 238 6 0.12096 0.2464 AT 
+0.024 149.374
+0.075 222.273
+0.127 222.339
+0.178 227.835
+0.229 234.963
+0.281 238.162
+0.333 240.252
+0.384 243.126
+0.435 240.757
+0.487 240.724
+0.539 236.311
+0.59 236.799
+0.642 234.897
+0.694 232.763
+0.745 229.198
+0.796 228.816
+0.848 231.906
+0.899 225.853
+0.95 188.285
+1.002 134.679
+1.054 78.94
+1.105 34.557
+1.156 15.482
+1.208 7.279
+1.26 3.585
+1.313 0
+;
+;AeroTech H210R
+;provided by ThrustCurve.org (www.thrustcurve.org)
+H210R 29 238 0 0.12096 0.2464 AT 
+0.019 105.923
+0.059 211.29
+0.099 219.77
+0.139 229.639
+0.179 235.082
+0.22 241.594
+0.26 242.706
+0.3 245.347
+0.341 249.1
+0.381 253.41
+0.421 258.553
+0.461 260.221
+0.502 257.997
+0.543 259.248
+0.583 256.607
+0.623 252.436
+0.663 245.056
+0.704 219.909
+0.744 209.344
+0.784 200.587
+0.824 193.565
+0.865 184.323
+0.905 153.881
+0.945 58.244
+0.986 13.21
+1.027 0
+;
+;
+H220T 29 239 6-10-14 0.1064 0.2386 AT 
+0 314.1
+0.1 236.61
+0.2 269.23
+0.3 261.06
+0.4 252.9
+0.72 252.9
+0.8 112.58
+0.9 9.78
+0.96 0
+;
+;AeroTech H238T
+;Copyright Tripoli Motor Testing 1997 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+H238T 29 194 6 0.08064 0.18816 AT 
+0.019 173.1
+0.059 206.876
+0.1 211.036
+0.141 214.353
+0.181 217.113
+0.222 219.343
+0.263 221.034
+0.303 224.951
+0.344 229.324
+0.384 229.308
+0.425 228.558
+0.466 226.573
+0.506 222.365
+0.547 219.205
+0.588 217.75
+0.628 213.35
+0.669 208.07
+0.709 200.966
+0.75 196.988
+0.791 151.387
+0.831 96.273
+0.872 59.475
+0.912 18.621
+0.953 7.986
+0.995 3.697
+1.036 0
+;
+;AeroTech H242T
+;Copyright Tripoli Motor Testing 1997 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+H242T 38 152 10 0.11648 0.2688 AT 
+0.03 164.06
+0.093 197.516
+0.155 204.324
+0.218 208.97
+0.28 211.481
+0.343 211.261
+0.405 209.291
+0.468 208.438
+0.531 206.707
+0.595 203.967
+0.657 198.175
+0.72 192.137
+0.782 186.84
+0.845 180.802
+0.907 174.635
+0.97 165.581
+1.033 159.726
+1.097 151.69
+1.159 144.167
+1.222 138.55
+1.284 119.114
+1.347 69.055
+1.409 21.396
+1.472 3.473
+1.535 0.594
+1.599 0
+;
+;I don't know that
+;these ejection
+;delays are correct.
+;This was made
+;using the Aerotech
+;test thrust curves.
+;By Tobin Yehle,
+;11/11/07.
+H250G 29 228.93 0-6-10-14 0.1163 0.256 AT 
+0.00250627 88.6915
+0.0125313 177.383
+0.0300752 279.719
+0.0726817 311.103
+0.145363 320.654
+0.24812 311.103
+0.308271 297.458
+0.398496 282.448
+0.45614 270.168
+0.593985 238.785
+0.691729 221.047
+0.799499 218.318
+0.83208 210.131
+0.844612 189.663
+0.907268 13.6449
+0.92 0
+;
+;AeroTech H268R
+;provided by ThrustCurve.org (www.thrustcurve.org)
+H268R 29 333 0 0.18368 0.3584 AT 
+0.022 268.095
+0.069 332.446
+0.116 312.429
+0.164 306.81
+0.211 305.757
+0.259 306.576
+0.306 312.546
+0.354 319.687
+0.401 321.234
+0.448 320.974
+0.495 321.208
+0.542 321.794
+0.59 323.315
+0.638 322.847
+0.685 307.044
+0.732 291.593
+0.779 277.713
+0.826 267.127
+0.874 257.529
+0.921 252.846
+0.969 222.645
+1.016 159.668
+1.064 108.747
+1.111 52.091
+1.159 15.569
+1.207 0
+;
+;38-240
+;Greg Gardner - 09/15/06
+H669N 38 152 0 0.096 0.252 AT 
+0.003 141
+0.006 523
+0.009 934
+0.012 1178
+0.016 926
+0.019 684
+0.022 487
+0.025 415
+0.028 622
+0.031 801
+0.0325 906
+0.034 866
+0.037 755
+0.04 737
+0.043 666
+0.047 737
+0.0485 802
+0.05 755
+0.053 791
+0.056 765
+0.059 755
+0.062 747
+0.069 737
+0.075 761
+0.082 755
+0.088 729
+0.093 741
+0.1 751
+0.2 703
+0.25 640
+0.3 586
+0.306 584
+0.309 576
+0.312 506
+0.318 292
+0.325 93
+0.329 0
+;
+;38-360
+;Greg Gardner - 09/15/06
+H999N 38 203 0 0.144 0.331 AT 
+0.003 204
+0.006 757
+0.009 1357
+0.012 1710
+0.016 1345
+0.019 995
+0.022 710
+0.025 606
+0.028 905
+0.031 1165
+0.0325 1311
+0.034 1258
+0.037 1098
+0.04 1072
+0.043 969
+0.047 1072
+0.0485 1166
+0.05 1098
+0.053 1160
+0.056 1117
+0.059 1103
+0.062 1093
+0.069 1076
+0.075 1110
+0.082 1105
+0.088 1065
+0.093 1082
+0.1 1092
+0.2 1022
+0.25 931
+0.3 853
+0.306 850
+0.309 838
+0.312 735
+0.318 435
+0.325 161
+0.329 0
+;
+;AeroTech I65W
+;Copyright Tripoli Motor Testing 1997 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+I65W 54 235 0 0.41216 0.7616 AT 
+0.18 125.414
+0.544 139.304
+0.908 145.369
+1.273 148.283
+1.638 146.745
+2.002 139.049
+2.367 131.2
+2.731 123.276
+3.096 113.454
+3.46 102.368
+3.825 90.21
+4.19 78.084
+4.554 66.812
+4.919 55.78
+5.283 47.281
+5.648 39.154
+6.012 32.528
+6.377 27.069
+6.742 22.099
+7.106 18.095
+7.471 14.819
+7.835 12.097
+8.2 9.763
+8.565 7.875
+8.929 5.999
+9.294 0
+;
+;Aerotech I115W from TRA Cert Data
+I115W 54 156 6-10-14-0 0.229 0.58 AT 
+0.034 12.095
+0.177 105.225
+0.206 113.087
+1.017 163.281
+1.166 161.466
+1.257 162.676
+1.343 166.909
+1.417 160.862
+1.514 162.676
+1.617 163.885
+1.686 160.257
+1.977 142.719
+2.497 106.435
+2.68 91.316
+2.994 72.569
+3.103 67.126
+3.189 65.917
+3.24 59.265
+3.291 42.937
+3.331 30.237
+3.377 20.561
+3.429 12.7
+3.491 7.257
+3.514 0
+;
+;AeroTech I132W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+I132W 38 335 0 0.365568 0.512064 AT 
+0.096 204.011
+0.29 174.236
+0.484 168.865
+0.679 170.783
+0.874 173.028
+1.069 174.287
+1.264 174.647
+1.458 174.364
+1.652 174.645
+1.847 173.002
+2.042 169.209
+2.236 164.309
+2.431 157.149
+2.626 149.58
+2.821 138.36
+3.016 124.171
+3.21 107.626
+3.404 89.785
+3.599 71.747
+3.794 55.124
+3.989 42.264
+4.183 31.373
+4.378 21.98
+4.573 14.389
+4.768 8.794
+4.962 0
+;
+;AeroTech I154J
+;Copyright Tripoli Motor Testing 1999 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+I154J 38 250 0 0.25088 0.491904 AT 
+0.066 120.409
+0.199 150.638
+0.332 151.666
+0.466 156.806
+0.599 150.331
+0.732 150.602
+0.866 145.101
+0.999 144.469
+1.133 145.159
+1.268 145.912
+1.401 141.71
+1.534 142.828
+1.668 141.187
+1.801 140.97
+1.934 137.832
+2.068 128.417
+2.202 122.339
+2.336 111.986
+2.47 105.295
+2.603 96.602
+2.736 90.469
+2.87 57.427
+3.003 20.489
+3.136 4.707
+3.271 2.966
+3.405 0
+;
+;AeroTech I161W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+I161W 38 191 0 0.189952 0.370048 AT 
+0.043 178.9
+0.131 206.77
+0.221 206.101
+0.31 205.175
+0.4 206.924
+0.49 210.603
+0.579 210.475
+0.669 211.555
+0.758 212.379
+0.848 212.096
+0.938 209.06
+1.027 202.345
+1.116 192.439
+1.204 179.499
+1.294 162.159
+1.383 148.446
+1.473 135.222
+1.563 120.095
+1.652 104.041
+1.742 87.962
+1.831 74.789
+1.921 54.362
+2.01 23.386
+2.1 7.332
+2.19 5.171
+2.279 0
+;
+;AeroTech I195J
+;Copyright Tripoli Motor Testing 1996 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+I195J 38 298 10 0.3136 0.59136 AT 
+0.05 258.67
+0.152 353.638
+0.254 300.655
+0.356 265.354
+0.458 266.338
+0.56 283.233
+0.662 332.442
+0.765 283.04
+0.867 230.795
+0.969 222.867
+1.071 217.091
+1.173 210.6
+1.275 202.722
+1.377 192.671
+1.479 182.571
+1.581 171.964
+1.683 162.238
+1.785 148.138
+1.888 130.259
+1.99 107.022
+2.092 80.23
+2.194 51.074
+2.296 26.313
+2.398 10.397
+2.5 3.977
+2.602 0
+;
+;AeroTech I200W
+;Copyright Tripoli Motor Testing 1999 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+I200W 29 333 0 0.181888 0.357504 AT 
+0.033 303.951
+0.103 273.452
+0.174 276.061
+0.245 271.625
+0.316 268.233
+0.386 258.449
+0.457 252.48
+0.528 246.642
+0.599 242.304
+0.67 237.737
+0.741 234.769
+0.811 233.171
+0.882 230.66
+0.953 224.985
+1.024 221.658
+1.095 214.548
+1.166 177.365
+1.236 154.208
+1.307 119.146
+1.378 91.586
+1.449 65.33
+1.52 32.877
+1.591 28.702
+1.661 22.211
+1.732 15.558
+1.803 0
+;
+;AeroTech I211W
+;Copyright Tripoli Motor Testing 1999 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+I211W 38 240 0 0.247296 0.466368 AT 
+0.044 257.326
+0.134 295.533
+0.226 296.087
+0.318 298.204
+0.408 295.082
+0.499 287.669
+0.591 282.578
+0.682 272.875
+0.773 266.997
+0.864 257.602
+0.955 250.495
+1.047 238.574
+1.138 228.571
+1.228 215.135
+1.32 198.047
+1.411 180.631
+1.502 161.261
+1.593 146.708
+1.684 134.484
+1.776 101.241
+1.867 52.688
+1.957 35.461
+2.049 24.321
+2.141 11.165
+2.232 4.587
+2.324 0
+;
+;Aerotech I215R from TRA Cert Data
+I215R 54 156 6-10-14-0 0.208 0.527 AT 
+0.049 88.39
+0.089 154.683
+0.094 206.914
+0.178 245.083
+0.251 255.127
+0.325 259.145
+0.404 249.1
+0.582 257.136
+0.631 253.118
+0.7 253.118
+0.774 245.083
+1.001 239.056
+1.509 192.852
+1.681 178.79
+1.716 180.799
+1.746 190.843
+1.775 178.79
+1.8 90.399
+1.82 34.151
+1.859 0
+;
+;AeroTech I218R
+;provided by ThrustCurve.org (www.thrustcurve.org)
+I218R 38 191 0 0.19264 0.37184 AT 
+0.027 136.078
+0.088 275.03
+0.148 280.998
+0.208 284.371
+0.268 284.037
+0.327 279.311
+0.388 277.791
+0.448 276.309
+0.509 269.384
+0.57 266.041
+0.63 261.907
+0.69 256.366
+0.75 250.565
+0.81 242.206
+0.87 234.607
+0.93 225.488
+0.991 216.166
+1.053 205.415
+1.112 193.238
+1.173 177.206
+1.233 161.304
+1.292 139.118
+1.353 96.082
+1.413 38.848
+1.474 5.978
+1.535 0
+;
+;
+I229T 54 156 6-10-14 0.206 0.52 AT 
+0.01 44.73
+0.02 216.65
+0.19 244.72
+0.4 266.64
+0.49 266.64
+0.52 273.66
+0.59 271.9
+0.75 272.78
+0.84 268.4
+0.88 271.9
+0.97 262.26
+1 265.76
+1.07 255.24
+1.21 249.1
+1.51 219.28
+1.6 230.68
+1.63 191.21
+1.64 132.44
+1.66 86.83
+1.7 44.73
+1.71 21.05
+1.73 0
+;
+;Ejection delays may not be corrrect.
+;From Aerotech pre-cert data.
+;Created 11/11/07 by Jim Yehle.
+I245G 38 192.532 0-6-10-14 0.1813 0.365 AT 
+0.0244989 234.061
+0.0550162 257.888
+0.0868597 368.567
+0.106904 382.335
+0.13363 390.808
+0.200445 405.635
+0.262806 410.931
+0.302895 411.99
+0.363029 408.813
+0.401294 398.43
+0.501114 363.271
+0.594655 320.907
+0.68932 278.355
+0.797327 212.879
+0.893204 181.477
+1.00647 154.187
+1.09061 133.72
+1.16036 120.737
+1.1804 122.856
+1.23625 106.43
+1.30421 75.0467
+1.3608 36.0094
+1.40312 19.0638
+1.43875 5.2955
+1.46325 0
+;
+;AeroTech I284W
+;Copyright Tripoli Motor Testing 1997 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+I284W 38 298 10 0.3136 0.55552 AT 
+0.033 370.682
+0.103 483.606
+0.174 483.282
+0.245 486.856
+0.316 490.842
+0.386 499.428
+0.457 508.8
+0.528 506.326
+0.599 485.287
+0.67 481.043
+0.741 455.776
+0.811 426.92
+0.882 393.422
+0.953 367.404
+1.024 347.49
+1.095 325.191
+1.166 304.064
+1.236 284.158
+1.307 271.165
+1.378 228.579
+1.449 130.521
+1.52 57.212
+1.591 29.552
+1.661 16.413
+1.732 10.365
+1.803 0
+;
+;AeroTech I285R
+;provided by ThrustCurve.org (www.thrustcurve.org)
+I285R 38 250 0 0.25088 0.4928 AT 
+0.027 171.405
+0.088 325.573
+0.148 341.697
+0.208 358.916
+0.268 373.706
+0.327 373.966
+0.388 368.442
+0.448 367.497
+0.507 361.9
+0.568 351.928
+0.628 346.109
+0.687 340.993
+0.749 329.382
+0.81 321.625
+0.87 310.856
+0.93 295.955
+0.99 283.704
+1.05 269.655
+1.11 253.419
+1.17 240.222
+1.23 224.116
+1.29 204.118
+1.35 118.73
+1.41 23.483
+1.471 2.046
+1.532 0
+;
+;
+I300T 38 250 6-10-14 0.2216 0.4405 AT 
+0 473.17
+0.1 395.68
+0.2 375.31
+0.3 367.14
+0.4 358.97
+0.5 346.72
+0.6 338.56
+0.7 318.19
+0.8 305.94
+0.9 295.35
+1.07 269.23
+1.1 258.01
+1.2 246.79
+1.3 179.49
+1.4 48.95
+1.5 13.91
+1.6 0
+;
+;AeroTech I357T
+;Copyright Tripoli Motor Testing 1997 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+I357T 38 203 14 0.1792 0.34944 AT 
+0.028 311.629
+0.087 351.768
+0.147 349.074
+0.206 346.175
+0.266 341.229
+0.325 336.857
+0.384 333.748
+0.444 326.96
+0.503 319.679
+0.563 312.533
+0.622 300.79
+0.681 292.787
+0.741 283.766
+0.8 274.578
+0.859 264.915
+0.919 254.273
+0.978 241.755
+1.037 229.02
+1.097 216.238
+1.156 187.776
+1.216 109.94
+1.275 56.459
+1.334 24.476
+1.394 10.977
+1.454 3.45
+1.515 0
+;
+;AeroTech I366R
+;provided by ThrustCurve.org (www.thrustcurve.org)
+I366R 38 298 0 0.3136 0.55552 AT 
+0.027 323.256
+0.088 485.393
+0.148 483.744
+0.208 479.926
+0.268 473.365
+0.327 466.192
+0.388 457.444
+0.448 448.751
+0.509 441.477
+0.57 430.236
+0.63 421.524
+0.69 411.757
+0.75 398.876
+0.81 387.496
+0.87 375.43
+0.93 361.325
+0.991 345.057
+1.053 330.392
+1.112 312.636
+1.173 293.508
+1.233 275.085
+1.292 262.408
+1.353 230.881
+1.413 118.008
+1.474 23.611
+1.535 0
+;
+;AeroTech I435T
+;Copyright Tripoli Motor Testing 1996 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+I435T 38 298 6 0.28672 0.52864 AT 
+0.026 684.626
+0.08 702.334
+0.134 655.13
+0.19 638.942
+0.245 624.098
+0.299 611.802
+0.354 602.601
+0.409 590.237
+0.464 575.712
+0.519 563.654
+0.574 548.912
+0.628 527.885
+0.683 504.211
+0.739 480.412
+0.793 459.219
+0.848 436.771
+0.903 414.493
+0.957 392.151
+1.012 366.634
+1.068 299.67
+1.122 182.639
+1.177 106.457
+1.232 55.447
+1.286 23.628
+1.342 11.052
+1.397 0
+;
+;Aerotech I599N from TRA Cert Data
+I599N 54 156 100 0.195 0.520051 AT 
+0.007 179.424
+0.01 495.908
+0.012 578.144
+0.014 647.92
+0.017 797.44
+0.024 593.096
+0.032 647.92
+0.045 677.824
+0.051 702.744
+0.055 677.824
+0.062 720.188
+0.076 707.728
+0.12 752.584
+0.202 757.568
+0.225 755.076
+0.241 735.14
+0.25 720.188
+0.263 730.156
+0.329 722.68
+0.399 697.76
+0.45 667.856
+0.501 618.016
+0.536 585.62
+0.55 580.636
+0.564 585.62
+0.578 632.968
+0.581 555.716
+0.584 426.132
+0.589 299.04
+0.595 176.932
+0.598 112.14
+0.604 57.316
+0.608 24.92
+0.619 12.46
+0.623 0
+;
+;I600R Data Entered by Tim Van Milligan
+;For RockSim: www.RockSim.com
+;Based on Aerotech's Reload Kit Instruction Sheet.
+;Not Officially Approved by TRA or Aerotech
+I600R 38 344.68 10 0.3237 0.617 AT 
+0.005 40.438
+0.046 817.754
+0.059 813.261
+0.1 772.822
+0.2 736.877
+0.4 696.439
+0.5 669.48
+0.6 620.055
+0.796 539.178
+0.894 485.261
+0.951 453.809
+0.964 435.836
+1 274.082
+1.052 152.767
+1.106 62.904
+1.144 13.48
+1.18 0
+;
+;Aerotech I117FJ from TRA Cert Data
+I117FJ 54 156 6-10-14-0 0.253 0.58 AT 
+0.014 65.9
+0.021 94.456
+0.055 120.816
+0.089 107.636
+0.179 107.636
+0.344 124.111
+0.385 133.996
+0.447 123.013
+0.509 138.389
+0.564 131.799
+0.646 146.077
+0.708 144.979
+0.736 127.406
+0.75 149.372
+0.798 141.684
+0.825 164.749
+0.866 152.667
+1.004 158.159
+1.141 155.962
+1.224 154.864
+1.492 155.962
+2.304 121.914
+2.407 118.619
+2.482 117.521
+2.544 128.504
+2.599 112.029
+2.654 75.784
+2.695 45.031
+2.75 16.475
+2.771 8.787
+2.806 0
+;
+;Entered by Jim Yehle
+;from TRA cert document
+I1299N 38 249 1000 0.192 0.422 AT
+0 15.7171
+0.00361 222.5
+0.0115 1112
+0.0134228 1237.11
+0.02 1287
+0.04 1359
+0.1 1451
+0.12 1470
+0.18 1491
+0.2 1483
+0.22 1462
+0.24 1399
+0.28 1208
+0.294743 1131.63
+0.3 1065
+0.304251 974.46
+0.32 305
+0.330537 55.0098
+0.333893 11.7878
+0.34 0
+;
+;AeroTech I225FJ
+;Curvefit to instruction sheet on Aerotech website (12/27/06)
+;by Chris Kobel
+;burn time: 1.8 seconds
+;total impulse: 350.5 newton-seconds
+;average thrust: 43.8 pounds
+I225FJ 38 202 6-10-14 0.2417 0.486 AT 
+0.04 213.6
+0.1 213.6
+0.2 218.1
+0.28 235.9
+0.3 249.2
+0.4 262.6
+0.5 267
+0.6 271.5
+0.7 275.9
+0.8 275.9
+0.87 271.5
+0.9 258.1
+1 240.3
+1.1 218.1
+1.2 200.3
+1.3 178
+1.4 160.2
+1.5 97.9
+1.6 40.1
+1.7 13.4
+1.8 0
+;
+;I305FJ based on Aerotech instruction sheet by C. Kobel 3/30/07
+I305FJ 38 298 6-10-14 0.302 0.581 AT 
+0.02 341.398
+0.1 365.497
+0.2 383.571
+0.3 403.653
+0.4 405.662
+0.5 405.662
+0.6 404.657
+0.7 374.534
+0.8 342.402
+0.9 309.267
+1 272.115
+1.1 238.979
+1.15 224.921
+1.2 194.798
+1.3 119.489
+1.4 62.255
+1.45 33.136
+1.5 23.095
+1.6 0
+;
+;AeroTech I364FJ
+;Curvefit to instruction sheet on Aerotech website (12/27/06)
+;by Chris Kobel
+;burn time: 1.7 seconds
+;total impulse: 551.2 newton-seconds
+;average thrust: 72.9 pounds
+I364FJ 38 345 6-10-14 0.3625 0.678 AT 
+0.02 356
+0.1 373.8
+0.2 387.2
+0.3 400.5
+0.4 400.5
+0.5 409.4
+0.6 413.9
+0.7 409.4
+0.8 382.7
+0.9 373.8
+1 351.6
+1.1 333.8
+1.2 320.4
+1.3 311.5
+1.4 244.8
+1.5 178
+1.6 80.1
+1.7 0
+;
+;AeroTech J125
+;Copyright Tripoli Motor Testing 1997 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J125 54 368 0 0.63392 1.288 AT 
+0.174 223.931
+0.525 254.842
+0.877 275.347
+1.229 285.163
+1.581 280.333
+1.933 264.476
+2.285 244.373
+2.638 223.774
+2.99 204.72
+3.342 185.434
+3.694 166.807
+4.046 147.653
+4.398 127.914
+4.75 108.483
+5.102 92.582
+5.454 77.817
+5.806 63.844
+6.158 53.017
+6.51 44.507
+6.862 37.543
+7.215 32.205
+7.567 27.212
+7.919 22.847
+8.271 18.596
+8.623 14.79
+8.975 0
+;
+;AeroTech J90W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J90W 54 243 0 0.427392 0.852544 AT 
+0.143 116.187
+0.43 165.444
+0.718 176.536
+1.005 184.645
+1.293 187.242
+1.58 183.651
+1.868 175.492
+2.155 167.687
+2.443 156.858
+2.73 143.514
+3.018 128.856
+3.305 110.879
+3.593 94.003
+3.88 79.657
+4.168 67.472
+4.455 57.268
+4.743 48.008
+5.03 40.523
+5.318 33.901
+5.605 28.248
+5.893 23.334
+6.18 19.275
+6.468 15.923
+6.755 12.727
+7.044 9.903
+7.332 0
+;
+;
+J125W 54 368 100 0.6433 1.115 AT 
+1 214
+3 200
+4.01 142
+7 120
+10.24 0
+;
+;AeroTech J135W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J135W 54 368 0 0.62272 1.14106 AT 
+0.147 226.295
+0.444 243.688
+0.742 250.916
+1.04 257.345
+1.338 259.308
+1.635 253.727
+1.933 246.071
+2.231 235.78
+2.529 221.775
+2.827 205.143
+3.125 183.57
+3.423 161.103
+3.72 140.983
+4.017 122.984
+4.315 106.605
+4.612 91.959
+4.91 77.693
+5.208 65.304
+5.506 54.347
+5.804 44.246
+6.102 35.395
+6.4 27.716
+6.698 21.121
+6.996 14.939
+7.294 9.737
+7.592 0
+;
+;AeroTech J145H
+;Copyright Tripoli Motor Testing 1999 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J145H 54 709 0 0.410816 1.79738 AT 
+0.113 253.118
+0.34 293.672
+0.567 300.149
+0.794 289.519
+1.021 253.366
+1.248 251.809
+1.476 246.042
+1.704 236.553
+1.931 229.907
+2.158 222.55
+2.385 211.12
+2.612 201.066
+2.841 191.143
+3.069 139.197
+3.296 79.889
+3.523 63.9
+3.75 51.048
+3.977 40.565
+4.205 31.71
+4.433 24.429
+4.66 19.95
+4.887 15.256
+5.115 12.412
+5.342 10.212
+5.57 9.135
+5.798 0
+;
+;AeroTech J180T
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J180T 54 230 0 0.429184 0.809088 AT 
+0.093 301.634
+0.281 313.236
+0.47 313.71
+0.658 308.334
+0.847 300.1
+1.035 290.743
+1.224 278.867
+1.412 263.823
+1.601 245.974
+1.79 226.651
+1.978 207.345
+2.167 187.053
+2.355 168.339
+2.544 149.993
+2.732 133.094
+2.921 116.33
+3.109 100.088
+3.298 84.507
+3.486 70.453
+3.675 57.263
+3.864 44.453
+4.052 33.34
+4.241 24.654
+4.429 17.964
+4.619 12.391
+4.808 0
+;
+;
+J210H 54 609.6 1000 0.471 1.497 AT 
+0.00772798 651.819
+0.0695518 528.502
+0.200927 488.864
+0.502318 409.589
+0.996909 374.355
+1.4915 312.697
+1.59196 286.272
+2.00927 167.359
+2.43431 88.0836
+2.50386 101.296
+2.55023 74.8711
+3.02164 57.2543
+4 0
+;
+;AeroTech J275W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J275W 54 230 0 0.468608 0.864192 AT 
+0.075 239.74
+0.227 289.133
+0.38 299.773
+0.533 312.721
+0.686 323.878
+0.84 332.165
+0.992 336.422
+1.145 335.11
+1.298 329.538
+1.451 325.343
+1.604 309.98
+1.756 292.901
+1.909 275.732
+2.063 257.341
+2.216 234.891
+2.369 213.102
+2.521 182.501
+2.674 167.853
+2.827 153.041
+2.98 138.115
+3.133 105.605
+3.285 67.369
+3.439 29.239
+3.592 14.599
+3.745 6.662
+3.898 0
+;
+;AeroTech J315R
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J315R 54 243 0 0.42112 0.8512 AT 
+0.051 189.719
+0.154 337.529
+0.259 354.534
+0.363 364.111
+0.468 371.479
+0.572 373.222
+0.676 376.062
+0.78 372.962
+0.884 368.988
+0.989 366.978
+1.093 358.752
+1.197 351.302
+1.301 339.336
+1.406 325.202
+1.51 311.322
+1.614 300.496
+1.718 288.598
+1.822 278.279
+1.927 270.538
+2.031 262.127
+2.136 245.027
+2.239 236.238
+2.344 188.308
+2.448 63.668
+2.552 18.746
+2.657 0
+;
+;AeroTech J415W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J415W 54 314 0 0.686336 1.15718 AT 
+0.065 431.3
+0.196 452.427
+0.327 489.904
+0.458 513.542
+0.591 523.192
+0.723 531.44
+0.854 542.165
+0.985 542.731
+1.118 549.788
+1.25 553.889
+1.381 537.331
+1.512 512.126
+1.645 517.338
+1.777 498.098
+1.908 473.365
+2.04 444.157
+2.172 413.187
+2.304 384.854
+2.435 360.556
+2.567 297.571
+2.699 178.288
+2.831 89.889
+2.962 43.066
+3.094 19.126
+3.226 8.995
+3.358 0
+;
+;AeroTech J420R
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J420R 38 337 0 0.37632 0.6496 AT 
+0.031 61.083
+0.095 563.47
+0.16 525.283
+0.224 521.242
+0.288 527.371
+0.352 537.088
+0.418 535.138
+0.481 534.623
+0.545 530.245
+0.61 526.447
+0.674 517.203
+0.738 510.279
+0.802 500.887
+0.868 479.45
+0.931 460.675
+0.995 438.594
+1.06 409.647
+1.124 383.454
+1.188 361.024
+1.252 339.741
+1.318 319.194
+1.381 296.714
+1.445 195.191
+1.51 61.984
+1.575 7.22
+1.64 0
+;
+;AeroTech J460T
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J460T 54 230 0 0.413504 0.801024 AT 
+0.041 500.927
+0.125 509.423
+0.209 516.357
+0.294 527.752
+0.379 535.135
+0.464 541.858
+0.548 545.793
+0.633 545.678
+0.718 544.832
+0.802 540.278
+0.887 533.698
+0.972 526.34
+1.056 511.003
+1.141 492.475
+1.225 474.977
+1.31 457.021
+1.395 437.203
+1.479 418.093
+1.565 403.24
+1.649 339.173
+1.733 203.861
+1.819 102.62
+1.903 49.295
+1.987 9.538
+2.073 2.155
+2.158 0
+;
+;Delays are speculation.
+;Taken from Aerotech curves, not cert docs.
+;Jim Yehle 15 Nov 07
+J500G 38 335.407 0-6-10-14 0.3626 0.654 AT 
+0.0134378 40.2458
+0.0335946 724.425
+0.0403135 781.616
+0.0604703 787.971
+0.0895857 711.716
+0.134378 686.297
+0.394177 637.578
+0.575588 588.86
+0.606943 622.751
+0.633819 620.633
+1.20045 360.094
+1.24076 345.267
+1.31019 182.165
+1.38186 65.6642
+1.43337 23.3002
+1.45 0
+;
+;AeroTech J540R
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J540R 54 314 0 0.61376 1.08416 AT 
+0.044 498.757
+0.134 639.617
+0.224 649.317
+0.314 657.966
+0.404 664.02
+0.494 666.924
+0.584 663.699
+0.675 658.398
+0.765 651.232
+0.855 638.505
+0.945 626.396
+1.035 612.557
+1.126 590.09
+1.216 562.391
+1.306 536.875
+1.396 511.607
+1.486 490.354
+1.576 468.978
+1.667 451.342
+1.758 430.18
+1.847 414.549
+1.937 398.116
+2.027 305.877
+2.118 55.541
+2.208 1.523
+2.299 0
+;
+;AeroTech J570W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J570W 38 479 0 0.547904 0.886144 AT 
+0.039 1149.8
+0.119 1042.85
+0.199 960.891
+0.279 900.02
+0.36 837.772
+0.441 792.834
+0.521 735.51
+0.602 685.857
+0.682 649.599
+0.762 608.757
+0.844 597.35
+0.924 568.934
+1.004 548.552
+1.084 505.08
+1.165 484.626
+1.246 452.328
+1.326 362.439
+1.406 297.973
+1.487 262.381
+1.568 195.696
+1.648 156.733
+1.729 124.649
+1.809 113.749
+1.89 69.812
+1.971 46.023
+2.052 0
+;
+;AeroTech J800T
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J800T 54 314 0 0.613312 1.08595 AT 
+0.04 841.341
+0.121 818.497
+0.203 776.386
+0.285 784.308
+0.367 785.314
+0.449 783.315
+0.531 782.539
+0.612 779.977
+0.695 773.68
+0.777 765.307
+0.858 755.517
+0.941 744.777
+1.023 733.131
+1.105 719.947
+1.187 702.235
+1.269 685.369
+1.351 668.265
+1.433 650.327
+1.515 630.472
+1.597 615.483
+1.679 470.262
+1.76 256.617
+1.843 108.716
+1.925 15.005
+2.007 1.249
+2.09 0
+;
+;Aerotech J825R
+J825R 38 479 10 0.53 0.88 AT 
+0 11.504
+0.048913 1069.87
+0.100155 977.842
+0.118789 1035.36
+0.652174 897.314
+0.801242 839.794
+0.899068 782.274
+0.999224 586.705
+1.09938 103.536
+1.14363 23.008
+1.18 0
+;
+;AeroTech 54-852
+;Greg Gardner - 09/15/06
+J1299N 54 230 0 0.3716 0.834 AT 
+0.01 548
+0.02 1152
+0.03 1232
+0.04 1277
+0.05 1272
+0.06 1288
+0.07 1333
+0.08 1347
+0.09 1378
+0.1 1383
+0.12 1405
+0.14 1410
+0.16 1440
+0.18 1444
+0.2 1446
+0.25 1449
+0.3 1452
+0.35 1448
+0.4 1440
+0.45 1405
+0.5 1320
+0.55 1248
+0.57 1224
+0.59 1210
+0.6 1180
+0.61 1188
+0.615 1195
+0.62 1188
+0.63 510
+0.64 220
+0.65 96
+0.66 46
+0.67 26
+0.678 0
+;
+;AeroTech 54-1280
+;Greg Gardner - 09/15/06
+J1999N 54 314 0 0.5574 1.111 AT 
+0.01 830
+0.02 1716
+0.03 1787
+0.04 1873
+0.05 1896
+0.06 1918
+0.07 1984
+0.08 2007
+0.09 2051
+0.1 2058
+0.12 2090
+0.14 2098
+0.16 2135
+0.18 2138
+0.2 2142
+0.25 2146
+0.3 2150
+0.35 2146
+0.4 2138
+0.45 2096
+0.5 1974
+0.55 1864
+0.57 1829
+0.59 1815
+0.6 1762
+0.61 1673
+0.62 1085
+0.63 490
+0.64 190
+0.65 81
+0.66 31
+0.67 0
+;
+;Aerotech J250FJ from TRA Cert Data
+J250FJ 54 241 6-10-14-18 0.511 0.92 AT 
+0.011 132.176
+0.021 263.335
+0.084 236.899
+0.168 252.151
+0.294 238.933
+0.494 261.301
+0.715 285.703
+0.993 295.87
+1.177 306.038
+1.267 305.021
+1.498 301.971
+1.64 292.82
+2.002 253.167
+2.344 224.699
+2.391 225.715
+2.502 233.849
+2.57 185.046
+2.659 116.925
+2.685 76.255
+2.738 32.536
+2.77 17.285
+2.796 0
+;
+;
+J260HW 54 708.66 1000 0.558 1.574 AT 
+0.00772798 598.969
+0.0386399 475.651
+0.108192 506.481
+0.463679 493.268
+0.780526 475.651
+1.01236 427.205
+2.00155 330.314
+2.48841 193.784
+2.99073 114.509
+4.01082 57.2543
+4.5 0
+;
+;
+J575FJ 38 478.79 6-10-14 0.576 0.91424 AT 
+0.0156556 656.682
+0.0195695 840.689
+0.037182 840.689
+0.0606654 839.001
+0.101761 839.001
+0.162427 839.001
+0.228963 839.001
+0.315068 839.001
+0.399217 837.312
+0.459883 837.312
+0.547945 822.119
+0.60274 801.862
+0.700587 742.777
+0.802348 685.381
+0.841487 646.554
+0.902153 573.964
+0.949791 483.69
+1 319.581
+1.05365 220.66
+1.12916 153.62
+1.19961 99.5997
+1.27593 43.8914
+1.34 0
+;
+;
+J350W-L 38 337 0 0.361 0.651 AT 
+0.041 841.443
+0.051 767.077
+0.088 698.219
+0.173 644.51
+0.256 621.098
+0.298 564.635
+0.547 543.977
+0.783 487.514
+0.989 418.656
+1.16 359.438
+1.192 340.158
+1.213 320.878
+1.287 216.214
+1.319 179.031
+1.342 126.699
+1.386 84.007
+1.427 53.709
+1.48 45.446
+1.591 20.657
+1.695 0
+;
+;
+J390HW-TURBO 54 708.66 1000 0.69 1.74 AT 
+0.015456 440.418
+0.100464 550.523
+0.193199 546.118
+0.301391 656.223
+0.502318 647.414
+0.973725 581.352
+1.48377 471.247
+1.98609 378.759
+2.17929 334.718
+2.30294 255.442
+2.49614 158.55
+3.01391 57.2543
+3.5 0
+;
+;AeroTech K185W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+K185W 54 437 0 0.827008 1.43405 AT 
+0.15 279.128
+0.452 308.22
+0.754 328.435
+1.056 338.929
+1.359 339.677
+1.663 333.166
+1.965 321.891
+2.267 309.687
+2.57 293.26
+2.873 271.536
+3.175 247.174
+3.477 216.883
+3.78 186.951
+4.083 161.096
+4.385 138.113
+4.688 117.749
+4.991 99.372
+5.294 82.759
+5.596 68.426
+5.898 55.126
+6.201 44.162
+6.504 34.209
+6.806 25.064
+7.108 16.88
+7.411 9.2
+7.715 0
+;
+;AeroTech K250W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+K250W 54 673 0 1.52902 2.21133 AT 
+0.199 365.33
+0.599 403.324
+0.999 418.669
+1.4 409.813
+1.801 408.949
+2.201 412.146
+2.602 411.952
+3.003 409.488
+3.403 393.214
+3.804 373.599
+4.205 348.913
+4.605 328.463
+5.006 307.163
+5.407 281.467
+5.807 249.011
+6.208 217.159
+6.609 185.908
+7.009 149.19
+7.41 119.808
+7.811 92.096
+8.211 69.726
+8.613 52.613
+9.014 35.876
+9.414 16.727
+9.815 4.086
+10.216 0
+;
+;Aerotech K270W-P Moon Burner from TRA Certification Data
+K270W 54 579 0 1.188 2.1 AT 
+0.046 177.061
+0.062 292.932
+0.092 425.727
+0.154 414.01
+0.277 389.273
+0.446 377.556
+0.585 381.462
+0.738 372.349
+1 377.556
+1.154 376.254
+1.231 378.858
+1.308 395.783
+1.4 380.16
+1.569 399.689
+1.615 381.462
+1.846 381.462
+2.369 368.443
+2.415 381.462
+2.554 360.631
+3.015 350.216
+3.354 328.083
+3.723 300.743
+4 273.403
+4.6 225.232
+5.262 175.759
+5.677 144.513
+6 124.984
+6.538 89.832
+7.015 66.398
+8 22.133
+8.323 10.415
+8.508 5.208
+8.692 0
+;
+;AeroTech K458W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+K458W 98 275 0 1.42778 3.16378 AT 
+0.133 294.911
+0.403 404.808
+0.674 462.021
+0.944 515.863
+1.214 555.072
+1.484 583.153
+1.755 600.299
+2.025 610.254
+2.295 618.543
+2.566 623.155
+2.835 618.885
+3.105 589.082
+3.376 546.307
+3.647 505.042
+3.917 451.412
+4.186 391.651
+4.457 338.409
+4.727 288.429
+4.997 245.814
+5.268 208.209
+5.539 178.153
+5.808 149.825
+6.078 62.931
+6.349 8.427
+6.62 2.562
+6.891 0
+;
+;AeroTech K550W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+K550W 54 410 0 0.919744 1.48736 AT 
+0.065 604.264
+0.196 642.625
+0.327 682.197
+0.458 732.995
+0.591 758.236
+0.723 780.289
+0.854 794.452
+0.985 797.939
+1.117 797.601
+1.249 773.842
+1.381 711.608
+1.512 646.522
+1.644 590.724
+1.775 537.505
+1.907 491.012
+2.04 445.836
+2.171 401.461
+2.302 364.291
+2.433 319.614
+2.566 255.577
+2.698 172.573
+2.829 103.501
+2.96 51.795
+3.092 26.814
+3.224 15.203
+3.356 0
+;
+;AeroTech K560W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+K560W 75 396 0 1.40806 2.71354 AT 
+0.096 552.123
+0.29 645.403
+0.484 681.109
+0.679 716.167
+0.874 742.678
+1.069 764.778
+1.264 775.71
+1.458 785.859
+1.653 789.305
+1.848 789.077
+2.043 744.622
+2.237 676.886
+2.432 614.711
+2.627 557.908
+2.822 503.641
+3.017 455.504
+3.211 412.045
+3.406 372.963
+3.601 335.987
+3.796 307.346
+3.991 279.856
+4.185 223.491
+4.38 70.441
+4.575 10.028
+4.77 2.445
+4.965 0
+;
+;AeroTech K650T
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+K650T 98 289 0 1.27008 2.9353 AT 
+0.079 514.338
+0.24 594.264
+0.401 618.849
+0.563 641.658
+0.723 665.057
+0.884 686.488
+1.046 704.685
+1.206 720.215
+1.368 730.072
+1.529 736.891
+1.69 743.109
+1.851 747.503
+2.013 747.557
+2.174 744.081
+2.335 732.294
+2.496 710.412
+2.657 682.67
+2.819 653.246
+2.979 627.02
+3.141 595.456
+3.302 563.844
+3.463 551.08
+3.624 236.059
+3.785 1.383
+3.947 1.234
+4.108 0
+;
+;Aerotech K680R RASP engine file
+;Data Entered by Tim Van Milligan
+;Source: TRA Certification paperwork, and
+;Aerotech's instruction sheet: RMS 98/2560-10240 REDLINE.
+K680R 98 289 1000 1.316 3.035 AT 
+0.085 629.798
+0.494 717.881
+0.996 797.157
+1.29 819.178
+1.506 819.178
+2.001 775.136
+2.519 673.84
+2.99 563.735
+3.137 541.714
+3.176 532.906
+3.238 563.735
+3.276 563.735
+3.408 52.85
+3.431 22.02
+3.49 0
+;
+;AeroTech K695R
+;provided by ThrustCurve.org (www.thrustcurve.org)
+K695R 54 410 0 0.9184 1.48736 AT 
+0.044 618.611
+0.134 727.84
+0.224 751.996
+0.314 812.48
+0.404 900.125
+0.495 884.763
+0.585 873.457
+0.675 864.561
+0.765 849.672
+0.856 838.886
+0.946 822.55
+1.036 806.24
+1.126 781.342
+1.216 753.973
+1.307 728.472
+1.398 697.629
+1.487 672.979
+1.578 646.66
+1.667 620.897
+1.758 595.574
+1.849 571.72
+1.939 546.822
+2.029 272.824
+2.119 57.95
+2.209 4.509
+2.3 0
+;
+;AeroTech K700W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+K700W 54 568 0 1.29158 2.03526 AT 
+0.069 1005.47
+0.209 1018.92
+0.35 1026.61
+0.491 1028.64
+0.632 1029.34
+0.773 1004.2
+0.914 970.694
+1.055 946.516
+1.196 918.437
+1.336 873.783
+1.478 821.276
+1.619 773.27
+1.759 735.553
+1.9 692.732
+2.041 658.984
+2.182 626.737
+2.323 591.431
+2.464 508.666
+2.605 420.175
+2.746 328.309
+2.886 202.409
+3.028 121.672
+3.169 80.453
+3.309 50.873
+3.451 31.548
+3.593 0
+;
+;AeroTech K780R
+;provided by ThrustCurve.org (www.thrustcurve.org)
+K780R 75 289 0 1.26784 2.9344 AT 
+0.053 383.29
+0.173 718.241
+0.292 849.343
+0.413 885.503
+0.533 903.243
+0.652 924.403
+0.772 938.825
+0.892 938.623
+1.013 947.13
+1.133 953.578
+1.253 944.001
+1.373 935.448
+1.495 929.447
+1.617 920.379
+1.737 897.293
+1.857 888.917
+1.977 861.127
+2.098 840.971
+2.217 812.36
+2.337 779.614
+2.457 747.866
+2.578 726.819
+2.697 729.258
+2.817 279.891
+2.94 10.969
+3.063 0
+;
+;AeroTech K1050W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+K1050W 54 676 0 1.34714 2.12845 AT 
+0.049 1305.65
+0.149 1270.39
+0.249 1288.92
+0.349 1327.06
+0.449 1345.72
+0.549 1359.79
+0.649 1364.45
+0.749 1365.49
+0.849 1377.19
+0.949 1379.52
+1.049 1346.59
+1.149 1286.74
+1.249 1232.1
+1.349 1186.48
+1.449 1156.52
+1.549 1120.05
+1.649 1098.71
+1.749 1070.19
+1.849 889.885
+1.949 646.691
+2.049 441.213
+2.149 302.245
+2.249 155.001
+2.349 52.187
+2.449 43.415
+2.549 0
+;
+;AeroTech K1100T
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+K1100T 54 398 0 0.7616 1.32518 AT 
+0.034 1234.65
+0.105 1233.43
+0.176 1192.39
+0.247 1163.04
+0.318 1147.96
+0.389 1146.32
+0.46 1140.96
+0.532 1132.64
+0.603 1123.82
+0.674 1108.92
+0.745 1090.97
+0.816 1073.94
+0.887 1049.13
+0.959 1021.22
+1.03 994.559
+1.101 966.571
+1.172 940.194
+1.243 909.792
+1.315 880.264
+1.386 844.477
+1.457 643.599
+1.528 401.861
+1.599 145.498
+1.67 28.372
+1.742 0
+;
+;AeroTech K1275R
+;provided by ThrustCurve.org (www.thrustcurve.org)
+K1275R 54 569 0 1.29024 2.03392 AT 
+0.039 1282.62
+0.119 1557.99
+0.199 1540.2
+0.279 1526.78
+0.359 1500.69
+0.44 1456.58
+0.52 1425.79
+0.6 1390.42
+0.68 1355.11
+0.761 1323.31
+0.841 1282.83
+0.921 1247.8
+1.001 1194.42
+1.081 1150.98
+1.162 1108.22
+1.242 1068.75
+1.322 1036.92
+1.403 997.444
+1.482 964.569
+1.563 933.305
+1.644 889.992
+1.724 599.467
+1.804 134.559
+1.884 5.63
+1.964 0.205
+2.045 0
+;
+;Entered by Jim Yehle
+;from TRA cert document
+K1499N 75 260 1000 0.604 1.741 AT
+0.01 1450
+0.2 1720.12
+0.35 1700
+0.5 1600
+0.6 1575
+0.7 1500
+0.82 1400
+0.84 250
+0.88 0
+;
+;AeroTech K1999N
+;Curvefit to instruction sheet on Aerotech website (1/29/07)
+;by Chris Kobel
+;burn time: 1.4 seconds
+;total impulse: 2522 newton-seconds
+;average thrust: 405 pounds
+K1999N 98 289 6-10-14-18 1.195 2.989 AT 
+0.02 1557.5
+0.08 1780
+0.1 1913.5
+0.12 1869
+0.18 2002.5
+1.08 2002.5
+1.1 1958
+1.2 1780
+1.25 1557.5
+1.27 1335
+1.31 890
+1.33 667.5
+1.35 222.5
+1.4 0
+;
+;AeroTech K485HW
+;Copyright Tripoli Motor Testing 1999 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+K485HW 54 699 0 0.910784 2.22029 AT 
+0.075 454.453
+0.227 568.735
+0.38 831.332
+0.533 825.584
+0.686 795.935
+0.84 759.473
+0.992 727.238
+1.145 680.051
+1.298 653.091
+1.451 627.316
+1.604 601.548
+1.756 576.27
+1.909 542.033
+2.063 479.078
+2.216 394.184
+2.369 346.719
+2.521 307.435
+2.674 276.291
+2.827 216.608
+2.98 146.021
+3.133 106.838
+3.285 81.226
+3.439 52.105
+3.592 37.385
+3.745 29.462
+3.898 0
+;
+;
+K828FJ 54 579 6-10-14-18 1.45 2.255 AT 
+0.01 1112.06
+0.02 1238.6
+0.04 1303.79
+0.06 1135.06
+0.08 1077.54
+0.13 1031.53
+0.2 1016.19
+0.5 993.18
+0.65 1004.68
+1 985.51
+1.08 974.01
+1.19 974.01
+1.42 954.83
+1.51 935.66
+1.69 912.65
+1.75 885.81
+1.83 893.48
+1.89 843.63
+1.95 774.6
+2 667.23
+2.15 444.82
+2.2 364.29
+2.23 260.76
+2.27 184.06
+2.33 111.21
+2.39 49.85
+2.5 0
+;
+;AeroTech L1150
+;provided by ThrustCurve.org (www.thrustcurve.org)
+L1150 75 531 0 2.06528 3.6736 AT 
+0.053 935.855
+0.175 1292.64
+0.3 1260.93
+0.425 1241.48
+0.55 1257.06
+0.675 1272.29
+0.8 1287.61
+0.925 1301.01
+1.048 1309.71
+1.17 1308.42
+1.295 1304.83
+1.42 1285.27
+1.545 1267.66
+1.67 1255.62
+1.795 1227.21
+1.92 1202.44
+2.043 1182.62
+2.165 1150.71
+2.29 1117.91
+2.415 1081.74
+2.54 1037.55
+2.665 1007.09
+2.79 1008.91
+2.915 643.124
+3.04 64.371
+3.165 0
+;
+;AeroTech L850W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+L850W 75 531 0 2.06528 3.67315 AT 
+0.091 1015.93
+0.274 1064.94
+0.458 1101.37
+0.643 1143.36
+0.827 1170.93
+1.011 1184.8
+1.196 1178.04
+1.38 1177.6
+1.564 1174.91
+1.748 1170.02
+1.932 1113.72
+2.117 1042.59
+2.301 972.795
+2.485 908.071
+2.67 844.471
+2.854 773.595
+3.039 714.046
+3.222 649.095
+3.406 597.341
+3.591 557.444
+3.775 422.233
+3.959 200.739
+4.144 79.411
+4.328 43.959
+4.513 14.862
+4.697 0
+;
+;AeroTech L952W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+L952W 98 427 0 2.73011 5.01222 AT 
+0.141 679.073
+0.425 801.562
+0.709 848.474
+0.994 913.345
+1.278 981.614
+1.562 1043.69
+1.847 1088.11
+2.131 1112.56
+2.416 1121.54
+2.7 1118.57
+2.984 1100.66
+3.269 1039.14
+3.553 965.784
+3.837 876.793
+4.122 780.693
+4.406 693.903
+4.691 608.03
+4.975 528.335
+5.259 463.528
+5.544 405.769
+5.828 358.367
+6.112 279.009
+6.397 99.897
+6.681 20.108
+6.967 3.317
+7.252 0
+;
+;AeroTech L1120W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+L1120W 75 665 0 2.75699 4.65786 AT 
+0.097 1377.21
+0.293 1442.67
+0.489 1496.99
+0.685 1537.06
+0.882 1554.96
+1.078 1554.13
+1.275 1547.97
+1.472 1533.46
+1.668 1510.34
+1.865 1472.28
+2.061 1362.53
+2.257 1245.42
+2.454 1148.86
+2.651 1062.68
+2.847 984.952
+3.044 916.169
+3.241 831.929
+3.436 766.45
+3.633 698.978
+3.83 562.966
+4.026 384.579
+4.223 227.654
+4.42 105.078
+4.616 56.339
+4.813 21.712
+5.009 0
+;
+;
+L1300R 98 443 1000 2.508 4.884 AT 
+0.0231839 1299.23
+0.502318 1332.26
+0.996909 1497.42
+1.49923 1552.47
+1.99382 1508.43
+2.49614 1354.29
+2.99845 1101.05
+3.12983 1090.03
+3.21484 1145.09
+3.3694 176.167
+3.5 0
+;
+;
+L1420R 75 443 1000 2.56 4.562 AT 
+0.0386399 1332.26
+0.123648 1563.48
+0.502318 1519.44
+0.996909 1574.49
+1.49923 1662.58
+2.00155 1574.49
+2.48068 1409.34
+2.92117 1299.23
+2.99073 1167.11
+3.11437 187.178
+3.24 0
+;
+;AeroTech L1500T
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+L1500T 98 443 0 2.464 4.6592 AT 
+0.073 1320.33
+0.222 1454.82
+0.372 1508.99
+0.522 1556.78
+0.672 1602.41
+0.822 1642
+0.971 1670.1
+1.12 1694.8
+1.27 1701.3
+1.42 1704.29
+1.57 1701.01
+1.72 1694.55
+1.869 1683.86
+2.018 1659.69
+2.168 1620.16
+2.318 1570.03
+2.468 1517.93
+2.618 1463.32
+2.767 1400.99
+2.916 1331.42
+3.066 1279.48
+3.216 1108.99
+3.366 217.788
+3.516 10.579
+3.666 3.245
+3.816 0
+;
+;75-6400 case
+;Greg Gardner - 10/25/07
+M650W 75 801 1000 3.351 5.125 AT 
+0.08 1240
+0.12 1328
+0.25 1230
+0.5 1142
+1 1071
+1.5 1048
+2 1018
+2.5 982
+3 950
+3.5 853
+4 781
+5 595
+6 443
+7 297
+8 155
+9 88
+10 32
+10.5 12
+11 4
+11.5 0
+;
+;98-10240 case
+;Greg Gardner - 10/25/07
+M750W 98 732 1000 5.3 8.776 AT 
+0.1 1032
+0.2 992
+0.3 974
+0.48 966
+1 1055
+1.5 1152
+2 1192
+2.5 1218
+4 1103
+6 818
+8 561
+10 318
+11 216
+12 125
+13 76
+14 47
+15 23
+15.5 9
+16 0
+;
+;Aerotech M1297W
+;Greg Gardner - 12/20/04
+M1297W 75 665 0 2.722 4.637 AT 
+0.1 1433.4
+0.15 1789.3
+0.2 1922.8
+0.25 1869.4
+0.3 1856
+0.35 1833.8
+0.4 1767
+0.5 1722.6
+0.6 1709.2
+0.9 1700.3
+1 1688.1
+1.5 1678.7
+1.75 1634.6
+1.85 1622.3
+1.95 1572.8
+2 1554
+2.5 1346.5
+3 1136
+3.2 1053.3
+3.25 1044.1
+3.35 1032
+3.38 1020
+3.4 937
+3.5 738
+3.6 545
+3.75 393
+4 226
+4.25 94
+4.35 45
+4.4 0
+;
+;AeroTech M1315W
+;Copyright Tripoli Motor Testing 1999 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+M1315W 75 801 0 3.4496 5.6448 AT 
+0.116 1728.68
+0.349 1673.34
+0.582 1686.81
+0.816 1696.07
+1.049 1663.17
+1.282 1631.24
+1.516 1620.47
+1.749 1619.7
+1.982 1621.04
+2.216 1615.32
+2.449 1567.09
+2.682 1493.72
+2.916 1420.08
+3.149 1358.66
+3.382 1292.51
+3.616 1224.81
+3.849 1171.99
+4.082 928.809
+4.316 577.949
+4.549 395.445
+4.782 314.006
+5.016 228.273
+5.249 159.803
+5.482 118.348
+5.716 109.782
+5.949 0
+;
+;AeroTech M1419W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+M1419W 98 579 0 4.032 6.91622 AT 
+0.154 1154.9
+0.465 1241.15
+0.776 1300.22
+1.087 1358.36
+1.399 1411.03
+1.71 1461.03
+2.022 1485.75
+2.333 1503.65
+2.644 1513.11
+2.955 1511.95
+3.267 1492.44
+3.578 1418.37
+3.89 1326.61
+4.201 1219.22
+4.513 1087.65
+4.824 937.068
+5.135 810.066
+5.446 709.13
+5.757 624.701
+6.069 557.223
+6.38 437.806
+6.692 252.076
+7.003 107.741
+7.315 19.973
+7.626 0.515
+7.937 0
+;
+;AeroTech M1550R
+;provided by ThrustCurve.org (www.thrustcurve.org)
+M1550R 75 800 0 3.4496 5.6448 AT 
+0.069 1720.76
+0.212 2125.33
+0.358 1995.95
+0.501 1908.44
+0.645 1868.71
+0.79 1835.5
+0.935 1808.66
+1.079 1796.3
+1.222 1785.42
+1.368 1773.15
+1.511 1746.59
+1.655 1715.71
+1.8 1689.63
+1.945 1660.72
+2.089 1633.28
+2.232 1606.04
+2.378 1570.22
+2.521 1534.71
+2.665 1503.35
+2.81 1461.32
+2.955 1427.57
+3.099 1393.23
+3.242 939.955
+3.388 268.504
+3.532 4.985
+3.677 0
+;
+;AeroTech M1600R
+;provided by ThrustCurve.org (www.thrustcurve.org)
+M1600R 98 579 0 4.032 6.91712 AT 
+0.088 1370.36
+0.268 1626.63
+0.448 1672.65
+0.628 1720.6
+0.808 1763.29
+0.987 1801.28
+1.167 1829.83
+1.348 1845.15
+1.529 1856.37
+1.71 1850.09
+1.89 1847.37
+2.07 1829.45
+2.25 1810.98
+2.43 1784.91
+2.61 1754.27
+2.79 1726.9
+2.971 1689.29
+3.152 1641.58
+3.332 1581.59
+3.513 1511.04
+3.692 1431.4
+3.872 1361.03
+4.053 1234.57
+4.232 621.206
+4.414 42.471
+4.595 0
+;
+;75-7680 case
+;Greg Gardner - 10/25/07
+M1850W 75 935 0 3.979 6.871 AT 
+0.1 2411
+0.2 2135
+0.3 2015
+0.4 2000
+0.5 2055
+1 2098
+1.5 1860
+2 1788
+2.5 1659
+3 1468
+3.25 1423
+3.35 1334
+3.5 1201
+3.75 934
+3.8 930
+4 881
+4.25 600
+4.5 468
+4.75 400
+5 290
+5.5 85
+6 23
+6.5 0
+;
+;AeroTech M1939W
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+M1939W 98 732 0 5.656 8.98822 AT 
+0.134 1905.18
+0.406 2021.15
+0.679 2095.9
+0.952 2158.09
+1.225 2198.21
+1.498 2219.69
+1.77 2228.64
+2.042 2229.88
+2.315 2225.64
+2.587 2211.71
+2.86 2164.72
+3.133 2047.01
+3.405 1916.24
+3.677 1805.66
+3.95 1658.49
+4.223 1497.7
+4.496 1339.45
+4.769 1213.06
+5.041 1102.13
+5.313 966.508
+5.585 670.253
+5.858 443.975
+6.131 155.355
+6.404 41.358
+6.677 5.775
+6.95 0
+;
+;AeroTech M2000R
+;provided by ThrustCurve.org (www.thrustcurve.org)
+M2000R 98 732 0 5.65824 8.98688 AT 
+0.091 1530.96
+0.279 2186.27
+0.466 2166.7
+0.655 2187.24
+0.844 2219.07
+1.031 2248.07
+1.22 2273.74
+1.409 2298.31
+1.596 2309.75
+1.785 2315.71
+1.974 2316.16
+2.161 2306.31
+2.35 2282.23
+2.539 2252.1
+2.726 2209.64
+2.915 2168.8
+3.104 2117.18
+3.291 2067.53
+3.48 2004.51
+3.669 1934.44
+3.856 1831.48
+4.045 1745.63
+4.234 1504.27
+4.421 649.796
+4.61 58.178
+4.799 0
+;
+;Took this data from the Aerotech Typical Time-Thrust Curve that comes with the M2030G motor.
+M2030G 75 653 1000 2.663 4.906 AT 
+0.00776398 1342.14
+0.0776398 2147.42
+0.15528 1840.64
+0.496894 2224.11
+0.784161 2607.58
+1.00155 2645.93
+1.3587 2530.88
+1.49068 2415.84
+1.99534 1802.3
+2.3913 1418.83
+2.5 805.282
+2.56211 191.734
+2.675 0
+;
+;AeroTech M2400T
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+M2400T 98 597 0 3.65254 6.4512 AT 
+0.07 2441.95
+0.211 2495.46
+0.353 2556.13
+0.495 2601.6
+0.636 2637.66
+0.778 2660.8
+0.92 2676.49
+1.061 2687.08
+1.203 2695.81
+1.345 2694.49
+1.486 2684.27
+1.628 2667.29
+1.771 2629.96
+1.914 2578.92
+2.055 2522.07
+2.197 2461.7
+2.339 2393.52
+2.48 2303.94
+2.622 2201.61
+2.764 2097.46
+2.905 2010.41
+3.047 1275.78
+3.189 418.836
+3.33 17.586
+3.473 3.669
+3.616 0
+;
+;AeroTech M2500T
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+M2500T 98 751 0 4.6592 8.064 AT 
+0.082 2651.86
+0.249 2780.28
+0.416 2820.73
+0.583 2843.01
+0.751 2847.76
+0.918 2851.22
+1.084 2854.74
+1.252 2861.69
+1.42 2858.09
+1.586 2851.09
+1.754 2844.62
+1.922 2830.86
+2.089 2804.71
+2.255 2765.8
+2.423 2710.51
+2.591 2648.26
+2.757 2586.91
+2.925 2520.79
+3.093 2462.22
+3.259 2419.94
+3.426 1894.94
+3.594 808.043
+3.761 282.403
+3.928 97.876
+4.096 24.492
+4.264 0
+;
+;
+M845HW 98 795.02 1000 3.569 6.833 AT 
+0.015456 1332.26
+0.0463679 1706.62
+0.0772798 1178.12
+0.185471 1310.24
+0.973725 1222.16
+1.51468 1200.14
+1.97836 1123.07
+3.97218 1057
+4.20402 880.836
+6.01236 627.596
+6.495 418.397
+7.017 99.0941
+7.5 0
+;
+;AeroTech N2000W
+;Copyright Tripoli Motor Testing 1997 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+N2000W 98 1046 0 7.66707 12.2828 AT 
+0.146 2775.07
+0.446 2831.81
+0.746 2834.35
+1.046 2829.56
+1.346 2777.65
+1.646 2688.25
+1.95 2597.97
+2.254 2501.04
+2.554 2415.75
+2.854 2343.62
+3.154 2262.58
+3.454 2178.18
+3.758 2104.16
+4.062 2024.47
+4.362 1935.62
+4.663 1839.78
+4.962 1756.91
+5.262 1351.81
+5.567 954.556
+5.871 681.831
+6.171 475.91
+6.471 361.124
+6.771 194.633
+7.071 44.938
+7.375 6.03
+7.679 0
+;
+;AeroTech N4800T
+;provided by ThrustCurve.org (www.thrustcurve.org)
+N4800T 98 1194 0 9.7664 14.784 AT 
+0.098 4752.72
+0.301 6007.53
+0.506 5594.23
+0.71 5270.36
+0.914 5150.12
+1.119 5108.05
+1.324 5086.21
+1.528 5031.65
+1.731 4941.81
+1.936 4800.4
+2.14 4664.88
+2.344 4527.84
+2.549 4401
+2.754 4263.56
+2.958 4120.41
+3.161 3971.14
+3.366 3876.42
+3.57 3916.23
+3.774 3913.51
+3.979 3312.76
+4.184 1649.27
+4.388 523.361
+4.591 327.209
+4.796 251.041
+5.001 128.177
+5.206 0
+;
+;Apogee A2 RASP.ENG file made from NAR published data
+;File produced September 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+A2 11 58 0-3-5-7 0.00300006 0.00670001 AP 
+0.014 0.241
+0.036 0.895
+0.064 2.618
+0.1 4.82
+0.111 4.133
+0.125 2.687
+0.139 2.307
+0.185 2.031
+0.296 1.928
+0.481 1.825
+0.517 1.722
+0.538 1.791
+0.649 1.688
+0.748 1.757
+0.869 1.825
+1.04 1.894
+1.101 1.894
+1.119 1.825
+1.144 1.928
+1.229 1.859
+1.265 1.894
+1.283 1.757
+1.29 1.412
+1.293 0.688
+1.3 0.275
+1.31 0
+;
+;Apogee B2 RASP.ENG file made from NAR published data
+;File produced September 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+B2 11 88 0-3-5-7-9 0.006 0.0106 AP 
+0.057 1.637
+0.093 4.091
+0.121 5.48
+0.143 4.787
+0.157 3.478
+0.207 2.578
+0.328 2.087
+0.371 2.087
+0.406 1.882
+0.641 1.841
+0.869 1.841
+1.283 1.882
+1.361 1.882
+1.397 1.718
+1.439 1.841
+1.532 1.718
+1.71 1.841
+1.888 1.882
+2.095 1.8
+2.23 1.8
+2.295 1.677
+2.423 1.759
+2.444 1.637
+2.466 0.982
+2.494 0.327
+2.53 0
+;
+;Apogee B7 RASP.ENG file made from NAR published data
+;File produced September 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+B7 13 50 4-6-8-10 0.0028 0.0091 AP 
+0.007 5.708
+0.013 7.211
+0.032 6.111
+0.045 8.116
+0.056 7.717
+0.069 9.02
+0.078 12.122
+0.087 14.76
+0.106 13.832
+0.117 13.733
+0.125 12.636
+0.155 12.438
+0.168 11.836
+0.2 11.243
+0.209 11.737
+0.219 10.739
+0.266 9.846
+0.29 9.849
+0.299 8.949
+0.367 7.456
+0.393 7.159
+0.429 5.761
+0.487 4.567
+0.571 2.975
+0.607 2.178
+0.669 1.084
+0.708 0.489
+0.74 0
+;
+;Apogee C4 RASP.ENG file made from NAR published data
+;File produced September 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+C4 18 50 3-5-7 0.0045 0.017 AP 
+0.018 3.23
+0.041 6.874
+0.147 8.779
+0.294 10.683
+0.365 11.31
+0.388 10.521
+0.412 8.779
+0.441 7.04
+0.465 4.555
+0.529 3.479
+0.629 2.981
+0.653 3.23
+0.718 2.816
+0.853 2.733
+1.065 2.65
+1.253 2.567
+1.453 2.401
+1.694 2.484
+1.794 2.484
+1.812 2.733
+1.841 2.401
+1.947 2.401
+2.112 2.401
+2.235 2.401
+2.282 2.236
+2.312 1.656
+2.329 0.662
+2.35 0
+;
+;Apogee C6 RASP.ENG file made from NAR published data
+;File produced September 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+C6 13 83 4-7-10 0.007 0.0151 AP 
+0.008 13.958
+0.016 21.1
+0.022 15.511
+0.03 12.831
+0.052 14.8
+0.081 15.927
+0.092 14.658
+0.114 16.069
+0.125 14.658
+0.136 15.369
+0.168 14.8
+0.214 13.816
+0.225 12.973
+0.247 13.958
+0.252 12.831
+0.285 12.547
+0.307 12.405
+0.317 12.831
+0.328 11.562
+0.347 11.988
+0.393 11.42
+0.442 10.719
+0.464 11.136
+0.488 9.164
+0.545 8.459
+0.624 7.754
+0.716 6.485
+0.838 5.075
+0.977 3.102
+1.096 1.833
+1.207 0.986
+1.32 0
+;
+;Apogee C10 RASP.ENG file made from NAR published data
+;File produced September 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+C10 18 50 4-7-10 0.0049 0.0176 AP 
+0.01 2.712
+0.019 5.842
+0.029 17.116
+0.037 25.72
+0.051 22.535
+0.07 20.446
+0.106 18.983
+0.164 17.085
+0.188 17.085
+0.2 15.824
+0.216 16.036
+0.255 15.602
+0.293 14.35
+0.343 13.503
+0.394 12.655
+0.41 11.605
+0.434 11.605
+0.521 9.287
+0.631 6.34
+0.741 4.021
+0.851 2.119
+0.911 1.48
+0.945 1.264
+0.96 0
+;
+;Apogee D3 RASP.ENG file made from NAR published data
+;File produced September 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+D3 18 77 3-5-7 0.0098 0.0249 AP 
+0.05 6.79
+0.168 8.788
+0.318 10.46
+0.385 10.07
+0.402 7.909
+0.469 5.432
+0.486 3.914
+0.687 3.115
+1.122 2.876
+2.06 2.636
+3.349 2.397
+4.639 2.156
+5.727 1.997
+6.163 1.837
+6.263 3.994
+6.347 2.317
+6.364 0.719
+6.39 0
+;
+;Apogee D10 RASP.ENG file made from NAR published data
+;File produced September 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+D10 18 70 3-5-7 0.0098 0.0259 AP 
+0.011 14.506
+0.018 25.13
+0.032 20.938
+0.079 19.065
+0.122 21.139
+0.136 19.686
+0.169 21.139
+0.201 20.728
+0.223 21.76
+0.233 20.938
+0.255 21.97
+0.276 20.938
+0.352 20.728
+0.402 20.107
+0.42 20.728
+0.459 20.107
+0.488 20.517
+0.556 18.243
+0.671 15.959
+0.707 14.717
+0.729 15.127
+0.779 12.853
+0.793 13.474
+0.836 11.401
+0.904 10.158
+0.926 10.569
+0.99 8.083
+1.026 8.498
+1.123 6.011
+1.231 2.487
+1.342 0.829
+1.4 0
+;
+;Aerotech E6 RASP.ENG file made from NAR published data
+;File produced July 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+E6 24 70 2-4-6-8-100 0.0215 0.0463 AT 
+0.056 18.59
+0.112 20.12
+0.168 17.575
+0.307 14.38
+0.531 10.45
+0.894 7.696
+1.146 6.244
+1.691 5.808
+2.836 5.663
+3.898 5.517
+4.275 5.227
+4.415 4.937
+5.058 5.082
+5.519 5.227
+5.603 6.679
+5.729 3.921
+5.882 2.323
+5.966 1.016
+6.06 0
+;
+;
+G100 38 406 0 0.093 0.511 Contrail 
+0 182.756
+0.199105 177.584
+0.606264 132.757
+0.986577 53.4476
+1.43 0
+;
+;
+G123 38 406 0 0.0830001 0.511 Contrail 
+0.00223714 217.239
+0.00671141 399.995
+0.0201342 220.687
+0.914989 72.4129
+0.955257 37.9306
+1.15 0
+;
+;
+G130 38 406 1000 0.093 0.516 Contrail 
+0 662.061
+0.0145414 448.27
+0.0234899 241.376
+0.642058 41.3788
+0.86 0
+;
+;G-234-HP Reload
+;38mm/16 Inch Hardware
+;Fast Nozzle
+G234 38 406.4 0 0.498 0.544 Contrail 
+0.00169492 245.419
+0.0973154 540.63
+0.183445 526.943
+0.202461 191.616
+0.237136 143.712
+0.260626 136.868
+0.533 0
+;
+;G-300 PVC Motor for 38mm/16 Inch Case.
+;Motor uses Fast Nozzle
+;90cc's of Nitrous Oxide Used
+G300 38 406.4 0 0.0229999 0.544 Contrail 
+0.00111857 602.221
+0.0497763 814.367
+0.100671 670.655
+0.114094 266.893
+0.158837 239.52
+0.25 0
+;
+;
+H121 38 516 1000 0.11 0.612 Contrail 
+0.00223714 251.721
+0.0402685 265.514
+0.0738255 203.446
+0.400447 179.308
+0.60179 134.481
+1.08949 127.585
+1.40268 93.1023
+1.61969 37.9306
+1.85 0
+;
+;
+H141 38 516 0 0.125 0.612 Contrail 
+0.00223714 265.514
+0.111857 262.066
+1.20134 106.895
+1.25951 55.1717
+1.3557 27.5859
+1.7 0
+;
+;
+H211 38 516 0 0.125 0.612 Contrail 
+0.00111857 531.028
+0.0190157 634.475
+0.0223714 593.096
+0.033557 544.821
+0.296421 317.238
+0.313199 186.205
+0.743848 96.5506
+0.97 0
+;
+;H-222-HP Reload
+;38mm/16 inch Case Used
+;Medium Nozzle Used For Reload
+;140cc of Nitrous Oxide Used
+H222 38 406.4 1000 0.0220001 0.52 Contrail 
+0 684.342
+0.0302013 656.968
+0.0525727 574.847
+0.0581655 349.014
+0.346756 260.05
+0.364653 191.616
+0.7 0
+;
+;H-246 HP Reload
+;38mm/20 Inch Case Used
+;Medium Nozzle Used
+;185cc Nitrous Oxide Used
+H246 38 508 0 0.0220001 0.598 Contrail 
+0.00111857 609.064
+0.0123043 499.57
+0.502237 253.206
+0.514541 157.399
+0.9 0
+;
+;H-248-PVC Reload
+;38mm/28 Inch Hardware
+;Fast Nozzle
+H248 38 711.2 0 0.0350001 0.794 Contrail 
+0.00223714 465.352
+0.082774 698.029
+0.111857 342.171
+0.536913 266.893
+0.639821 191.616
+0.700224 184.772
+0.738255 164.242
+1.1 0
+;
+;
+H277 38 719 1000 0.11 0.71 Contrail 
+0 765.508
+0.0738255 703.44
+0.118568 337.927
+0.917226 179.308
+0.957494 75.8612
+0.995526 41.3788
+1.02908 48.2753
+1.15 0
+;
+;
+H300 38 516.001 0 0.11 0.612 Contrail 
+0 558.614
+0.115213 717.233
+0.12528 268.962
+0.214765 248.273
+0.286353 241.376
+0.334452 227.583
+0.62 0
+;
+;H-303-PVC Hybrid Motor
+;Uses Fast Nozzle
+;38mm/20 Inch Hardware
+;Uses 185cc Nitrous Oxide
+H303 38 508 0 0.0229999 0.589 Contrail 
+0 663.812
+0.0447427 780.15
+0.108501 704.872
+0.111857 342.171
+0.176734 328.484
+0.196868 307.954
+0.6 0
+;
+;
+H340 38 711.2 1000 0.024 0.816 Contrail 
+0 920.322
+0.0847458 715.806
+0.101695 345.121
+0.683051 332.338
+0.740678 255.645
+0.766102 153.387
+0.95 0
+;
+;
+I155 38 711.2 0 0.045 0.725 Contrail 
+0.0111857 222.411
+2.71253 150.555
+2.82998 82.121
+2.96421 58.1691
+3.5 0
+;
+;
+I210 38 922 0 0.125 0.87 Contrail 
+0 468.96
+0.464206 386.202
+0.497763 206.894
+2.25391 110.343
+2.34899 41.3788
+2.40492 13.7929
+2.72 0
+;
+;
+I221 38 719 1000 0.125 0.71 Contrail 
+0 482.753
+0.503356 358.616
+0.519016 179.308
+1.49217 103.447
+1.53691 27.5859
+1.74 0
+;
+;I-250-HP
+;38mm/28 Inch Hardware
+;430cc
+;Medium Nozzle
+I250 38 711.2 0 0.066 0.724 Contrail 
+0.00447427 622.751
+0.0246085 437.979
+1.00447 273.737
+1.02237 171.085
+1.20134 157.399
+1.23937 136.868
+1.7 0
+;
+;
+I290 38 914.4 0 0.0679998 0.884 Contrail 
+0 521.516
+0.0847458 337.451
+0.138983 357.903
+0.19661 398.806
+0.308475 490.838
+0.40339 449.935
+0.589831 357.903
+0.762712 419.258
+0.932203 265.871
+1.08814 163.613
+1.24068 81.8064
+1.5 0
+;
+;
+I307 38 922 1000 0.11 0.81 Contrail 
+0.00223714 551.717
+0.199105 717.233
+0.210291 386.202
+0.756152 620.682
+0.834452 455.167
+0.941834 310.341
+1.09172 199.998
+1.22371 117.24
+1.85 0
+;
+;I-333-PVC Reload
+;38mm/36 Inch Hardware
+;Uses Fast Nozzle
+;460cc Nitrous Oxide
+I333 38 914.4 0 0.0679998 0.929 Contrail 
+0.00894855 855.427
+0.0290828 881.09
+0.0536913 504.702
+0.604027 342.171
+0.796421 461.931
+1.7 0
+;
+;I-400-HP
+;38mm/36 Inch Hardware
+;Uses Fast/X-Fast Nozzle
+;460cc Nitrous Oxide
+I400 38 914.4 0 0.0860002 0.925 Contrail 
+0.00447427 667.233
+0.0782998 898.199
+0.116331 598.799
+0.297539 521.811
+0.420582 410.605
+0.559284 487.594
+0.738255 367.834
+1 0
+;
+;
+I500 38 719 1000 0.748 0.8 Contrail 
+0.00111857 1155.16
+0.0201342 706.888
+0.0313199 999.988
+0.574944 103.447
+0.623043 120.688
+0.7 0
+;
+;
+I727 38 914.4 0 0.0220001 0.929 Contrail 
+0.00847458 1278.22
+0.0355932 1661.69
+0.0983051 1508.31
+0.144068 1482.74
+0.171186 1175.97
+0.218644 1022.58
+0.422034 792.499
+0.75 0
+;
+;
+I747 38 711.2 0 0.0679998 0.839 Contrail 
+0 1917.34
+0.45 0
+;
+;J-150-HP
+;38mm/36 Inch
+;550cc
+;Slow Nozzle
+J150 38 914.4 1000 0.0910002 0.839 Contrail 
+0 266.893
+2.00224 184.772
+2.75727 150.555
+3.00895 92.3861
+4.1 0
+;
+;J-222-HP Reload
+;Medium Nozzle
+;38mm/48 Inch Hardware
+;830cc
+J222 38 1219.2 0 0.0910002 1.043 Contrail 
+0.00559284 547.473
+0.167785 355.858
+2.86353 191.616
+2.95861 143.712
+3.08725 130.025
+3.46756 95.8079
+4.3 0
+;
+;J-234-BG Reload
+;Slow Nozzle
+;54mm/36 Inch Hardware
+J234 54 914.4 0 0.177 1.764 Contrail 
+0.00559284 229.255
+0.503356 349.014
+3.47875 208.724
+3.62416 116.338
+3.75839 78.6993
+4.3 0
+;
+;
+J242 38 1227 0 0.11 1.065 Contrail 
+0.0111857 448.27
+1.73937 268.962
+1.76174 165.515
+2.97539 48.2753
+3.1 0
+;
+;J-245-BG Reload
+;Slow Nozzle
+;54mm/28 Inch Hardware
+J245 54 711.2 0 0.1 1.55 Contrail 
+0 444.822
+0.139821 355.858
+1.05145 307.954
+2.06376 184.772
+2.15884 102.651
+2.28188 68.4342
+2.62 0
+;
+;J-246-HP Reload
+;38mm/36 Inch Hardware
+;550cc
+;Medium Nozzle
+J246 38 914.4 0 0.0679998 0.861 Contrail 
+0.0167785 492.726
+0.0279642 328.484
+0.134228 526.943
+0.341163 403.762
+0.520134 349.014
+2.00224 191.616
+2.12528 116.338
+2.8 0
+;
+;
+J272 54 914.4 0 0.114 1.746 Contrail 
+0.00847458 398.806
+0.169492 572.645
+0.533898 460.161
+0.872881 388.58
+1.05932 357.903
+2.91525 204.516
+3.19492 71.5806
+3.51695 40.9032
+3.63559 51.129
+3.86 0
+;
+;
+J292 54 711.2 0 0.136 1.542 Contrail 
+0.00847458 552.193
+0.262712 480.612
+0.423729 419.258
+0.762712 337.451
+1.97458 245.419
+2.07627 143.161
+2.53 0
+;
+;
+J333 38 1227 0 0.11 1.064 Contrail 
+0 717.233
+0.204139 799.99
+0.752237 448.27
+0.763423 268.962
+2.16443 62.0682
+2.23714 27.5859
+2.4 0
+;
+;J-345-PVC
+;38mm/48 Inch Hardware
+;735cc
+;Fast Nozzle
+J345 38 1219.2 0 0.098 1.118 Contrail 
+0.00559284 881.09
+0.0782998 667.233
+1.21924 376.388
+1.26398 359.279
+2.7 0
+;
+;
+J355 54 711.2 0 0.09 1.564 Contrail 
+0 562.419
+0.176271 501.064
+0.2 286.322
+0.433898 286.322
+0.688136 337.451
+0.701695 501.064
+0.80678 490.838
+1.00339 521.516
+1.21695 419.258
+1.31186 429.484
+1.37627 460.161
+1.49831 429.484
+1.54576 224.968
+1.64068 122.71
+1.91 0
+;
+;
+J358 54 914.4 0 0.111 1.743 Contrail 
+0.00847458 726.032
+0.0932203 726.032
+0.110169 501.064
+0.483051 480.612
+0.550847 398.806
+2.23729 286.322
+2.32203 153.387
+2.44915 112.484
+2.69 0
+;
+;
+J416 54 914.4 0 0.158 1.7 Contrail 
+0 787.386
+0.0762712 777.161
+0.211864 572.645
+0.432203 531.741
+0.864407 511.29
+1.26271 480.612
+1.82203 470.387
+2.00847 347.677
+2.13559 276.097
+2.24576 184.064
+2.40678 81.8064
+2.75 0
+;
+;
+J555 38 1227 0 0.166 1.132 Contrail 
+0 931.023
+0.0581655 1344.81
+0.277405 810.335
+1.17226 241.376
+1.2774 68.9647
+1.31767 51.7235
+1.6 0
+;
+;
+J642 54 914.4 0 0.159 1.791 Contrail 
+0.00677966 1482.74
+0.0779661 997.015
+0.471186 1303.79
+0.542373 818.064
+0.633898 741.37
+0.742373 587.983
+1.25085 485.725
+1.29831 332.338
+1.39661 178.951
+1.47458 51.129
+1.72 0
+;
+;J-800-HP
+;38mm/48 Inch
+;685cc
+;XXF Nozzle (Short Nozzle)
+J800 38 1219.2 0 0.105 1.148 Contrail 
+0.00223714 1830.61
+0.52349 889.644
+0.639821 650.125
+0.740492 444.822
+0.823266 273.737
+0.90604 153.977
+0.997763 136.868
+1.2 0
+;
+;K-234-BG Reload
+;Slow Nozzle
+;54mm/48 Inch Hardware
+K234 54 1219.2 0 0.385 2.063 Contrail 
+0 92.3861
+0.234899 396.918
+0.973154 338.749
+5.97315 171.085
+6.05145 106.073
+6.19687 78.6993
+6.37584 54.7473
+7.05 0
+;
+;
+K265 54 1219.2 0 0.271 2.085 Contrail 
+0 470.387
+2.44068 347.677
+3.91525 224.968
+4.77966 173.839
+5.13559 112.484
+5.33898 51.129
+6.26 0
+;
+;K-300-BS
+;75mm/40 Inch Hardware
+;2050cc
+;Slow Nozzle
+K300 75 1016 0 0.181 4.059 Contrail 
+0 431.135
+0.324385 526.943
+0.98434 479.039
+1.1745 369.545
+5 280.58
+5.19016 171.085
+5.35794 102.651
+5.6264 54.7473
+5.79418 27.3737
+6.5 0
+;
+;K-321-BG Reload
+;54mm/48 Inch Hardware
+;Medium Nozzle
+K321 54 1219.2 0 0.183 2.043 Contrail 
+0.00559284 218.989
+0.218121 410.605
+0.973154 718.559
+0.989933 732.246
+1.05705 444.822
+1.4877 403.762
+3.97092 232.676
+4.11633 88.9644
+4.23378 54.7473
+4.34564 54.7473
+4.9 0
+;
+;K-404-Sparky
+;75mm/40 Inch Hardware
+;2050cc
+;Slow Nozzle
+K404 75 1016 0 0.318 4.15 Contrail 
+0.0111857 670.655
+4.63087 335.328
+4.80984 205.303
+4.9217 130.025
+5.0783 82.121
+5.26846 41.0605
+6.4 0
+;
+;
+K456 75 813.001 0 0.58 3.704 Contrail 
+0.00559284 681.026
+0.212528 896.541
+0.503356 775.853
+1.36465 577.579
+1.52685 525.856
+2.51119 370.685
+2.66779 129.309
+3.7 0
+;
+;Contrail Rockets Hybrid Rocket Motor (K543)
+;75mm-1400cc Motor Hardware w/ Slow Injector Kit and Nozzle
+;Black Smoke Reload
+;Data Input By Tom R. Sanders of Contrail Rockets LLC
+K543 75 787.4 0 1.5 3.6 Contrail 
+0 900
+2.98992 472.868
+3.1243 108.527
+3.6 0
+;
+;K-555-BG Reload
+;54mm/48 Inch Case
+;XF Nozzle
+K555 54 1219.2 0 0.156 2.038 Contrail 
+0.0503356 769.885
+0.33557 889.644
+0.559284 1385.79
+0.844519 872.536
+1.0123 581.691
+2.48881 342.171
+2.56711 222.411
+2.63982 136.868
+2.74049 51.3256
+2.8132 17.1085
+3.04 0
+;
+;K-630-Sparky Reload
+;75mm/41 Inch Hardare
+;1400cc
+;Medium Nozzle
+K630 75 1041.4 0 0.075 3.55 Contrail 
+0.00559284 307.954
+0.0978747 573.136
+0.500559 889.644
+1.75336 667.233
+1.85403 410.605
+1.93792 239.52
+2.04978 128.314
+2.2 0
+;
+;K-678-Sparky
+;75mm/40 Inch Hardware
+;2050cc
+;Medium Nozzle
+K678 75 1016 0 0.827 4.05 Contrail 
+0.00559284 1163.38
+2.21477 444.822
+2.32103 256.628
+2.38814 102.651
+2.8 0
+;
+;K-707-BG Reload
+;Medium Nozzle
+;1400cc
+K707 75 1041.4 0 0.136 3.674 Contrail 
+0.0111857 684.342
+0.195749 1351.58
+0.288031 1180.49
+0.369128 1129.16
+1.50168 496.148
+1.566 307.954
+1.63591 171.085
+1.68345 119.76
+2 0
+;
+;
+K777 75 1016 0 0.645 4.05 Contrail 
+0 931.023
+0.0950783 965.506
+0.111857 1793.08
+0.167785 1741.36
+0.206935 1344.81
+0.727069 1137.92
+1.00112 810.335
+1.97427 413.788
+2.04698 172.412
+2.6 0
+;
+;Contrail Rockets Hybrid Rocket Motor (K888)
+;75mm-2000cc Hardware with Medium Injector Kit and Nozzle
+;Black Smoke Reload
+;Data Input By Tom R. Sanders of Contrail Rockets LLC.
+K888 75 990.6 0 2.1 4.1 Contrail 
+0 1365
+0.5 1365
+1.04143 1069.77
+2.4972 434.109
+2.54199 124.031
+2.7 0
+;
+;L-369-Sparky
+;Slow nozzle
+;75mm/54 Inch Hardware
+;3200cc
+L369 75 1371.6 0 0.514 4.8 Contrail 
+0.0223714 540.63
+1.45414 533.787
+8.92617 260.05
+9.08277 130.025
+9.28412 68.4342
+10.6 0
+;
+;L-800-Sparky
+;75mm/54 Inch Hardware
+;3200cc
+;Medium Nozzle
+L800 75 1371.6 0 0.988 4.726 Contrail 
+0.00559284 1351.58
+0.167785 1129.16
+0.329978 1266.03
+0.553691 1248.92
+0.665548 1129.16
+3.48434 821.21
+3.5962 496.148
+3.69687 273.737
+3.83669 153.977
+4.6 0
+;
+;Contrail Rockets LLC Hybrid Rocket Motor (L1222)
+;75mm-3200cc Motor System
+;Sparky Hybrid Fuel
+;Data Input By Tom R. Sanders of Contrail Rockets
+L1222 75 1339.85 0 3.9 4.989 Contrail 
+0 455
+0.25 455
+0.5 2725
+0.75 1816
+2.75 680
+3.1 0
+;
+;Contrail Rockets LLC. Hybrid Rocket Motor (L1428)
+;75mm-3200cc Motor Using Fast Injector Kit and Nozzle
+;Data Input By Tom R. Sanders of Contrail Rockets
+L1428 75 1492.25 0 3.5 5.738 Contrail 
+0 1425
+0.403135 2751.94
+0.8 2725
+1.20941 1511.63
+2.65 800
+3 800
+3.1 0
+;
+;
+L2525 75 1492.25 0 3.5 5.579 Contrail 
+0 4200
+0.754759 3294.57
+1.9 0
+;
+;Contrail Rockets LLC Hybrid Rocket Motor. (M-711)
+;75-3200cc Hardware Set
+;Black Smoke Fuel
+M711 75 1340 0 4.2 4.9 Contrail 
+0 1140
+1.46697 1069.77
+4 680
+6.47256 589.147
+6.67413 279.07
+7.22 0
+;
+;Contrail Rockets LLC. Hybrid Rocket Motor (M1491
+;75mm-3200cc Motor Using Medium Injector Kit and Nozzle
+;Data Input By Tom R. Sanders of Contrail Rockets
+M1491 75 1339.85 0 3.85 4.876 Contrail 
+0 2725
+0.481523 2635.66
+0.81187 2286.82
+1.33259 1860.47
+3 900
+3.09071 503.876
+3.35 0
+;
+;M-1575-Black Gold Reload
+;5300cc
+;98mm/60 Inch Hardware
+M1575 98 1524 0 0.726 10.863 Contrail 
+0.139821 2429.41
+0.503356 2976.89
+2.95302 1402.9
+3.06488 923.861
+3.21029 376.388
+3.31096 205.303
+4.2 0
+;
+;Contrail Rockets LLC. Hybrid Rocket Motor (M2281)
+;75mm-3200cc Motor Using Fast Injector Kit and Nozzle
+;Data Input By Tom R. Sanders of Contrail Rockets
+M2281 75 1492.25 0 3.95 5.579 Contrail 
+0 2725
+0.2 4550
+0.6 4550
+0.8 4550
+0.9 4000
+0.95 2725
+1.98768 116.279
+2.14 0
+;
+;
+M2700 98 1524 0 0.412 10.432 Contrail 
+0.00847458 2965.48
+0.0508475 3272.26
+0.105932 5930.96
+0.347458 5828.7
+0.504237 6442.25
+0.512712 5726.45
+0.601695 5112.9
+0.745763 3681.29
+0.902542 3067.74
+1.06356 2454.19
+1.18644 1942.9
+1.34322 1738.39
+1.75 715.806
+1.95763 102.258
+2.3 0
+;
+;M-2800-Black Gold Reload
+;5300cc
+;98mm/60 inch Hardware
+M2800 98 1524 0 0.476 10.704 Contrail 
+0.00838926 2395.2
+0.251678 2805.8
+0.545302 3695.45
+0.75783 5611.6
+0.911633 4311.35
+1.1745 3558.58
+1.4094 2258.33
+1.70861 1505.55
+2.3 0
+;
+;
+O6300 152 1828.8 0 3.175 28.576 Contrail 
+0.0338983 12271
+0.728814 9714.51
+1.65254 9203.22
+2.37288 8947.57
+2.51695 6646.77
+2.78814 4601.61
+2.99153 4857.25
+3.27966 3579.03
+3.61017 1278.22
+4.29 0
+;
+;Apogee 1/4A2 RASP.ENG file made from NAR published data
+;File produced September 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+1/4A2 11 38 2-4 0.000800137 0.00360016 AP 
+0.007 0.162
+0.023 0.65
+0.041 1.463
+0.058 2.519
+0.074 3.738
+0.079 3.9
+0.088 4.915
+0.097 5.119
+0.106 5.4
+0.11 5.119
+0.118 3.981
+0.125 3.656
+0.132 3.453
+0.136 3.209
+0.151 3.169
+0.156 2.966
+0.168 2.884
+0.18 2.397
+0.194 1.625
+0.207 1.056
+0.218 0.406
+0.23 0
+;
+;Estes 1/4A3T RASP.ENG file made from NAR published data
+;File produced October 3, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+1/4A3T 13 45 3 0.000830074 0.00609991 ES 
+0.016 0.243
+0.044 1.164
+0.08 2.698
+0.088 2.851
+0.096 3.312
+0.105 3.804
+0.116 4.325
+0.129 4.754
+0.131 4.754
+0.135 4.95
+0.139 4.815
+0.143 4.814
+0.149 4.66
+0.157 4.289
+0.173 3.548
+0.187 2.808
+0.194 2.592
+0.197 2.13
+0.202 1.913
+0.206 1.512
+0.213 1.389
+0.218 1.112
+0.227 0.802
+0.236 0.493
+0.241 0.277
+0.25 0
+;
+;Apogee 1/2A2 RASP.ENG file made from NAR published data
+;File produced September 4, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+1/2A2 11 57 2-4-6 0.0015 0.0044 AP 
+0.007 0.19
+0.045 1.494
+0.078 3.152
+0.088 3.805
+0.093 3.805
+0.1 3.97
+0.105 3.696
+0.11 3.071
+0.117 2.554
+0.123 2.582
+0.132 2.31
+0.163 2.146
+0.2 1.984
+0.242 1.902
+0.253 2.01
+0.275 1.929
+0.342 1.929
+0.403 1.929
+0.41 1.848
+0.42 1.902
+0.467 1.902
+0.528 1.929
+0.565 1.929
+0.58 1.902
+0.593 1.848
+0.603 1.657
+0.61 1.141
+0.615 0.597
+0.622 0.244
+0.63 0
+;
+;Estes 1/2A3T RASP.ENG file made from NAR published data
+;File produced October 3, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+1/2A3T 13 45 2-4 0.002 0.0066 ES 
+0.024 0.501
+0.042 1.454
+0.064 3.009
+0.076 4.062
+0.088 4.914
+0.093 5.065
+0.103 6.068
+0.112 6.87
+0.117 7.021
+0.126 7.62
+0.137 7.472
+0.146 6.87
+0.153 6.118
+0.159 5.065
+0.166 4.363
+0.179 3.66
+0.197 2.908
+0.222 2.256
+0.25 2.156
+0.277 2.106
+0.294 2.056
+0.304 2.156
+0.316 1.955
+0.326 1.554
+0.339 1.053
+0.35 0.651
+0.36 0
+;
+;Estes 1/2A6 RASP.ENG file made from NAR published data
+;File produced October 3, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+1/2A6 18 70 2 0.0026 0.0138 ES 
+0.031 0.404
+0.064 1.258
+0.096 2.263
+0.124 3.467
+0.149 4.72
+0.172 6.023
+0.196 7.027
+0.21 7.528
+0.225 7.86
+0.235 7.482
+0.244 6.683
+0.254 5.685
+0.263 4.487
+0.269 4.087
+0.279 3.039
+0.29 1.79
+0.297 1.042
+0.306 0.593
+0.314 0.344
+0.33 0
+;
+;Estes A3T RASP.ENG file made from NAR published data
+;File produced October 3, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+A3T 13 45 4 0.0033 0.0085 ES 
+0.024 0.195
+0.048 0.899
+0.086 2.658
+0.11 4.183
+0.14 5.83
+0.159 5.395
+0.18 4.301
+0.199 3.635
+0.215 2.736
+0.234 2.267
+0.258 2.15
+0.315 2.072
+0.441 1.993
+0.554 2.033
+0.605 2.072
+0.673 1.954
+0.764 1.954
+0.874 2.072
+0.931 2.15
+0.953 2.072
+0.966 1.719
+0.977 1.173
+0.993 0.547
+1.01 0
+;
+;Estes A8 RASP.ENG file made from NAR published data
+;File produced October 3, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+A8 18 70 3-5 0.0033 0.01635 ES 
+0.041 0.512
+0.084 2.115
+0.127 4.358
+0.166 6.794
+0.192 8.588
+0.206 9.294
+0.226 9.73
+0.236 8.845
+0.247 7.179
+0.261 5.063
+0.277 3.717
+0.306 3.205
+0.351 2.884
+0.405 2.499
+0.467 2.371
+0.532 2.307
+0.589 2.371
+0.632 2.371
+0.652 2.243
+0.668 1.794
+0.684 1.153
+0.703 0.448
+0.73 0
+;
+;Estes A10T RASP.ENG file made from NAR published data
+;File produced October 3, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+A10T 13 45 3-100 0.0038 0.00525 ES 
+0.026 0.478
+0.055 1.919
+0.093 4.513
+0.124 8.165
+0.146 10.956
+0.166 12.64
+0.179 11.046
+0.194 7.966
+0.203 6.042
+0.209 3.154
+0.225 1.421
+0.26 1.225
+0.333 1.41
+0.456 1.206
+0.575 1.195
+0.663 1.282
+0.76 1.273
+0.811 1.268
+0.828 0.689
+0.85 0
+;
+;Estes B4 RASP.ENG file made from NAR published data
+;File produced October 3, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+B4 18 70 2-4 0.006 0.0189 ES 
+0.02 0.418
+0.04 1.673
+0.065 4.076
+0.085 6.69
+0.105 9.304
+0.119 11.496
+0.136 12.75
+0.153 11.916
+0.173 10.666
+0.187 9.304
+0.198 7.214
+0.207 5.645
+0.226 4.809
+0.258 4.182
+0.326 3.763
+0.422 3.554
+0.549 3.345
+0.665 3.345
+0.776 3.345
+0.863 3.345
+0.94 3.449
+0.991 3.449
+1.002 2.404
+1.01 1.254
+1.03 0
+;
+;Estes C5 RASP.ENG file made from NAR published data
+;File produced October 3, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+C5 18 70 3 0.0113 0.0248 ES 
+0.042 2.195
+0.107 9.118
+0.159 16.213
+0.21 21.85
+0.233 18.407
+0.27 13.677
+0.289 9.793
+0.303 7.092
+0.326 5.065
+0.401 4.39
+0.55 3.883
+0.802 3.714
+1.026 3.883
+1.291 3.883
+1.524 4.221
+1.683 4.221
+1.702 2.195
+1.73 0
+;
+;Estes C6 RASP.ENG file made from NAR published data
+;File produced October 3, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+C6 18 70 0-3-5-7 0.0108 0.0231 ES 
+0.031 0.946
+0.092 4.826
+0.139 9.936
+0.192 14.09
+0.209 11.446
+0.231 7.381
+0.248 6.151
+0.292 5.489
+0.37 4.921
+0.475 4.448
+0.671 4.258
+0.702 4.542
+0.723 4.164
+0.85 4.448
+1.063 4.353
+1.211 4.353
+1.242 4.069
+1.303 4.258
+1.468 4.353
+1.656 4.448
+1.821 4.448
+1.834 2.933
+1.847 1.325
+1.86 0
+;
+;ESTES C11 RASP.ENG file made from NAR published data
+;File produced JANUARY 1, 2002
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+C11 24 70 0-3-5-7 0.012 0.0353 ES 
+0.034 1.692
+0.066 3.782
+0.107 7.566
+0.145 10.946
+0.183 14.832
+0.214 17.618
+0.226 18.213
+0.256 20.107
+0.281 21.208
+0.298 21.73
+0.306 20.206
+0.323 17.321
+0.337 14.931
+0.358 13.236
+0.385 11.947
+0.413 11.65
+0.468 10.946
+0.539 10.45
+0.619 10.648
+0.683 10.648
+0.715 10.648
+0.726 10.053
+0.74 8.163
+0.758 5.773
+0.778 3.185
+0.795 1.394
+0.81 0
+;
+;Estes D11 RASP.ENG file made from NAR published data
+;File produced October 3, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+D11 24 70 100 0.0245 0.0448 ES 
+0.033 2.393
+0.084 5.783
+0.144 12.17
+0.214 20.757
+0.261 24.35
+0.289 26.01
+0.311 23.334
+0.325 18.532
+0.338 14.536
+0.356 12.331
+0.398 10.72
+0.48 9.303
+0.618 8.676
+0.761 8.247
+0.955 8.209
+1.222 7.955
+1.402 8.319
+1.54 8.291
+1.701 8.459
+1.784 8.442
+1.803 6.239
+1.834 3.033
+1.86 0
+;
+;Estes D12 RASP.ENG file made from NAR published data
+;File produced October 3, 2000
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+D12 24 70 0-3-5-7 0.0211 0.0426 ES 
+0.049 2.569
+0.116 9.369
+0.184 17.275
+0.237 24.258
+0.282 29.73
+0.297 27.01
+0.311 22.589
+0.322 17.99
+0.348 14.126
+0.386 12.099
+0.442 10.808
+0.546 9.876
+0.718 9.306
+0.879 9.105
+1.066 8.901
+1.257 8.698
+1.436 8.31
+1.59 8.294
+1.612 4.613
+1.65 0
+;
+;Estes B6-0 from NAR data by Mark Koelsch
+B6-0 18 70 0 0.0056 0.0156 ES 
+0.036 1.364
+0.064 2.727
+0.082 4.215
+0.111 6.694
+0.135 9.05
+0.146 9.545
+0.172 11.901
+0.181 12.149
+0.191 11.901
+0.211 9.174
+0.239 7.314
+0.264 6.074
+0.275 5.95
+0.333 5.207
+0.394 4.835
+0.445 4.835
+0.556 4.339
+0.667 4.587
+0.723 4.339
+0.78 4.339
+0.793 4.091
+0.812 2.603
+0.833 1.24
+0.857 0
+;
+;Estes E9-0 by Mark Koelsch from NAR data
+E9-0 24 95 0 0.0358 0.0568 ES 
+0.046 1.913
+0.235 16.696
+0.273 18.435
+0.326 14.957
+0.38 12.174
+0.44 10.435
+0.835 9.043
+1.093 8.87
+1.496 8.696
+1.997 8.696
+2.498 8.696
+3.014 9.217
+3.037 5.043
+3.067 1.217
+3.09 0
+;
+;
+G69 38 127 3-5-7-9-12 0.0839999 0.2051 CTI 
+0.06 80.77
+0.2 84.5
+0.41 82.74
+0.59 80.11
+0.81 76.82
+1 72.87
+1.2 68.92
+1.4 64.31
+1.61 59.48
+1.82 50.92
+1.9 21.4
+1.93 0
+;
+;
+G185 38 127 3-5-7-9-12 0.0717 0.188 CTI 
+0.01 108.72
+0.02 131.19
+0.05 153.14
+0.1 168.97
+0.2 189.92
+0.3 199.95
+0.35 203.59
+0.4 205.03
+0.45 202.6
+0.5 203.06
+0.55 199.34
+0.6 194.71
+0.61 194.1
+0.63 193.49
+0.64 193.68
+0.65 202.91
+0.67 163.39
+0.68 80.44
+0.69 0
+;
+;
+G79SS 38 127 13-10-8-6-4 0.085 0.226 CTI 
+0 9.07
+0.03 54.45
+0.07 76.33
+0.09 70.95
+0.11 65.92
+0.17 68.59
+0.2 70.64
+0.3 74.89
+0.4 80.39
+0.5 83.76
+0.6 86.45
+0.7 88.65
+0.81 91.4
+0.9 93.06
+1 93.99
+1.1 95.81
+1.2 90.7
+1.3 86.92
+1.4 81.98
+1.5 76.54
+1.55 58.92
+1.6 16.41
+1.62 5.16
+1.63 0
+;
+;
+G115-13A 38 127 13 0.0618 0.195 CTI 
+0.00787402 10.3447
+0.0183727 117.671
+0.0209974 128.447
+0.0446194 131.895
+0.0577428 125.861
+0.0629921 119.395
+0.0787402 113.792
+0.107612 115.947
+0.149606 118.964
+0.188976 119.395
+0.233596 121.981
+0.278215 122.412
+0.322835 122.843
+0.380577 123.274
+0.440945 122.843
+0.480315 123.274
+0.540682 122.843
+0.590551 122.412
+0.622047 120.688
+0.67979 120.257
+0.734908 119.395
+0.790026 117.671
+0.845144 116.809
+0.88189 116.378
+0.929134 113.361
+0.979003 113.361
+1.0315 111.206
+1.07087 108.188
+1.11286 108.188
+1.16535 106.033
+1.18373 112.499
+1.18635 96.5506
+1.19685 81.0335
+1.2021 51.7235
+1.2126 30.172
+1.21522 16.8101
+1.21785 7.75853
+1.24 0
+;
+;
+H153 38 186 4-6-8-10-13 0.1439 0.3039 CTI 
+0.13 149.36
+0.17 173.7
+0.23 171.77
+0.39 179.91
+0.6 188.3
+0.81 180.4
+1.01 168.25
+1.18 160.91
+1.29 149.64
+1.41 136.95
+1.6 105.37
+1.69 23.58
+1.75 0
+;
+;
+H400 38 186 4-6-8-10-13 0.1352 0.2836 CTI 
+0.01 222.15
+0.02 305.29
+0.03 314.52
+0.05 342.46
+0.1 382.51
+0.15 407.45
+0.2 420.81
+0.25 433.45
+0.3 439.18
+0.4 436.45
+0.5 422.67
+0.6 423.13
+0.62 364.93
+0.63 117.61
+0.64 0
+;
+;
+H565 38 245 5-7-9-11-14 0.1742 0.3622 CTI 
+0.01 106.91
+0.02 479.76
+0.0347144 528.926
+0.0515118 553.719
+0.0761478 578.512
+0.100784 586.777
+0.150056 611.57
+0.2 607.1
+0.3 614.73
+0.4 616.58
+0.5 622.37
+0.51 645.28
+0.52 628.99
+0.53 535.19
+0.54 327.35
+0.55 147.98
+0.56 60.36
+0.57 0
+;
+;
+H143SS 38 186 4-6-8-10-13 0.1654 0.347 CTI 
+0.06 114.68
+0.19 134.25
+0.4 149.61
+0.6 158.1
+0.8 163.77
+1 167
+1.21 160.93
+1.4 148.8
+1.6 128.59
+1.63 117.26
+1.65 106.35
+1.7 35.63
+1.73 0
+;
+;
+I205 38 245 5-7-9-11-14 0.2061 0.4022 CTI 
+0.1 181.5
+0.13 213.3
+0.2 210.1
+0.4 226.61
+0.6 235.8
+0.8 234
+1 232.8
+1.2 227.7
+1.4 216.8
+1.6 197.21
+1.74 183.13
+1.8 87.3
+1.88 0
+;
+;
+I285 38 303 6-8-10-12-15 0.2724 0.5059 CTI 
+0.1 350.6
+0.15 318.73
+0.2 312.3
+0.4 322.37
+0.6 330.57
+0.8 329.4
+1 319.64
+1.2 294.14
+1.4 271.9
+1.6 239.9
+1.66 178.1
+1.8 44.8
+1.91 0
+;
+;
+I566 38 245 6-8-10-12-15 0.1978 0.3842 CTI 
+0.01 396.82
+0.02 462.72
+0.04 473.24
+0.07 512.07
+0.1 537.85
+0.15 572.85
+0.2 587.73
+0.25 600.41
+0.3 609.75
+0.4 611.42
+0.5 602.61
+0.6 600.26
+0.61 607.55
+0.62 628.65
+0.63 612.18
+0.64 388.73
+0.65 0
+;
+;
+I800 38 303 6-8-10-12-15 0.2325 0.457 CTI 
+0.01 276.1
+0.02 680.47
+0.05 741.02
+0.1 791.43
+0.2 830.85
+0.3 851.45
+0.4 853.81
+0.5 888.69
+0.51 760.61
+0.52 0
+;
+;
+I212SS 38 245 5-7-9-11-14 0.2481 0.475 CTI 
+0.04 189.66
+0.2 207.11
+0.4 222.41
+0.6 236.62
+0.8 249.6
+0.95 255.15
+1.01 250.22
+1.21 233.54
+1.4 208.99
+1.55 183.99
+1.6 168.08
+1.63 134.62
+1.69 25.86
+1.71 0
+;
+;
+I287SS 38 303 6-8-10-12-15 0.3308 0.605 CTI 
+0.05 275.86
+0.2 292.53
+0.41 309.2
+0.61 327.53
+0.8 341.7
+0.9 344.2
+1.01 331.7
+1.2 311.7
+1.4 280.03
+1.53 245.02
+1.58 176.62
+1.6 141.76
+1.64 68.99
+1.69 17.48
+1.7 0
+;
+;
+I350SS 38 367 7-9-11-13-16 0.4135 0.782 CTI 
+0.05 399.74
+0.13 390.06
+0.19 386.19
+0.4 388.13
+0.6 388.13
+0.8 388.13
+1 389.91
+1.2 387.38
+1.33 368.77
+1.44 350.38
+1.52 320.37
+1.6 164.79
+1.68 36.77
+1.71 0
+;
+;
+I540WT 38 367 7-9-11-13-16 0.3288 0.5982 CTI 
+0.03 597.86
+0.04 611.31
+0.06 605.64
+0.12 612.36
+0.24 624.54
+0.36 626
+0.48 623.63
+0.6 616.42
+0.72 598.14
+0.84 583.16
+0.95 568.92
+0.96 558.53
+0.98 533.45
+1.02 436.53
+1.06 303.15
+1.09 184.92
+1.13 74.27
+1.18 0
+;
+;
+J210 54 236 6-16 0.396 0.842 CTI 
+0.04 335
+0.16 270.92
+0.41 269.3
+0.8 268.49
+1.18 256.32
+1.62 236.85
+2.03 214.14
+2.38 193.86
+2.79 174.39
+3.2 163.85
+3.6 157.36
+3.75 135.46
+3.86 85.17
+3.99 0
+;
+;
+J285 38 367 6-8-10-12-15 0.3125 0.595 CTI 
+0.06 351.01
+0.15 346.01
+0.25 357.64
+0.5 363.9
+0.75 369.26
+1.03 343.33
+1.27 337.07
+1.51 317.4
+1.75 282.53
+1.93 127.86
+2.02 84.94
+2.25 11.02
+2.26 0
+;
+;
+J295 54 329 6-16 0.594 1.119 CTI 
+0.04 450.52
+0.28 428.7
+0.54 423.25
+1 391.61
+1.48 352.34
+1.99 304.35
+2.51 266.17
+3 243.26
+3.5 216.92
+3.67 126.54
+3.82 64.36
+4 0
+;
+;
+J330 38 421 7-9-11-13-16 0.375 0.702 CTI 
+0.05 459.32
+0.16 448.2
+0.27 440.41
+0.51 437.08
+0.75 427.07
+1.02 412.61
+1.26 387.03
+1.5 360.34
+1.69 321.41
+1.79 300.28
+1.91 126.79
+1.99 107.88
+2.23 22.56
+2.26 0
+;
+;
+J280SS 54 236 6-16 0.512 0.954 CTI 
+0.1 259.43
+0.3 278.91
+0.6 293.07
+0.9 306.85
+1.2 319.19
+1.5 321.1
+1.8 310.85
+2.11 279.89
+2.35 286.7
+2.4 269.17
+2.44 178.24
+2.49 42.8
+2.54 0
+;
+;
+J380SS 54 320 6-16 0.769 1.2933 CTI 
+0.05 368.48
+0.3 348.31
+0.6 378.83
+0.9 400.93
+1.2 419.52
+1.5 433.09
+1.8 434.6
+2.1 408.81
+2.4 369.92
+2.56 410.58
+2.59 297.8
+2.71 45.25
+2.73 0
+;
+;
+J400SS 38 421 7-9-11-13-16 0.4896 0.702 CTI 
+0.05 451.79
+0.2 461.14
+0.31 465.81
+0.44 463.47
+0.6 477.48
+0.8 482.15
+1 461.31
+1.2 433.12
+1.35 402.76
+1.4 382.92
+1.47 321.04
+1.55 258
+1.6 178.62
+1.73 14.58
+1.75 0
+;
+;
+K445 54 404 7-17 0.792 1.398 CTI 
+0.05 664.83
+0.19 640.68
+0.48 622.98
+1 576.29
+1.51 515.12
+2 442.68
+2.5 392.26
+3.02 350.93
+3.13 339.66
+3.31 210.88
+3.47 78.88
+3.67 0
+;
+;
+K510 75 350 0 1.197 2.59 CTI 
+0.04 394.38
+0.07 617.68
+0.1 645.17
+0.21 658.16
+0.35 669.23
+0.53 667.72
+0.82 661.58
+1.18 626.92
+1.72 588.46
+2.15 557.69
+2.39 542.31
+2.9 492.86
+3.07 470.31
+3.56 426.81
+3.98 398.96
+4.32 393.98
+4.48 380.63
+4.6 364.22
+4.65 290.91
+4.8 91.23
+4.83 45.82
+4.84 0
+;
+;
+K570 54 488 7-17 0.99 1.685 CTI 
+0.04 892.67
+0.5 797.99
+1 738.68
+1.5 659.37
+2 585.96
+2.5 512.88
+2.97 417.16
+3.2 224.79
+3.47 67
+3.59 0
+;
+;
+K660 54 572 7-17 1.177 1.949 CTI 
+0.07 1078.9
+0.23 1006.47
+0.4 966.76
+0.8 897.52
+1.2 842.72
+1.6 794.15
+2.01 744.52
+2.4 692.27
+2.54 671.37
+2.68 439.08
+2.8 400.68
+3.01 386.9
+3.2 234.31
+3.45 106.65
+3.6 44.03
+3.69 0
+;
+;
+K1200 54 488 7-17 0.9814 1.6319 CTI 
+0.01 492.25
+0.01 1235.24
+0.02 1369.46
+0.05 1236.01
+0.1 1279.47
+0.2 1311.39
+0.3 1319.85
+0.4 1331.39
+0.5 1325.23
+0.7 1323.31
+0.8 1304.08
+0.9 1280.62
+1 1249.86
+1.1 1217.94
+1.2 1199.29
+1.3 1158.77
+1.4 1112.56
+1.5 1099.87
+1.55 941.81
+1.6 726.07
+1.62 559.17
+1.64 399.95
+1.66 317.66
+1.67 247.28
+1.68 198.05
+1.69 67.3
+1.7 0
+;
+;
+K1440 54 572 7-17 1.1624 1.8926 CTI 
+0.01 1061.8
+0.01 2168.21
+0.02 2036.3
+0.07 1691.73
+0.1 1805.18
+0.2 1747.49
+0.3 1721.72
+0.4 1712.49
+0.5 1709.03
+0.6 1682.11
+0.7 1678.65
+0.8 1638.27
+0.9 1601.35
+1.01 1539.56
+1.11 1462.58
+1.21 1398.43
+1.3 1111.41
+1.4 1039.5
+1.45 922.2
+1.5 701.07
+1.55 556.47
+1.6 272.66
+1.65 66.53
+1.66 0
+;
+;
+K530SS 54 404 6-16 1.025 1.6398 CTI 
+0.05 533.59
+0.09 503.98
+0.29 514.09
+0.6 534.31
+0.9 557.41
+1.2 577.63
+1.5 587.74
+1.8 596.4
+2.1 535.44
+2.31 502.54
+2.47 551.63
+2.56 393.94
+2.6 274.37
+2.64 137.19
+2.67 0
+;
+;
+K650SS 54 488 6-16 1.281 1.9899 CTI 
+0.04 664.52
+0.12 645.9
+0.31 642.24
+0.6 664.78
+0.91 684.59
+1.22 712.82
+1.5 723.41
+1.8 728.7
+2.1 664.52
+2.4 614.68
+2.51 680.53
+2.55 534.62
+2.61 268.19
+2.66 0
+;
+;
+L610 98 394 0 2.415 4.975 CTI 
+0.06 262.5
+0.12 667.2
+0.25 929.7
+0.39 871.21
+0.65 849.83
+1.05 823.1
+1.5 785.69
+2 747.3
+2.5 707.3
+3 667.2
+3.48 641.38
+4 593.28
+4.47 561.21
+5 523.79
+5.44 502.41
+5.68 491.72
+6 475.69
+6.5 459.66
+7.01 443.62
+7.5 413.7
+8 284.7
+8.12 53.3
+8.13 0
+;
+;
+L730 54 649 0 1.351 2.247 CTI 
+0 81.36
+0.01 1079.71
+0.02 1216.59
+0.04 1154.68
+0.2 1127.51
+0.45 1055.11
+0.6 1028.17
+0.75 995.24
+1 959.33
+1.5 898.71
+2 830.7
+2.5 730.76
+2.6 592.55
+2.7 510.96
+2.9 487.88
+3 405.72
+3.1 299.8
+3.2 296.09
+3.3 251.85
+3.4 171.7
+3.5 165.26
+3.6 139.38
+3.65 117.77
+3.76 45.38
+3.77 0
+;
+;
+L800 75 486 0 1.795 3.511 CTI 
+0 27.28
+0.01 402.41
+0.1 1285.54
+0.12 1056.51
+0.26 1041.73
+0.71 1026.95
+1.28 998.38
+2.05 901.36
+2.41 849.64
+2.83 763.51
+3.25 707.06
+3.65 655.14
+3.8 651.74
+4 624.07
+4.1 601.34
+4.19 536.17
+4.31 415.67
+4.41 270.17
+4.52 140.2
+4.6 76.92
+4.65 54.94
+4.67 40.16
+4.68 0
+;
+;
+L1115 75 621 0 2.394 4.404 CTI 
+0.01 45.46
+0.05 522.52
+0.08 984.04
+0.1 1256.1
+0.15 1389.85
+0.18 1713.25
+0.24 1515.65
+0.3 1474.74
+0.4 1443.28
+0.42 1446.25
+0.5 1430.02
+0.76 1392.85
+1 1361.7
+1.28 1339.45
+1.84 1259.35
+2.25 1201.5
+3 1076.11
+3.5 990.86
+3.92 832.85
+4 607.78
+4.1 434.99
+4.22 288.73
+4.38 156.49
+4.48 86.39
+4.49 0
+;
+;
+M520 98 548 0 3.658 6.693 CTI 
+0.01 1077
+0.25 1062.83
+0.38 1065.66
+0.5 985
+0.71 945
+0.93 925
+1.23 898
+2.07 919
+2.61 908
+3.03 898
+3.5 878
+3.93 852
+4.96 765
+6.08 657.54
+7.05 549.84
+7.79 461.98
+8.39 391.12
+9.06 323.1
+10.01 243.74
+11.01 172.89
+12 116.2
+13.81 0
+;
+;
+M795 98 702 0 4.892 8.492 CTI 
+0.15 612.31
+0.21 1532.76
+0.25 1722
+0.43 1717.66
+0.5 1542.85
+0.62 1430.02
+0.8 1389.71
+1 1374.27
+1.5 1338.9
+2 1305.38
+3 1271.81
+4 1204
+5 1078
+6 928
+7 743
+8 563
+9 424.9
+10 299.7
+11 196.16
+12 116.76
+12.7 65.43
+12.76 0
+;
+;
+M1060 98 548 0 3.622 6.673 CTI 
+0.07 131
+0.1 594
+0.2 1453
+0.24 1494
+0.38 1450
+0.38 1425
+0.5 1423
+1 1462
+1.5 1456
+2 1430
+2.5 1376
+3 1280
+3.5 1190
+4 1051
+4.5 976
+5 883
+5.5 835
+6 793
+6.5 321
+7 13
+7.23 0
+;
+;
+M1400 75 757 0 2.992 5.302 CTI 
+0.02 991.61
+0.07 1939.66
+0.11 2291.75
+0.14 1976.39
+0.19 1962.48
+0.29 1936.13
+0.52 1881.02
+0.75 1833.4
+1 1778.08
+1.25 1738.57
+1.7 1654.82
+2.4 1502.39
+2.85 1389.48
+3.25 1283
+3.4 1232.23
+3.53 1199.64
+3.65 1083.69
+3.7 909.39
+3.9 641.5
+4 502.82
+4.03 463.03
+4.22 336.09
+4.43 138.68
+4.47 93.21
+4.48 0
+;
+;
+M1450 98 702 0 4.83 8.578 CTI 
+0.01 60
+0.06 524
+0.1 2164
+0.15 2416
+0.25 2162
+0.5 2037
+0.75 2022
+1 2009
+1.5 2006
+2 1968
+2.5 1895
+3 1770
+3.5 1673
+4 1517
+4.5 1337
+5 1166
+5.5 954
+5.8 687
+6.2 360
+6.86 79
+6.87 0
+;
+;
+M2505 98 548 0 3.423 6.258 CTI 
+0.12 2600
+0.21 2482
+0.6 2715
+0.9 2876
+1.2 2938
+1.5 2889
+1.8 2785
+2.1 2573
+2.4 2349
+2.7 2182
+2.99 85
+3 0
+;
+;
+N1100 98 1010 0 6.79 11.644 CTI 
+0.16 2624
+0.33 2708
+0.91 2055
+1.22 1896
+2.44 1793
+3.66 1625
+4.88 1402
+6.12 1158
+7.41 854
+9.77 494
+12.18 111.2
+12.19 0
+;
+;
+N2500 98 1010 0 6.778 11.668 CTI 
+0.02 773.7
+0.05 3356.6
+0.06 3657.8
+0.1 3546.8
+0.25 3403.8
+0.4 3309.2
+0.8 3262.5
+1 3206.1
+1.5 3095
+2 3030
+2.5 2988
+3 2848
+3.5 2462
+4 2227
+4.25 2152.5
+4.4 2102.5
+4.5 2007
+4.6 1683.8
+4.75 1269.5
+5 767.3
+5.41 341.3
+5.42 0
+;
+;Cesaroni Technologies Inc Motor Data File
+;Composed by Carl Tulanko for 150mm "O" CAR Certed Motor
+;24-Jun-2003 using CTI Cert graph to chart points
+O5100 150 803 1000 13.245 23.577 CTI 
+0.01 815.07
+0.02 1407.85
+0.03 2334.11
+0.04 3260.42
+0.05 4001.47
+0.07 4927.78
+0.07 5483.57
+0.09 5817.04
+0.13 6057.88
+0.2 6206.09
+0.3 6298.72
+0.43 6280.19
+0.6 6261.67
+0.78 6298.72
+0.97 6354.3
+1.05 6428.4
+1.12 6391.35
+1.34 6465.46
+1.49 6502.51
+1.75 6539.56
+1.88 6558.09
+2.16 6521.03
+2.36 6465.46
+2.58 6372.82
+2.96 6113.46
+3.56 5557.67
+4.13 4909.25
+4.72 4260.83
+4.83 4149.68
+4.93 3038.1
+5 2612
+5.1 2111.79
+5.23 1741.29
+5.32 1537.53
+5.52 1222.61
+5.8 907.69
+5.85 666.88
+5.89 333.44
+5.9 0
+;
+;Pro 150 O5800 White Thunder
+O5800 150 754 0 13.95 26.368 CTI 
+0.069 6337.62
+0.103 5700.97
+0.218 5874.6
+0.378 6135.05
+0.561 6337.62
+0.745 6221.86
+0.985 6221.86
+1.18 6192.93
+1.455 6308.68
+1.753 6366.56
+1.994 6337.62
+2.269 6395.5
+2.509 6308.68
+2.83 6192.93
+3.14 6048.23
+3.426 5874.6
+3.69 5729.9
+3.965 5585.21
+4.263 5382.64
+4.572 5295.82
+4.939 5180.06
+5.053 5035.37
+5.11 4717.04
+5.133 4225.08
+5.145 3675.24
+5.156 3038.59
+5.179 2344.05
+5.214 1475.88
+5.259 607.717
+5.294 57.878
+5.295 0
+;
+;Pro 150 O8000 White Thunder
+O8000 150 957 0 18.61 32.672 CTI 
+0.045 3964.63
+0.046 6742.77
+0.047 8623.79
+0.125 7929.26
+0.239 8160.77
+0.364 8392.28
+0.489 8508.04
+0.614 8536.98
+0.773 8392.28
+0.989 8421.22
+1.273 8479.1
+1.602 8623.79
+2.011 8565.92
+2.33 8565.92
+2.682 8479.1
+3.102 8276.53
+3.568 8045.02
+3.886 7900.32
+4.239 7668.81
+4.591 7524.12
+4.739 7524.12
+4.909 7263.67
+4.955 7003.22
+4.977 6540.19
+4.989 5845.66
+5 5006.43
+5.023 4051.45
+5.034 3067.52
+5.045 1996.79
+5.08 1012.86
+5.114 318.328
+5.17 0
+;
+;
+A6Q 18 70 4 0.00349992 0.0153001 QU 
+0.1 4.8
+0.2 11.82
+0.23 7.9
+0.3 4.8
+0.41 0
+;
+;
+B6Q 18 70 4 0.00649998 0.0162001 QU 
+0.1 7
+0.18 14.38
+0.2 10.2
+0.24 6.6
+0.3 6
+0.4 6.1
+0.5 6.2
+0.6 6.3
+0.65 6.6
+0.7 3
+0.75 0
+;
+;
+C6 18 70 0-3-5 0.0110001 0.0203999 QU 
+0.05 3.8
+0.1 6.5
+0.15 11.75
+0.2 13.4
+0.25 9.25
+0.3 7
+0.4 5.6
+0.5 5.2
+0.6 5.05
+0.7 4.8
+0.8 4.5
+0.9 4.6
+1 4.45
+1.2 4.2
+1.35 4
+1.62 4
+1.63 0
+;
+;Quest C6-0 from NAR data
+C6-0 18 70 0 0.0083 0.0216 QU 
+0.02 0.497
+0.057 2.539
+0.089 5.132
+0.129 7.947
+0.159 9.437
+0.171 21.247
+0.181 23.234
+0.194 22.958
+0.204 22.185
+0.218 19.592
+0.233 17.881
+0.258 10.486
+0.308 2.428
+0.338 2.539
+0.385 2.98
+0.412 3.091
+0.442 3.422
+0.459 2.98
+0.536 3.256
+0.732 3.311
+0.747 2.483
+0.78 2.98
+1.323 3.587
+1.365 2.815
+1.887 3.808
+1.974 3.256
+2.1 3.532
+2.227 3.201
+2.247 0
+;
+;Quest D5-0 by Mark Koelsch from NAR data
+D5-0 20 88 0 0.025 0.0384 QU 
+0.096 1.241
+0.252 5.897
+0.304 8.586
+0.357 10.552
+0.391 11.483
+0.435 9.828
+0.557 6.103
+0.583 5.172
+0.67 5.172
+1.078 4.966
+1.2 4.345
+1.73 4.759
+1.8 4.759
+1.887 4.138
+2.391 5.069
+2.626 4.966
+3.009 5.379
+3.357 5.276
+3.661 5.69
+3.835 3.103
+3.887 1.655
+3.983 0
+;
+;Sky Ripper Systems 29/75 G63
+G63 29 304.8 1000 0.0649998 0.236 SRS 
+0.01 121.91
+0.03 142.66
+0.07 156.57
+0.09 133.6
+0.13 100.62
+0.18 114.82
+0.2 105.21
+0.27 104.91
+0.35 93.38
+0.41 83.85
+0.5 67.95
+0.65 61.99
+0.83 61.99
+0.93 40.14
+1.09 17.09
+1.18 13.78
+1.29 5.56
+1.3 0
+;
+;Sky Ripper Systems 29/125 G69
+G69 29 406.4 1000 0.107 0.333 SRS 
+0.01 99.8
+0.04 137.51
+0.07 103.01
+0.13 94.13
+0.3 80.09
+0.49 72.2
+0.57 70.72
+0.65 71.96
+0.74 80.83
+0.81 81.81
+0.94 73.43
+1.01 74.42
+1.06 85.02
+1.11 83.78
+1.19 62.1
+1.24 60.62
+1.32 65.3
+1.37 64.81
+1.43 52.98
+1.49 48.55
+1.55 44.85
+1.64 28.59
+1.85 17.74
+1.99 14.29
+2 0
+;
+;
+G125 38 408 1000 0.158 0.537 SRS 
+0.01 346.87
+0.04 325.72
+0.07 324.57
+0.08 415.57
+0.09 219.61
+0.13 194.84
+0.2 177.77
+0.4 157.13
+0.6 131.89
+0.8 88.31
+1 42.44
+1.09 14.64
+1.2 0
+;
+;Sky Ripper Systems 29/185 H78
+H78 29 520.7 1000 0.158 0.418 SRS 
+0.01 138.21
+0.08 150.1
+0.12 142.67
+0.15 132.27
+0.22 130.49
+0.29 90.3
+0.34 88.27
+0.4 86.81
+0.61 86.52
+0.72 81.59
+0.76 71.72
+0.86 64.46
+1.01 63.3
+1.18 62.42
+1.28 60.39
+1.5 57.49
+1.8 58.36
+1.89 59.23
+2.01 55.46
+2.21 36.29
+2.36 22.94
+2.54 13.36
+2.72 9.58
+2.75 0
+;
+;Sky Ripper Systems 38mm hybrid motors
+;prepared by Andrew MacMillen NAR 77472 8/10/04
+;based on TMT thrust data & cert docs
+;NOX weight calc'd at 90 deg. F; 0.5469 gm/cc; 984 psi
+;compiled with RockSim6 EngEdit
+;SRS H155 38/220 PP
+H155_pp 38 508 0 0.142 0.664 SRS 
+0.03 308.75
+0.05 362.22
+0.09 252.41
+1.02 102.11
+1.08 119.98
+1.45 33.45
+1.66 19.06
+1.68 12.59
+1.69 0
+;
+;Sky Ripper Systems 38mm hybrid motors
+;prepared for SRS by Andrew MacMillen NAR 77472 8/10/04
+;based on TMT thrust data & cert docs
+;NOX weight calc'd at 90 deg. F; 0.5469 gm/cc; 984 psi
+;compiled with RockSim6 EngEdit
+;SRS H124 38/220 PVC
+H124_pvc 38 508 0 0.142 0.664 SRS 
+0.01 198.24
+0.02 300.84
+0.03 314.34
+0.03 316
+0.04 305.39
+0.08 280.35
+0.11 221.43
+0.69 168.38
+0.78 180.85
+0.81 158.64
+0.84 167.59
+0.89 152.32
+0.92 120.7
+0.95 123.55
+1.06 82.23
+1.35 48.36
+1.55 25.63
+1.6 21.88
+1.62 23.66
+1.66 18.58
+1.67 12.46
+1.68 0
+;
+;Sky Ripper Systems 38mm hybrid motors
+;prepared by Andrew MacMillen NAR 77472 8/10/04
+;based on TMT thrust data & cert docs
+;NOX weight calc'd at 90 deg. F; 0.5469 gm/cc; 984 psi
+;compiled with RockSim6 EngEdit
+;SRS I147 38/400 PP
+I147_pp 38 711 0 0.264 0.967 SRS 
+0 194.47
+0.02 366.71
+0.03 390.09
+0.03 392.3
+0.05 359.02
+0.07 217.4
+0.1 207.68
+0.38 241.52
+1.07 183.8
+2.33 141.34
+2.51 100.04
+2.75 71.51
+3.32 34.49
+3.89 17.18
+4.43 7.17
+4.45 0
+;
+;Sky Ripper Systems 38mm hybrid motors
+;prepared by Andrew MacMillen NAR 77472 8/10/04
+;based on TMT thrust data & cert docs
+;NOX weight calc'd at 90 deg. F; 0.5469 gm/cc; 984 psi
+;compiled with RockSim6 EngEdit
+;SRS I117 38/580 PVC
+I117_pvc 38 914 0 0.37 1.133 SRS 
+0.01 203.36
+0.02 339.95
+0.02 358.77
+0.03 367.94
+0.03 361.47
+0.06 277.4
+0.08 277.11
+0.15 250.99
+0.27 256.14
+0.3 248.56
+0.42 194.78
+0.47 222.59
+1.35 174.82
+1.39 184.03
+1.79 150.12
+2.12 156.59
+3.42 54.16
+3.8 40
+4.2 17.22
+4.23 0
+;
+;Sky Ripper Systems 38mm hybrid motors
+;prepared by Andrew MacMillen NAR 77472 8/10/04
+;based on TMT thrust data & cert docs
+;NOX weight calc'd at 90 deg. F; 0.5469 gm/cc; 984 psi
+;compiled with RockSim6 EngEdit
+;SRS I119 38/400 PVC
+I119_pvc 38 711 0 0.264 0.967 SRS 
+0 192.14
+0.01 262.2
+0.02 341.53
+0.03 338.42
+0.06 221.25
+0.07 195.93
+0.11 189.23
+0.15 202.2
+0.18 233.36
+0.47 230.26
+0.99 200.9
+1.18 165.36
+1.27 172.11
+1.48 162.61
+2.18 74.18
+2.92 24.69
+2.97 10.98
+3.1 10.06
+3.12 0
+;
+;Sky Ripper Systems 54/830 J261 Gold Insert
+J261 54 731.5 0 0.5647 1.9025 SRS 
+0.02 1303.39
+0.09 903.88
+0.21 591.22
+0.42 349.57
+0.61 304.62
+0.81 329.59
+1.01 277.16
+1.21 294.64
+1.39 232.21
+1.61 197.26
+1.82 255.99
+2 274.66
+2.2 269.67
+2.41 189.77
+2.61 294.64
+2.82 212.24
+3.01 254.69
+3.21 225.29
+3.41 194.76
+3.59 156.32
+3.74 229.72
+3.85 237.71
+3.9 156.32
+4 112.76
+4.2 140.19
+4.4 192.26
+4.48 106.66
+4.61 54.86
+4.76 33.52
+4.95 0
+;
+;Sky Ripper Systems 54/550 J263 Gold Insert
+J263 54 606.5 0 0.3742 1.5983 SRS 
+0.01 1359.46
+0.09 794.32
+0.15 559.93
+0.21 419.3
+0.4 296.89
+0.61 286.48
+0.81 265.64
+1.01 244.81
+1.2 247.41
+1.4 244.81
+1.6 231.79
+1.81 200.53
+2.01 205.74
+2.21 205.74
+2.41 195.32
+2.6 174.49
+2.8 166.68
+2.91 161.47
+3 138.03
+3.08 98.96
+3.21 62.5
+3.41 28.74
+3.6 0
+;
+;Sky Ripper Systems 54/830 J337 Black Insert
+J337 54 731.5 0 0.5647 1.9025 SRS 
+0 8.88
+0.01 1521.03
+0.1 585.29
+0.2 651.28
+0.41 589.45
+0.5 548.23
+0.6 539.99
+0.99 461.67
+1.4 416.33
+1.6 391.59
+1.8 387.47
+1.91 364.9
+2.01 239.43
+2.2 171.02
+2.4 119.72
+2.6 72.68
+2.8 42.76
+3 21.68
+3.1 0
+;
+;Sky Ripper Systems 54/550 J348 Black Insert
+J348 54 606.5 0 0.3742 1.5983 SRS 
+0 8.88
+0.02 451.8
+0.13 557.6
+0.14 1203.84
+0.2 617.65
+0.4 549.02
+0.6 494.69
+0.79 406.05
+1.01 354.57
+1.2 334.56
+1.31 303.1
+1.4 237.34
+1.6 148.69
+1.8 82.92
+2 37.17
+2.2 0
+;
+;Sky Ripper Systems 38mm hybrid motors
+;prepared by Andrew MacMillen NAR 77472 8/10/04
+;based on TMT thrust data & cert docs
+;NOX weight calc'd at 90 deg. F; 0.5469 gm/cc; 984 psi
+;compiled with RockSim6 EngEdit
+;SRS J144 38/580 PP
+J144_pp 38 914 0 0.37 1.133 SRS 
+0.01 301.25
+0.03 376.44
+0.03 376.86
+0.08 247.31
+0.22 273.45
+0.45 263.59
+0.79 231.99
+1.09 175.69
+1.21 185.68
+2.05 149.6
+2.86 127.64
+3.42 69.07
+3.88 42.69
+4.59 20.49
+5.2 10
+5.8 6.12
+5.8 0
+;
+;Sky Ripper Systems 54/1130 K257 Gold Insert
+K257 54 911.4 0 0.7688 2.3107 SRS 
+0.07 1133.08
+0.2 529.98
+0.4 333.69
+0.59 363.13
+0.8 347.18
+0.98 366.4
+1.2 356.59
+1.4 310.79
+1.6 274.8
+1.81 337.71
+2 356.59
+2.2 294.43
+2.4 314.06
+2.6 294.43
+2.81 333.69
+3 340.23
+3.22 319.78
+3.41 292.68
+3.59 249.32
+3.79 278.07
+4 243.9
+4.21 281.35
+4.41 235.54
+4.6 251.9
+4.81 211.38
+5.01 222.22
+5.2 189.7
+5.41 153.23
+5.6 81.4
+5.8 23.94
+6.1 0
+;
+;Sky Ripper Systems 54/1130 K347 Black Insert
+K347 54 911.4 0 0.7688 2.3107 SRS 
+0 8.88
+0.03 1474.51
+0.11 972.2
+0.19 737.25
+0.4 697.22
+0.61 673.87
+0.81 653.85
+1.01 600.4
+1.2 550.44
+1.4 530.42
+1.6 533.76
+1.8 517.08
+1.89 396.98
+1.95 493.19
+2.06 393.65
+2.13 443.69
+2.3 365.38
+2.3 292.31
+2.4 257.92
+2.6 184.84
+2.79 124.66
+3 81.67
+3.21 51.58
+3.41 21.49
+3.58 0
+;
+;RATT Works H70H
+;Copyright Tripoli Motor Testing 2002 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+H70H 29 457 0 0.106176 0.348992 RTW 
+0.051 124.137
+0.156 134.902
+0.261 127.047
+0.367 115.87
+0.473 110.286
+0.578 108.63
+0.683 105.741
+0.789 104.108
+0.894 101.515
+1 98.471
+1.105 93.809
+1.21 90.543
+1.316 85.219
+1.421 74.353
+1.527 57.739
+1.632 44.019
+1.738 34.554
+1.843 27.992
+1.948 22.691
+2.054 19.064
+2.159 15.665
+2.265 12.897
+2.37 11.332
+2.475 10.107
+2.581 8.591
+2.688 0
+;
+;RATT Works I80H
+;Copyright Tripoli Motor Testing 2002 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+I80H 29 730 0 0.21952 0.549248 RTW 
+0.093 84.101
+0.28 102.075
+0.469 118.708
+0.657 117.13
+0.846 114.829
+1.034 112.225
+1.222 109.818
+1.41 107.622
+1.599 105.945
+1.787 102.168
+1.976 100.449
+2.164 99.265
+2.352 96.272
+2.541 91.951
+2.729 89.38
+2.918 86.43
+3.105 54.544
+3.294 41.902
+3.482 33.368
+3.671 26.516
+3.859 21.324
+4.047 16.951
+4.235 14.387
+4.424 13.456
+4.612 12.777
+4.801 0
+;
+;RATT Works I90LH
+;Copyright Tripoli Motor Testing 2002 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+I90LH 29 921 0 0.285376 0.684544 RTW 
+0.127 137.737
+0.383 121.431
+0.64 117.048
+0.897 121.354
+1.154 118.436
+1.41 116.538
+1.668 114.826
+1.925 112.358
+2.181 110.303
+2.439 107.768
+2.696 105.749
+2.952 104.733
+3.209 102.802
+3.467 95.41
+3.723 68.281
+3.98 55
+4.237 43.62
+4.494 33.784
+4.751 31.704
+5.008 27.714
+5.265 24.875
+5.522 22.93
+5.779 21.379
+6.035 20.884
+6.293 18.637
+6.55 0
+;
+;RATT Works K240H
+;Copyright Tripoli Motor Testing 2002 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+K240H 64 908 0 1.29338 2.81434 RTW 
+0.164 413.978
+0.493 392.975
+0.822 370.841
+1.151 362.058
+1.48 337.839
+1.809 321.401
+2.139 285.118
+2.468 280.031
+2.798 275.06
+3.128 278.392
+3.457 274.394
+3.786 252.302
+4.116 272.858
+4.445 264.671
+4.774 255.572
+5.103 210.314
+5.433 163.955
+5.764 126.239
+6.093 98.015
+6.422 74.491
+6.751 55.617
+7.08 40.778
+7.409 29.618
+7.739 21.915
+8.069 17.214
+8.399 0
+;
+;ROADRUNNER F35 RASP.ENG FILE
+;File produced April 5, 2006
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+F35 29 112 6-10 0.04 0.111 RR 
+0.023 33.7
+0.04 44.462
+0.081 47.206
+0.121 48.579
+0.166 49.27
+0.242 49.55
+0.315 51.01
+0.411 50.111
+0.528 49.71
+0.664 48.208
+0.791 47.256
+0.896 46.986
+1 45.484
+1.097 44.943
+1.194 42.338
+1.277 40.4
+1.323 40.706
+1.356 37.691
+1.402 35.637
+1.451 32.753
+1.505 29.467
+1.578 25.491
+1.675 20.833
+1.75 17.137
+1.828 13.021
+1.907 8.638
+1.984 5.075
+2.049 2.61
+2.13 0
+;
+;ROADRUNNER F45R RASP ENG FILE
+F45R 29 93 5-8-14 0.03 0.093 RR 
+0 4.1971
+0.019 45.5
+0.038 53.07
+0.057 52.402
+0.095 54.741
+0.113 55.298
+0.132 56.744
+0.151 57.19
+0.227 60.419
+0.284 61.754
+0.416 62.422
+0.491 60.753
+0.51 61.42
+0.567 60.307
+0.624 58.414
+0.662 58.08
+0.737 55.298
+0.775 52.959
+0.813 51.513
+0.888 46.169
+0.983 34.701
+1.002 31.807
+1.096 23.902
+1.134 21.453
+1.21 14.106
+1.229 12.992
+1.285 8.4282
+1.342 5.5328
+1.361 5.4218
+1.418 2.9723
+1.42 0
+;
+;ROADRUNNER F60 RASP.ENG FILE
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+F60R 29 112 4-7-10 0.038 0.109 RR 
+0.013 45.86
+0.021 63.937
+0.029 72.291
+0.041 75.214
+0.061 74.374
+0.087 76.872
+0.155 83.122
+0.231 86.44
+0.309 88.088
+0.329 90.07
+0.345 88.33
+0.395 87.9
+0.454 87.208
+0.514 87.188
+0.616 82.141
+0.699 77.105
+0.765 70.4
+0.807 61.611
+0.859 51.983
+0.926 42.355
+0.978 33.556
+1.022 21.43
+1.061 13.056
+1.101 6.776
+1.133 3.423
+1.19 0
+;
+;ROADRUNNER G80 RASP.ENG FILE
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+G80R 29 140 4-7-10 0.055 0.133 RR 
+0.012 63.563
+0.028 84.077
+0.057 89.563
+0.119 96.03
+0.206 102.518
+0.242 104.42
+0.297 106.923
+0.356 109.826
+0.422 111.829
+0.483 111.328
+0.558 112.632
+0.622 112.75
+0.683 112.129
+0.739 109.125
+0.796 102.017
+0.863 90.494
+0.901 82.75
+0.935 72.41
+0.976 59.869
+1.018 49.826
+1.028 44.321
+1.042 39.805
+1.073 28.272
+1.113 18.231
+1.17 11.176
+1.218 4.636
+1.31 0
+;
+;Rocketvision F32
+;from NAR data sheet updated 11/2000
+;created by John Coker 5/2006
+F32 24 124 5-10-15 0.0377 0.0695 RV 
+0.01 50
+0.05 56
+0.1 48
+2 24
+2.2 19
+2.45 5
+2.72 0
+;
+;Same motor as the Aerotech F72T single use from NAR cert data
+F72T 24 124 5-10-15 0.0368 0.0746 RV 
+0.004 37.671
+0.01 78.082
+0.017 97.26
+0.027 91.781
+0.043 89.726
+0.06 80.822
+0.087 84.932
+0.101 78.767
+0.132 81.507
+0.143 78.767
+0.171 81.507
+0.192 78.082
+0.215 80.822
+0.24 78.082
+0.264 81.507
+0.279 78.767
+0.298 80.137
+0.517 76.027
+0.68 70.548
+0.855 58.219
+0.934 49.315
+0.961 43.151
+0.996 31.507
+1.025 21.233
+1.054 14.384
+1.103 7.534
+1.147 3.425
+1.196 0
+;
+;Same motor as the Aerotech G55W single use from NAR cert data
+G55W 24 177 5-10-15 0.0625 0.115 RV 
+0.004 74.648
+0.012 85.211
+0.054 81.69
+0.128 73.239
+0.182 73.944
+0.231 69.718
+0.508 69.014
+0.868 67.606
+1.037 65.493
+1.07 67.606
+1.091 64.085
+1.14 63.38
+1.161 66.901
+1.19 62.676
+1.269 62.676
+1.397 59.155
+1.496 57.042
+1.583 52.113
+1.653 45.07
+1.719 38.028
+1.76 31.69
+1.831 24.648
+1.901 19.014
+1.988 12.676
+2.083 9.155
+2.169 5.634
+2.252 3.521
+2.36 0
+;
+;West Coast Hybrid motor
+;prepared for WestCoast/Scott Harrison by
+;Andrew MacMillen NAR 77472 9/13/02
+;based on CAR thrust curves & cert letters
+;since the cert letters and test curves don't agree
+;the data is hand entered data points from CAR thrust curves
+;NOX weight calc'd at 90 deg. F; 0.5469 gm/cc; 984 psi
+;compiled with RockSim5 EngEdit
+;within 2-3 percent for total impulse, peak and average thrust
+;accurate thrust profile
+;NOTE: NOT WCH, CAR, TMT OR NAR APPROVED
+;West Coast Hybrids I110
+I110H 38 606 0 0.327 0.824 WCH 
+0.05 240
+0.38 200
+0.76 182
+1.14 160
+1.52 142
+1.9 125
+2.23 113
+2.66 71
+3.04 44
+3.42 29
+3.78 22
+4 0
+;
+;Animal Motor Works 38-640
+I375GG 38 369 20 0.3936 0.7338 AMW 
+0.013 223.878
+0.045 273.929
+0.092 312.421
+0.14 334.383
+0.219 357.983
+0.298 381.992
+0.377 410.267
+0.457 431.141
+0.536 454.458
+0.615 476.825
+0.694 495.473
+0.773 504.665
+0.852 510.942
+0.931 511.972
+1.011 489.639
+1.09 441.35
+1.169 392.762
+1.248 354.753
+1.327 292.385
+1.406 177.309
+1.486 63.879
+1.565 14.901
+1.583 0
+;
+;Animal Motor Works 38-640
+I315SK 38 369 20 0.3829 0.7166 AMW 
+0.011 314.573
+0.03 312.796
+0.066 300.786
+0.12 304.087
+0.084 300.502
+0.175 312.998
+0.266 324.086
+0.356 332.224
+0.447 347.855
+0.538 371.972
+0.629 382.833
+0.719 385.552
+0.81 385.586
+0.901 384.836
+0.992 382.296
+1.082 378.323
+1.173 370.837
+1.264 357.564
+1.355 347.122
+1.445 328.332
+1.536 202.733
+1.627 90.867
+1.718 35.427
+1.808 8.192
+1.815 0
+;
+;Animal Motor Works 54-1050
+J230SK 54 326 0 0.6578 1.1835 AMW 
+0.054 273.635
+0.132 235.131
+0.248 218.229
+0.365 218.503
+0.481 222.04
+0.597 226.658
+0.714 231.969
+0.83 235.208
+0.946 238.968
+1.063 243.012
+1.179 245.522
+1.295 249.208
+1.412 252.897
+1.528 256.528
+1.644 260.244
+1.76 265.497
+1.877 270.48
+1.993 273.227
+2.109 275.693
+2.226 279.851
+2.342 280.76
+2.458 274.551
+2.575 262.987
+2.691 247.241
+2.807 228.611
+2.924 213.841
+3.04 185.353
+3.156 137.595
+3.273 85.388
+3.46 0
+;
+;Animal Motor Works 54-1050
+;AMW J357WW RASP.ENG file made from NAR published data
+;File produced December 25, 2002
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+J357WW 54 326 0 0.5481 1.2101 AMW 
+0.02 129.64
+0.03 205.95
+0.05 265
+0.06 316.51
+0.09 326.05
+0.13 314.6
+0.18 301.25
+0.24 299.34
+0.35 312.69
+0.5 326.05
+0.66 333.68
+0.87 345.13
+1.07 358.48
+1.46 383.18
+1.77 398.45
+1.86 400.36
+1.98 402.35
+2.18 398.45
+2.29 390.82
+2.41 369.93
+2.51 354.67
+2.55 352.76
+2.6 347.03
+2.65 335.59
+2.69 310.79
+2.75 249.73
+2.81 175.43
+2.84 108.65
+2.9 53.38
+2.92 20.98
+2.95 0
+;
+;Animal Motor Works 54-1050
+;AMW J370GG RASP.ENG file made from NAR data
+;File produced FEB 20, 2003
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+J370GG 54 326 0 0.5983 1.2491 AMW 
+0.008 185.496
+0.024 149.516
+0.063 225.273
+0.087 272.647
+0.122 304.829
+0.158 304.829
+0.273 335.212
+0.431 363.796
+0.573 390.381
+0.707 413.168
+0.877 428.459
+1.019 441.852
+1.126 441.852
+1.224 458.46
+1.284 443.951
+1.386 440.153
+1.572 438.454
+1.651 438.554
+1.813 417.765
+2.022 404.673
+2.141 385.883
+2.212 385.883
+2.255 374.59
+2.299 387.882
+2.362 357.599
+2.401 384.184
+2.421 348.204
+2.457 316.122
+2.559 251.758
+2.697 115.635
+2.753 45.624
+2.82 0
+;
+;Animal Motor Works 54-1050
+;AMW J400RR RASP.ENG file made from NAR published data
+;File produced April 19, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+J400RR 54 326 0 0.558 1.2314 AMW 
+0.043 246.55
+0.06 317.381
+0.081 344.709
+0.107 358.372
+0.15 356.062
+0.201 365.204
+0.308 392.532
+0.568 435.734
+0.863 458.339
+1.094 469.24
+1.209 467.18
+1.466 460.148
+1.705 443.972
+1.923 423.275
+2.132 409.411
+2.303 413.831
+2.402 420.563
+2.47 413.831
+2.517 395.445
+2.543 347.421
+2.568 265.238
+2.598 128.198
+2.615 68.801
+2.632 25.398
+2.66 0
+;
+;Animal Motor Works 54-1050
+;AMW J450ST RASP.ENG file made from NAR published data
+;File produced SEPT 4, 2002
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+J450ST 54 326 0 0.5331 1.1964 AMW 
+0.009 251.586
+0.016 376.074
+0.03 413.45
+0.051 430.832
+0.094 423.296
+0.162 413.149
+0.262 395.566
+0.402 420.182
+0.495 444.898
+0.805 504.078
+1.048 536.028
+1.223 550.597
+1.299 563.18
+1.334 555.319
+1.47 560.042
+1.588 559.841
+1.764 546.98
+1.921 516.838
+1.993 496.743
+2.025 499.154
+2.047 479.16
+2.086 414.354
+2.115 344.525
+2.141 252.29
+2.177 140.161
+2.213 82.78
+2.239 50.347
+2.271 27.861
+2.296 12.86
+2.33 0
+;
+;Animal Motor Works 54-1050
+;AMW J480BB RASP.ENG file made from NAR published data
+;File produced April 19, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+J480BB 54 326 0 0.556 1.2131 AMW 
+0.015 225.429
+0.041 348.18
+0.071 388.127
+0.194 422.453
+0.385 459.49
+0.699 502.347
+0.968 528.042
+1.2 536.573
+1.454 543.15
+1.674 533.763
+1.887 522.321
+2.044 519.41
+2.108 525.131
+2.164 528.042
+2.197 488.095
+2.25 419.543
+2.283 333.928
+2.328 231.15
+2.354 176.95
+2.392 111.309
+2.418 68.501
+2.436 37.106
+2.49 0
+;
+;AMW J500ST RASP.ENG file made from Tripoli published data
+;File produced May 15, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to the people who produced the data.
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+J500ST 38 370 0 0.3265 0.744 AMW 
+0.008 448.516
+0.027 506.086
+0.048 448.426
+0.08 450.851
+0.101 498.901
+0.117 532.131
+0.163 563.565
+0.227 616.105
+0.285 666.398
+0.312 668.643
+0.32 692.444
+0.362 728.024
+0.442 757.108
+0.493 771.477
+0.528 778.578
+0.576 779
+0.631 778.662
+0.706 716.631
+0.754 620.146
+0.77 598.591
+0.813 526.293
+0.887 439.895
+0.973 343.841
+1.074 230.949
+1.095 238.089
+1.111 214.11
+1.13 185.279
+1.194 98.836
+1.255 36.368
+1.3 0
+;
+;Animal Motor Works 54-1400
+J365SK 54 403 0 0.7571 1.4593 AMW 
+0.029 389.731
+0.123 360.219
+0.218 334.2
+0.376 326.15
+0.534 334.217
+0.692 341.669
+0.85 347.676
+1.007 359.408
+1.165 370.043
+1.323 383.343
+1.481 399.248
+1.639 417.477
+1.797 443.735
+1.955 472.683
+2.112 501.668
+2.27 497.077
+2.428 425.371
+2.586 349.017
+2.744 262.068
+2.902 107.073
+3.06 41.821
+3.157 0
+;
+;Animal Motor Works 75-1700
+;AMW K365RR RASP.ENG file made from NAR published data
+;File produced April 19, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+K365RR 75 244 0 0.946 2.3456 AMW 
+0.049 138.157
+0.068 381.241
+0.084 454.75
+0.106 481.536
+0.164 488.182
+0.291 514.867
+0.435 545.982
+0.666 561.49
+0.868 565.73
+1.082 565.518
+1.296 550.111
+1.591 529.871
+1.805 509.731
+1.828 536.517
+1.886 498.554
+2.124 467.237
+2.501 411.35
+2.924 328.677
+3.296 241.573
+3.638 172.293
+3.969 100.798
+4.195 56.098
+4.265 51.607
+4.346 35.959
+4.433 15.859
+4.51 0
+;
+;AMW K450BB RASP.ENG file made from NAR published data
+;File produced Aug 19, 2003
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane.
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+K450BB 75 302 0 0.8816 2.8349 AMW 
+0.03 78.903
+0.045 227.9
+0.064 449.955
+0.069 508.417
+0.094 555.187
+0.151 563.956
+0.362 625.442
+0.562 651.85
+0.825 660.62
+1.134 652.254
+1.453 626.147
+1.793 594.296
+2.113 538.958
+2.458 469.106
+2.798 384.538
+3.165 276.686
+3.201 279.609
+3.325 232.94
+3.51 171.757
+3.732 107.65
+3.861 58.018
+3.959 40.55
+4.036 20.149
+4.11 0
+;
+;AMW K470ST RASP.ENG file made from Tripoli published data
+;File produced May 15, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to the people who produced the data.
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+K470ST 75 302 0 0.826 2.779 AMW 
+0.028 699.309
+0.039 799.337
+0.09 765.845
+0.157 770.311
+0.258 785.941
+0.41 804
+0.572 794.425
+0.707 794.425
+0.886 792.192
+0.998 783.261
+1.15 752.002
+1.318 709.579
+1.447 655.992
+1.593 595.707
+1.728 522.025
+1.885 444.101
+2.092 354.923
+2.356 270.167
+2.664 187.554
+2.945 131.734
+3.27 78.058
+3.433 55.686
+3.478 48.987
+3.556 28.909
+3.7 0
+;
+;Animal Motor Works 54-1400
+;AMW K475WW RASP.ENG file made from NAR data
+;File produced Feb 22, 2003
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+K475WW 54 403 0 0.7286 1.4925 AMW 
+0.022 127.831
+0.041 386.016
+0.063 548.326
+0.096 521.308
+0.134 499.129
+0.18 486.83
+0.285 486.83
+0.478 501.649
+0.731 523.727
+1.096 553.266
+1.433 577.962
+1.601 588.29
+1.756 582.704
+1.895 580.284
+1.958 575.344
+2.063 550.746
+2.209 518.788
+2.344 477.051
+2.495 417.974
+2.561 354.058
+2.582 334.399
+2.599 331.98
+2.62 297.501
+2.67 226.226
+2.707 157.37
+2.74 98.353
+2.799 49.176
+2.853 17.208
+2.94 0
+;
+;Animal Motor Works 54-1400
+;AMW K530GG RASP.ENG file made from NAR data
+;File produced Feb 25, 2003
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+K350GG 54 403 0 0.7967 1.616 AMW 
+0.013 129.764
+0.054 171.852
+0.096 284.122
+0.138 392.892
+0.171 455.975
+0.217 501.662
+0.238 498.063
+0.326 508.66
+0.542 564.745
+0.755 613.831
+1.01 645.423
+1.17 657.23
+1.273 648.922
+1.51 638.425
+1.656 634.925
+1.702 606.833
+1.803 606.833
+1.857 585.839
+1.936 589.338
+1.974 575.242
+2.015 589.338
+2.04 564.745
+2.132 536.652
+2.207 540.251
+2.291 522.656
+2.357 487.566
+2.42 375.297
+2.478 242.033
+2.529 140.361
+2.583 66.651
+2.66 0
+;
+;Animal Motor Works 54-1400
+;AMW K560RR RASP.ENG file made from NAR published data
+;File produced April 19, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+K560RR 54 430 0 0.75 1.5866 AMW 
+0.023 229.13
+0.046 415.135
+0.059 485.264
+0.078 512.268
+0.106 525.67
+0.154 523.05
+0.211 528.39
+0.261 536.451
+0.369 560.734
+0.511 587.738
+0.657 603.86
+0.77 612.022
+1.096 625.73
+1.358 620.083
+1.627 612.022
+1.839 603.86
+2.057 590.459
+2.218 598.52
+2.335 609.301
+2.385 601.24
+2.407 585.018
+2.426 533.831
+2.467 385.511
+2.507 283.037
+2.542 164.441
+2.576 67.399
+2.595 29.653
+2.62 0
+;
+;Animal Motor Works 54-1750
+;AMW K570WW RASP.ENG file made from NAR published data
+;File produced December 25, 2002
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+K570WW 54 492 0 0.9146 1.8151 AMW 
+0.02 364.42
+0.03 664.79
+0.051 751.47
+0.071 745.81
+0.096 705.25
+0.137 674.93
+0.284 661.38
+0.528 651.24
+0.913 644.51
+1.192 651.24
+1.43 651.24
+1.649 651.24
+1.872 644.51
+2.176 624.23
+2.318 600.64
+2.394 597.33
+2.455 546.63
+2.501 485.89
+2.562 421.84
+2.597 340.83
+2.638 266.54
+2.734 175.48
+2.836 97.86
+2.927 47.24
+3.04 0
+;
+;Animal Motor Works 75-2500
+;AMW K600WW RASP.ENG file made from NAR data
+;File produced August 22, 2002
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+K600WW 75 368 0 1.2233 2.9129 AMW 
+0.01 412.229
+0.029 522.21
+0.059 547.215
+0.083 524.8
+0.122 497.305
+0.181 484.852
+0.333 495.113
+0.69 560.464
+1.195 643.548
+1.4 673.833
+1.42 708.799
+1.508 701.427
+1.591 721.551
+1.782 731.712
+2.017 752.035
+2.174 756.816
+2.257 765.2
+2.502 766.44
+2.727 752.931
+2.918 738.187
+3.143 705.91
+3.408 643.847
+3.603 569.131
+3.692 526.793
+3.745 439.426
+3.799 289.596
+3.883 112.272
+3.922 64.862
+3.971 37.437
+3.995 22.474
+4.07 0
+;
+;Animal Motor Works 75-2500
+;AMW K605RR RASP.ENG file made from NAR published data
+;File produced April 19, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+K605RR 75 368 0 1.231 2.7688 AMW 
+0.03 165.845
+0.053 309.12
+0.077 361.916
+0.142 392.042
+0.527 501.412
+0.988 606.905
+1.515 682.37
+2.101 730.593
+2.355 737.58
+2.692 731.289
+3 712.497
+3.361 671.036
+3.503 663.479
+3.586 659.701
+3.645 633.353
+3.692 573
+3.734 444.838
+3.775 297.785
+3.828 162.066
+3.864 98.015
+3.905 41.471
+3.95 0
+;
+;Animal Motor Works 54-1750
+;AMW K650RR RASP.ENG file made from NAR published data
+;File produced April 19, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+K650RR 54 492 0 0.931 1.8087 AMW 
+0.022 308.257
+0.045 566.48
+0.058 620.44
+0.081 639.668
+0.135 639.668
+0.229 643.494
+0.351 662.823
+0.594 701.38
+0.81 724.434
+0.999 743.763
+1.151 751.22
+1.381 747.588
+1.61 736.001
+1.835 709.031
+2.073 685.876
+2.244 674.4
+2.334 682.051
+2.429 685.876
+2.469 666.648
+2.528 597.285
+2.573 481.714
+2.609 358.391
+2.631 250.471
+2.681 146.477
+2.721 65.507
+2.748 23.124
+2.77 0
+;
+;Animal Motor Works 54-2550
+;AMW K670GG RASP.ENG file made from NAR data
+;File produced August 22, 2002
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+K670GG 54 492 0 1.014 1.9145 AMW 
+0.016 294.054
+0.035 398.582
+0.086 506.299
+0.153 496.434
+0.264 506.1
+0.461 558.114
+0.722 629.56
+0.983 688.052
+1.116 714.06
+1.193 785.805
+1.409 788.794
+1.737 804.56
+2.074 781.42
+2.195 764.879
+2.226 781.221
+2.277 764.779
+2.398 751.527
+2.44 744.95
+2.468 718.843
+2.484 666.529
+2.525 418.112
+2.551 218.821
+2.573 120.77
+2.595 52.144
+2.62 0
+;
+;Animal Motor Works 54-1400
+;AMW K700BB RASP.ENG file made from NAR published data
+;File produced April 19, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+K700BB 54 430 0 0.754 1.4831 AMW 
+0.014 359.559
+0.022 625.425
+0.03 737.756
+0.047 771.505
+0.082 786.516
+0.106 771.505
+0.144 775.233
+0.272 786.516
+0.477 812.71
+0.693 842.632
+0.97 847.06
+1.283 838.904
+1.516 816.438
+1.706 801.427
+1.779 793.972
+1.811 775.233
+1.841 726.573
+1.873 625.425
+1.909 509.367
+1.95 393.208
+1.982 337.093
+2.035 292.16
+2.073 228.489
+2.111 153.535
+2.155 86.137
+2.193 37.446
+2.24 0
+;
+;Animal Motor Works 54-1750
+;AMW K800BB RASP.ENG file made from NAR published data
+;File produced April 19, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+K800BB 54 492 0 0.914 1.7866 AMW 
+0.017 516.316
+0.035 745.845
+0.046 817.592
+0.09 860.56
+0.191 889.338
+0.27 908.424
+0.438 918.017
+0.689 945.892
+0.996 955.09
+1.325 922.713
+1.557 894.035
+1.726 874.949
+1.849 884.542
+1.92 894.035
+1.954 894.035
+1.984 855.863
+2.011 741.048
+2.049 592.859
+2.079 492.433
+2.113 430.28
+2.154 377.719
+2.196 329.854
+2.237 243.818
+2.275 152.986
+2.309 71.716
+2.339 33.465
+2.38 0
+;
+;Animal Motor Works 54-1750
+;AMW K950ST RASP.ENG file made from NAR published data
+;File produced SEPT 4, 2002
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+K950ST 54 492 0 0.8874 1.7949 AMW 
+0.011 771.836
+0.025 1204.52
+0.039 1083.24
+0.053 1158.05
+0.067 1036.36
+0.085 1110.18
+0.099 1022.4
+0.135 982.102
+0.22 968.835
+0.404 1010.43
+0.566 1044.34
+0.701 1079.25
+0.867 1106.19
+0.995 1134.12
+1.211 1114.17
+1.313 1101.2
+1.43 1067.29
+1.529 1020.4
+1.579 993.772
+1.642 892.43
+1.674 818.119
+1.717 757.273
+1.738 621.918
+1.766 466.313
+1.791 351.306
+1.823 249.864
+1.865 175.553
+1.908 87.696
+1.943 33.654
+1.97 0
+;
+;Animal Motor Works 54-2550
+;AMW K975WW RASP.ENG file made from NAR published data
+;File produced December 25, 2002
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+K975WW 54 728 0 1.3573 2598.5 AMW 
+0.017 526.644
+0.029 901.85
+0.038 1098.92
+0.046 1151.72
+0.076 1112.87
+0.13 1060.06
+0.219 1053.09
+0.336 1053.09
+0.479 1059.07
+0.609 1091.94
+0.866 1136.78
+1.046 1176.63
+1.164 1175.63
+1.202 1228.44
+1.239 1208.51
+1.315 1215.49
+1.353 1267.29
+1.387 1228.44
+1.487 1241.39
+1.538 1260.32
+1.634 1290.9
+1.723 1281.24
+1.794 1266.3
+1.836 1207.52
+1.933 1049.1
+1.992 851.437
+2.08 666.923
+2.118 640.521
+2.193 462.582
+2.269 212.311
+2.378 119.854
+2.51 0
+;
+;Animal Motor Works 54-2550
+;AMW K1000SK RASP.ENG file made from NAR published data
+;File produced April 19, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+K1000SK 54 728 0 1.297 2.556 AMW 
+0.019 1155.06
+0.045 1426.12
+0.094 1248.23
+0.161 1112.99
+0.239 1128.02
+0.343 1113.99
+0.377 1149.05
+0.44 1121
+0.544 1221.18
+0.633 1178.11
+0.674 1221.18
+0.737 1193.13
+0.883 1200.14
+1.009 1194.13
+1.057 1236.21
+1.188 1137.03
+1.299 1145.05
+1.396 1087.94
+1.516 954.104
+1.631 855.228
+1.717 827.077
+1.777 650.061
+1.848 465.932
+1.93 303.141
+2.023 147.463
+2.083 83.879
+2.132 41.484
+2.18 0
+;
+;Animal Motor Works 54-2550
+;AMW K1075GG RASP.ENG file made from NAR data
+;File produced Feb 22, 2003
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+K1075GG 54 726 0 1.3999 2.6658 AMW 
+0.009 672.664
+0.015 963.511
+0.022 860.518
+0.047 987.857
+0.075 975.835
+0.106 921.332
+0.215 958.001
+0.529 1092.05
+0.878 1220.29
+1.077 1269.39
+1.158 1311.47
+1.235 1293.43
+1.448 1330.5
+1.577 1318.48
+1.672 1319.48
+1.721 1337.52
+1.759 1337.52
+1.805 1337.52
+1.829 1331.5
+1.856 1384.67
+1.889 1277.4
+1.906 1216.29
+1.938 1052.98
+1.96 871.338
+1.988 659.239
+2.027 453.352
+2.062 301.967
+2.115 138.46
+2.168 41.608
+2.2 0
+;
+;AMW L700BB RASP.ENG file made from NAR published data
+;File produced Aug 19, 2003
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane.
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+L700BB 75 368 0 1.1931 2.732 AMW 
+0.024 221.872
+0.033 399.33
+0.048 467.56
+0.076 494.892
+0.134 498.409
+0.239 535.991
+0.482 614.671
+0.769 683.202
+1.232 755.251
+1.623 789.717
+1.919 810.417
+2.258 821.14
+2.582 817.853
+2.912 801.072
+3.136 773.941
+3.255 750.126
+3.322 743.393
+3.37 729.828
+3.418 688.83
+3.461 593.368
+3.499 484.14
+3.532 368.179
+3.57 248.802
+3.618 149.824
+3.661 61.135
+3.72 0
+;
+;Animal Motor Works 75-3500
+;AMW L777WW RASP.ENG file made from NAR published data
+;File produced SEPT 4, 2002
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+L777WW 75 497 0 1.7623 3.6987 AMW 
+0.025 140.882
+0.064 209.474
+0.108 360.055
+0.204 652.185
+0.36 641.518
+0.373 693.745
+0.418 683.28
+0.528 730.073
+0.67 761.268
+0.761 781.998
+0.787 802.828
+0.871 802.728
+1.065 854.754
+1.338 911.811
+1.668 963.636
+1.914 989.498
+2.115 1000.16
+2.368 962.831
+2.647 926
+2.985 878.603
+3.303 805.143
+3.472 752.815
+3.55 705.72
+3.602 648.26
+3.647 611.631
+3.693 512.409
+3.779 334.897
+3.857 178.216
+3.935 89.379
+3.981 26.687
+4.05 0
+;
+;Animal Motor Works 75-3500
+;AMW L900RR RASP.ENG file made from NAR published data
+;File produced April 19, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+L900RR 75 497 0 1.771 3.5888 AMW 
+0.029 464.292
+0.053 630.937
+0.059 684.506
+0.096 702.328
+0.133 696.387
+0.201 714.311
+0.486 803.524
+0.777 910.661
+1.099 988.093
+1.26 1041.16
+1.284 1071.37
+1.378 1053.24
+1.607 1101.57
+1.917 1142.86
+2.208 1173.56
+2.413 1160.98
+2.624 1107.62
+2.866 976.211
+3.053 886.897
+3.208 839.27
+3.314 827.388
+3.382 809.465
+3.432 720.252
+3.495 547.564
+3.57 345.273
+3.627 214.273
+3.714 77.382
+3.79 0
+;
+;Animal Motor Works 75-3500
+;AMW L1060GG RASP.ENG file made from NAR data
+;File produced August 22, 2002
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+L1060GG 75 497 0 1.9188 3.9388 AMW 
+0.02 258.765
+0.024 368.224
+0.032 328.375
+0.076 427.947
+0.1 567.267
+0.116 751.329
+0.128 791.178
+0.169 816.045
+0.225 816.045
+0.309 875.768
+0.518 985.227
+0.763 1079.61
+1.024 1174.48
+1.308 1229.41
+1.606 1288.34
+1.782 1298.25
+1.983 1293.33
+2.256 1239.4
+2.525 1184.47
+2.822 1129.54
+3.038 1069.62
+3.111 1044.65
+3.135 995.114
+3.183 835.92
+3.239 552.286
+3.299 268.652
+3.327 164.187
+3.339 84.59
+3.36 44.782
+3.4 0
+;
+;Animal Motor Works 75-3500
+;AMW L1080BB RASP.ENG file made from NAR published data
+;File produced April 19, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+L1080BB 75 497 0 1.717 3.5922 AMW 
+0.024 406.295
+0.043 812.489
+0.052 895.202
+0.088 929.641
+0.314 991.55
+0.626 1087.69
+0.988 1163.44
+1.346 1218.99
+1.638 1246.25
+1.864 1257.91
+2.247 1254.84
+2.6 1218.99
+2.766 1211.92
+2.851 1197.78
+2.942 1204.85
+3.002 1226.06
+3.033 1204.85
+3.089 1040.23
+3.124 874.499
+3.15 660.999
+3.191 461.336
+3.232 275.408
+3.268 144.622
+3.303 75.744
+3.339 41.316
+3.39 0
+;
+;Animal Motor Works 54-2550
+;AMW L1100RR RASP.ENG file made from NAR published data
+;File produced April 19, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+L1100RR 54 728 0 1.346 2.5881 AMW 
+0.013 681.489
+0.029 1116.88
+0.041 1196.3
+0.079 1210.38
+0.147 1203.34
+0.257 1218.42
+0.366 1225.45
+0.567 1254.61
+0.824 1282.76
+1.059 1311.91
+1.267 1340.23
+1.459 1311.91
+1.622 1297.84
+1.713 1290.8
+1.785 1268.68
+1.83 1218.42
+1.886 1080.69
+1.969 819.214
+2.048 558.24
+2.108 376.985
+2.156 246.498
+2.205 144.963
+2.269 72.501
+2.35 0
+;
+;AMW L1111ST RASP.ENG file made from Tripoli published data
+;File produced May 15, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to the people who produced the data.
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+L1111ST 75 497 0 1.642 3.517 AMW 
+0.012 947.531
+0.034 1002.77
+0.055 956.063
+0.109 947.531
+0.238 986.151
+0.485 1058
+0.732 1138.83
+1.027 1232.24
+1.312 1317.56
+1.527 1359.77
+1.624 1372.8
+1.726 1379.4
+1.866 1368.31
+1.93 1343.16
+2.075 1296.01
+2.275 1211.13
+2.469 1130.3
+2.609 1066.53
+2.738 998.724
+2.76 964.595
+2.803 934.957
+2.879 790.357
+2.928 624.652
+2.993 433.483
+3.031 254.979
+3.08 140.243
+3.1 67.989
+3.14 0
+;
+;Animal Motor Works 54-2550
+;AMW L1300BB RASP.ENG file made from NAR published data
+;File produced April 19, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+L1300BB 54 728 0 1.314 2.5454 AMW 
+0.014 710.467
+0.025 1247.64
+0.039 1384.13
+0.053 1447.83
+0.074 1420.53
+0.12 1447.83
+0.276 1474.12
+0.475 1519.61
+0.712 1555
+0.942 1586.74
+1.147 1562.08
+1.36 1534.78
+1.484 1551.97
+1.537 1551.97
+1.569 1497.37
+1.59 1406.38
+1.604 1451.87
+1.615 1333.58
+1.64 1168.78
+1.689 986.687
+1.753 767.749
+1.824 512.503
+1.891 275.512
+1.933 147.816
+1.987 74.737
+2.06 0
+;
+;Animal Motor Works 75-6000
+;AMW M1350WW RASP.ENG file made from NAR data
+;File produced Nov 3, 2002
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+M1350WW 75 785 0 2.9673 5.6322 AMW 
+0.026 728.705
+0.046 1381.7
+0.066 1609.64
+0.092 1662.71
+0.151 1609.64
+0.242 1592.57
+0.478 1592.57
+1.041 1592.57
+1.71 1635.75
+2.299 1643.78
+2.672 1601.61
+3.092 1508.22
+3.197 1500.19
+3.249 1423.87
+3.301 1338.52
+3.386 1067.4
+3.524 788.05
+3.721 440.617
+3.779 389.807
+3.838 381.272
+3.904 364.402
+3.976 305.058
+4.055 194.903
+4.14 93.214
+4.23 0
+;
+;Animal Motor Works 75-6000
+;AMW M1480RR RASP.ENG file made from NAR published data
+;File produced April 19, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+M1480RR 75 785 0 3 5.5248 AMW 
+0.022 713.002
+0.032 1254.68
+0.055 1473.37
+0.078 1569.11
+0.156 1569.11
+0.352 1559.03
+0.642 1597.33
+0.974 1644.69
+1.289 1702.13
+1.52 1739.42
+1.918 1796.87
+2.279 1814.83
+2.481 1796.87
+2.707 1739.42
+2.968 1644.69
+3.058 1616.47
+3.135 1520.73
+3.218 1378.64
+3.284 1217.39
+3.332 1065.22
+3.344 1140.8
+3.368 1016.85
+3.41 741.522
+3.5 522.935
+3.613 275.727
+3.691 171.12
+3.768 66.553
+3.85 0
+;
+;AMW M1850GG RASP.ENG file made from Tripoli published data
+;File produced May 15, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to the people who produced the data.
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+M1850GG 75 781 0 3.375 5.851 AMW 
+0.012 1326.73
+0.018 894.224
+0.069 1177.46
+0.099 1244.68
+0.211 1319.32
+0.271 1535.34
+0.434 1714.28
+0.642 1990.1
+0.779 2012.35
+1.069 2191.29
+1.257 2263.51
+1.46 2267.93
+1.658 2269
+1.959 2268.48
+2.254 2258.04
+2.508 2183.87
+2.564 2235.79
+2.595 2153.74
+2.687 2124.07
+2.733 2064.27
+2.779 1833.41
+2.82 1468.12
+2.857 1118.13
+2.903 752.835
+2.97 424.814
+3.042 201.235
+3.149 59.614
+3.2 0
+;
+;Animal Motor Works 75-6000
+;AMW M1900BB RASP.ENG file made from NAR published data
+;File produced April 19, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+M1900BB 75 785 0 2.733 5.4225 AMW 
+0.018 1109.21
+0.044 1761.75
+0.061 1910.65
+0.085 1938.62
+0.159 1929.63
+0.29 1956.62
+0.409 2031.56
+0.438 1974.6
+0.569 2011.58
+0.815 2104.51
+1.073 2197.44
+1.401 2280.39
+1.688 2324.7
+1.905 2297.37
+2.073 2241.41
+2.254 2138.49
+2.397 2063.54
+2.479 2016.57
+2.54 2025.57
+2.581 2006.58
+2.63 1885.67
+2.716 1493.94
+2.805 1120.21
+2.887 840.605
+2.972 569.996
+3.046 299.488
+3.119 150.193
+3.168 56.829
+3.23 0
+;
+;Animal Motor Works 75-7600
+;AMW M2200SK RASP.ENG file made from NAR published data
+;File produced April 19, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+M2200SK 75 1039 0 3.766 7.0098 AMW 
+0.02 972.329
+0.049 1612.84
+0.101 1601.78
+0.243 1701.33
+0.482 1878.3
+0.571 1889.36
+0.802 2088.45
+0.997 2254.36
+1.073 2254.36
+1.227 2486.63
+1.426 2574.11
+1.616 2651.53
+1.681 2751.08
+1.782 2839.56
+1.831 2817.44
+1.961 2916.99
+2.07 2979.38
+2.155 2939.11
+2.196 2961.23
+2.256 2872.75
+2.321 2839.56
+2.374 2684.72
+2.422 2331.78
+2.483 1568.6
+2.524 1215.66
+2.584 1094
+2.674 1060.81
+2.747 961.268
+2.868 740.358
+2.953 464.043
+3.046 165.708
+3.11 0
+;
+;Animal Motor Works 75-7600
+;AMW M2500GG RASP.ENG file made from NAR data
+;File produced DEC 25, 2002
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+M2500GG 75 1039 0 4.248 7.5515 AMW 
+0.026 1288.79
+0.053 2021.4
+0.079 2140.01
+0.123 2105.12
+0.207 2117.09
+0.54 2309.46
+0.971 2560.64
+1.265 2727.09
+1.48 2836.74
+1.678 2920.46
+1.757 2980.27
+1.946 2995.51
+2.047 2959.34
+2.24 2889.56
+2.31 2854.68
+2.486 2820.79
+2.526 2880.59
+2.592 2773.94
+2.653 2821.78
+2.706 2752.01
+2.758 2752.01
+2.807 2763.97
+2.842 2504.82
+2.886 2115.09
+2.93 1630.67
+2.987 1051.57
+3.04 437.571
+3.057 284.072
+3.079 142.434
+3.097 83.497
+3.11 0
+;
+;AMW M3000ST RASP.ENG file made from Tripoli published data
+;File produced May 15, 2004
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to the people who produced the data.
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+M3000ST 75 1038 0 3.819 7.5515 AMW 
+0.014 2721.02
+0.032 2553.37
+0.096 2601.84
+0.22 2722.8
+0.353 2807.73
+0.476 2928.24
+0.518 3048.75
+0.577 3061.2
+0.76 3314.22
+0.944 3519.67
+1.14 3772.69
+1.315 3942.12
+1.511 4039.5
+1.617 4088.42
+1.708 4115
+1.791 4089.75
+1.837 4006.15
+1.873 3814.49
+1.951 3359.58
+2.002 2784.61
+2.052 2257.66
+2.111 1587.08
+2.162 1108.15
+2.221 629.227
+2.308 318.126
+2.395 139.052
+2.446 67.503
+2.5 0
+;
+;Animal Motor Works 98-11000
+M1730SK 98 870 0 4.9452 9.8718 AMW 
+0.04 682.642
+0.064 1153.39
+0.221 1354.66
+0.269 1414.77
+0.381 1458.03
+0.541 1526.92
+0.701 1589.2
+0.861 1675.2
+1.021 1732.67
+1.181 1802.23
+1.341 1886.64
+1.5 1973.71
+1.66 2070.51
+1.82 2183.82
+1.98 2299.31
+2.14 2433.86
+2.3 2568.12
+2.46 2679.42
+2.62 2638.38
+2.78 2484.18
+2.94 2306.04
+3.099 2173.85
+3.259 2074.69
+3.419 1961.3
+3.579 1807.81
+3.739 1640.26
+3.899 1303.04
+4.059 940.6
+4.219 567.152
+4.379 309.143
+4.539 188.981
+4.637 0
+;
+;Animal Motor Works 98-11000
+N2020WT 98 870 0 5.1609 9.9693 AMW 
+0.106 1941.34
+0.221 2151.15
+0.381 2253.41
+0.541 2340.79
+0.701 2400.85
+0.861 2453.82
+1.021 2506.31
+1.181 2556.31
+1.341 2607.25
+1.5 2652.79
+1.66 2688.66
+1.82 2710.68
+1.98 2729.8
+2.14 2733.89
+2.3 2704.26
+2.46 2634.58
+2.62 2532.16
+2.78 2433.38
+2.94 2329.74
+3.099 2234.25
+3.259 2165.8
+3.419 2099.68
+3.579 2028.35
+3.739 1951.01
+3.899 1871.32
+4.059 1558.11
+4.219 1053.38
+4.379 890.506
+4.539 636.689
+4.998 0
+;
+;Animal Motor Works 98-11000
+N2700BB 98 870 0 4.7837 9.9308 AMW 
+0.027 2229.53
+0.069 2476.18
+0.111 2539.74
+0.36 2723.21
+0.527 2863.83
+0.735 3016.48
+0.943 3141.25
+1.151 3241.72
+1.359 3335.56
+1.567 3519.92
+1.775 3425.88
+1.983 3420.56
+2.191 3356.08
+2.399 3270.48
+2.607 3182.6
+2.815 3098.31
+3.023 3002.95
+3.231 2888.73
+3.439 2266.61
+3.647 1498.26
+3.855 780.04
+4.063 233.545
+4.16 0
+;
+;Animal Motor Works 98-11000
+N2600GG 98 870 0 4.8812 10.4726 AMW 
+0.024 1674.37
+0.064 1949.62
+0.104 2039.52
+0.306 2189.98
+0.508 2334.45
+0.709 2491.23
+0.911 2668.93
+1.113 2874.7
+1.314 3038.83
+1.516 3191.29
+1.718 3266.01
+1.92 3318.98
+2.121 3336.18
+2.323 3229.26
+2.525 3089.68
+2.726 2943.98
+2.928 2847.69
+3.13 2751.68
+3.331 2682.22
+3.533 2463.48
+3.735 1339.63
+3.937 269.834
+4.034 0
+;
+;Animal Motor Works 98-17500
+N4000BB 98 1213 0 6.1026 13.6683 AMW 
+0.029 4207.59
+0.071 4709.55
+0.113 4906.31
+0.155 5007.78
+0.239 5041.56
+0.323 4993.6
+0.534 5046.91
+0.744 5145.82
+0.954 5248.06
+1.165 5293.2
+1.375 5232.46
+1.585 5209.53
+1.796 5165.47
+2.006 5047.7
+2.216 4913.09
+2.427 4783.45
+2.637 4659.16
+2.847 4195.99
+3.058 2850.73
+3.268 1981.97
+3.478 1295.54
+3.689 907.699
+3.899 490.196
+4.11 316.338
+4.207 0
+;
+;Animal Motor Works 38-390
+I195WT 38 249 17 0.193 0.495 AMW 
+0.002 10.548
+0.018 42.653
+0.046 136.214
+0.064 179.784
+0.072 191.248
+0.078 197.211
+0.088 198.587
+0.126 198.587
+0.175 207.759
+0.217 211.887
+0.349 216.931
+0.401 221.059
+0.554 225.646
+0.586 228.856
+0.626 228.48
+0.65 230.232
+1.013 231.607
+1.105 230.691
+1.2 225.187
+1.356 210.511
+1.392 207.759
+1.441 206.842
+1.457 205.007
+1.519 181.159
+1.563 155.936
+1.693 49.992
+1.727 28.435
+1.756 16.512
+1.798 7.338
+1.86 1.376
+1.89 0
+;
+;Animal Motor Works 38-390
+I220SK 38 249 20 0.202 0.495 AMW 
+0.005 12.747
+0.019 45.25
+0.036 79.666
+0.052 125.554
+0.069 162.519
+0.076 169.53
+0.095 174.629
+0.167 176.541
+0.229 191.199
+0.447 235.175
+0.602 260.668
+0.733 288.073
+0.85 302.095
+0.974 301.457
+1.094 289.985
+1.184 268.954
+1.268 240.273
+1.302 219.879
+1.388 177.178
+1.418 147.224
+1.435 127.467
+1.473 91.139
+1.504 65.645
+1.543 40.789
+1.593 19.12
+1.622 10.197
+1.65 0
+;
+;AMW 38-390
+I271BB 38 258 0 0.189 0.493 AMW 
+0.011 119.53
+0.035 213.907
+0.05 245.903
+0.074 262.705
+0.115 269.446
+0.225 267.736
+0.346 282.929
+0.465 296.411
+0.584 303.152
+0.727 311.504
+0.916 318.245
+1.054 324.986
+1.162 331.4
+1.201 326.696
+1.225 313.214
+1.242 286.249
+1.268 240.99
+1.294 188.888
+1.323 136.833
+1.346 87.565
+1.368 45.467
+1.392 18.523
+1.43 0
+;
+;AMW 38-390
+I285GG 38 258 0 0.206 0.515 AMW 
+0.013 61.575
+0.032 119.327
+0.055 164.575
+0.076 191.004
+0.094 201.014
+0.139 212.326
+0.232 231.247
+0.357 258.876
+0.456 267.686
+0.592 278.998
+0.716 289.358
+0.841 291.2
+0.936 290.31
+1.051 285.204
+1.139 277.696
+1.204 280.199
+1.243 278.998
+1.265 268.887
+1.286 242.559
+1.319 187.2
+1.359 134.443
+1.387 86.702
+1.407 52.776
+1.428 31.413
+1.448 16.337
+1.465 5.026
+1.48 0
+;
+;Animal Motor Works 38-640
+I325WT 38 370 17 0.317 0.712 AMW 
+0.014 68.71
+0.022 113.038
+0.026 153.671
+0.037 244.545
+0.045 299.216
+0.055 330.246
+0.065 350.194
+0.079 365.709
+0.094 376.79
+0.124 381.963
+0.185 373.836
+0.252 373.836
+0.35 381.224
+0.47 382.701
+0.622 388.611
+1.102 384.179
+1.366 364.971
+1.379 360.537
+1.415 331.724
+1.49 223.119
+1.505 211.298
+1.551 187.657
+1.592 162.538
+1.688 80.529
+1.726 50.978
+1.775 27.336
+1.806 16.993
+1.834 9.605
+1.901 0
+;
+;Animal Motor Works 54-1750 K555 skidmark
+;File provide by Joel Rogers of AMW
+K555SK 54 492 0 0.8707 1.7343 AMW 
+0.063 507.328
+0.144 535.181
+0.226 559.826
+0.308 585.793
+0.389 607.239
+0.471 629.034
+0.553 664.586
+0.634 683.688
+0.716 697.625
+0.798 719.618
+0.879 756.521
+0.961 777.7
+1.043 789.004
+1.124 797.934
+1.206 801.689
+1.288 804.331
+1.369 799.414
+1.451 768.014
+1.533 704.469
+1.614 641.709
+1.696 568.727
+1.778 481.013
+1.859 401.614
+1.941 333.897
+2.023 277.226
+2.104 205.009
+2.186 129.425
+2.268 73.717
+2.349 22.38
+2.368 0
+;
+;Animal Motor Works 75-3500
+L666SK 75 497 0 1.8877 3.5344 AMW 
+0.096 105.88
+0.175 509.783
+0.312 549.481
+0.449 577.319
+0.586 602.9
+0.722 615.605
+0.859 632.54
+0.996 652.072
+1.133 671.418
+1.27 685.671
+1.407 701.286
+1.543 718.069
+1.68 734.116
+1.817 753.292
+1.954 771.589
+2.091 790.453
+2.228 819.222
+2.364 846.663
+2.501 874.629
+2.638 890.083
+2.775 898.271
+2.912 899.312
+3.049 881.683
+3.185 845.157
+3.322 768.451
+3.459 672.771
+3.596 525.466
+3.733 304.694
+3.87 86.663
+3.968 0
+;
+;@File: N2800b.txt, @Pts-I: 5383, @Pts-O: 31, @Sm: 8, @CO: 5%
+;@TI: 14810.26, @TIa: 14792.71, @TIe: 0.0%, @ThMax: 3650.74, @ThAvg: 2770.17, @Tb: 5.34
+;Exported using ThrustCurveTool, www.ThrustGear.com, by John DeMar
+N2800 98 1213 100 7.6947 13.8 AMW 
+0 93.0947
+0.002 168.347
+0.006 387.836
+0.019 1271.17
+0.029 1776.34
+0.043 2298.6
+0.062 2841.03
+0.072 3021.31
+0.084 3128.89
+0.14 3296.17
+0.277 3483.35
+0.293 3431.67
+0.369 3495.76
+0.978 3598.65
+1.973 3655.16
+2.977 3534.8
+3.3 3437.12
+3.497 3308.46
+3.583 3193.8
+3.651 3015.65
+3.748 2548.37
+3.836 2223.91
+4.109 1644.08
+4.245 1443.68
+4.272 1447.01
+4.397 1163.58
+4.489 1022.95
+4.516 1057.2
+4.574 883.885
+4.647 776.407
+5.569 0
+;
+;
+G20 29 149 3 0.0729 0.1179 EM 
+0.0463679 46.6843
+0.278207 30.3888
+0.479134 26.8655
+1.00464 24.6634
+3.47759 22.0209
+4.32767 13.653
+5.11592 3.08293
+5.47 0
+;
+;Ellis Mountain G35 Single Use Motor
+G35EM 29 165 6-10 0.082 0.135 EM 
+0.01 51.12
+0.04 57.55
+0.08 43.78
+2.73 28.16
+3.28 28.16
+3.78 6.73
+4 0
+;
+;
+G37 24 181 6-10-100 0.068 0.1133 EM 
+0.0231839 69.586
+0.162287 55.9331
+0.332303 48.0056
+0.502318 44.9226
+0.996909 40.9589
+1.49923 38.7568
+2.00155 34.3526
+2.49614 28.1868
+2.75116 18.4976
+2.99845 5.28502
+3.1 0
+;
+;Ellis Mountain Rocket Works
+;H48 Single Use motor
+H48 38 200 100 0.154 0.292 EM 
+0.05 101.5
+0.1 101.5
+0.21 92.18
+0.46 86.48
+0.74 83.38
+1 80
+1.49 74.57
+1.99 68.36
+2.48 63.18
+2.99 56.45
+3.2 34.18
+3.5 18
+3.69 13.46
+4 11
+4.36 7.77
+4.4 0
+;
+;Ellis Mountain Rocket Works
+;H50 Single Use motor
+H50 29 279 6-10 0.163 0.3 EM 
+0.01 63.67
+0.17 108.9
+0.27 94.9
+0.47 81.43
+0.79 71.02
+1.27 64.9
+1.97 60.61
+2.56 56.94
+3.01 52.04
+3.52 45.31
+3.97 34.9
+4.49 18.37
+4.97 4.9
+5.28 0
+;
+;
+H275 29 275 10 0.142 0.255 EM 
+0.0123648 792.752
+0.015456 356.739
+0.197836 312.697
+0.797527 268.655
+0.911901 255.442
+0.992272 123.317
+1.04173 39.6376
+1.1 0
+;
+;Ellis Mountain Rocket Works
+;I69 38mm Single Use motor
+I69 29 406 10 0.236 0.4 EM 
+0.05 78.67
+0.1 149.7
+0.25 133.5
+0.49 111.51
+0.75 100
+1.07 93.18
+1.48 87.83
+2 82.49
+2.5 78
+2.99 73.32
+3.5 64.5
+3.99 48.88
+4.5 29.79
+4.99 9.17
+5.28 0
+;
+;
+I130 38 330 100 0.308 0.625 EM 
+0.015456 266.453
+0.0540958 160.753
+0.502318 169.561
+2.23338 180.571
+2.48841 149.742
+2.99073 136.53
+3.49304 77.0732
+4.01082 26.4251
+4.43 0
+;
+;Ellis Mountain Rocket Works
+;I134 38mm Single Use motor
+I134 38 355 15 0.2807 0.5812 EM 
+0.1 268.8
+0.2 138
+1 116
+2 102
+3 85
+4 67
+4.65 16.46
+4.82 6.86
+5.07 6.86
+5.15 0
+;
+;
+I150 38 229 20-100 0.1718 0.3983 EM 
+0 101.15
+0.1 155.94
+0.15 155.94
+0.3 177.01
+0.4 181.23
+0.7 198.09
+0.9 198.09
+1.1 181.23
+1.9 160.15
+2 147.51
+2.1 126.44
+2.3 21.07
+2.4 8.43
+2.67 0
+;
+;
+I160 38 280 100 0.2319 0.4867 EM 
+0.01 205.72
+0.01 192.73
+0.2 192.73
+0.4 201.39
+0.5 199.22
+0.75 199.22
+0.76 197.06
+0.95 194.89
+1.5 203.55
+2.2 199.22
+2.35 155.91
+2.4 41.14
+2.7 42.88
+3.25 0
+;
+;
+I230 38 331 20-100 0.292 0.5751 EM 
+0 309.64
+0 305.28
+0.1 346.71
+0.15 322.72
+0.5 290.01
+1 283.47
+1.5 270.39
+1.7 252.94
+2 218.05
+2.25 82.86
+2.4 78.5
+2.45 47.97
+2.6 43.61
+2.8 4.36
+2.83 0
+;
+;
+J110 54 276 100 0.45359 0.8754 EM 
+0.108192 193.784
+0.386399 147.54
+1.00464 139.833
+4.034 116.711
+5.00773 94.6899
+6.01236 67.1637
+6.53787 37.4355
+6.8 0
+;
+;
+J148 54 355 14 0.67 1.179 EM 
+0.139104 218.007
+0.231839 183.875
+0.448223 171.763
+1.00464 170.662
+2.10201 170.662
+5.02318 147.54
+5.31685 133.226
+5.67233 49.547
+6.1 0
+;
+;
+J228 38 562 6 0.27 0.8391 EM 
+0.0309119 665.031
+0.0927357 444.822
+0.262751 356.739
+0.664606 343.526
+0.989181 317.101
+1.96291 259.847
+2.99845 193.784
+4.01855 118.913
+4.99227 35.2334
+5.2 0
+;
+;
+J270 38 384 20-100 0.3471 0.6868 EM 
+0 308.91
+0.1 419.24
+0.15 441.3
+0.2 397.17
+0.3 375.11
+0.33 353.04
+1.5 330.98
+1.9 286.85
+2 165.49
+2.1 110.33
+2.5 66.19
+2.65 22.07
+2.9 0
+;
+;
+J330 38 433 20-100 0.4119 0.78 EM 
+0.05 541.77
+0.07 520.1
+0.2 485.43
+0.5 507.1
+1 455.09
+1.25 433.42
+1.5 379.24
+1.77 216.71
+2 104.02
+2.1 99.69
+2.2 86.68
+2.5 73.68
+2.75 0
+;
+;
+K475 54 663 14 1.035 2.168 EM 
+0.0463679 797.157
+0.15456 616.585
+0.278207 585.756
+0.479134 568.139
+2.92117 576.948
+3.29212 568.139
+4.00309 303.888
+4.51314 224.613
+5.02318 74.8711
+5.5 0
+;
+;
+L330-76mm 76 381 100 1.4899 2.3959 EM 
+0.05 343
+0.25 381.58
+0.5 362.29
+1 360.15
+2.5 390.16
+3.5 392.3
+6.5 325.85
+7.5 321.56
+7.6 317.27
+8 150.06
+8.5 64.31
+8.9 21.44
+9.35 0
+;
+;Ellis Mountain L600
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+L600 76 584 100 2.4407 4.11981 EM 
+0.186 829.668
+0.561 773.861
+0.936 767.837
+1.313 755.034
+1.689 736.454
+2.064 722.717
+2.44 706.215
+2.816 688.253
+3.191 673.457
+3.567 660.981
+3.943 648.124
+4.318 634.689
+4.694 622.058
+5.07 607.97
+5.445 594.926
+5.821 583.003
+6.197 573.084
+6.572 553.53
+6.948 399.379
+7.324 270.41
+7.699 211.401
+8.075 144.237
+8.451 74.227
+8.826 19.378
+9.202 4.274
+9.578 0
+;
+;
+M1000 75 787 100 3.47514 5.5776 EM 
+0.16 1897.85
+0.48 1606.84
+0.8 1442.25
+1.13 1360.56
+1.45 1300.03
+1.77 1259.95
+2.09 1231.62
+2.41 1203.01
+2.73 1180.44
+3.06 1155.04
+3.38 1109.26
+3.7 1075.88
+4.02 1045.73
+4.34 1010.71
+4.67 951.57
+4.99 860.89
+5.31 727.66
+5.63 595.9
+5.96 519.12
+6.28 440.08
+6.6 347.88
+6.92 239.48
+7.24 144.67
+7.57 75.14
+7.89 33.55
+8.21 0
+;
+;The J465GT "Green Tornado" motor is a green flame, low smoke propellant.
+;This reload produces a 60% "J" motor with 1023 N-seconds of total impulse,
+;maximum thrust of 662.6 Newtons, and an average thrust of 466.9 Newtons,
+;for a 2.24 second burn time.
+J465GT 54 326 0 0.566 1.1818 GM 
+0.0475391 200
+0.09 364.9
+0.1 382.7
+0.14 400.5
+0.313199 453.846
+0.53132 515.385
+0.788591 576.923
+1.04306 638.462
+1.16 662.6
+1.27 650
+1.43456 592.308
+1.62192 523.077
+1.82886 423.077
+2 335.78
+2.05 231.4
+2.1 124.6
+2.24 0
+;
+;The J365BL "Black Lightning" motor is a black smoke sparky propellant This
+;reload produces a 33.2% "J" motor that has 852.4 N-seconds total impulse,
+;maximum thrust of 498 Newtons, and an average impulse of 364.9 Newtons for a
+;2.38 second burn time.
+J365BL 54 326 1000 0.498 1.20454 GM 
+0.04 102.35
+0.06 155.75
+0.1 192.8
+0.159574 242.308
+0.4 315.95
+0.6 400.5
+0.7 436.1
+0.88 480.6
+1.18 498.4
+1.6 455.6
+1.84564 418.846
+2.05 378.25
+2.14 213.6
+2.2 102.35
+2.3 22.25
+2.38 0
+;
+;The J450BL "Black Lightning" motor is a black smoke sparky propellant This
+;reload produces a 75% "J" motor that has 1120 N-seconds total impulse, maximum
+;thrust of 601 Newtons, and an average impulse of 442.4 Newtons for a 2.57
+;second burn time.
+J450BL 54 430 1000 0.658 1.45454 GM 
+0.08 124.6
+0.130872 215.385
+0.19 333.75
+0.3 413.85
+0.469799 480
+0.68 556.25
+0.8 578.5
+1.05 601
+1.27181 590.769
+1.49329 566.154
+1.68792 535.385
+1.90268 498.35
+2.2 409.4
+2.3 267
+2.4 87.2
+2.57 0
+;
+;The K533BL "Black Lightning" motor is a black smoke sparky propellant This
+;reload produces a 10% "K" motor that has 1419.75 N-seconds total impulse,
+;maximum thrust of 1419.76 Newtons, and an average impulse of 533.45 Newtons
+;for a 2.66 second burn time.
+K533BL 54 492 1000 0.9 1.7167 GM 
+0.075 525.1
+0.11745 491.538
+0.15 467.25
+0.228188 484.615
+0.290828 498.462
+0.40604 546.923
+0.530201 616.154
+0.661074 678.462
+0.75 699.56
+1 699.231
+1.19128 692.308
+1.35906 671.538
+1.55369 643.846
+1.87919 581.538
+2.2 493.95
+2.32886 353.077
+2.46644 207.692
+2.65 22.5
+2.7 0
+;
+;The K327WC "White Cloud" motor is a white smoke propellant This reload
+;produces a 26% "K" motor that has 1615.57 N-seconds total impulse, maximum
+;thrust of 684.54 Newtons, and an average impulse of 326.52 Newtons for a 5.18
+;second burn time.
+K327WC 54 492 1000 1 1.8167 GM 
+0.05 556.25
+0.10179 529.231
+0.15 520.65
+0.242729 553.846
+0.375839 603.077
+0.5 658.6
+0.571588 596.923
+0.65 520.65
+1.3311 455.385
+1.79306 412.308
+2.50559 332.308
+2.99888 276.923
+3.47651 227.692
+4.00112 166.154
+4.49441 110.769
+4.92506 61.5385
+5.25 22.25
+5.65 0
+;
+;The K222WC "White Cloud" motor is a white smoke propellant This reload
+;produces a 2% "K" motor that has 1314.46 N-seconds total impulse, maximum
+;thrust of 444.35 Newtons, and an average impulse of 221.56 Newtons for a
+;5.937 second burn time.
+K222WC 54 430 1000 0.8 1.59654 GM 
+0.1 396.05
+0.15 378.25
+0.232662 388.462
+0.322148 411.538
+0.4 433.875
+0.456376 400
+0.5 347.1
+0.7 311.5
+1.15 289.25
+1.68233 276.923
+2.25 267
+3 231.4
+3.51678 200
+4 169.1
+4.55481 130.769
+5.18121 88.4615
+5.68233 57.6923
+6.2 22.25
+6.7 0
+;
+;The J167WC "White Cloud" motor is a white smoke propellant This reload
+;produces a 48% "J" motor that has 949.97 N-seconds total impulse, maximum
+;thrust of 366.47 Newtons, and an average impulse of 167.21 Newtons for a
+;5.677 second burn time.
+J167WC 54 326 1000 0.8 1.2158 GM 
+0.1 333.75
+0.143177 315
+0.2 307.05
+0.268456 332.308
+0.35 363.66
+0.45 311.5
+0.6 293.7
+1.00224 273.462
+1.50336 249.231
+2.01342 225
+2.56823 197.308
+3.22148 162.692
+4 121.154
+4.53691 90
+5.00224 65.7692
+5.46756 41.5385
+5.85 22.25
+6.25 0
+;
+;The K555GT "Green Tornado" motor is a green flame, low smoke propellant.
+;This reload produces a 9% "K" motor with 1397 N-seconds of total impulse,
+;maximum thrust of 645.3 Newtons, and an average thrust of 556 Newtons,
+;for a 2.51 second burn time.
+K555GT 54 430 1000 0.78 1.52 GM 
+0.025 267
+0.05 338.2
+0.1 471.7
+0.12 498.4
+0.15 511.75
+0.18 522.875
+0.2 534
+0.7 631.9
+0.75 636.35
+0.9 645.25
+1.15 636.35
+1.57 623
+1.87 614.1
+2.17 600.75
+2.25 578.5
+2.27 480.6
+2.3 356
+2.35 178
+2.45 66.75
+2.51 0
+;
+;The K763GT "Green Tornado" motor is a green flame, low smoke propellant.
+;This reload produces a 36% "K" motor with 1740.27 N-seconds of total impulse,
+;maximum thrust of 867.75 Newtons, and an average thrust of 763.56 Newtons,
+;for a 2.27 second burn time.
+K763GT 54 492 1000 0.954 1.81 GM 
+0.05 498.4
+0.07 565.15
+0.08 623
+0.1 689.75
+0.12 720.9
+0.25 801
+0.38 845.5
+0.65 867.75
+0.83 854.4
+1.95 778.75
+2.1 712
+2.15 400.5
+2.25 44.5
+2.27 0
+;
+;
+J395RT 54 326 1000 0.5406 1.1604 GM 
+0.06 267
+0.1 333.75
+0.16 356
+0.21 360.45
+0.33 387.15
+1 460.157
+1.5 453.9
+2.2 409.4
+2.4 360.45
+2.48 267
+2.57 44.5
+2.59 0
+;
+;
+K520RT 54 430 1000 0.7211 1.4421 GM 
+0.05 400.5
+0.07 471.7
+0.16 502.85
+0.23 498.4
+0.35 529.55
+0.87 593.13
+1.2 605.2
+1.55 578.5
+1.85 569.6
+2.32 511.75
+2.45 387.15
+2.58 26.7
+2.61 0
+;
+;
+K470WC 54 728 1000 1.4 2.327 GM 
+0.025 1001.25
+0.175 905
+0.45 1050.2
+0.65 827.7
+1.091 716.45
+1.633 623
+5.275 0
+;
+;
+K1075RT 54 728 1000 1.314 2.541 GM 
+0.017 687.71
+0.042 1026.66
+0.134 1121.18
+0.242 1171.15
+0.325 1203.77
+1.225 1247.2
+1.659 1238.53
+1.742 1223.36
+1.8 1123.36
+2.24 0
+;
+;
+K700RT 54 492 1000 0.90135 0.17535 GM 
+0.12 534
+0.18 658.6
+0.2 725.35
+0.24 747.6
+0.28 747.6
+0.4 783.2
+0.65 788.215
+1 787.65
+1.65 769.85
+2 729.8
+2.1 712
+2.2 645.25
+2.38 115.7
+2.41 0
+;
+;
+K980BL 54 728 1000 1.23 2.457 GM 
+0.05 1186.45
+0.07 1021.76
+0.25 1135.45
+0.35 1200
+0.5 1225.45
+0.75 1297.45
+0.91 1265.75
+1.1 1201.5
+1.58 1045.75
+1.65 1068
+1.7 1001.25
+1.8 495
+2 222.5
+2.17 0
+;
+;HyperTek I310
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+I310 54 645 0 0.40096 1.30502 HT 
+0.042 465.886
+0.128 450.815
+0.216 438.421
+0.303 443.241
+0.391 433.808
+0.478 415.992
+0.566 406.746
+0.653 380.383
+0.741 385.17
+0.828 372.458
+0.916 358.282
+1.003 348.621
+1.091 337.887
+1.178 333.898
+1.266 303.469
+1.353 301.589
+1.441 268.788
+1.528 222.719
+1.616 155.314
+1.703 112.163
+1.791 80.51
+1.878 58.562
+1.966 41.774
+2.053 30.243
+2.141 21.27
+2.228 0
+;
+;HyperTek J115 (440CC076J)
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J115 54 614 0 0.411264 1.28218 HT 
+0.129 218.303
+0.391 230.563
+0.653 216.171
+0.916 165.676
+1.178 158.834
+1.441 161.888
+1.703 157.955
+1.966 152.977
+2.228 148.337
+2.491 141.919
+2.753 136.97
+3.016 129.152
+3.278 121.815
+3.541 111.971
+3.803 79.163
+4.066 53.433
+4.328 42.975
+4.591 38.391
+4.853 33.418
+5.116 28.709
+5.378 23.886
+5.641 19.658
+5.903 15.894
+6.166 11.955
+6.428 9.151
+6.691 0
+;
+;HyperTek J120 (440CC076JFX)
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J120 54 614 0 0.442176 1.29338 HT 
+0.134 232.707
+0.405 264.084
+0.676 230.699
+0.948 185.971
+1.22 174.226
+1.491 173.853
+1.763 165.828
+2.034 158.016
+2.305 152.389
+2.577 143.399
+2.849 135.969
+3.12 129.537
+3.392 124.822
+3.664 118.872
+3.934 109.922
+4.206 69.777
+4.478 47.837
+4.749 40.178
+5.021 35.768
+5.293 31.265
+5.564 26.359
+5.835 21.215
+6.107 17.175
+6.378 12.931
+6.65 9.463
+6.922 0
+;
+;HyperTek J150
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J150 54 645 0 0.428288 1.30592 HT 
+0.111 177.498
+0.336 193.696
+0.561 200.136
+0.786 204.034
+1.011 200.531
+1.236 197.233
+1.461 192.706
+1.686 189.854
+1.911 185.892
+2.136 183.117
+2.361 179.325
+2.586 174.178
+2.813 171.123
+3.039 164.933
+3.264 160.032
+3.489 154.604
+3.714 148.653
+3.939 92.092
+4.164 55.325
+4.389 42.913
+4.614 32.903
+4.839 24.742
+5.064 16.445
+5.289 8.527
+5.515 4.923
+5.741 0
+;
+;HyperTek J170 (440CC098J)
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J170 54 614 0 0.4032 1.28218 HT 
+0.092 315.198
+0.278 351.486
+0.466 314.152
+0.653 255.278
+0.841 235.396
+1.027 234.785
+1.214 230.871
+1.401 223.051
+1.589 217.688
+1.776 209.94
+1.962 203.806
+2.149 197.52
+2.336 191.243
+2.524 178.598
+2.711 129.785
+2.898 82.459
+3.084 71.693
+3.272 64.633
+3.459 54.015
+3.647 45.022
+3.833 36.373
+4.02 28.397
+4.207 21.518
+4.395 16.072
+4.582 11.712
+4.77 0
+;
+;HyperTek J190 (440CC098JFX)
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J190 54 614 0 0.439488 1.29338 HT 
+0.095 338.583
+0.287 384.416
+0.481 341.472
+0.674 279.175
+0.867 267.528
+1.06 256.325
+1.254 250.108
+1.447 244.404
+1.64 238.846
+1.833 236.505
+2.026 232.026
+2.219 223.962
+2.413 213.236
+2.606 201.661
+2.799 150.523
+2.992 101.327
+3.185 84.001
+3.378 73.902
+3.571 60.222
+3.765 49.208
+3.958 39.096
+4.151 29.873
+4.344 22.6
+4.538 16.842
+4.731 11.964
+4.925 0
+;
+;HyperTek J220
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J220 54 645 0 0.417984 1.30502 HT 
+0.071 277.975
+0.215 271.735
+0.358 289.851
+0.502 298.227
+0.647 293.803
+0.792 290.609
+0.935 283.211
+1.079 276.013
+1.223 271.808
+1.368 269.774
+1.513 262.986
+1.656 257.451
+1.8 253.286
+1.944 245.781
+2.089 239.739
+2.233 230.852
+2.377 220.234
+2.521 159.239
+2.665 97.18
+2.809 73.147
+2.954 58.766
+3.098 48.973
+3.242 37.549
+3.385 27.41
+3.53 19.267
+3.675 0
+;
+;HyperTek J250 (440CC125J)
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J250 54 614 0 0.40768 1.29248 HT 
+0.064 409.711
+0.194 453.238
+0.324 416.509
+0.454 383.773
+0.584 359.202
+0.715 343.963
+0.845 336.331
+0.975 328.849
+1.105 318.614
+1.235 309.097
+1.366 306.155
+1.496 290.597
+1.626 283.18
+1.756 261.19
+1.886 200.168
+2.017 143.646
+2.147 126.521
+2.277 113.229
+2.407 91.31
+2.538 71.216
+2.668 54.183
+2.798 40.347
+2.928 29.057
+3.058 20.139
+3.19 13.793
+3.321 0
+;
+;HyperTek J270 (440CC125JFX)
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J270 54 614 0 0.419776 1.29606 HT 
+0.064 438.643
+0.193 498.603
+0.322 468.869
+0.451 438.261
+0.581 412.686
+0.711 390.684
+0.841 376.193
+0.97 362.205
+1.1 347.649
+1.23 333.459
+1.359 324.401
+1.489 311.483
+1.619 298.076
+1.749 278.397
+1.878 220.239
+2.007 150.276
+2.137 125.603
+2.268 121.989
+2.397 91.398
+2.526 71.671
+2.656 55.779
+2.786 41.822
+2.916 30.46
+3.045 22.243
+3.175 16.42
+3.305 0
+;
+;HyperTek J317 (835CC172J)
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J317 81 552 0 0.704256 1.7575 HT 
+0.071 438.483
+0.215 471.024
+0.358 459.716
+0.502 447.348
+0.647 431.653
+0.792 418.545
+0.935 407.806
+1.079 400.212
+1.223 395.752
+1.368 382.516
+1.513 372.89
+1.656 368.033
+1.8 349.298
+1.944 336.071
+2.089 324.486
+2.233 301.205
+2.377 233.601
+2.521 176.972
+2.665 132.539
+2.809 96.229
+2.954 69.718
+3.098 49.457
+3.242 33.983
+3.385 23.063
+3.53 16.524
+3.675 0
+;
+;HyperTek J330 (835CC172JFX)
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+J330 81 552 0 0.727104 1.77722 HT 
+0.068 453.5
+0.206 485.741
+0.345 476.873
+0.483 463.622
+0.623 439.951
+0.761 423.26
+0.9 426.386
+1.04 415.245
+1.178 443.371
+1.317 431.352
+1.456 407.015
+1.595 392.143
+1.733 390.332
+1.872 360.092
+2.01 334.24
+2.15 307.215
+2.289 225.611
+2.427 169.224
+2.567 126.562
+2.705 93.167
+2.844 68.293
+2.983 48.099
+3.122 32.856
+3.26 21.857
+3.4 15.193
+3.54 0
+;
+;HyperTek K240
+;Copyright Tripoli Motor Testing 1998 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+K240 81 552 0 0.789376 1.80723 HT 
+0.131 278.007
+0.396 329.552
+0.66 338.024
+0.925 334.092
+1.191 326.199
+1.456 319.745
+1.721 315.195
+1.985 311.182
+2.25 302.916
+2.516 305.943
+2.781 289.975
+3.046 281.781
+3.31 273.33
+3.575 268.852
+3.841 255.702
+4.106 251.068
+4.371 234.82
+4.635 159.972
+4.9 96.543
+5.166 73.367
+5.431 55.477
+5.696 40.928
+5.96 29.542
+6.225 21.25
+6.491 14.787
+6.756 0
+;
+;HyperTek L200 (1685CC098L)
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+L200 111 724 0 1.59398 3.89491 HT 
+0.292 310.935
+0.877 311.934
+1.464 284.574
+2.05 259.236
+2.636 245.149
+3.223 240.798
+3.809 246.021
+4.396 251.509
+4.981 255.559
+5.568 250.045
+6.154 242.343
+6.741 236.221
+7.327 230.527
+7.914 224.062
+8.5 218.24
+9.086 212.215
+9.673 189.706
+10.258 94.608
+10.845 67.128
+11.431 53.35
+12.018 41.55
+12.604 31.112
+13.191 22.445
+13.777 16.763
+14.364 10.892
+14.95 0
+;
+;HyperTek L225 (1685CC098LFX)
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+L225 111 724 0 1.66118 3.94822 HT 
+0.271 380.609
+0.815 364.078
+1.359 347.671
+1.904 311.98
+2.449 292.842
+2.994 284.62
+3.539 284.123
+4.083 295.754
+4.628 286.654
+5.173 271.822
+5.718 258.225
+6.263 249.357
+6.807 240.396
+7.352 232.666
+7.897 226.844
+8.442 217.601
+8.986 208.639
+9.531 122.739
+10.076 74.667
+10.621 60.93
+11.166 48.898
+11.71 38.996
+12.255 29.719
+12.8 21.925
+13.345 16.36
+13.89 0
+;
+;HyperTek L350 (1685CC125L)
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+L350 111 724 0 1.6025 3.90342 HT 
+0.188 592.182
+0.566 598.015
+0.945 479.774
+1.324 427.223
+1.702 406.561
+2.08 395.128
+2.459 393.279
+2.839 410.729
+3.217 517.335
+3.595 506.496
+3.974 439.49
+4.353 391.732
+4.731 463.388
+5.109 446.876
+5.489 436.237
+5.868 387.456
+6.246 247.342
+6.624 147.845
+7.003 117.459
+7.382 93.081
+7.76 73.034
+8.139 55.605
+8.518 40.854
+8.897 29.575
+9.276 21.627
+9.655 0
+;
+;HyperTek L355 (1685CC125LFX)
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+L355 111 724 0 1.61952 3.95405 HT 
+0.185 638.681
+0.559 623.792
+0.933 538.081
+1.307 493.173
+1.682 465.144
+2.056 432.702
+2.43 410.644
+2.804 388.862
+3.178 395.452
+3.553 384.851
+3.927 370.103
+4.301 356.484
+4.675 346.195
+5.049 342.684
+5.424 325.43
+5.798 317.798
+6.172 272.453
+6.546 156.214
+6.92 117.579
+7.295 93.203
+7.669 73.056
+8.043 56.997
+8.417 42.994
+8.791 30.338
+9.166 21.725
+9.541 0
+;
+;HyperTek L475 (1685CC172L)
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+L475 111 724 0 1.52992 3.89805 HT 
+0.129 640.755
+0.391 638.069
+0.652 619.018
+0.914 609.661
+1.176 597.937
+1.437 596.251
+1.699 594.039
+1.961 572.245
+2.223 578.304
+2.484 589.224
+2.747 578.752
+3.008 612.426
+3.27 646.188
+3.531 674.617
+3.793 652.574
+4.055 555.384
+4.317 299.749
+4.578 220.284
+4.841 170.007
+5.102 127.011
+5.364 94.998
+5.626 70.208
+5.888 49.458
+6.149 32.102
+6.411 18.382
+6.674 0
+;
+;HyperTek L535 (1685CC172LFX)
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+L535 111 724 0 1.59667 3.94822 HT 
+0.119 838.518
+0.358 768.667
+0.598 727.551
+0.838 745.172
+1.077 712.851
+1.317 694.613
+1.556 672.145
+1.796 656.726
+2.035 685.07
+2.275 808.735
+2.515 798.521
+2.754 755.277
+2.995 726.985
+3.235 699.331
+3.475 670.049
+3.715 515.315
+3.954 293.947
+4.194 227.905
+4.433 180.167
+4.673 140.714
+4.912 107.564
+5.152 80.907
+5.392 58.898
+5.631 39.782
+5.872 24.901
+6.113 0
+;
+;HyperTek L540 (2800CC172L)
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+L540 111 876 0 2.5303 5.656 HT 
+0.191 685.548
+0.574 665.171
+0.957 635.467
+1.341 634.122
+1.725 656.225
+2.109 706.931
+2.493 696.526
+2.876 777.726
+3.26 775.919
+3.645 781.611
+4.028 712.736
+4.411 695.555
+4.796 701.251
+5.18 645.985
+5.564 607.757
+5.947 546.408
+6.331 387.372
+6.716 234.214
+7.099 181.086
+7.482 139.253
+7.867 106.109
+8.251 78.293
+8.634 54.851
+9.018 36.384
+9.402 20.375
+9.786 0
+;
+;HyperTek L550 (1685CCRGL)
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+L550 111 724 0 1.53261 3.89805 HT 
+0.124 816.849
+0.375 796.043
+0.626 781.861
+0.877 767.44
+1.129 759.627
+1.38 735.948
+1.631 714.454
+1.883 701.582
+2.134 674.667
+2.385 656.493
+2.637 636.076
+2.889 612.409
+3.14 587.801
+3.391 567.17
+3.642 559.971
+3.894 534.157
+4.145 444.562
+4.396 280.51
+4.648 216.702
+4.899 163.136
+5.15 120.571
+5.402 86.544
+5.653 59.99
+5.904 39.527
+6.156 25.914
+6.408 0
+;
+;HyperTek L570 (2800CC172LFX)
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+L570 111 876 0 2.57734 5.70618 HT 
+0.181 793.916
+0.547 800.029
+0.914 811.765
+1.28 761.283
+1.647 725.674
+2.014 733.246
+2.38 783.159
+2.747 795.348
+3.112 823.178
+3.478 831.812
+3.845 805.614
+4.211 780.534
+4.578 741.917
+4.945 628.98
+5.311 547.886
+5.678 537.83
+6.044 330.85
+6.409 230.792
+6.776 180.51
+7.143 140.226
+7.509 108.348
+7.876 81.342
+8.243 59.608
+8.609 41.592
+8.976 25.536
+9.343 0
+;
+;HyperTek L575 (2800CCRGL)
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+L575 111 876 0 2.52134 5.65286 HT 
+0.19 705.343
+0.572 723.437
+0.955 738.414
+1.337 749.383
+1.72 735.169
+2.103 725.088
+2.486 733.751
+2.869 700.454
+3.251 690.771
+3.634 682.897
+4.017 674.825
+4.399 687.463
+4.782 675.411
+5.166 645.685
+5.548 643.612
+5.93 634.693
+6.314 559.731
+6.696 304.009
+7.078 229.423
+7.461 167.643
+7.845 121.036
+8.227 83.673
+8.609 54.311
+8.993 33.029
+9.376 19.886
+9.759 0
+;
+;HyperTek L610 (1685CCRGLFX)
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+L610 111 724 0 1.57696 3.95091 HT 
+0.11 850.823
+0.333 837.7
+0.556 775.061
+0.779 739.656
+1.002 807.273
+1.225 809.462
+1.448 801.752
+1.671 789.534
+1.894 763.842
+2.117 858.087
+2.34 890.644
+2.563 837.593
+2.785 749.631
+3.008 648.961
+3.231 643.064
+3.454 637.413
+3.677 431.325
+3.9 276.205
+4.123 220.93
+4.346 166.632
+4.569 124.031
+4.792 89.721
+5.015 64.295
+5.237 45.36
+5.461 30.4
+5.685 0
+;
+;HyperTek L625 (2800CCRGLFX)
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+L625 111 876 0 2.56614 5.70618 HT 
+0.169 855.024
+0.509 896.169
+0.851 905.926
+1.193 902.118
+1.534 853.016
+1.876 953.21
+2.218 904.246
+2.559 856.525
+2.901 743.522
+3.243 758.646
+3.584 751.619
+3.926 745.737
+4.267 751.907
+4.607 728.305
+4.949 691.703
+5.291 658.843
+5.632 504.45
+5.974 279.745
+6.316 216.661
+6.657 164.957
+6.999 123.426
+7.341 89.428
+7.682 62.955
+8.024 43.519
+8.366 27.956
+8.707 0
+;
+;Data entered by Tim Van Milligan
+;Based on TRA Certification 6-19-2002
+;And Instructions provided by Aerotech.
+I170S 38 258 14 0.1819 0.52 KBA 
+0.019 194.885
+0.131 190.481
+0.255 191.582
+0.513 199.289
+0.641 204.794
+0.753 206.996
+0.88 209.199
+1 208.098
+1.051 208.098
+1.147 206.996
+1.24 201.491
+1.391 198.188
+1.537 190.481
+1.707 181.672
+1.746 178.369
+1.781 173.96
+1.808 168.46
+1.854 132.12
+1.939 53.951
+2.005 22.02
+2.059 9.909
+2.13 0
+;
+;
+I280F 38 258 14 0.182 0.52 KBA 
+0.009 253.24
+0.055 255.442
+0.219 277.463
+0.482 301.686
+0.67 323.707
+0.735 330.314
+0.797 323.707
+1.001 297.282
+1.162 266.453
+1.205 259.847
+1.236 237.826
+1.363 50.6481
+1.428 26.4251
+1.5 0
+;
+;Kosdon by AeroTech I310S
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+I310S 38 368 100 0.312256 0.713216 KBA 
+0.045 334.66
+0.136 314.409
+0.228 322.556
+0.32 326.871
+0.411 331.851
+0.503 335.911
+0.595 336.933
+0.686 340.151
+0.778 342.066
+0.87 344.722
+0.961 348.578
+1.053 349.548
+1.146 351.943
+1.239 347.939
+1.33 345.079
+1.422 337.035
+1.514 333.332
+1.605 323.832
+1.697 289
+1.789 215.097
+1.88 136.596
+1.972 83.863
+2.064 37.922
+2.155 20.736
+2.248 5.943
+2.341 0
+;
+;Kosdon by AeroTech I370F
+;Copyright Tripoli Motor Testing 2001 (www.tripoli.org)
+;provided by ThrustCurve.org (www.thrustcurve.org)
+I370F 38 368 100 0.312256 0.705152 KBA 
+0.035 373.074
+0.109 389.927
+0.184 401.07
+0.259 416.613
+0.334 429.598
+0.409 438.025
+0.484 443.83
+0.559 447.326
+0.634 446.764
+0.709 447.263
+0.784 444.735
+0.859 441.302
+0.933 435.676
+1.007 425.29
+1.082 414.897
+1.157 404.222
+1.232 395.358
+1.307 382.062
+1.382 334.152
+1.457 275.974
+1.532 179.654
+1.607 83.023
+1.682 39.608
+1.757 16.105
+1.832 4.151
+1.907 0
+;
+;
+I450F 38 370 14 0.3032 0.73 KBA 
+0.012 634.202
+0.037 550.523
+0.108 519.693
+0.241 510.885
+0.639 550.523
+0.729 554.927
+0.809 546.118
+0.939 497.672
+1.072 471.247
+1.128 440.418
+1.165 387.568
+1.211 206.996
+1.295 88.0836
+1.36 26.4251
+1.41 0
+;
+;
+J405S 38 476 14 0.367 0.88 KBA 
+0.009 528.502
+0.024 488.864
+0.046 462.439
+0.136 462.439
+0.268 458.035
+0.986 453.631
+1.421 444.822
+1.523 255.442
+1.697 92.4878
+1.93 0
+;
+;
+J605F 38 476 14-100 0.367 0.88 KBA 
+0.024 886.341
+0.037 704.669
+0.077 660.627
+0.438 704.669
+0.506 715.679
+0.59 710.174
+0.853 655.122
+0.973 594.564
+1.041 412.892
+1.091 324.808
+1.177 132.125
+1.3 0
+;
+;
+K400S 54 403 6-10-14 0.713216 1.50931 KBA 
+0.074 465.928
+0.225 441.922
+0.377 442.414
+0.529 445.492
+0.681 449.048
+0.833 451.88
+0.985 454.481
+1.138 456.929
+1.29 458.237
+1.442 457.021
+1.594 455.62
+1.746 451.772
+1.897 446.421
+2.048 438.843
+2.2 429.377
+2.352 419.003
+2.504 408.274
+2.656 397.608
+2.808 388.018
+2.96 367.07
+3.113 263.666
+3.265 114.378
+3.417 46.238
+3.569 8.62
+3.721 2.401
+3.873 0
+;
+;
+K600F 54 403 6-10-14-100 0.68096 1.41568 KBA 
+0.045 639.654
+0.148 711.292
+0.252 695.617
+0.358 696.252
+0.462 701.336
+0.568 703.242
+0.67 705.265
+0.772 704.302
+0.878 702.819
+0.982 701.336
+1.088 696.888
+1.192 689.262
+1.295 681.245
+1.398 668.928
+1.502 653.465
+1.608 637.366
+1.712 619.785
+1.818 599.451
+1.92 586.275
+2.022 510.698
+2.128 334.676
+2.232 125.397
+2.338 37.916
+2.442 17.157
+2.548 4.025
+2.653 0
+;
+;
+L1000S 54 727.96 100 1.301 1.248 KBA 
+0.038 1310.24
+0.085 1090.03
+0.139 1023.97
+0.216 1001.95
+0.479 979.93
+1.035 1112.06
+1.993 1244.18
+2.047 1222.16
+2.094 1189.13
+2.179 924.878
+2.233 737.7
+2.264 847.805
+2.295 682.648
+2.295 539.512
+2.302 649.617
+2.318 451.428
+2.7 0
+;
+;
+L1400F 54 727 14-100 1.248 2.502 KBA 
+0.037 1541.46
+0.061 1453.38
+0.166 1354.29
+1.001 1772.68
+1.279 1783.69
+1.329 1882.79
+1.387 1992.89
+1.486 1387.32
+1.604 869.826
+1.65 748.711
+1.666 726.69
+1.69 924.878
+1.697 594.564
+1.758 319.303
+1.88 0
+;
+;
+J528-LW 38 406 5-8-10-13-17 0.372 0.752 LR 
+0.01 704.2
+0.02 1019
+0.03 983.9
+0.05 881.1
+0.1 797.5
+0.15 771.7
+0.17 765.72
+0.21 765.72
+0.25 778.2
+0.42 789.28
+0.51 771.61
+0.6 756.89
+0.66 751
+0.71 762.78
+0.76 697.99
+0.8 665.59
+0.84 612.58
+0.92 488.88
+0.95 385.81
+1.02 282.73
+1.06 179.65
+1.14 53.01
+1.19 35.34
+1.23 32.2
+1.25 0
+;
+;
+I405-LW 38 292 5-8-10-13-17 0.24 0.54 LR 
+0.01 151.1
+0.03 781.4
+0.05 800.7
+0.06 755.7
+0.09 724.3
+0.12 697.7
+0.15 701
+0.17 675.3
+0.2 643.1
+0.3 607.7
+0.4 569.2
+0.5 517.7
+0.6 472.7
+0.7 392.3
+0.8 318.3
+0.9 241.2
+1 151.1
+1.1 93.3
+1.15 40
+1.2 0
+;
+;
+H144-LW 38 178 5-8-10-13-17 0.12 0.335 LR 
+0.02 209
+0.04 247.6
+0.05 241.2
+0.1 247.6
+0.15 244.4
+0.2 237.9
+0.25 231.54
+0.3 228.3
+0.4 215.32
+0.45 212.43
+0.5 204.48
+0.6 194.36
+0.7 189.7
+0.8 170.4
+0.9 154.3
+1 127.83
+1.1 109.3
+1.2 80.4
+1.3 64.6
+1.4 44.6
+1.5 32.1
+1.6 0
+;
+;
+J175-LW 54 327 0 0.59 1.264 LR 
+0.01 4.8
+0.1 420.4
+0.2 347.5
+0.3 349.9
+0.4 364.5
+0.5 320.7
+1 296.4
+1.5 279.4
+2 260
+2.5 238.1
+3 209
+3.5 172
+4 133.6
+4.5 102
+5 75.3
+5.5 46.2
+6 17
+6.5 0
+;
+;
+J525-LW 54 327 0 0.59 1.264 LR 
+0.01 210.9
+0.03 499.3
+0.05 628.5
+0.1 594
+0.13 568.2
+0.15 559.6
+0.2 555.3
+0.3 572.5
+0.4 589.7
+0.5 606.9
+0.6 624.2
+0.7 637.1
+0.8 645.7
+0.9 650
+1 658.6
+1.1 637.1
+1.2 628.5
+1.3 615.5
+1.41 586.27
+1.52 561.52
+1.67 536.78
+1.78 517.74
+1.85 485.38
+1.92 91.37
+2 0
+;
+;
+J820-LW 54 327 0 0.57 1.244 LR 
+0.01 4.8
+0.02 982.43
+0.07 1033.1
+0.11 982.43
+0.2 959.9
+0.3 943.02
+0.4 947
+0.5 972.8
+0.6 981.4
+0.7 990
+0.8 990
+0.9 981.4
+0.95 1033.1
+1 981.4
+1.1 641.4
+1.2 353
+1.3 206.6
+1.4 120.5
+1.5 0
+;
+;
+M1882-LW 76 785 0 3.12979 5.53383 LR 
+0.01 4.8
+0.0174014 2579.22
+0.0696056 2392.32
+0.232019 2298.87
+0.50464 2261.49
+0.771462 2298.87
+0.986079 2411.01
+1.1891 2579.22
+1.49652 2597.91
+1.72854 2485.77
+2.00116 2354.94
+2.5 1644.72
+2.99884 242.97
+3.25 0
+;
+;
+I110-LW 38 292 5-8-12 0.289 0.589 LR 
+0 282.365
+0.0348028 218.735
+0.12181 170.944
+0.214617 163.592
+0.400232 169.106
+1.50232 176.458
+2.00116 152.563
+2.5 108.448
+2.99884 64.3338
+4 0
+;
+;
+L1400-LW 54 726 0 1.4 2.54 LR 
+0.00580046 1606.3
+0.11891 1535.7
+0.327726 1535.7
+0.49884 1588.65
+1.00058 1782.82
+1.40661 1906.38
+1.49942 1376.83
+1.60673 953.19
+1.74594 547.202
+1.90545 335.382
+1.99826 211.82
+2 0
+;
+;
+L930-LW 76 498 0 1.81437 3.53802 LR 
+0.025 532
+0.05 1123
+0.075 1123
+0.125 1094
+0.2 930
+0.5 881
+0.6 878
+0.75 898
+1 921
+1.25 940
+1.5 1012
+1.75 1081
+2 1100
+2.25 1120
+2.5 1051
+2.75 980
+3 934
+3.25 826
+3.5 722
+3.75 280
+4 0
+;
+;
+K350-LW 54 702 0 1.4 2.54012 LR 
+0.025 1329
+0.0375 1061
+0.1 1006
+0.15 891
+0.2 768
+0.4 571
+0.5 542
+0.75 486
+1 486
+1.25 477
+1.5 481
+2.5058 460
+3.00464 427
+3.5 375
+4 333
+4.5 297
+5 249
+5.5 210
+6 164
+6.5 98
+7 0
+;
+;
+K250-LW 54 498 0 0.952544 1.79169 LR 
+0.03 800
+0.1 682
+0.125 574
+0.15 476
+0.175 447
+0.25 385
+0.45 340
+0.6 320
+1 313
+1.5 300
+2 297
+2.5 303
+3 294
+3.5 287
+4 248
+4.5 222
+5 187
+5.5 147
+6 114
+6.5 62
+7 0
+;
+;
+K960-LW 54 498 0 0.929864 1.74633 LR 
+0.03 1210
+0.05 1512
+0.075 1535
+0.1 1502
+0.125 1437
+0.2 1237
+0.3 1175
+0.5 1139
+0.6 1130
+0.7 1156
+0.8 1182
+0.9 1192
+1 1166
+1.1 1139
+1.2 1101
+1.3 1091
+1.4 1026
+1.5 839
+1.6 790
+1.7 575
+1.8 284
+1.9 150
+2 0
+;
+;
+H500-LW 38 292 5-7-9-12-15 0.16 0.454 LR 
+0.001 189.286
+0.0116009 534.733
+0.099768 539.465
+0.199536 544.197
+0.302784 553.662
+0.402552 548.93
+0.50464 544.197
+0.584687 435.358
+0.61949 9.4643
+0.62 0
+;
+;
+H100-SP 38 178 5-8-10-13-17 0.12 0.335 LR 
+0.015528 127.586
+0.151398 127.586
+0.477484 139.655
+0.74146 146.552
+1.00543 150
+1.13742 122.414
+1.30823 86.2069
+1.59938 39.6552
+2 0
+;
+;
+I316-SP 38 292 5-8-10-13-17 0.24 0.54 LR 
+0.00931677 448.276
+0.127329 491.379
+0.242236 500
+0.347826 482.759
+0.484472 439.655
+1 258.621
+1.5 0
+;
+;
+J396-SP 38 406 5-8-10-13-17 0.372 0.752 LR 
+0.00621118 396.552
+0.201863 413.793
+0.400621 439.655
+0.593168 491.379
+0.717391 543.103
+0.801242 508.621
+0.993789 491.379
+1.20186 448.276
+1.40062 250
+1.6 0
+;
+H90-LR 38 178 5-8-10-14 0.12 0.335 LR 
+0.0543478 146.552
+1.51398 94.8276
+2.1972 44.8276
+2.6087 0
+;
+;
+I210-LR 38 292 5-8-10-14 0.24 0.54 LR 
+0.00388199 452.586
+0.0427019 387.931
+1.00155 271.552
+1.80901 77.5862
+2.3 0
+;
+;
+J320-LR 38 406 5-8-10-14 0.372 0.752 LR 
+0.015528 534.031
+0.100932 439.791
+1.94099 319.372
+2.18944 78.534
+2.6 0
+;
+;
+G80-LW 38 127 5-8-10-13-17 0.06 0.275 LR 
+0.00931677 112.069
+0.416149 112.069
+0.872671 89.6552
+1.5 0
+;
+;
+J712-LB 38 406 7-9-12-15 0.372 0.752 LR 
+0.00931677 870.69
+0.0496894 810.345
+0.791925 793.103
+1 706.897
+1.06211 172.414
+1.2 0
+;
+;
+H160-LB 38 178 7-9-12-15 0.12 0.335 LR 
+0.015528 288.793
+0.599379 237.069
+1.03106 107.759
+1.5 0
+;
+;
+I430-LB 38 292 7-9-12-15 0.24 0.54 LR 
+0.00931677 534.483
+0.0310559 448.276
+0.0962733 465.517
+0.372671 456.897
+0.748447 439.655
+1.14907 422.414
+1.2 0
+;
+;
+L1482 76 498 0 1.814 3.538 LR 
+0.00776398 1344.83
+0.0465839 1241.38
+0.48913 1551.72
+1.01708 1568.97
+1.99534 1603.45
+2.3913 1586.21
+2.48447 1758.62
+2.50776 103.448
+2.6 0
+;
+;
+M2550 76 785 0 3.13 5.53 LR 
+0.00776398 2974.14
+0.0621118 2887.93
+0.427019 2887.93
+0.861801 3017.24
+1.49845 2974.14
+2.11957 2413.79
+2.45342 474.138
+2.6 0
+;
+;
+F50T 29 98 4-6-9 0.0379 0.0849 AT 
+0.01 37.97
+0.02 56.27
+0.03 65.08
+0.12 71.86
+0.23 75.25
+0.33 77.29
+0.35 77.7
+0.45 75.25
+0.59 71.86
+0.72 65.76
+0.83 58.98
+1.01 43.39
+1.19 25.76
+1.25 15.59
+1.3 8.81
+1.36 4.75
+1.42 0
+;
+;PML G40W is the same as the Aerotech G40W.
+G40W 29 124 4-7-10 0.0624 0.115 PML 
+0.015 40
+0.037 66.479
+0.066 60.845
+0.161 55.775
+0.308 55.775
+0.447 54.085
+0.549 52.394
+0.637 51.268
+0.857 52.958
+1.018 52.394
+1.172 50.141
+1.362 46.761
+1.611 41.69
+1.691 41.127
+1.845 34.366
+1.999 30.423
+2.372 23.099
+2.585 13.521
+2.738 6.761
+3.039 0
+;
+;PML G80T is the same as the old Aerotech G80T.
+G80T 29 124 4-7-10 0.0574 0.106 PML 
+0.007 82.746
+0.018 104.754
+0.051 104.754
+0.095 97.711
+0.245 94.19
+0.458 95.07
+0.6 93.31
+0.86 84.507
+1.003 76.585
+1.139 69.542
+1.252 57.218
+1.303 51.056
+1.34 37.852
+1.38 19.366
+1.424 7.923
+1.461 2.641
+1.497 0
+;
+;Ace Aeronautics L500 (Historical)
+;Kline-Rogers
+;"D" Grain Motor
+L500 54 1016 0 1.53638 2.61184 Hist 
+0 733.957
+0.5 782.887
+1 800.68
+1.5 796.232
+2 760.646
+2.5 702.819
+3 631.648
+3.5 538.235
+4 440.374
+4.5 333.617
+5 226.859
+6 35.586
+6.23 0
+;
+;Aerotech J100 (Historical)
+;Old single-use Aerotech J100
+;delays: 5/10/15
+J100 54 251 0 0.445 0.8 Hist 
+0 187.804
+0.11 160.981
+0.3 144.879
+0.6 136.783
+2.2 128.776
+4 109.96
+8.2 29.492
+10.8 0
+;
+;Aerotech J125 (Historical)
+;Old single-use Aerotech J125
+J125 54 334 0 0.001644 0.002425 Hist 
+0.02 212.091
+0.07 238.87
+0.24 224.546
+0.49 221.655
+0.71 224.546
+0.98 228.372
+1.17 235.044
+1.95 233.131
+2.25 223.568
+2.68 212.091
+3.19 193.943
+3.59 178.641
+4.03 162.405
+4.46 142.388
+5.25 110.85
+5.8 87.897
+6.34 66.857
+6.88 52.578
+7.56 37.276
+8 33.451
+8.44 24.866
+8.98 18.149
+9.31 11.476
+9.46 5.738
+9.61 5.738
+9.8 0
+;
+;Kosdon O10000 (Historical)
+O10000 98 1651 0 11.34 16.840 Hist
+0.01 6844.983
+2.27 12127.03
+2.28 0.0
+;
+;Animal Motor Works 38-640 
+J440BB 38 369 20 0.3853 0.6985 AMW
+0.007	468.505
+0.022	509.996
+0.037	527.687
+0.052	532.792
+0.082	530.181
+0.127	525.586
+0.202	521.566
+0.277	519.840
+0.352	521.522
+0.426	525.414
+0.501	531.248
+0.576	538.724
+0.651	541.761
+0.726	538.508
+0.801	531.072
+0.876	516.175
+0.950	494.942
+1.025	477.251
+1.100	433.297
+1.175	313.900
+1.250	187.467
+1.325	101.546
+1.400	45.751
+1.474	22.083
+1.497	0.000
+;
+;Animal Motor Works K475 RASP.ENG file made from NAR data
+;File produced Feb 22, 2003
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+K475WW 54 403 100 0.7286 1.4925 AMW 
+0.022 127.831
+0.041 386.016
+0.063 548.326
+0.096 521.308
+0.134 499.129
+0.18 486.83
+0.285 486.83
+0.478 501.649
+0.731 523.727
+1.096 553.266
+1.433 577.962
+1.601 588.29
+1.756 582.704
+1.895 580.284
+1.958 575.344
+2.063 550.746
+2.209 518.788
+2.344 477.051
+2.495 417.974
+2.561 354.058
+2.582 334.399
+2.599 331.98
+2.62 297.501
+2.67 226.226
+2.707 157.37
+2.74 98.353
+2.799 49.176
+2.853 17.208
+2.94 0
+;
+; Entered by Tim Van Milligan. Used John Coker's ThrustCurve Tracer software and
+; data from NAR certification dated May 7, 2007
+K500SK 75 368 100 1.1235 2.713 AMW
+   0.018 194.373
+   0.031 207.161
+   0.036 268.542
+   0.103 319.693
+   0.138 322.251
+   0.17 314.578
+   0.67 309.463
+   0.692 322.251
+   0.902 319.693
+   0.929 332.481
+   1.263 355.499
+   1.585 383.632
+   1.969 411.765
+   2.112 416.88
+   2.272 447.57
+   2.415 488.491
+   2.46 485.934
+   2.634 534.527
+   2.83 618.926
+   3.018 710.997
+   3.143 767.263
+   3.228 815.857
+   3.339 841.432
+   3.402 826.087
+   3.504 785.166
+   3.585 718.67
+   3.661 631.714
+   3.728 519.182
+   3.772 365.729
+   3.826 181.586
+   3.862 99.744
+   3.893 43.478
+   3.946 0.0
+;
+;Animal Motor Works 54-1400
+;AMW K530GG RASP.ENG file made from NAR data
+;File produced Feb 25, 2003
+;This file my be used or given away. All I ask is that this header
+;is maintained to give credit to NAR S&T. Thank you, Jack Kane
+;The total impulse, peak thrust, average thrust and burn time are
+;the same as the averaged static test data on the NAR web site in
+;the certification file. The curve drawn with these data points is as
+;close to the certification curve as can be with such a limited
+;number of points (32) allowed with wRASP up to v1.6.
+K530GG 54 403 1000 0.7967 1.616 AMW 
+0.013 129.764
+0.054 171.852
+0.096 284.122
+0.138 392.892
+0.171 455.975
+0.217 501.662
+0.238 498.063
+0.326 508.66
+0.542 564.745
+0.755 613.831
+1.01 645.423
+1.17 657.23
+1.273 648.922
+1.51 638.425
+1.656 634.925
+1.702 606.833
+1.803 606.833
+1.857 585.839
+1.936 589.338
+1.974 575.242
+2.015 589.338
+2.04 564.745
+2.132 536.652
+2.207 540.251
+2.291 522.656
+2.357 487.566
+2.42 375.297
+2.478 242.033
+2.529 140.361
+2.583 66.651
+2.66 0
+;
+; Blue Baboon
+K1130-BB 54 728 0 1.359 2.574 AMW/ProX 
+0.01 1000
+0.013 1490
+0.02 1548
+0.04 1500
+0.09 1335
+0.2 1325
+1 1325
+1.5 1325
+1.63 1345
+1.7 1155
+1.8 805
+1.9 685
+2 475
+2.1 315
+2.2 145
+2.3 0
+;
+K1250-WW 54 491 0 0.925 1.815 AMW/ProX 
+0.01 600
+0.02 1400
+0.03 1610
+0.05 1360
+0.07 1410
+0.1 1440
+0.15 1470
+0.2 1480
+0.4 1480
+0.8 1395
+1.28 1185
+1.36 985
+1.4 680
+1.45 570
+1.5 210
+1.6 60
+1.7 0
+;
+; Skidmark
+K610-SK 54 491 0 0.866 1.765 AMW/ProX 
+0.01 300
+0.02 745
+0.035 650
+0.06 560
+0.12 635
+0.21 670
+0.4 695
+0.7 700
+1 690
+1.35 665
+1.7 630
+2.05 585
+2.19 590
+2.24 500
+2.3 350
+2.4 205
+2.5 60
+2.6 15
+2.7 0
+;
+K710-BB 54 491 0 0.902 1.812 AMW/ProX 
+0.01 500
+0.02 850
+0.025 910
+0.03 840
+0.06 860
+0.12 875
+0.2 875
+0.3 872
+1.1 815
+1.85 740
+1.95 720
+2.2 295
+2.37 280
+2.5 90
+2.6 20
+2.8 0
+; AMX/ProX 2729L1276 RR
+L1276RR 54 728 P 1.475 2.96 AMW
+   0.015 76.924
+   0.017 692.317
+   0.026 1495.003
+   0.037 1244.164
+   0.052 1401.357
+   0.084 1307.71
+   0.127 1307.71
+   0.181 1367.911
+   0.289 1401.357
+   0.384 1408.046
+   0.807 1421.424
+   0.993 1461.558
+   1.215 1491.659
+   1.673 1474.936
+   1.727 1384.634
+   1.798 1083.627
+   1.947 531.78
+   1.986 351.175
+   2.047 177.26
+   2.092 93.647
+   2.144 33.445
+   2.185 0.0
+;
+;@File: E20.txt, @Pts-I: 1001, @Pts-O: 32, @Sm: 3, @CO: 5%
+;@TI: 34.6666, @TIa: 34.5451, @TIe: 0.0%, @ThMax: 34.6991, @ThAvg: 22.1301, @Tb: 1.561
+;Exported using ThrustCurveTool, www.ThrustGear.com
+E20 24 65 4-7-10 0.0162 0.049 AT 
+0 0.0290422
+0.024 0.227567
+0.038 1.39403
+0.048 2.6721
+0.056 5.81661
+0.06 7.76916
+0.062 9.00446
+0.064 10.7176
+0.072 20.3365
+0.074 22.4147
+0.08 27.1311
+0.084 28.9874
+0.09 30.5394
+0.104 32.9513
+0.124 34.2647
+0.138 34.677
+0.252 33.8465
+0.36 32.0816
+0.63 29.8124
+0.672 28.8301
+0.77 27.3596
+0.8 26.3903
+0.9 24.2069
+1.084 18.0681
+1.134 16.8918
+1.16 15.8701
+1.2899 12.1921
+1.3719 9.38065
+1.5079 4.03928
+1.5519 2.72185
+1.6019 1.72082
+1.7579 0
+;
+; From AT Instruction Sheet by C. Kobel  1/4/11
+F30FJ 24 90 4-6-8 0.0318 0.070 AT
+   0.056 22.706
+   0.102 34.315
+   0.134 36.363
+   0.200 36.876
+   0.300 36.705
+   0.400 37.217
+   0.500 38.241
+   0.600 37.900
+   0.700 37.900
+   0.800 37.217
+   0.900 36.363
+   1.000 35.168
+   1.100 33.291
+   1.175 32.608
+   1.200 31.413
+   1.260 26.974
+   1.300 22.706
+   1.400 9.219
+   1.453 5.805
+   1.500 4.097
+   1.600 0.0
+;
+; AeroTech G138T
+; from the reload instruction sheet 08/11/2010
+; Created by Scott Sager 10/10/2010
+G138T 29 123.8 14 0.0704 0.152 AT
+   0.0020 113.497
+   0.043 118.736
+   0.098 125.065
+   0.138 126.157
+   0.198 133.578
+   0.251 140.999
+   0.293 146.019
+   0.347 148.856
+   0.398 156.932
+   0.447 160.861
+   0.5 165.881
+   0.548 169.591
+   0.601 173.738
+   0.646 177.449
+   0.697 183.123
+   0.739 182.032
+   0.798 182.469
+   0.839 181.159
+   0.901 182.469
+   0.947 194.691
+   0.972 185.306
+   0.986 174.611
+   0.998 161.515
+   1.0 156.714
+   1.012 143.618
+   1.018 133.796
+   1.026 120.263
+   1.031 111.969
+   1.036 98.437
+   1.041 89.052
+   1.044 77.484
+   1.049 67.662
+   1.054 54.784
+   1.059 46.708
+   1.064 33.176
+   1.073 23.136
+   1.082 12.659
+   1.098 0.873
+   1.099 0.0
+;
+; @File: G142_Typical.txt, @Pts-I: 451, @Pts-O: 32, @Sm: 0, @CO: 5% 
+; @TI: 84.5422, @TIa: 84.2303, @TIe: 0.0%, @ThMax: 173.4408, @ThAvg: 135.8554, @Tb: 0.62 
+; Exported using ThrustCurveTool, www.ThrustGear.com 
+G142 29 113 6-10-14 0.0386 0.0976 AT
+  0.016      4.06052 
+  0.018      6.53754 
+  0.02       13.44075 
+  0.022      24.4211 
+  0.024      43.7388 
+  0.026      72.8495 
+  0.028      106.9426 
+  0.03       132.0076 
+  0.032      141.5423 
+  0.034      147.6844 
+  0.038      154.1148 
+  0.054      165.5675 
+  0.076      166.3214 
+  0.084      168.7605 
+  0.118      172.9402 
+  0.15       173.3837 
+  0.224      171.8426 
+  0.3        164.7803 
+  0.372      156.6537 
+  0.418      148.9594 
+  0.432      144.9903 
+  0.452      137.0965 
+  0.518      96.8779 
+  0.568      69.3937 
+  0.576      63.1618 
+  0.618      21.4754 
+  0.628      13.57047 
+  0.64       7.98504 
+  0.652      2.92169 
+  0.672      0.966347 
+  0.9        0.687625 
+  0.901      0
+;
+; Curve fit of AT Instruction sheet by C. Kobel  7/29/08
+G76G 29 124 4-7-10 0.06 0.147 AT
+   0.025 89.368
+   0.042 133.581
+   0.052 144.87
+   0.067 154.277
+   0.098 144.399
+   0.117 136.873
+   0.150 132.64
+   0.196 129.348
+   0.255 123.233
+   0.299 118.059
+   0.349 112.885
+   0.399 108.652
+   0.449 101.126
+   0.486 101.597
+   0.511 105.36
+   0.516 118.53
+   0.543 100.186
+   0.601 95.482
+   0.656 88.897
+   0.720 81.842
+   0.737 93.601
+   0.754 80.431
+   0.797 70.553
+   0.856 63.498
+   0.898 58.794
+   0.948 51.739
+   1.000 47.976
+   1.063 43.273
+   1.102 41.391
+   1.152 39.04
+   1.200 36.688
+   1.301 30.103
+   1.347 25.399
+   1.401 19.755
+   1.499 12.229
+   1.547 7.996
+   1.599 5.644
+   1.699 2.352
+   1.750 0.0
+;
+; Exported using ThrustCurveTool, www.ThrustGear.com 
+; @File: G79_Ave.txt, @Pts-I: 1162, @Pts-O: 33, @Sm: 5, @CO: 5% 
+; @TI: 106.4155, @TIa: 106.0632, @TIe: 0.0%, @ThMax: 82.1771, @ThAvg: 64.1443, @Tb: 1.659 
+G79 29 146 4,7,10 0.0601 0.124 AT 
+  0.000        0.4562 
+  0.014        1.1376 
+  0.018        3.2129 
+  0.022        6.2017 
+  0.034      27.3705 
+  0.040      33.5757 
+  0.044      34.8528 
+  0.062      33.5201 
+  0.096      39.9175 
+  0.128      56.9842 
+  0.138      60.0917 
+  0.182      59.6191 
+  0.230      68.8942 
+  0.266      71.3440 
+  0.300      71.6246 
+  0.360      75.8167 
+  0.484      79.6244 
+  0.516      78.6333 
+  0.678      82.1075 
+  0.700      78.8360 
+  0.720      78.1790 
+  0.772      79.5565 
+  1.054      73.7176 
+  1.086      71.1520 
+  1.182      68.8555 
+  1.420      57.2479 
+  1.520      40.7567 
+  1.562      30.5794 
+  1.628      11.8028 
+  1.652        7.1707 
+  1.680        3.9601 
+  1.738        1.6764 
+  1.928        0.0000
+;
+; Aerotech I170G from TRA Cert Data
+; Created by Mark Hairfield 12-29-10
+I170G 54 151 10 0.227 0.528 AT
+   0.06 89.0
+   0.16 169.0
+   0.25 184.6
+   0.5 202.4
+   0.75 207.3
+   1.0 202.4
+   1.5 177.9
+   2.18 137.9
+   2.25 139.7
+   2.30 131.2
+   2.35 22.2
+   2.40 0.0
+;
+; Aerotech I49N-P
+I49N-P 38 184 P 0.20500000000000002 0.398 AT
+   0.0080 1.406
+   0.025 48.594
+   0.093 52.031
+   0.429 57.344
+   0.665 60.313
+   0.841 60.625
+   1.06 62.344
+   1.295 63.438
+   1.556 62.344
+   1.825 62.344
+   1.994 60.625
+   2.212 60.156
+   3.003 56.719
+   3.785 52.344
+   4.349 49.375
+   4.997 46.563
+   5.998 43.438
+   6.393 42.031
+   6.831 41.563
+   6.999 36.875
+   7.083 33.125
+   7.184 31.406
+   7.369 23.125
+   7.495 16.406
+   7.764 4.219
+   7.882 1.875
+   7.941 0.0
+;
+; Aerotech I59WN-P
+I59WN-P 38 232 P 0.272 0.487 AT
+   0.0090 0.357
+   0.046 138.571
+   0.12 150.0
+   0.193 147.857
+   0.368 157.857
+   0.506 167.857
+   0.699 171.071
+   0.791 171.786
+   0.893 168.571
+   1.058 158.214
+   1.233 146.429
+   1.417 132.143
+   1.509 125.714
+   1.61 100.357
+   1.675 80.357
+   1.785 60.357
+   1.96 53.571
+   2.209 48.571
+   2.531 45.357
+   2.669 43.214
+   3.009 40.714
+   3.387 40.714
+   4.021 38.929
+   4.261 37.5
+   4.997 36.429
+   6.0 33.929
+   6.883 31.429
+   7.003 33.571
+   7.187 30.714
+   7.334 27.5
+   7.574 22.5
+   7.96 17.5
+   8.117 9.643
+   8.319 4.643
+   8.604 0.0
+;
+; Input by Tim Van Milligan using ThrustCurve Tracer by John Coker. Data from
+; Tripoli certification paperwork dated 25 November 2007.
+J401FJ 54 325 6 0.511 0.912 AT
+   0.011 440.414
+   0.022 488.102
+   0.075 427.791
+   0.116 422.18
+   0.191 446.024
+   0.277 453.037
+   0.382 462.855
+   0.513 468.466
+   0.712 472.673
+   0.775 471.271
+   0.948 471.271
+   1.06 472.673
+   1.281 469.868
+   1.431 462.855
+   1.607 453.037
+   1.858 426.388
+   2.034 403.946
+   2.135 384.31
+   2.202 378.7
+   2.258 374.492
+   2.277 374.492
+   2.3 380.102
+   2.322 380.102
+   2.345 370.284
+   2.367 359.064
+   2.408 314.181
+   2.461 244.051
+   2.502 186.545
+   2.566 103.792
+   2.607 64.519
+   2.652 42.078
+   2.704 18.234
+   2.783 0.0
+;
+;
+J510 38 584 P 0.662 1.08 AT
+   0.032 1055.904
+   0.11 865.54
+   0.161 829.933
+   0.267 794.325
+   0.351 780.63
+   0.512 705.306
+   0.682 654.633
+   1.318 624.504
+   1.461 475.225
+   1.623 345.121
+   1.934 153.387
+   2.039 115.04
+   2.177 41.086
+   2.317 5.478
+   2.5 0.0
+;
+;
+J99 54 231 P 0.556 0.899 AT
+   0.031 117.296
+   0.078 135.045
+   0.242 144.305
+   0.828 131.38
+   2.539 110.737
+   3.594 102.056
+   4.82 94.146
+   5.938 86.043
+   7.523 81.22
+   8.984 76.976
+   9.047 74.082
+   9.547 16.012
+   9.711 5.209
+   9.82 1.929
+   10.0 0.0
+;
+; From AT Instruction Sheet by C. Kobel 3/12/10
+K375NW-P 54 568 P 1.238 2.126 AT
+   0.027 886.971
+   0.036 1115.263
+   0.054 1268.705
+   0.135 1279.933
+   0.197 1313.615
+   0.292 1317.357
+   0.422 1343.555
+   0.444 1302.387
+   0.489 1336.07
+   0.552 452.842
+   0.574 396.704
+   0.718 452.842
+   0.794 460.327
+   0.902 437.872
+   0.992 411.674
+   1.189 404.189
+   1.400 366.764
+   1.575 381.734
+   1.791 370.507
+   4.000 366.764
+   4.165 344.309
+   4.290 239.520
+   4.398 239.520
+   4.537 183.382
+   4.645 183.382
+   4.761 93.562
+   5.000 93.562
+   5.200 63.622
+   5.400 44.910
+   5.600 33.682
+   5.800 0.0
+;
+; From AT Instruction Sheet by C. Kobel 3/12/10
+K480W-P 54 568 P 1.232 2.059 AT
+   0.030 535.684
+   0.045 860.341
+   0.057 915.996
+   0.098 830.194
+   0.159 832.513
+   0.246 795.409
+   0.307 811.642
+   0.398 793.090
+   0.492 809.323
+   0.557 823.237
+   0.621 811.642
+   0.689 779.176
+   0.735 795.409
+   0.845 767.581
+   0.989 718.883
+   1.091 707.288
+   1.250 684.098
+   1.307 667.865
+   1.500 653.952
+   1.606 656.271
+   1.742 651.633
+   1.909 628.443
+   2.000 605.253
+   2.250 586.701
+   2.500 565.830
+   2.750 547.279
+   2.886 544.960
+   3.000 524.089
+   3.064 491.623
+   3.144 417.416
+   3.250 394.226
+   3.292 338.571
+   3.451 271.320
+   3.500 231.898
+   3.625 178.561
+   3.700 143.777
+   3.871 132.182
+   4.000 88.121
+   4.133 41.742
+   4.246 23.190
+   4.500 18.552
+   4.800 0.0
+;
+; Input by Tim Van Milligan using ThrustCurve Tracer by John Coker. Data from
+; Tripoli certification paperwork dated 25 November 2007.
+K513FJ 54 410 6 0.974 1.647 AT
+   0.0070 555.093
+   0.015 652.655
+   0.041 551.729
+   0.059 592.099
+   0.074 551.729
+   0.2 575.278
+   0.282 582.007
+   0.412 605.556
+   0.519 615.649
+   0.679 635.834
+   0.823 642.562
+   0.986 649.291
+   1.12 652.655
+   1.328 656.019
+   1.48 649.291
+   1.602 629.105
+   1.854 585.371
+   1.999 555.093
+   2.054 545.0
+   2.08 545.0
+   2.114 528.179
+   2.184 524.815
+   2.229 521.451
+   2.258 504.63
+   2.295 474.352
+   2.325 437.346
+   2.358 380.155
+   2.37 349.877
+   2.399 312.871
+   2.451 272.5
+   2.492 238.858
+   2.529 161.482
+   2.57 84.105
+   2.592 43.735
+   2.618 26.914
+   2.655 13.457
+   2.692 6.728
+   2.726 0.0
+;
+; From the curve of the motor instruction sheet.
+; Made using Thrust Curve Tracer.
+; Tom Koszuta 12/26/2008.
+K805G 54 410 P 0.871 1.543 AT
+   0.0050 443.21
+   0.032 817.925
+   0.053 825.983
+   0.098 854.187
+   0.199 902.537
+   0.298 918.654
+   0.399 938.8
+   0.5 950.888
+   0.595 950.888
+   0.699 950.888
+   0.8 942.829
+   0.903 934.771
+   1.002 922.683
+   1.1 902.537
+   1.201 874.333
+   1.254 866.275
+   1.267 878.362
+   1.299 854.187
+   1.334 846.129
+   1.35 850.158
+   1.398 821.954
+   1.499 781.662
+   1.522 789.72
+   1.536 781.662
+   1.546 765.545
+   1.597 757.487
+   1.698 721.224
+   1.799 701.078
+   1.897 688.991
+   1.95 693.02
+   1.961 705.107
+   1.982 697.049
+   1.995 668.845
+   2.014 596.319
+   2.035 447.24
+   2.051 342.481
+   2.064 269.955
+   2.08 205.488
+   2.099 165.197
+   2.123 120.876
+   2.147 84.613
+   2.171 52.379
+   2.197 0.0
+;
+;
+L1170FJ 75 665 P 2.8000000000000003 4.99 AT
+   0.031 992.64
+   0.072 1400.144
+   0.113 1473.286
+   0.144 1389.696
+   0.351 1285.207
+   1.495 1431.491
+   1.856 1431.491
+   2.227 1358.349
+   2.753 1201.616
+   2.928 1170.27
+   3.0 1065.782
+   3.113 679.175
+   3.247 355.261
+   3.361 177.63
+   3.464 83.591
+   3.67 0.0
+;
+;Input by Tim Van Milligan for RockSim users. Used John Coker's ThrustCruve
+;Tracer program. Thrust curve and engine data from Aerotech thrust stand.
+L1390G 75 517.91 1000 1.973 3.876 AT 
+0.018 906.203
+0.041 1249.41
+0.055 1336.72
+0.099 1369.84
+0.173 1402.96
+0.236 1411.99
+0.284 1411.99
+0.678 1586.61
+0.869 1649.83
+0.939 1640.8
+1.102 1625.74
+1.197 1628.76
+1.293 1619.72
+1.374 1607.68
+1.455 1601.66
+1.518 1589.62
+1.592 1550.48
+1.691 1499.3
+1.838 1424.03
+1.96 1366.83
+2.1 1312.64
+2.225 1261.46
+2.343 1228.34
+2.417 1213.29
+2.479 1204.26
+2.524 1198.23
+2.564 1198.23
+2.601 1165.12
+2.638 1074.8
+2.66 957.383
+2.689 839.968
+2.712 713.522
+2.737 590.085
+2.763 427.511
+2.8 295.043
+2.844 153.543
+2.877 69.245
+2.911 0
+;
+; Based on AT Instruction Sheet by C. Kobel  12/22/2010
+L1520T 75 531 P 1.773 3.620 AT
+   0.011 1484.553
+   0.055 1506.304
+   0.089 1468.239
+   0.155 1560.684
+   0.200 1571.559
+   0.300 1582.435
+   0.400 1598.749
+   0.500 1620.501
+   0.600 1642.252
+   0.700 1653.128
+   0.800 1674.88
+   0.900 1691.194
+   1.000 1685.756
+   1.100 1696.632
+   1.200 1691.194
+   1.300 1691.194
+   1.400 1680.318
+   1.500 1664.004
+   1.600 1636.814
+   1.700 1620.501
+   1.800 1604.187
+   1.900 1576.997
+   2.000 1560.684
+   2.100 1538.932
+   2.200 1500.866
+   2.227 1435.611
+   2.250 1125.65
+   2.290 832.002
+   2.366 647.113
+   2.400 456.785
+   2.440 244.706
+   2.500 59.817
+   2.600 0.0
+;
+; Curvefit of Aerotech Instructions by C. Kobel  11/19/08
+L2200G 75 665 0-6-10-14-18 2.516 4.751 AT
+   0.011 1195.177
+   0.024 2029.903
+   0.037 2380.868
+   0.050 2542.122
+   0.100 2570.578
+   0.150 2561.093
+   0.200 2523.151
+   0.250 2485.208
+   0.300 2523.151
+   0.350 2570.578
+   0.400 2674.919
+   0.500 2912.057
+   0.600 3073.311
+   0.700 3073.311
+   0.800 3101.768
+   0.900 3092.282
+   1.000 3092.282
+   1.100 2959.485
+   1.186 2807.716
+   1.227 2437.781
+   1.270 2257.556
+   1.300 2162.701
+   1.400 1991.961
+   1.500 1878.135
+   1.600 1792.765
+   1.700 1688.424
+   1.800 1612.54
+   1.900 1584.083
+   2.000 1536.656
+   2.048 1498.714
+   2.084 1403.858
+   2.102 1166.72
+   2.134 796.784
+   2.186 455.305
+   2.237 237.138
+   2.300 94.855
+   2.400 0.0
+;
+; Entered by Tim Van Milligan. Used John Coker's ThrustCurve Tracer software and
+; data supplied by Aerotech thrust stand data. The total weight is a guess.
+L339N 98 309 4 1.796 4.5 AT
+   0.049 2.884
+   0.074 373.449
+   0.123 399.403
+   0.156 408.054
+   0.279 415.984
+   0.427 417.426
+   0.476 421.031
+   0.509 416.705
+   0.632 415.984
+   0.837 414.542
+   0.894 418.868
+   0.943 405.17
+   1.026 400.124
+   1.124 402.286
+   1.255 397.961
+   1.362 392.914
+   1.51 391.472
+   1.575 394.356
+   1.592 385.705
+   1.657 387.147
+   1.838 384.984
+   2.026 382.821
+   2.174 379.937
+   2.404 377.053
+   2.478 378.495
+   2.552 377.053
+   2.617 378.495
+   2.683 366.96
+   2.773 359.751
+   2.806 363.355
+   2.937 359.751
+   3.232 351.099
+   3.314 355.425
+   3.356 351.099
+   3.815 345.332
+   3.979 340.285
+   4.233 336.681
+   4.414 333.797
+   4.668 330.913
+   4.996 329.471
+   5.39 323.704
+   5.686 320.099
+   5.989 314.331
+   6.178 310.727
+   6.325 306.401
+   6.514 302.075
+   6.621 302.075
+   6.851 297.75
+   7.195 290.54
+   7.277 293.424
+   7.326 287.656
+   7.441 283.331
+   7.49 286.214
+   7.54 283.331
+   7.696 275.4
+   7.81 273.958
+   7.884 276.842
+   7.942 278.284
+   8.015 276.121
+   8.073 270.354
+   8.188 155.003
+   8.212 118.956
+   8.278 54.071
+   8.311 26.675
+   8.352 7.93
+   8.426 0.0
+;
+; Curvefit of AeroTech Instructions by C. Kobel 11/19/08
+M1500G 75 665 0-6-10-14-18 2.631 4.896 AT
+   0.012 1183.8
+   0.023 1614.273
+   0.050 1694.987
+   0.100 1716.511
+   0.150 1694.987
+   0.200 1603.512
+   0.250 1517.417
+   0.300 1490.512
+   0.400 1474.37
+   0.500 1485.132
+   0.600 1512.036
+   0.700 1533.56
+   0.800 1571.226
+   0.900 1608.892
+   1.000 1630.416
+   1.100 1657.321
+   1.200 1684.225
+   1.300 1694.987
+   1.400 1694.987
+   1.500 1700.368
+   1.600 1700.368
+   1.700 1705.749
+   1.800 1689.606
+   1.900 1662.702
+   2.000 1657.321
+   2.100 1608.892
+   2.200 1581.988
+   2.300 1555.083
+   2.400 1522.798
+   2.500 1490.512
+   2.600 1463.608
+   2.700 1431.322
+   2.800 1415.18
+   2.900 1388.275
+   3.000 1361.371
+   3.100 1372.132
+   3.200 1286.038
+   3.250 1226.848
+   3.300 973.945
+   3.400 478.901
+   3.450 220.617
+   3.500 80.714
+   3.600 0.0
+;
+; Entered by Tim Van Milligan. Used John Coker's ThrustCurve Tracer software and
+; data from TRA certification dated 10-14-08
+M1800FJ 98 751 4 5.599 9.162 AT
+   0.021 3007.361
+   0.043 1964.715
+   0.059 1858.322
+   0.069 1766.116
+   0.134 1829.951
+   0.192 1822.858
+   0.267 1822.858
+   0.363 1865.415
+   0.502 1936.344
+   0.582 1922.158
+   0.684 1964.715
+   1.132 2071.107
+   1.581 2149.129
+   1.923 2198.778
+   2.142 2220.057
+   2.393 2220.057
+   2.463 2198.778
+   2.655 2106.572
+   2.831 2007.272
+   2.922 1978.901
+   3.029 1915.065
+   3.21 1808.673
+   3.349 1695.187
+   3.526 1588.795
+   3.723 1439.845
+   3.851 1397.288
+   3.921 1361.824
+   4.017 1255.432
+   4.097 1120.668
+   4.167 978.811
+   4.263 780.212
+   4.327 624.169
+   4.402 453.941
+   4.428 375.92
+   4.482 276.621
+   4.53 177.321
+   4.583 99.3
+   4.653 42.557
+   4.76 21.279
+   4.952 0.0
+;
+;
+M1845 98 597 P 3.7720000000000002 6.682 AT
+   0.024 2261.638
+   0.067 2115.94
+   1.032 2268.261
+   1.354 2433.828
+   2.253 2288.129
+   2.406 2149.053
+   2.578 1821.232
+   3.065 1579.504
+   3.583 1410.627
+   3.838 1364.268
+   3.913 1218.569
+   3.995 685.445
+   4.109 400.671
+   4.352 248.35
+   4.498 33.113
+   4.729 0.0
+;
+; Entered by Tim Van Milligan for RockSim Users. Used John Coker's ThrustCurve
+; Tracer software and TRA cert paperwork dated 10-14-08.
+M2100G 98 597 4 4.03 7.03 AT
+   0.014 72.789
+   0.017 1148.45
+   0.021 1552.833
+   0.038 1593.272
+   0.042 1908.691
+   0.052 2062.357
+   0.077 2151.321
+   0.115 2207.935
+   0.167 2240.285
+   0.223 2256.461
+   0.272 2256.461
+   0.31 2232.198
+   0.415 2280.724
+   0.59 2385.863
+   0.701 2410.126
+   0.876 2507.179
+   0.959 2555.705
+   1.043 2588.055
+   1.176 2677.02
+   1.263 2782.159
+   1.333 2830.685
+   1.437 2846.861
+   1.517 2879.211
+   1.608 2968.176
+   1.667 2943.913
+   1.81 2935.825
+   1.926 2895.387
+   1.999 2846.861
+   2.041 2782.159
+   2.152 2531.442
+   2.393 1949.129
+   2.484 1787.376
+   2.56 1674.148
+   2.738 1504.307
+   2.836 1439.606
+   2.958 1366.817
+   3.091 1285.94
+   3.178 1229.326
+   3.23 1196.976
+   3.283 1180.8
+   3.401 1188.888
+   3.447 1140.362
+   3.478 1035.222
+   3.513 913.907
+   3.516 541.874
+   3.527 444.822
+   3.541 0.0
+;
+; @TI: 14137.65, @TIa: 14071.08, @TIe: 0.0%, @ThMax: 2137.42, @ThAvg: 1048.203, @Tb: 13.424
+; Exported using ThrustCurveTool, www.ThrustGear.com
+N1048 98 1046 P 7.925 12.777 AT
+0.0 0.457288
+0.152 0.314574
+0.162 40.2069
+0.164 148.3954
+0.168 598.904
+0.172 890.058
+0.176 995.096
+0.178 1158.031
+0.182 1342.306
+0.19 1556.716
+0.222 1959.8
+0.234 2050.53
+0.254 2111.01
+0.308 2119.9
+0.356 2073.29
+0.47 2091.07
+0.528 1989.543
+0.582 1825.825
+0.648 1733.526
+0.782 1658.07
+0.892 1701.725
+0.914 1633.231
+0.966 1669.558
+1.7839 1594.076
+1.8239 1551.156
+3.1999 1533.43
+5.4538 1378.986
+6.9577 1170.933
+10.9216 424.692
+13.5895 106.0499
+14.6754 12.60914
+16.1354 0.0
+;
+;
+N3300 98 1046 P 7.5120000000000005 12.054 AT
+   0.0070 2069.581
+   0.025 2444.865
+   0.298 2654.583
+   0.852 3068.499
+   1.197 3576.236
+   1.502 3841.143
+   1.719 3929.445
+   2.007 4188.832
+   2.419 4172.276
+   2.753 3885.294
+   3.193 3278.217
+   3.552 2847.744
+   3.786 2665.621
+   3.871 2345.525
+   4.003 866.465
+   4.092 209.718
+   4.18 0.0
+;
+; Pro29-1G 56F120-VM 14A
+F120-VM 29 98 14-11-9-7-5 0.0314 0.1062 CTI
+   0.013 79.242
+   0.017 90.427
+   0.04 101.422
+   0.125 127.583
+   0.179 136.114
+   0.222 139.905
+   0.289 143.507
+   0.354 138.578
+   0.394 125.498
+   0.406 123.602
+   0.416 125.118
+   0.423 130.047
+   0.431 120.569
+   0.447 25.592
+   0.453 8.72
+   0.455 0.0
+;
+; Pro-24-3G VMax
+F240-VM-15A 24 133 3-5-6-8-9-10 0.0303 0.0918 CTI
+   0.0040 100.528
+   0.0070 197.493
+   0.01 222.032
+   0.022 241.425
+   0.028 237.863
+   0.041 239.446
+   0.058 252.507
+   0.077 263.984
+   0.089 275.462
+   0.097 271.504
+   0.104 273.879
+   0.119 278.628
+   0.147 281.398
+   0.177 272.296
+   0.207 258.443
+   0.246 226.385
+   0.253 218.47
+   0.259 188.786
+   0.266 127.045
+   0.272 74.802
+   0.28 31.266
+   0.286 15.831
+   0.294 8.707
+   0.31 3.562
+   0.328 0.0
+;
+; Pro29-1G 55F29-IM 12A
+F29-IM 29 98 12-9-7-5-3 0.0376 0.1058 CTI
+   0.0060 5.661
+   0.038 23.312
+   0.05 26.309
+   0.229 30.257
+   0.327 32.208
+   0.485 33.159
+   1.031 31.78
+   1.516 27.07
+   1.688 24.834
+   1.765 20.172
+   1.852 9.467
+   1.963 2.093
+   2.0 0.0
+;
+; Pro-24-3G White Long Burn
+F30-WH_LB-6A 24 133 2-3-5-6 0.04 0.1022 CTI
+   0.014 54.222
+   0.056 43.456
+   0.092 50.185
+   0.16 54.063
+   0.232 48.364
+   0.363 45.752
+   0.499 43.14
+   0.655 40.29
+   0.843 37.836
+   1.216 32.612
+   1.368 30.317
+   1.54 26.359
+   1.675 23.509
+   1.861 19.077
+   2.013 14.565
+   2.159 10.053
+   2.302 4.828
+   2.462 1.504
+   2.598 0.0
+;
+;
+F36-SS 29 98 2-4-6-8-11 0.035 0.104 CTI 
+0.01 12
+0.02 46
+0.03 75
+0.04 79
+0.06 77
+0.07 62
+0.08 32
+0.1 35
+0.2 38
+0.3 39
+0.4 41
+0.5 43
+0.6 43
+0.7 43
+0.8 43
+0.85 47
+0.92 54
+0.95 32
+0.99 8
+1.05 0
+;
+;
+F36-BS 29 98 5-7-9-11-14 0.032 0.101 CTI 
+0.01 12
+0.02 25
+0.03 41
+0.04 42
+0.05 42
+0.06 40
+0.07 34
+0.08 34
+0.09 35
+0.1 36
+0.2 40
+0.3 42
+0.4 43
+0.5 43
+0.6 43
+0.7 43
+0.8 42
+0.9 41
+1 40
+1.1 38
+1.24 37
+1.3 12
+1.4 2
+1.5 0
+;
+;
+F59-WT 29 98 3-5-7-9-12 0.031 0.099 CTI 
+0.01 16
+0.02 62
+0.03 67
+0.04 71
+0.07 58
+0.1 63
+0.2 67
+0.3 69
+0.4 67
+0.5 65
+0.6 63
+0.7 61
+0.87 60
+0.9 23
+0.97 0
+;
+; Pro-24-3G Smoky Sam
+F79-SS-13A 24 133 4-6-7-9-11 0.0401 0.1075 CTI
+   0.0050 60.0
+   0.013 89.007
+   0.022 96.291
+   0.043 81.722
+   0.119 85.563
+   0.198 87.947
+   0.267 89.272
+   0.343 89.934
+   0.404 90.861
+   0.498 91.523
+   0.555 89.669
+   0.622 83.974
+   0.663 80.53
+   0.704 78.94
+   0.729 74.172
+   0.747 66.887
+   0.768 53.775
+   0.793 36.556
+   0.821 18.543
+   0.852 7.815
+   0.892 2.119
+   0.928 0.795
+   0.997 0.0
+;
+;
+G106-SK 29 187 5-7-9-11-14 0.081 0.187 CTI 
+0.018 20
+0.023 80
+0.03 131
+0.05 105
+0.065 75
+0.1 94
+0.25 104
+0.4 111
+0.65 120
+0.86 123
+1.05 124
+1.13 121
+1.17 110
+1.2 85
+1.23 40
+1.25 20
+1.3 5
+1.36 0
+;
+; Pro-24-6G White/Dual Thrust
+G107-WH_DT-12A 24 228 3-5-6-8-9-10 0.0757 0.1698 CTI
+   0.0060 133.228
+   0.011 198.418
+   0.022 221.835
+   0.046 212.658
+   0.081 218.354
+   0.125 214.873
+   0.168 210.443
+   0.219 204.43
+   0.253 195.886
+   0.274 183.544
+   0.305 88.291
+   0.412 93.671
+   0.529 93.987
+   0.663 94.304
+   0.789 93.987
+   0.899 91.139
+   0.953 89.873
+   0.999 87.025
+   1.03 81.329
+   1.057 69.937
+   1.102 54.114
+   1.154 42.405
+   1.197 31.646
+   1.277 17.089
+   1.335 9.81
+   1.398 3.165
+   1.451 0.0
+;
+; Pro-24-6G White
+G117-WH-11A 24 228 4-6-8-9-10 0.0791 0.1725 CTI
+   0.0080 168.643
+   0.013 177.339
+   0.022 177.866
+   0.035 171.278
+   0.063 157.839
+   0.103 154.941
+   0.151 151.515
+   0.196 148.88
+   0.246 147.563
+   0.311 144.137
+   0.391 140.711
+   0.474 138.076
+   0.564 135.705
+   0.662 131.225
+   0.762 125.955
+   0.858 116.733
+   0.928 101.713
+   0.973 83.004
+   1.038 57.444
+   1.08 42.688
+   1.131 31.884
+   1.185 17.655
+   1.224 9.486
+   1.258 5.27
+   1.322 2.372
+   1.4 0.791
+   1.441 0.0
+;
+;
+G118-BS 29 187 6-8-10-12-15 0.083 0.188 CTI 
+0.005 1.3
+0.012 80
+0.02 156
+0.04 148
+0.05 105
+0.11 121
+0.3 131
+0.5 134
+0.7 130
+0.95 126
+1.13 126
+1.18 115
+1.27 40
+1.31 20
+1.35 6
+1.37 0
+;
+; Pro29 3G 159G125-RL 14A
+G125-RL 29 187 14-11-9-7-5 0.0896 0.1945 CTI
+   0.0040 15.683
+   0.022 170.834
+   0.039 116.877
+   0.122 142.642
+   0.236 149.737
+   0.589 142.642
+   0.801 131.253
+   1.068 122.104
+   1.118 107.915
+   1.145 78.416
+   1.174 43.129
+   1.211 21.471
+   1.247 8.775
+   1.299 0.0
+;
+;
+G126-WT 29 142 4-6-8-10-13 0.059 0.145 CTI 
+0.01 55
+0.02 168
+0.03 157
+0.04 148
+0.05 125
+0.1 135
+0.2 141
+0.3 142
+0.4 141
+0.6 133
+0.75 127
+0.81 128
+0.86 60
+0.9 15
+0.95 0
+;
+;
+G131-SS 29 187 5-7-9-11-14 0.094 0.2 CTI 
+0.01 6
+0.02 40
+0.03 116
+0.04 131
+0.05 146
+0.06 147
+0.07 140
+0.08 136
+0.09 130
+0.1 126
+0.2 129
+0.3 132
+0.4 137
+0.5 139
+0.6 141
+0.7 142
+0.8 145
+0.85 150
+0.87 155
+0.9 116
+0.93 60
+0.95 30
+1 3
+1.1 0
+;
+; Pro-24-6G Blue Streak
+G150-BS-13A 24 228 4-6-8-9-11-12 0.0659 0.1599 CTI
+   0.0050 114.776
+   0.0060 177.441
+   0.01 222.625
+   0.016 243.404
+   0.019 247.032
+   0.037 215.369
+   0.077 206.135
+   0.12 204.485
+   0.163 200.198
+   0.204 195.91
+   0.249 192.942
+   0.316 186.675
+   0.387 180.409
+   0.444 176.121
+   0.536 168.206
+   0.616 160.62
+   0.639 156.662
+   0.676 142.48
+   0.715 114.776
+   0.75 93.008
+   0.784 72.23
+   0.831 49.802
+   0.889 31.662
+   0.923 21.768
+   0.953 14.842
+   0.996 8.245
+   1.03 5.937
+   1.061 2.309
+   1.099 0.0
+;
+; Pro29-2G 110G250-VM 14A
+G250-VM 29 142 14-11-9-7-5 0.0575 0.1413 CTI
+   0.0060 151.621
+   0.011 198.079
+   0.016 203.121
+   0.031 201.681
+   0.075 226.17
+   0.122 250.3
+   0.216 280.192
+   0.25 287.035
+   0.287 284.874
+   0.354 269.748
+   0.374 258.583
+   0.4 233.373
+   0.413 234.094
+   0.42 227.611
+   0.433 137.935
+   0.445 33.854
+   0.454 0.0
+;
+;
+G50-IM 38 127 6-8-11-12-15 0.0777 0.218 CTI
+0.02 10
+0.04 58
+0.052 72
+0.07 65
+0.106 43
+0.23 51
+0.4 55
+0.85 57
+1.5 55
+2 51
+2.5 44.5
+2.78 44
+2.86 37
+2.93 20
+3.02 0
+;
+; Pro29-3G 159G54-RL 12A
+G54-RL 29 187 12-9-7-5-3 0.0968 0.1982 CTI
+   0.018 107.269
+   0.031 113.588
+   0.059 103.508
+   0.135 121.712
+   0.22 104.561
+   0.299 95.534
+   0.432 88.312
+   0.959 69.657
+   1.757 43.479
+   2.418 20.762
+   2.851 9.478
+   3.013 5.567
+   3.026 0.0
+;
+;
+G57-CL 29 142 3-5-7-9-12 0.059 0.146 CTI 
+0.01 8
+0.02 70
+0.04 88
+0.05 80
+0.06 71
+0.08 76
+0.11 79
+0.2 81
+0.6 72
+1 56
+1.5 47
+1.6 48
+1.7 28
+1.8 14
+1.9 3
+1.93 0
+;
+; Pro-38-1G White
+G58-WH-13A 38 127 5-7-8-10-12-13 0.0763 0.2125 CTI
+   0.029 90.25
+   0.046 69.17
+   0.058 59.947
+   0.084 47.167
+   0.171 57.971
+   0.28 59.552
+   0.455 61.265
+   0.586 61.66
+   0.741 62.319
+   0.952 63.768
+   1.217 64.69
+   1.43 63.768
+   1.626 61.265
+   1.807 58.103
+   1.959 53.887
+   2.104 48.353
+   2.168 47.563
+   2.21 44.005
+   2.247 37.286
+   2.329 22.266
+   2.375 10.277
+   2.414 2.767
+   2.442 1.186
+   2.5 0.0
+;
+; Cesaroni G60
+; converted from TMT test stand data 2002 (www.tripoli.org)
+; provided by ThrustCurve.org (www.thrustcurve.org)
+G60 38 125 0 0.077056 0.2016 CTI
+   0.043 65.216
+   0.130 74.906
+   0.218 84.596
+   0.305 83.963
+   0.393 81.982
+   0.480 81.956
+   0.568 81.138
+   0.655 80.530
+   0.743 79.923
+   0.830 78.867
+   0.918 76.675
+   1.005 75.118
+   1.094 73.732
+   1.182 71.315
+   1.270 68.781
+   1.357 66.853
+   1.445 65.111
+   1.532 63.526
+   1.620 61.229
+   1.707 59.249
+   1.795 57.110
+   1.882 51.671
+   1.970 18.562
+   2.057 2.667
+   2.146 1.470
+   2.234 0.000
+;
+; Pro-24-6G White Long Burn
+G65-WH_LB-8A 24 228 3-5-6-7 0.08 0.1740 CTI
+   0.011 157.857
+   0.024 149.524
+   0.042 132.143
+   0.057 125.476
+   0.094 134.048
+   0.122 131.19
+   0.175 106.429
+   0.269 94.048
+   0.376 87.381
+   0.54 82.143
+   0.707 78.333
+   0.845 74.762
+   1.002 71.19
+   1.206 65.476
+   1.376 57.857
+   1.553 48.333
+   1.726 39.048
+   1.914 28.333
+   2.061 18.095
+   2.205 8.571
+   2.299 3.095
+   2.398 0.0
+;
+; Pro-29-2G White
+G68-WH-13A 29 142 5-6-7-9-10-11 0.0599 0.1559 CTI
+   0.012 50.329
+   0.017 79.315
+   0.019 86.693
+   0.03 91.831
+   0.047 73.386
+   0.048 81.686
+   0.049 65.876
+   0.061 58.235
+   0.088 66.798
+   0.12 70.883
+   0.2 72.991
+   0.307 75.099
+   0.38 75.626
+   0.487 76.416
+   0.614 76.548
+   0.726 75.626
+   0.818 73.518
+   0.987 70.487
+   1.096 68.116
+   1.269 63.505
+   1.388 61.528
+   1.446 57.444
+   1.483 49.144
+   1.537 29.381
+   1.569 18.05
+   1.613 5.665
+   1.638 2.899
+   1.676 1.449
+   1.723 0.395
+   1.759 0.0
+;
+; CTI Pro38-1G 117 G69SK - 14A
+G69SK 38 126 14-11-9-7-5 0.067 0.198 CTI
+   0.015 49.371
+   0.023 79.41
+   0.035 91.872
+   0.064 82.605
+   0.099 52.407
+   0.166 57.041
+   0.228 59.278
+   0.375 64.231
+   1.297 69.024
+   1.453 68.864
+   1.533 67.746
+   1.589 65.189
+   1.686 58.639
+   1.735 42.821
+   1.781 26.363
+   1.816 13.901
+   1.89 5.432
+   1.954 1.278
+   1.969 0.0
+;
+;CTI Pro38-1G 141 G78BS - 15A
+G78BS 38 126 15-12-10-8-6 0.069 0.197 CTI 
+0.006 104.068
+0.018 137.928
+0.036 70.707
+0.047 62.242
+0.084 73.694
+0.135 78.176
+0.238 84.151
+0.438 89.628
+0.63 88.135
+0.859 87.139
+1.283 77.18
+1.447 70.707
+1.643 67.719
+1.713 64.234
+1.743 54.275
+1.79 18.424
+1.818 6.473
+1.852 0
+;
+; Pro29-3G 93G80-SK 14A
+G80-SK 29 142 14-11-9-7-5 0.0564 0.1432 CTI
+   0.0070 51.315
+   0.025 108.143
+   0.047 65.31
+   0.122 78.032
+   0.307 89.059
+   0.446 93.865
+   0.581 95.137
+   0.75 91.886
+   0.924 84.252
+   0.972 83.404
+   1.038 88.352
+   1.064 67.147
+   1.08 40.43
+   1.093 21.629
+   1.11 9.754
+   1.131 2.545
+   1.178 0.0
+;
+;
+G83-BS 29 142 5-7-9-11-14 0.058 0.145 CTI 
+0.01 13
+0.02 82
+0.03 98
+0.04 100
+0.05 90
+0.06 86
+0.12 93
+0.2 96
+0.3 96
+0.7 92
+0.9 88
+1.07 83
+1.1 80
+1.2 30
+1.3 4
+1.33 0
+;
+; Pro-24-6G Green3
+G84-GR-10A 24 228 4-5-7-8-9 0.0773 0.1720 CTI
+   0.0050 80.264
+   0.017 94.69
+   0.023 108.745
+   0.031 124.835
+   0.044 129.828
+   0.081 124.28
+   0.149 116.513
+   0.224 111.149
+   0.301 107.635
+   0.386 103.382
+   0.506 98.203
+   0.623 94.135
+   0.759 89.696
+   0.849 85.997
+   0.974 81.374
+   1.09 77.86
+   1.149 74.716
+   1.171 78.97
+   1.202 70.832
+   1.244 69.168
+   1.3 68.243
+   1.326 56.777
+   1.373 52.523
+   1.403 40.687
+   1.447 29.036
+   1.515 14.425
+   1.562 6.103
+   1.597 2.034
+   1.641 0.0
+;
+;
+G88-SS 29 142 2-4-6-8-11 0.064 0.152 CTI 
+0.03 7
+0.04 60
+0.05 90
+0.06 113
+0.07 116
+0.08 113
+0.1 86
+0.12 81
+0.15 86
+0.3 92
+0.4 95
+0.5 97
+0.75 100
+0.82 108
+0.84 106
+0.9 56
+0.93 25
+1 0
+;
+;
+H100-IM 38 186 6-8-11-12-15 0.1544 0.327 CTI
+0.016 68
+0.056 116
+0.09 118
+0.14 115
+0.5 116
+0.6 114
+1.25 113
+2.32 99
+2.44 100
+2.55 89
+2.77 0
+;
+; Pro-38-2G White
+H110-WH-14A 38 186 5-7-9-11-13-14 0.1526 0.3253 CTI
+   0.029 93.733
+   0.052 118.066
+   0.093 98.531
+   0.153 109.327
+   0.238 113.439
+   0.461 118.923
+   0.592 120.979
+   0.72 122.693
+   0.896 124.406
+   1.15 124.92
+   1.246 122.521
+   1.461 119.608
+   1.622 117.381
+   1.79 115.667
+   1.922 112.583
+   2.114 112.754
+   2.174 111.726
+   2.21 98.874
+   2.259 69.4
+   2.319 47.466
+   2.365 28.96
+   2.441 12.166
+   2.526 7.368
+   2.597 2.228
+   2.692 0.0
+;
+;
+H118-CL 29 231 3-5-7-9-12 0.111 0.232 CTI 
+0.01 7
+0.02 144
+0.04 183
+0.06 182
+0.08 176
+0.09 173
+0.1 172
+0.2 160
+0.4 147
+0.5 142
+0.7 134
+0.8 127
+1 121
+1.1 118
+1.2 115
+1.4 109
+1.5 104
+1.6 75
+1.7 31
+1.8 13
+1.9 0
+;
+;Pro-38 Red Lightning 2 Grain reload
+H120-14A 38 186 14-11-9-7-5 0.1366 0.295 CTI 
+0.016 53.023
+0.029 107.113
+0.036 124.55
+0.049 129.532
+0.062 117.789
+0.072 98.217
+0.131 123.838
+0.199 136.649
+0.258 144.122
+0.313 147.681
+0.369 146.257
+0.441 145.19
+0.558 143.411
+0.683 141.631
+0.777 140.92
+0.859 139.14
+0.98 136.293
+1.097 133.091
+1.251 128.82
+1.434 122.771
+1.558 118.856
+1.639 117.077
+1.731 117.077
+1.884 117.077
+1.927 105.334
+1.959 88.964
+1.995 68.325
+2.031 41.991
+2.083 18.505
+2.142 6.761
+2.181 2.135
+2.24 0
+;
+;
+H123-SK-29mm 29 231 3-5-7-9-12 0.106 0.228 CTI 
+0.021 10
+0.028 139
+0.055 139
+0.075 108
+0.13 120
+0.35 132
+0.65 140
+1 144
+1.15 143
+1.22 145
+1.35 23
+1.53 0
+;
+; Entered by Tim Van Milligan for RockSim users. Used ThrustCurve Tracer by John
+; Coker. Data from CAR web site.
+H123-38mm 38 186 14 0.123 0.297 CTI
+   0.02 143.233
+   0.039 136.193
+   0.057 141.067
+   0.061 138.088
+   0.072 95.308
+   0.084 86.644
+   0.112 108.575
+   0.17 113.72
+   0.243 120.76
+   0.327 125.904
+   0.413 130.236
+   0.487 134.839
+   0.699 142.15
+   0.71 142.42
+   0.765 143.503
+   0.812 142.691
+   0.871 148.377
+   0.888 143.774
+   0.914 144.586
+   0.949 144.857
+   0.99 141.879
+   1.033 145.399
+   1.072 145.399
+   1.112 144.045
+   1.143 142.42
+   1.182 144.316
+   1.241 142.691
+   1.307 141.608
+   1.387 138.63
+   1.448 135.651
+   1.499 133.485
+   1.552 129.965
+   1.577 131.59
+   1.605 131.59
+   1.634 132.402
+   1.652 132.402
+   1.669 129.153
+   1.685 121.843
+   1.699 108.575
+   1.744 61.463
+   1.775 27.347
+   1.822 14.892
+   1.869 7.581
+   1.912 1.895
+   1.939 0.0
+;
+;
+H125-TamedTiger 38 186 3-5-7-9-12 0.1380 0.293 CTI    
+0.01 1.252
+0.02 2.921
+0.03 9.635
+0.04 78.025
+0.05 128.019
+0.06 139.095
+0.07 98.5463
+0.08 93.122
+0.09 98.0152
+0.1 102.947
+0.2 128.398
+0.3 135.947
+0.4 140.309
+0.5 145.961
+0.6 148.616
+0.7 149.906
+0.8 150.589
+0.9 152.675
+1.0 154.078
+1.1 153.471
+1.2 151.992
+1.3 151.537
+1.4 146.757
+1.5 145.961
+1.6 141.371
+1.7 139.209
+1.8 133.595
+1.9 70.7805
+2.0 18.4726
+2.1 4.58967
+2.15 0.0
+;
+;
+H133-BS 29 187 5-7-9-11-14 0.085 0.19 CTI 
+0.01 10
+0.017 100
+0.023 190
+0.028 200
+0.042 140
+0.05 135
+0.12 152
+0.35 154
+1 135
+1.065 110
+1.2 25
+1.28 0
+;
+; Pro-29-4G White
+H135-WH-12A 29 231 3-5-7-8-10-11 0.1198 0.2512 CTI
+   0.012 166.804
+   0.054 158.622
+   0.101 155.718
+   0.156 153.079
+   0.223 151.496
+   0.312 150.44
+   0.566 150.968
+   0.706 149.12
+   0.946 143.842
+   1.121 140.411
+   1.222 136.452
+   1.278 136.979
+   1.341 131.437
+   1.374 126.686
+   1.4 117.185
+   1.431 100.029
+   1.482 71.261
+   1.535 49.355
+   1.558 30.88
+   1.598 11.877
+   1.62 5.015
+   1.644 2.375
+   1.676 0.0
+;
+;
+H140-CL 29 276 2-4-6-8-11 0.139 0.277 CTI 
+0.015 30
+0.025 240
+0.04 245
+0.09 220
+0.2 200
+0.4 185
+0.8 160
+1.4 140
+1.49 100
+1.63 50
+1.75 35
+1.9 12
+2.05 0
+;
+; Pro29-4G 207H151-RL 15A
+H151-RL 29 231 15-12-10-8-6 0.118 0.238 CTI
+   0.0080 125.295
+   0.021 209.602
+   0.052 160.928
+   0.118 186.779
+   0.293 190.738
+   0.465 183.518
+   0.683 171.641
+   0.988 145.557
+   1.133 134.145
+   1.221 74.292
+   1.293 29.81
+   1.372 10.014
+   1.398 6.521
+   1.4 0.0
+;
+;
+H152BS 38 186 15-12-10-8-6 0.138 0.298 CTI
+   0.018 212.503
+   0.051 207.443
+   0.059 153.052
+   0.077 153.052
+   0.099 163.172
+   0.139 166.966
+   0.168 174.556
+   0.223 173.291
+   0.256 175.821
+   0.304 175.821
+   0.396 179.615
+   0.538 175.821
+   0.659 174.556
+   0.714 174.556
+   0.758 174.556
+   0.802 170.761
+   0.89 172.026
+   0.974 165.701
+   1.022 168.231
+   1.084 163.172
+   1.212 155.582
+   1.293 151.788
+   1.385 146.728
+   1.447 149.258
+   1.484 144.198
+   1.531 145.463
+   1.575 144.198
+   1.601 137.874
+   1.615 134.079
+   1.623 120.165
+   1.663 82.218
+   1.714 46.801
+   1.766 34.152
+   1.788 30.358
+   1.821 26.563
+   1.828 0.0
+;
+; Pro29-6G 298H159-GR 15A
+H159-GR 29 320 15-12-10-8-6 0.1874 0.3428 CTI
+   0.012 117.276
+   0.032 158.638
+   0.103 177.806
+   0.171 184.868
+   0.299 185.372
+   0.511 178.058
+   0.717 179.319
+   1.272 162.926
+   1.424 159.647
+   1.519 152.585
+   1.584 149.811
+   1.632 146.28
+   1.727 89.281
+   1.768 109.962
+   1.834 25.977
+   1.865 10.593
+   1.887 0.0
+;
+;
+H160-CL 29 320 3-5-7-9-12 0.166 0.319 CTI 
+0.015 10
+0.022 260
+0.04 316
+0.1 280
+0.25 241
+0.6 201
+1 175
+1.27 165
+1.35 140
+1.45 100
+1.65 48
+1.85 25
+2.2 0
+;
+;
+H160-SK 29 276 5-7-9-11-14 0.132 0.272 CTI 
+0.01 10
+0.02 160
+0.03 185
+0.09 170
+0.25 168
+0.5 176
+0.9 184
+1.1 185
+1.16 180
+1.31 28
+1.383 0
+;
+;
+H163-WT 29 187 5-7-9-11-14 0.086 0.187 CTI 
+0.018 10
+0.026 225
+0.055 165
+0.1 170
+0.2 175
+0.35 180
+0.9 175
+0.95 100
+0.98 45
+1.062 0
+;
+;
+H170-BS 29 231 5-7-9-11-14 0.111 0.232 CTI 
+0.01 150
+0.015 200
+0.025 240
+0.075 210
+0.13 205
+0.35 204
+0.7 205
+0.8 190
+0.9 185
+0.99 173
+1.1 60
+1.22 25
+1.34 0
+;
+;
+H175-SS 29 231 5-7-9-11-14 0.122 0.247 CTI 
+0.021 13
+0.032 175
+0.057 215
+0.08 180
+0.13 175
+0.4 185
+0.6 190
+0.76 195
+0.84 236
+0.88 150
+0.92 30
+1 0
+;
+;
+H180-SK 29 320 5-7-9-11-14 0.158 0.314 CTI 
+0.01 10
+0.02 250
+0.03 270
+0.07 239
+0.13 227
+0.35 218
+0.6 216
+0.8 207
+0.98 208
+1.06 204
+1.15 135
+1.23 65
+1.4 12
+1.56 0
+;
+; Pro29-5G 260H194-RL 14A
+H194-RL 29 276 14-11-9-7-5 0.145 0.284 CTI
+   0.0060 179.792
+   0.011 244.07
+   0.021 285.99
+   0.049 204.944
+   0.117 233.823
+   0.181 241.275
+   0.386 236.152
+   0.98 193.765
+   1.075 170.476
+   1.136 144.392
+   1.19 80.58
+   1.285 22.823
+   1.347 0.0
+;
+;
+H200-BS 29 276 5-7-9-11-14 0.136 0.274 CTI 
+0.01 40
+0.018 280
+0.026 295
+0.06 250
+0.15 236
+0.65 235
+0.8 227
+0.9 212
+0.98 205
+1.09 135
+1.2 68
+1.3 20
+1.4 0
+;
+;
+H226-SK 29 365 5-7-9-11-14 0.175 0.360 CTI
+0.007 9
+0.012 178
+0.017 320
+0.023 362
+0.047 319
+0.08 302
+0.14 291
+0.615 276
+0.95 257.5
+1 215
+1.077 105
+1.18 81
+1.29 31
+1.34 16
+1.5 0
+;
+; Pro29 6G 311H233-RL 14A
+H233-RL 29 320 14-11-9-7-5 0.1738 0.3276 CTI
+   0.0040 98.643
+   0.01 263.822
+   0.018 348.041
+   0.051 263.822
+   0.156 299.185
+   0.82 262.426
+   0.988 228.46
+   1.05 214.501
+   1.111 142.38
+   1.17 84.218
+   1.242 49.321
+   1.331 17.681
+   1.399 0.0
+;
+;
+H237-SS 29 276 4-6-8-10-13 0.151 0.294 CTI 
+0.026 10
+0.028 154
+0.033 238
+0.055 270
+0.07 234
+0.71 259
+0.78 296
+0.8 280
+0.87 50
+0.9 10
+0.937 0
+;
+;
+H255-BS 29 320 5-7-9-11-14 0.162 0.318 CTI 
+0.015 10
+0.018 260
+0.024 404
+0.03 412
+0.047 375
+0.08 340
+0.2 316
+0.4 303
+0.6 295
+0.87 285
+0.93 273
+1 200
+1.1 80
+1.252 0
+;
+;
+H255-WT 29 231 5-7-9-11-14 0.113 0.232 CTI 
+0.018 10
+0.023 345
+0.039 325
+0.05 276
+0.13 287
+0.35 292
+0.75 259
+0.78 265
+0.87 40
+0.936 0
+;
+;
+H295-SS 29 320 4-6-8-10-13 0.181 0.342 CTI 
+0.03 15
+0.031 320
+0.05 355
+0.075 325
+0.13 312
+0.35 315
+0.66 327
+0.72 368
+0.75 370
+0.78 290
+0.8 150
+0.85 25
+0.925 0
+;
+;
+H340-SS 29 365 5-7-9-11-14 0.2067 0.391 CTI
+0.017 6
+0.024 255
+0.0311 395
+0.035 423
+0.043 447.5
+0.06 398
+0.064 389
+0.075 397.5
+0.25 388
+0.4 382
+0.542 376
+0.62 379
+0.66 400
+0.68 407
+0.705 398
+0.74 248
+0.8 59.5
+0.85 8
+0.9 0
+;
+;
+H399-WT 29 320 3-5-7-9-12 0.14 0.294 CTI 
+0.015 10
+0.02 320
+0.024 555
+0.05 490
+0.075 475
+0.1 468
+0.2 463
+0.53 451
+0.55 460
+0.575 400
+0.64 200
+0.685 25
+0.71 0
+;
+; Pro-29-3G White Long Burn
+H54-WH_LB-10A 29 187 3-5-7-8-9 0.0966 0.209 CTI
+   0.017 103.061
+   0.047 83.272
+   0.088 91.821
+   0.155 97.836
+   0.199 89.288
+   0.271 80.264
+   0.406 76.623
+   0.599 73.773
+   0.898 69.024
+   1.182 66.016
+   1.475 60.475
+   1.785 53.826
+   2.099 44.802
+   2.296 38.945
+   2.577 27.546
+   2.845 16.148
+   3.097 6.491
+   3.199 2.058
+   3.298 1.108
+   3.5 0.0
+;
+;
+H87-IM 29 187 3-5-7-9-12 0.0927 0.205 CTI
+0.018 5
+0.027 73
+0.032 139.2
+0.048 117
+0.056 87
+0.081 95
+0.147 101
+0.336 103
+0.52 101
+1.6 83
+1.686 81
+1.72 79
+1.778 60
+1.82 38
+1.94 0
+;
+;
+H90-CL 29 187 3-5-7-9-12 0.084 0.19 CTI 
+0.021 10
+0.028 154
+0.055 155
+0.075 108
+0.13 120
+0.35 115
+1.4 83
+1.48 84
+1.56 73
+1.69 22
+1.76 8
+1.85 0
+;
+; Pro-54-2G Red Lightning Long Burn
+I100-RL_LB-17A 54 236 9-11-12-13-15-17 0.3501 0.807 CTI
+   0.042 269.267
+   0.043 332.429
+   0.07 225.102
+   0.091 202.307
+   0.14 234.125
+   0.202 245.522
+   0.349 220.828
+   0.523 202.307
+   0.837 183.311
+   1.186 164.315
+   1.681 139.62
+   2.358 110.651
+   3.321 76.459
+   4.095 55.563
+   4.919 37.042
+   5.944 21.37
+   6.726 12.347
+   7.437 6.174
+   8.142 2.849
+   8.735 0.95
+   8.993 0.0
+;
+; Pro54-1G 502I120-IM 15A
+I120-IM 54 143 15-14-13-12-11-10-9-8-7-6-5 0.3 0.6232000000000001 CTI
+   0.035 13.687
+   0.047 87.183
+   0.067 148.493
+   0.096 129.744
+   0.212 141.931
+   0.385 142.118
+   0.671 141.743
+   1.032 139.681
+   1.545 136.868
+   2.15 127.869
+   3.757 92.433
+   4.031 89.058
+   4.122 67.122
+   4.216 23.436
+   4.283 5.25
+   4.3 0.0
+;
+; CTI Pro54-1G 465 I150BS 11A
+I150BS 54 153 11-10-9-8-7-6-5-4-3-2-1 0.226 0.5700000000000001 CTI
+   0.017 11.039
+   0.039 103.397
+   0.045 164.846
+   0.065 179.932
+   0.09 153.439
+   0.166 162.638
+   0.194 161.902
+   0.303 169.261
+   0.483 171.837
+   0.666 173.309
+   0.834 171.469
+   1.275 168.525
+   1.725 156.015
+   2.559 128.05
+   2.77 122.53
+   2.899 118.851
+   2.978 119.219
+   3.003 99.349
+   3.034 82.791
+   3.087 66.233
+   3.16 19.502
+   3.208 0.0
+;
+; Cesaroni I170
+; converted from TMT test stand data 2002 (www.tripoli.org)
+; provided by ThrustCurve.org (www.thrustcurve.org)
+I170 38 242 0 0.209216 0.404992 CTI
+   0.044 133.251
+   0.134 230.114
+   0.226 224.136
+   0.318 223.695
+   0.409 223.888
+   0.501 225.265
+   0.593 226.670
+   0.684 229.397
+   0.775 231.998
+   0.866 233.034
+   0.957 233.144
+   1.049 232.703
+   1.141 231.574
+   1.232 227.745
+   1.324 225.844
+   1.416 221.160
+   1.506 217.396
+   1.597 211.711
+   1.689 205.678
+   1.780 198.020
+   1.872 125.016
+   1.964 61.847
+   2.055 23.279
+   2.147 2.066
+   2.239 0.799
+   2.330 0.000
+;
+; Pro38-3G White
+I175-WH-14A 38 245 6-8-9-11-12-13 0.22890000000000002 0.4375 CTI
+   0.019 149.422
+   0.038 180.347
+   0.052 166.763
+   0.106 184.971
+   0.148 187.572
+   0.232 187.861
+   0.338 189.017
+   0.518 190.751
+   0.604 192.197
+   0.733 193.353
+   0.877 195.087
+   1.005 193.931
+   1.128 193.353
+   1.333 193.064
+   1.495 190.751
+   1.648 188.15
+   1.79 183.526
+   1.921 178.035
+   2.001 178.324
+   2.043 176.59
+   2.089 151.156
+   2.147 115.318
+   2.212 70.231
+   2.274 47.11
+   2.32 22.832
+   2.368 8.671
+   2.396 3.757
+   2.435 3.179
+   2.5 0.0
+;
+;
+I204-IM 29 320 4-6-8-10-13 0.194 0.349 CTI 
+0.01 100
+0.012 395
+0.03 310
+0.3 286
+0.5 270
+0.7 251
+1 228
+1.1 215
+1.2 165
+1.3 125
+1.4 95
+1.5 52
+1.6 36
+1.72 0
+;
+;
+I216-CL(I) 38 367 5-7-9-11-14 0.3125 0.601 CTI
+0.017 35
+0.03 300
+0.035 345
+0.05 325
+0.07 275
+0.14 292
+0.26 296
+0.8 280
+1.1 280.4
+1.62 255
+1.8 226
+2.105 210
+2.2 195
+2.45 80
+2.75 36
+3.1 0
+;
+; CTI Pro54-1G 491 I218WT - 14A
+I218WT 54 153 14-13-12-11-10-9-8-7-6-5-4 0.23 0.58 CTI
+   0.01 12.222
+   0.022 129.788
+   0.047 215.926
+   0.072 250.846
+   0.079 208.36
+   0.11 233.968
+   0.188 249.1
+   0.436 263.651
+   0.783 258.994
+   1.195 235.714
+   1.614 201.375
+   1.834 191.481
+   1.964 183.915
+   2.074 178.095
+   2.143 179.841
+   2.172 87.884
+   2.188 50.053
+   2.217 18.624
+   2.252 0.0
+;
+; CTI Pro38-4G 434 I223 Skidmark 14A
+I223SK 38 302 5-7-9-11-14 0.266 0.494 CTI
+   0.016 199.183
+   0.024 260.157
+   0.07 207.313
+   0.148 227.637
+   0.425 244.71
+   0.721 254.466
+   1.015 256.905
+   1.3 248.775
+   1.459 240.645
+   1.615 234.954
+   1.712 195.931
+   1.782 119.51
+   1.9 24.39
+   1.984 0.0
+;
+; Pro29-6GXL 381I224-CL 15A
+I224-CL 29 365 15-12-10-8-6 0.19669999999999999 0.37 CTI
+   0.0080 357.455
+   0.02 433.079
+   0.111 343.833
+   0.229 318.938
+   0.479 295.922
+   0.836 277.133
+   1.022 269.618
+   1.097 233.919
+   1.233 117.899
+   1.294 93.004
+   1.39 62.003
+   1.667 26.774
+   1.692 17.38
+   1.7 0.0
+;
+;
+I236BS 38 245 17-14-12-10-8 0.20400000000000001 0.4 CTI
+   0.028 290.772
+   0.042 313.594
+   0.049 267.95
+   0.053 253.58
+   0.072 245.973
+   0.095 256.961
+   0.127 262.033
+   0.153 266.259
+   0.243 268.795
+   0.338 269.64
+   0.454 270.486
+   0.633 266.259
+   0.753 262.878
+   0.89 256.116
+   1.01 251.89
+   1.119 247.663
+   1.277 236.675
+   1.353 231.603
+   1.453 227.377
+   1.525 225.686
+   1.555 195.257
+   1.581 158.91
+   1.618 119.183
+   1.685 89.598
+   1.729 56.633
+   1.743 36.347
+   1.766 21.977
+   1.81 0.0
+;
+; Cesaroni I240
+; converted from TMT test stand data 2002 (www.tripoli.org)
+; provided by ThrustCurve.org (www.thrustcurve.org)
+I240 38 302 0 0.274624 0.503552 CTI
+   0.043 265.317
+   0.131 320.903
+   0.221 314.148
+   0.310 312.413
+   0.399 313.564
+   0.488 314.335
+   0.577 321.117
+   0.667 325.923
+   0.755 327.040
+   0.844 326.831
+   0.933 324.348
+   1.023 321.063
+   1.111 317.446
+   1.200 308.301
+   1.290 300.612
+   1.379 293.536
+   1.468 283.358
+   1.556 273.832
+   1.646 259.708
+   1.735 190.662
+   1.824 124.130
+   1.912 60.875
+   2.002 26.967
+   2.092 7.636
+   2.181 2.296
+   2.271 0.000
+;
+; Pro-38-4G White
+I242-WH-15A 38 303 6-8-9-11-13 0.22480000000000003 0.5498999999999999 CTI
+   0.015 241.029
+   0.035 272.691
+   0.063 286.148
+   0.094 277.045
+   0.184 265.567
+   0.299 262.797
+   0.403 262.797
+   0.537 266.359
+   0.734 269.921
+   0.884 271.504
+   1.049 269.921
+   1.223 265.567
+   1.384 260.422
+   1.61 249.34
+   1.727 243.008
+   1.865 235.092
+   1.954 231.135
+   2.0 220.844
+   2.088 155.541
+   2.164 93.008
+   2.211 43.536
+   2.278 10.29
+   2.345 3.958
+   2.402 0.0
+;
+; Pro-29-6XGL White
+I243-WH-13A 29 365 4-6-7-9-11-12 0.2121 0.3986 CTI
+   0.016 443.392
+   0.03 416.3
+   0.061 365.419
+   0.082 331.718
+   0.122 317.181
+   0.174 303.304
+   0.268 298.018
+   0.367 295.374
+   0.514 294.714
+   0.701 290.749
+   0.808 280.837
+   0.968 266.96
+   1.058 247.797
+   1.105 224.009
+   1.155 207.489
+   1.178 202.203
+   1.206 167.181
+   1.254 158.59
+   1.297 154.626
+   1.336 132.819
+   1.395 109.692
+   1.486 69.383
+   1.574 25.771
+   1.649 6.608
+   1.692 0.0
+;
+; CTI Pro38-5G 543 I297 Skidmark 15A
+I297SM 38 360 6-8-10-12-15 0.329 0.591 CTI
+   0.013 340.903
+   0.036 375.121
+   0.069 354.844
+   0.129 335.834
+   0.281 338.369
+   0.662 344.705
+   0.855 344.705
+   1.084 329.498
+   1.295 319.359
+   1.359 313.023
+   1.447 314.29
+   1.534 269.935
+   1.637 119.126
+   1.681 69.701
+   1.74 40.554
+   1.846 12.673
+   1.943 0.0
+;
+;
+I303BS 38 303 16-13-11-9-7 0.27 0.5 CTI
+   0.035 415.763
+   0.053 402.352
+   0.054 329.705
+   0.072 324.117
+   0.109 348.705
+   0.18 353.175
+   0.28 357.646
+   0.432 354.293
+   0.557 353.175
+   0.684 348.705
+   0.886 337.528
+   1.054 325.234
+   1.212 310.705
+   1.371 299.528
+   1.475 292.823
+   1.519 277.176
+   1.542 245.882
+   1.568 204.529
+   1.609 149.764
+   1.639 108.411
+   1.757 50.294
+   1.827 22.353
+   1.887 0.0
+;
+;
+I360 38 367 15 0.3346 0.5963 CTI
+0.08 555.5
+0.1 489.7
+0.13 448
+0.2 449
+0.4 483.7
+0.55 498
+0.6 494.9
+0.7 481.91
+0.8 457.9
+1 406.6
+1.2 344.4
+1.3 309.3
+1.4 182.2
+1.55 158.9
+1.6 101.8
+1.7 55.8
+1.77 0
+;
+; Pro-54-3G White long Burn Plugged
+J140-WH_LB-P 54 329 P 0.68 1.2798 CTI
+   0.073 191.23
+   0.109 196.102
+   0.219 193.362
+   0.51 211.328
+   0.801 216.2
+   0.991 216.2
+   1.195 212.546
+   1.53 209.501
+   2.521 198.234
+   3.096 188.185
+   3.781 174.482
+   4.174 165.043
+   4.794 146.468
+   5.464 125.457
+   6.207 98.356
+   7.001 65.164
+   7.781 36.845
+   8.444 11.267
+   8.771 4.568
+   9.158 1.218
+   9.464 0.0
+;
+; CTI Pro54-2G 683 I250 Skidmark 15A
+J250SK 54 237 6-8-10-12-15 0.406 0.8300000000000001 CTI
+   0.031 191.478
+   0.051 271.111
+   0.082 161.056
+   0.148 206.689
+   0.3 234.426
+   0.413 244.269
+   0.635 264.848
+   0.849 270.217
+   1.06 276.48
+   1.449 283.638
+   1.644 277.375
+   1.8 279.164
+   1.932 272.901
+   2.135 261.269
+   2.291 249.637
+   2.447 246.953
+   2.525 251.427
+   2.579 227.268
+   2.614 157.477
+   2.665 51.896
+   2.727 14.316
+   2.825 6.263
+   2.965 0.0
+;
+; Pro-38-5G Green3
+J270-GR-13A 38 367 5-7-8-9-10-11 0.376 0.6548 CTI
+   0.0080 194.095
+   0.022 192.747
+   0.061 279.461
+   0.114 287.548
+   0.229 289.345
+   0.311 289.345
+   0.382 292.041
+   0.478 294.288
+   0.587 296.534
+   0.701 297.882
+   0.828 301.926
+   0.981 300.128
+   1.116 299.679
+   1.233 296.085
+   1.323 293.389
+   1.488 289.795
+   1.594 287.099
+   1.676 287.548
+   1.701 293.838
+   1.75 286.65
+   1.797 290.244
+   1.868 280.359
+   1.956 275.866
+   2.052 276.316
+   2.126 265.982
+   2.181 224.198
+   2.234 163.094
+   2.292 97.946
+   2.359 49.872
+   2.428 15.276
+   2.5 0.0
+;
+; Pro-38-5G White
+J290-WH-15A 38 367 7-8-9-11-12-13 0.3815 0.6597999999999999 CTI
+   0.015 334.565
+   0.028 364.116
+   0.037 379.42
+   0.061 391.557
+   0.083 379.42
+   0.107 372.559
+   0.169 355.145
+   0.289 343.536
+   0.381 341.425
+   0.588 337.203
+   0.803 334.565
+   1.011 330.871
+   1.256 324.538
+   1.498 321.372
+   1.684 312.929
+   1.805 306.069
+   1.844 301.319
+   1.89 269.129
+   1.942 243.272
+   1.979 223.747
+   2.043 156.201
+   2.128 118.734
+   2.192 86.016
+   2.279 35.356
+   2.334 15.831
+   2.402 0.0
+;
+; CTI Pro54-2G 838 J293BS 13A
+J293BS 54 237 13-12-11-10-9-8-7-6-5-4-3 0.41600000000000004 0.84 CTI
+   0.019 22.847
+   0.032 250.277
+   0.044 386.32
+   0.06 302.202
+   0.073 256.508
+   0.13 285.586
+   0.266 309.471
+   0.487 318.818
+   0.734 325.049
+   1.432 324.01
+   1.786 309.471
+   2.074 294.933
+   2.33 280.394
+   2.488 273.124
+   2.58 272.086
+   2.634 258.585
+   2.713 163.044
+   2.795 70.618
+   2.852 20.77
+   2.896 0.0
+;
+; Cesaroni J300
+; converted from TMT test stand data 2002 (www.tripoli.org)
+; provided by ThrustCurve.org (www.thrustcurve.org)
+J300 38 360 0 0.340032 0.606592 CTI
+   0.043 357.026
+   0.131 436.586
+   0.221 407.925
+   0.310 399.528
+   0.400 400.588
+   0.490 406.733
+   0.578 414.302
+   0.667 417.117
+   0.756 418.415
+   0.846 421.302
+   0.935 422.229
+   1.025 415.951
+   1.114 406.356
+   1.202 395.237
+   1.292 381.728
+   1.381 369.861
+   1.471 355.451
+   1.560 331.691
+   1.649 246.243
+   1.738 161.766
+   1.827 109.478
+   1.917 71.413
+   2.006 37.058
+   2.096 13.880
+   2.185 5.059
+   2.275 0.000
+;
+;
+J357BS 38 367 17-14-12-10-8 0.337 0.601 CTI
+   0.019 514.383
+   0.042 502.824
+   0.054 446.473
+   0.073 434.914
+   0.122 433.469
+   0.258 430.579
+   0.474 427.69
+   0.952 404.571
+   1.236 381.453
+   1.386 372.784
+   1.454 367.004
+   1.487 345.33
+   1.515 317.877
+   1.552 268.751
+   1.615 196.506
+   1.655 134.375
+   1.721 49.127
+   1.758 26.008
+   1.824 0.0
+;
+; CTI Pro54-3G 1016 J3360 Skidmark 15A
+J360SM-54mm 54 321 6-8-10-12-15 0.606 1.104 CTI
+   0.017 560.653
+   0.058 287.423
+   0.167 328.23
+   0.358 363.715
+   0.538 374.36
+   0.85 397.425
+   1.163 400.973
+   1.458 400.973
+   1.733 395.651
+   1.983 381.457
+   2.271 356.618
+   2.496 340.65
+   2.592 351.295
+   2.646 289.198
+   2.679 172.099
+   2.725 86.937
+   2.804 19.516
+   2.904 5.323
+   2.975 0.0
+;
+; Cesaroni J360
+; converted from TMT test stand data 2002 (www.tripoli.org)
+; provided by ThrustCurve.org (www.thrustcurve.org)
+J360-38mm 38 419 0 0.409024 0.709184 CTI
+   0.041 618.905
+   0.124 616.584
+   0.207 563.785
+   0.291 557.730
+   0.374 558.409
+   0.457 562.088
+   0.541 561.267
+   0.624 563.219
+   0.708 565.328
+   0.793 566.558
+   0.876 549.383
+   0.959 529.633
+   1.043 511.099
+   1.126 483.285
+   1.209 445.397
+   1.293 421.658
+   1.377 378.330
+   1.461 261.647
+   1.545 197.445
+   1.628 146.570
+   1.711 101.807
+   1.795 78.039
+   1.878 47.847
+   1.961 31.861
+   2.046 9.220
+   2.130 0.000
+;
+; CTI Pro38-6G 660 G381SK - 15A
+J381SK 38 419 15-12-10-8-6 0.396 0.6880000000000001 CTI
+   0.048 505.029
+   0.111 473.244
+   0.294 461.471
+   0.968 436.75
+   1.353 392.015
+   1.385 366.116
+   1.556 137.735
+   1.662 47.089
+   1.706 22.367
+   1.874 0.0
+;
+; Pro-386GXL Green3
+J394-GR-13A 38 500 4-7-9-11-13-14 0.5721 0.9389 CTI
+   0.014 331.731
+   0.038 359.203
+   0.046 406.593
+   0.08 441.621
+   0.219 426.511
+   0.331 421.703
+   0.486 422.39
+   0.657 423.764
+   0.795 430.632
+   0.936 436.813
+   1.12 439.56
+   1.297 445.742
+   1.329 440.247
+   1.381 449.176
+   1.425 448.489
+   1.472 448.489
+   1.512 458.791
+   1.544 447.802
+   1.572 462.225
+   1.624 456.731
+   1.731 445.742
+   1.801 456.731
+   1.853 456.731
+   1.873 474.588
+   1.885 491.758
+   1.952 451.923
+   2.008 416.896
+   2.034 385.302
+   2.078 376.374
+   2.152 296.703
+   2.229 203.297
+   2.305 133.242
+   2.395 65.934
+   2.48 19.231
+   2.518 7.555
+   2.55 0.0
+;
+; Pro38 Red Lightning 6G.
+J410-16A 38 421 16 0.4098 0.735 CTI
+   0.023 375.45
+   0.029 446.221
+   0.042 510.996
+   0.11 499.0
+   0.22 495.402
+   0.442 491.803
+   0.675 475.01
+   0.901 464.214
+   1.092 448.62
+   1.221 437.825
+   1.34 429.428
+   1.492 419.832
+   1.553 389.844
+   1.592 349.06
+   1.65 273.491
+   1.689 196.721
+   1.75 122.351
+   1.809 64.774
+   1.889 28.788
+   1.941 13.195
+   1.989 0.0
+;
+;
+J420-CL 38 500 6-8-10-12-15 0.522 0.874 CTI 
+0.015 360
+0.02 660
+0.035 800
+0.075 660
+0.25 625
+0.7 560
+1.45 495
+1.51 480
+1.62 350
+1.8 220
+1.9 150
+2 120
+2.25 48
+2.62 0
+;
+;
+J425BS 38 421 16-13-11-9-7 0.405 0.7000000000000001 CTI
+   0.028 141.739
+   0.053 133.043
+   0.079 126.957
+   0.126 123.478
+   0.574 116.957
+   1.014 110.0
+   1.3 105.652
+   1.34 102.609
+   1.374 95.217
+   1.414 77.826
+   1.437 73.478
+   1.472 72.174
+   1.519 64.783
+   1.547 54.783
+   1.595 36.087
+   1.658 18.261
+   1.695 13.913
+   1.747 10.87
+   1.821 9.13
+   1.898 6.087
+   1.935 4.783
+   1.944 3.478
+   1.945 0.0
+;
+; Pro-54-2G White Thunder
+J430-WT-18A 54 236 8-10-11-13-14-15-16 0.384 0.7998 CTI
+   0.017 400.0
+   0.025 501.107
+   0.034 538.745
+   0.069 432.472
+   0.111 440.59
+   0.192 458.303
+   0.328 469.373
+   0.508 473.801
+   0.697 473.801
+   0.899 468.635
+   0.996 461.255
+   1.2 446.494
+   1.401 429.52
+   1.593 415.498
+   1.696 410.332
+   1.739 414.76
+   1.785 354.244
+   1.807 277.491
+   1.83 180.074
+   1.839 145.387
+   1.853 107.749
+   1.885 49.446
+   1.914 19.188
+   1.943 2.952
+   1.963 0.0
+;
+; CTI Pro54-3G 1261 J449BS 15A
+J449BS 54 321 15-14-13-12-11-10-9-8-7-6-5 0.624 1.122 CTI
+   0.012 16.22
+   0.021 330.299
+   0.027 504.295
+   0.046 586.87
+   0.055 508.719
+   0.07 440.89
+   0.137 477.754
+   0.241 495.448
+   0.348 505.77
+   0.69 514.617
+   1.153 504.295
+   1.938 468.906
+   2.292 452.686
+   2.417 455.635
+   2.475 446.788
+   2.505 440.89
+   2.52 408.45
+   2.566 293.435
+   2.612 157.777
+   2.688 69.304
+   2.771 28.016
+   2.847 0.0
+;
+;
+J475-BB 54 403 0 0.714 1.493 CTI
+0.03 30
+0.04 500
+0.075 600
+0.1 515
+0.2 530
+0.4 540
+0.6 535
+0.8 535
+1 530
+1.2 520
+1.4 510
+1.6 500
+1.8 490
+2 480
+2.2 490
+2.28 450
+2.43 180
+2.5 100
+2.6 60
+2.8 28
+3 10
+3.2 0
+;
+;CTI Pro38-6GXL 848 G520SK - 16A
+J520SK 38 500 16-13-11-9-7 0.498 0.85 CTI 
+0.034 658.701
+0.076 614.964
+0.12 585.807
+0.225 580.505
+0.533 622.916
+0.724 626.893
+0.83 612.314
+0.982 607.012
+1.17 595.084
+1.259 569.902
+1.296 458.573
+1.329 405.558
+1.378 388.329
+1.418 302.181
+1.461 197.478
+1.493 135.186
+1.529 87.473
+1.587 45.062
+1.756 0
+;
+;
+J530-IM 38 500 6-8-10-12-15 0.625 0.977 CTI 
+0.01 30
+0.02 700
+0.06 790
+0.1 800
+0.2 760
+0.4 725
+0.6 695
+0.8 680
+1 658
+1.32 600
+1.55 400
+1.7 180
+1.87 175
+2 75
+2.1 0
+;
+; CTI Pro38-6GXL 896 J580SS - 17A
+J580SS 38 510 17-14-12-10-8 0.6880000000000001 1.044 CTI
+   0.0060 82.313
+   0.013 460.952
+   0.016 692.925
+   0.031 600.136
+   0.041 634.557
+   0.058 624.081
+   0.243 621.088
+   0.405 621.088
+   0.511 631.564
+   0.632 646.53
+   0.898 671.972
+   1.019 686.938
+   1.098 691.428
+   1.163 674.965
+   1.229 514.829
+   1.325 496.87
+   1.36 445.986
+   1.405 332.245
+   1.461 221.496
+   1.518 71.837
+   1.559 28.435
+   1.59 8.98
+   1.613 0.0
+;
+;CTI Pro38-6GXL 985 J595BS - 16A
+J595BS 38 500 16-13-11-9-7 0.511 0.866 CTI 
+0.009 644.368
+0.015 924.98
+0.032 868.858
+0.075 752.456
+0.168 729.591
+0.315 719.198
+0.475 712.962
+0.632 712.962
+0.775 704.648
+0.897 702.569
+0.979 700.491
+1.109 683.862
+1.178 600.718
+1.226 507.18
+1.293 411.564
+1.451 270.219
+1.529 205.782
+1.614 112.245
+1.644 58.201
+1.707 0
+;
+; CTI Pro38-6GXL 999 J600RL - 16A
+J600RL 38 510 16-13-11-9-7 0.551 0.906 CTI
+   0.011 533.291
+   0.023 683.326
+   0.029 721.949
+   0.051 721.949
+   0.091 701.152
+   0.202 701.152
+   0.376 696.695
+   0.572 698.181
+   0.72 696.695
+   0.847 698.181
+   0.963 711.55
+   1.028 720.463
+   1.109 710.065
+   1.19 698.181
+   1.245 681.84
+   1.304 610.537
+   1.385 420.394
+   1.408 371.373
+   1.515 147.064
+   1.61 62.391
+   1.716 0.0
+;
+; Pro-54-3G White Thunder
+J760-WT-19A 54 329 8-10-12-14-16-18-19 0.5760 1.0768 CTI
+   0.012 600.251
+   0.019 833.333
+   0.026 938.596
+   0.04 794.486
+   0.054 756.892
+   0.094 778.195
+   0.129 800.752
+   0.165 813.283
+   0.218 825.815
+   0.279 830.827
+   0.377 835.84
+   0.496 837.093
+   0.617 829.574
+   0.709 819.549
+   0.811 802.005
+   0.917 785.714
+   1.041 764.411
+   1.201 750.627
+   1.331 741.855
+   1.455 729.323
+   1.488 729.323
+   1.514 735.589
+   1.556 749.373
+   1.568 729.323
+   1.575 665.414
+   1.589 533.835
+   1.616 327.068
+   1.646 122.807
+   1.659 72.682
+   1.681 30.075
+   1.713 6.266
+   1.731 0.0
+;
+; AMW 54-2500 Skidmark Plugged
+K1075-SK-P 54 728 P 1.259 2.6388 CTI
+   0.0070 1574.366
+   0.012 1038.184
+   0.017 1476.101
+   0.024 1083.044
+   0.029 1365.02
+   0.034 1117.223
+   0.041 1266.756
+   0.046 1162.083
+   0.049 1226.168
+   0.069 1159.947
+   0.107 1130.04
+   0.151 1108.678
+   0.21 1100.134
+   0.274 1102.27
+   0.332 1102.27
+   0.432 1115.087
+   0.523 1119.359
+   0.611 1132.176
+   0.674 1140.721
+   0.766 1149.266
+   0.881 1159.947
+   0.979 1179.172
+   1.141 1191.989
+   1.257 1189.853
+   1.379 1191.989
+   1.504 1202.67
+   1.599 1211.215
+   1.67 1232.577
+   1.744 1249.666
+   1.772 1226.168
+   1.802 1155.674
+   1.841 993.324
+   1.888 736.983
+   1.944 455.007
+   2.002 267.023
+   2.065 128.171
+   2.11 68.358
+   2.149 34.179
+   2.198 0.0
+;
+; Pro54 4G 1526 K160-CL 6
+K160-CL 54 404 6 0.848 1.472 CTI
+   0.027 160.187
+   0.08 242.037
+   0.321 260.656
+   0.455 259.602
+   0.957 270.492
+   1.593 272.248
+   2.102 265.222
+   2.564 254.333
+   2.925 239.578
+   3.956 190.047
+   5.301 138.759
+   7.617 67.799
+   9.19 25.644
+   9.572 15.808
+   9.679 0.0
+;
+; Pro54 6G 2285 K260-CL P
+; Longburn
+K260-CL 54 572 P 1.2413 2.0475 CTI
+   0.042 325.731
+   0.101 430.409
+   0.422 422.807
+   0.773 426.901
+   1.178 429.825
+   1.517 425.731
+   2.011 413.45
+   3.195 356.725
+   4.51 289.474
+   6.015 174.269
+   6.997 91.228
+   7.366 66.667
+   7.902 43.275
+   8.479 25.731
+   8.687 0.0
+;
+; Pro-54-5G White Long Burn Plugged
+K261-WH_LB-P 54 488 P 1.1519 1.9317 CTI
+   0.035 283.061
+   0.069 321.706
+   0.124 345.797
+   0.228 336.763
+   0.525 347.302
+   0.85 359.348
+   1.334 356.336
+   1.79 359.348
+   2.039 354.329
+   2.412 353.325
+   2.793 349.812
+   3.131 344.291
+   3.774 323.714
+   4.652 278.545
+   5.281 230.866
+   5.571 206.775
+   5.993 166.625
+   6.325 137.516
+   6.615 102.384
+   7.085 55.207
+   7.362 35.634
+   7.694 20.577
+   8.129 9.536
+   8.502 2.509
+   8.979 0.0
+;
+;Pro54 6GXL 2546 K300-CL P
+;Longburn
+;Uses a new threaded forward closure
+K300-CL 54 649 0 1.3776 2.27 CTI 
+0.036 495.273
+0.132 543.273
+0.265 506.909
+0.734 493.091
+1.258 489.455
+1.811 482.909
+2.467 453.818
+3.737 375.273
+4.705 299.636
+6.047 165.091
+6.474 120.727
+6.829 90.182
+7.323 63.273
+7.72 46.545
+8.309 30.545
+8.37 0
+;
+; Pro54 4G 1597 K400-GR 14A
+K400-GR 54 404 14-13-12-11-10-9-8-7-6-5-4 0.969 1.5513 CTI
+   0.014 359.164
+   0.102 475.4
+   1.193 444.649
+   2.807 384.994
+   3.364 370.234
+   3.599 363.469
+   3.693 329.028
+   3.859 169.742
+   3.967 57.196
+   4.017 0.0
+;
+;
+K454-SK 54 404 10-11-12-13-14-15-16-17-18-19 0.821 1.391 CTI 
+0.021 10
+0.028 421
+0.032 586
+0.069 405
+0.2 475
+0.4 510
+0.6 530
+0.9 532
+1.2 525
+1.6 505
+2 470
+2.4 415
+2.55 410
+2.69 430
+2.93 70
+3 27
+3.15 0
+;
+; Pro54-5G 1990K490-GR 16A
+K490-GR 54 488 16-15-14-13-12-11-10-9-8-7-6 1.2012 1.8540999999999999 CTI
+   0.013 445.79
+   0.024 376.662
+   0.083 559.232
+   0.121 584.047
+   0.316 573.412
+   0.727 569.867
+   1.116 553.914
+   1.875 522.009
+   1.893 593.796
+   1.944 519.35
+   2.658 479.468
+   3.063 473.264
+   3.358 444.018
+   3.618 448.449
+   3.894 240.177
+   4.055 31.019
+   4.066 0.0
+;
+;
+K515-SK 54 488 6-7-8-9-10-11-12-13-14-15-16 1.013 1.654 CTI 
+0.01 10
+0.02 250
+0.028 550
+0.035 710
+0.06 540
+0.065 530
+0.1 560
+0.25 600
+0.5 612
+0.75 612
+1.1 602
+1.5 578
+2 531
+2.6 460
+2.78 458
+2.85 450
+2.95 300
+3.03 200
+3.18 40
+3.35 0
+;
+;
+K575SS 75 395 1000 1.803 3.143 CTI
+0 16
+0.11 664.5
+0.43 620.2
+0.87 629
+1.3 637.92
+1.73 637.92
+2.17 629
+2.6 615.77
+3.03 553.75
+3.47 518.31
+3.9 438.57
+4.18 79.74
+4.33 0
+;
+; CTI Pro54-4G 1679 K630BS 15A
+K630BS 54 405 15-14-13-12-11-10-9-8-7-6-5 0.912 1.41 CTI
+   0.014 164.444
+   0.025 676.277
+   0.034 791.388
+   0.059 781.111
+   0.074 674.222
+   0.102 705.055
+   0.212 713.277
+   0.696 715.333
+   0.974 721.5
+   1.143 709.166
+   1.489 680.389
+   2.055 629.0
+   2.284 612.555
+   2.318 587.889
+   2.355 518.0
+   2.389 427.555
+   2.417 382.333
+   2.471 349.444
+   2.51 265.167
+   2.57 127.444
+   2.598 76.056
+   2.646 49.333
+   2.816 0.0
+;
+;
+K675-SK 54 572 8-9-10-11-12-13-14-15-16-17-18 1.2 1.94 CTI 
+0.01 10
+0.02 154
+0.025 930
+0.04 850
+0.05 800
+0.07 680
+0.1 700
+0.2 750
+0.3 780
+0.5 795
+1 808
+1.5 795
+1.9 751
+2.26 700
+2.43 450
+2.6 440
+2.68 400
+2.96 40
+3.09 0
+;
+; CTI Pro54-5G 2108 J780BS 15A
+K780BS 54 489 15-14-13-12-11-10-9-8-7-6-5 1.1400000000000001 1.7 CTI
+   0.0080 15.972
+   0.016 511.106
+   0.017 1014.226
+   0.039 892.439
+   0.065 936.362
+   0.094 942.352
+   0.153 916.397
+   0.205 906.415
+   0.294 914.401
+   0.455 900.425
+   0.718 896.432
+   1.016 886.45
+   1.38 858.498
+   1.799 818.568
+   1.913 804.593
+   2.072 798.603
+   2.225 788.621
+   2.272 758.673
+   2.34 606.938
+   2.379 561.019
+   2.412 495.134
+   2.558 211.63
+   2.628 141.752
+   2.711 77.864
+   2.756 0.0
+;
+;
+K815-SK 54 649 0 1.371 2.197 CTI 
+0.01 400
+0.015 600
+0.02 1200
+0.05 620
+0.07 720
+0.1 825
+0.3 910
+1 945
+1.5 970
+1.8 970
+2.12 930
+2.3 650
+2.43 640
+2.58 300
+2.7 150
+2.85 0
+;
+;
+K820-BS 54 572 7-8-9-10-11-12-13-14-15-16-17 1.232 1.982 CTI 
+0.01 800
+0.02 1400
+0.029 1720
+0.04 960
+0.1 1050
+0.2 1060
+0.4 1040
+0.6 1030
+1 1020
+1.5 980
+2 880
+2.1 800
+2.2 640
+2.3 520
+2.4 410
+2.5 390
+2.6 280
+2.7 180
+2.8 110
+2.9 50
+3 0
+;
+; Pro-54-4G White Thunder
+K940-WT-18A 54 404 8-10-12-14-15-17-18 0.768 1.3665 CTI
+   0.01 885.714
+   0.011 1006.015
+   0.021 1115.789
+   0.035 1087.218
+   0.053 963.91
+   0.061 957.895
+   0.094 975.94
+   0.183 998.496
+   0.321 1022.556
+   0.394 1037.594
+   0.515 1046.617
+   0.626 1046.617
+   0.769 1033.083
+   0.929 1013.534
+   1.089 981.955
+   1.24 942.857
+   1.343 912.782
+   1.426 894.737
+   1.474 881.203
+   1.533 875.188
+   1.575 873.684
+   1.596 845.113
+   1.606 800.0
+   1.642 615.038
+   1.661 479.699
+   1.683 320.301
+   1.703 200.0
+   1.735 76.692
+   1.753 45.113
+   1.776 22.556
+   1.797 0.0
+;
+;
+L1090SS 75 665 1000 3.491 5.461 CTI
+0 487.3
+0.11 1639.1
+0.22 1484.05
+0.44 1417.6
+0.87 1373.3
+1.31 1329
+1.74 1306.85
+2.18 1262.55
+2.61 1218.25
+3.05 1151.8
+3.21 775.25
+3.48 598.05
+3.92 553.75
+4.13 221.5
+4.35 0
+;
+; ABC-76-6000 4701L1290-SK P
+L1290-SK 76 785 P 3.047 5.399 CTI
+   0.022 117.623
+   0.081 786.023
+   0.11 797.226
+   0.176 1226.645
+   0.691 1357.337
+   1.231 1461.891
+   1.761 1476.828
+   2.008 1467.493
+   2.311 1417.082
+   2.835 1299.459
+   3.101 1235.98
+   3.167 1230.379
+   3.34 1321.863
+   3.373 1286.39
+   3.532 365.94
+   3.602 201.64
+   3.734 91.485
+   3.782 69.08
+   3.8 0.0
+;
+;
+L1355-SS 75 621 0 3.076 4.962 CTI 
+0.1 80
+0.12 1300
+0.15 1600
+0.2 1500
+0.3 1540
+0.4 1560
+1.05 1660
+1.3 1750
+1.4 1750
+1.8 1590
+2.2 1270
+2.6 860
+2.82 680
+3.05 83
+3.25 0
+;
+;
+L1395-BS 75 621 0 2.475 4.323 CTI 
+0.02 100
+0.04 1400
+0.1 1800
+0.2 1500
+0.4 1540
+0.8 1591
+1.1 1641
+2.4 1481
+2.8 1446
+3 1500
+3.18 830
+3.35 100
+3.45 0
+;
+;
+L1410-SK 75 757 P 2.875 5.115 CTI
+0.04 133
+0.065 1200
+0.077 1510
+0.13 1250
+0.35 1400
+1 1530
+1.5 1595
+2 1630
+2.3 1600
+2.6 1510
+2.9 1350
+3.25 1032
+3.4 120
+3.48 0
+;
+;
+L1685-SS 75 757 0 3.83 6.051 CTI 
+0.055 100
+0.07 1000
+0.092 2300
+0.12 2150
+0.4 2150
+0.9 2050
+1.1 2060
+1.3 2150
+1.6 1900
+2.1 1600
+2.5 1150
+2.7 1000
+2.85 750
+3.02 200
+3.18 0
+;
+;
+L585-IM 75 350 0 1.524 2.784 CTI 
+0.01 200
+0.02 300
+0.04 500
+0.08 630
+0.1 650
+0.25 629
+0.4 639
+0.8 648
+1.2 654
+1.6 659
+2 653
+2.4 640
+2.8 610
+3.2 580
+3.6 550
+4 515
+4.2 510
+4.45 110
+4.57 0
+;
+;
+L640-DT 54 649 P 1.293 2.244 CTI
+0.02 1200
+0.034 1540
+0.07 1300
+0.15 1460
+0.35 1510
+0.65 1540
+0.7 1510
+0.79 800
+0.86 570.25
+3.26 518
+3.55 330
+3.65 318
+4.15 102
+4.5 30
+5 0
+;
+;
+L890SS 75 530 1000 2.671 4.346 CTI
+0 20
+0.05 1151.8
+0.41 1054.34
+0.83 1045.48
+1.24 1036.62
+1.65 1027.76
+2.07 1018.9
+2.89 886
+3.31 775.25
+3.72 664.5
+3.98 177.2
+4.13 0
+;
+;
+L990-BS 54 649 0 1.417 2.236 CTI 
+0.01 800
+0.012 1450
+0.02 1625
+0.05 1320
+0.15 1230
+1.8 1150
+1.88 1105
+2 845
+2.203 825
+2.41 355
+2.6 320
+2.9 0
+;
+;
+L995-RL 75 486 0 1.996 3.591 CTI 
+0.02 50
+0.05 200
+0.09 1110
+0.14 1250
+0.25 1211
+0.9 1220
+1.2 1280
+1.4 1245
+2.4 940
+3.1 745
+3.32 740
+3.6 110
+3.8 0
+;
+; Pro75-4G 5506M1230-IM P
+M1230-IM 75 621 P 2.992 4.844 CTI
+   0.117 270.318
+   0.144 912.788
+   0.212 1296.047
+   0.408 1444.167
+   1.087 1497.861
+   1.767 1507.118
+   2.403 1434.91
+   2.949 1314.562
+   3.352 1209.027
+   3.648 1118.304
+   3.909 868.352
+   4.409 201.813
+   4.586 111.09
+   4.67 79.614
+   4.7 0.0
+;
+; Pro98 3G 7649 M1290-WH Plugged
+M1290-WH-P 98 548 P 4.421 7.4110000000000005 CTI
+   0.024 227.074
+   0.063 873.362
+   0.107 1161.572
+   0.166 1399.563
+   0.292 1358.079
+   0.892 1434.498
+   1.398 1513.1
+   2.484 1558.952
+   2.748 1550.218
+   3.009 1506.55
+   4.091 1281.659
+   5.347 1026.201
+   5.473 984.716
+   5.596 718.341
+   5.663 469.432
+   5.789 213.974
+   5.856 192.14
+   6.046 0.0
+;
+; Pro75-5G 6438M1300-IM/DT P
+M1300-IM 75 757 P 3.595 5.657 CTI
+   0.0090 394.105
+   0.057 934.778
+   0.086 2146.406
+   0.154 2615.423
+   0.314 2827.132
+   0.671 2758.734
+   0.97 2752.22
+   1.082 1172.543
+   1.187 1120.43
+   2.14 1172.543
+   2.7 1139.973
+   3.884 915.235
+   4.372 771.924
+   4.6 400.619
+   4.697 335.478
+   4.9 120.511
+   4.901 0.0
+;
+; Pro98-3G 7579M1520-BS P
+M1520-BS 98 548 P 3.737 6.718 CTI
+   0.04 1427.795
+   0.082 1706.389
+   0.176 1620.489
+   0.748 1734.249
+   1.652 1827.113
+   2.676 1715.676
+   3.89 1423.152
+   4.399 1404.579
+   4.616 661.661
+   4.877 69.649
+   4.897 0.0
+;
+;
+M1540-IM 75 757 0 3.778 5.906 CTI 
+0.02 800
+0.04 1250
+0.06 1800
+0.08 2400
+0.15 2060
+0.2 2000
+0.35 2100
+0.55 1940
+0.7 1900
+1.7 1830
+2.5 1720
+3.38 1550
+3.83 680
+4 530
+4.5 0
+;
+; Pro-75-6GXL Green3 Plugged
+M1545-GR-P 75 1025 P 4.835 7.8783 CTI
+   0.038 1517.15
+   0.063 1076.517
+   0.068 1282.322
+   0.076 1509.235
+   0.144 1741.425
+   0.207 1765.172
+   0.334 1749.34
+   0.537 1791.557
+   0.753 1794.195
+   1.053 1775.726
+   1.383 1788.918
+   1.704 1820.58
+   1.856 1828.496
+   2.013 1799.472
+   2.601 1686.016
+   2.905 1641.161
+   3.188 1617.414
+   3.472 1598.945
+   3.738 1583.113
+   3.958 1564.644
+   4.14 1543.536
+   4.216 1543.536
+   4.33 1482.85
+   4.453 1358.839
+   4.55 1187.335
+   4.723 1052.77
+   4.876 891.821
+   4.969 783.641
+   5.028 643.799
+   5.231 184.697
+   5.303 68.602
+   5.396 0.0
+;
+; Pro98-2G 5342M1560-WT P
+M1560-WT 98 394 P 2.583 4.977 CTI
+   0.037 1474.119
+   0.121 1436.502
+   0.328 1523.492
+   1.299 1775.056
+   1.545 1807.971
+   1.797 1807.971
+   1.998 1786.811
+   2.208 1737.439
+   2.462 1572.864
+   2.782 1415.343
+   3.086 1309.545
+   3.213 1290.736
+   3.258 1309.545
+   3.328 679.459
+   3.383 173.979
+   3.428 68.181
+   3.5 0.0
+;
+; AMW75-7600 8212M1630-TT/DT P
+M1630-TT 75 1039 P 4.349 7.237 CTI
+   0.0030 147.481
+   0.032 2040.948
+   0.078 3235.069
+   0.158 3368.278
+   0.463 3258.856
+   0.647 2992.439
+   0.949 2697.477
+   1.052 2040.948
+   1.101 1883.952
+   1.392 1907.739
+   1.786 1812.59
+   3.6 1327.33
+   3.899 875.372
+   4.595 347.294
+   4.857 195.056
+   4.891 166.511
+   4.9 0.0
+;
+;
+M1670-BS 75 757 0 3.101 5.231 CTI 
+0.055 100
+0.092 1500
+0.1 2000
+0.15 2200
+0.2 1800
+0.5 1950
+1 2034
+1.5 2000
+2 1900
+2.5 1760
+2.9 1700
+3 1650
+3.3 530
+3.4 350
+3.9 0
+;
+; Pro75-5G 6162M1675-PK P
+M1675-PK 75 757 P 3.1590000000000003 5.223 CTI
+   0.04 1350.521
+   0.077 1718.845
+   0.166 1877.036
+   0.307 2011.615
+   0.49 2028.143
+   0.616 2028.143
+   1.018 2073.003
+   1.594 1992.727
+   2.246 1860.508
+   2.762 1754.261
+   2.908 1737.734
+   3.023 1563.016
+   3.206 909.005
+   3.409 377.768
+   3.493 278.604
+   3.577 259.716
+   3.69 113.33
+   3.796 0.0
+;
+; Pro98-4G 8088M1790-SK P
+M1790-SK 98 702 P 4.817 8.298 CTI
+   0.059 1791.514
+   0.199 1596.375
+   0.6 1782.109
+   1.215 1913.769
+   1.973 2021.918
+   2.742 1970.195
+   3.387 1833.833
+   3.812 1652.801
+   4.28 1556.407
+   4.385 1295.438
+   4.476 355.011
+   4.541 91.692
+   4.597 0.0
+;
+; Pro98-4G 9870M1800-BS P
+M1800-BS 98 702 P 4.9590000000000005 8.342 CTI
+   0.02 1873.084
+   0.059 2177.212
+   0.265 1932.773
+   1.312 2077.731
+   1.826 2108.996
+   3.07 2009.515
+   4.468 1750.865
+   4.674 1736.653
+   4.89 1023.233
+   5.178 451.928
+   5.384 318.339
+   5.548 99.481
+   5.6 0.0
+;
+;
+M1810-RL 75 757 0 3.297 5.416 CTI 
+0.01 30
+0.03 120
+0.065 1000
+0.093 1500
+0.11 1950
+0.16 1850
+0.35 1915
+0.6 1965
+1.15 2085
+1.35 2080
+2.15 1970
+2.6 1820
+2.95 1810
+3.06 1715
+3.15 1185
+3.32 240
+3.4 90
+3.58 0
+;
+; Pro-75-6G IMax Plugged
+M2020-IM-P 75 757 P 4.349 7.0318 CTI
+   0.023 2070.111
+   0.036 1929.889
+   0.053 2147.601
+   0.073 2369.004
+   0.089 2505.535
+   0.136 2649.446
+   0.182 2627.306
+   0.262 2608.856
+   0.364 2616.236
+   0.566 2623.616
+   1.387 2575.646
+   1.639 2538.745
+   1.986 2450.185
+   2.198 2394.834
+   2.457 2295.203
+   2.708 2206.642
+   2.831 2162.362
+   2.933 2088.561
+   3.036 1988.93
+   3.109 1800.738
+   3.175 1594.096
+   3.307 1335.793
+   3.45 1014.76
+   3.589 708.487
+   3.698 601.476
+   3.814 461.255
+   3.996 339.483
+   4.115 202.952
+   4.201 88.561
+   4.301 0.0
+;
+; Pro75-6G 7388-M2045-BS P
+M2045-BS 75 893 P 3.739 6.071 CTI
+   0.0040 556.851
+   0.019 1690.324
+   0.063 2359.204
+   0.153 2339.434
+   0.182 2570.083
+   0.247 2471.233
+   0.616 2497.593
+   1.028 2547.018
+   2.111 2316.369
+   2.551 2273.535
+   2.635 2253.765
+   2.796 1696.914
+   3.009 1472.855
+   3.349 247.123
+   3.541 108.734
+   3.587 0.0
+;
+; AMX75-7600 6774-M2050-SK P
+M2050-BS 75 1039 P 4.172 7.1290000000000004 CTI
+   0.038 2152.81
+   0.833 2506.091
+   1.189 2539.211
+   1.546 2500.571
+   1.775 2415.011
+   1.907 2279.77
+   2.168 2086.569
+   2.401 1973.409
+   2.616 1909.929
+   2.776 1871.288
+   2.918 1203.365
+   3.056 706.563
+   3.309 135.241
+   3.4 0.0
+;
+; Pro75-6G 6287M2075-SS Plugged
+M2075-SS 75 893 P 4.5931 7.1913 CTI
+   0.034 2350.685
+   0.18 2652.055
+   0.243 2931.507
+   0.303 2734.247
+   0.453 2624.658
+   0.552 2564.384
+   0.813 2487.671
+   1.172 2498.63
+   2.028 2038.356
+   2.415 1610.959
+   2.567 1506.849
+   2.69 1386.301
+   3.01 224.658
+   3.029 0.0
+;
+; Pro-75-6GXL Skidmark Plugged
+M2080-SK-P 75 1025 P 4.107 7.0395 CTI
+   0.027 1813.539
+   0.04 2084.323
+   0.067 2344.418
+   0.097 2276.722
+   0.132 2262.47
+   0.172 2269.596
+   0.218 2319.477
+   0.323 2415.677
+   0.447 2490.499
+   0.541 2522.565
+   0.676 2547.506
+   0.816 2554.632
+   1.026 2522.565
+   1.23 2519.002
+   1.459 2461.995
+   1.669 2369.359
+   1.987 2241.093
+   2.21 2134.204
+   2.539 2002.375
+   2.63 1991.686
+   2.7 1941.805
+   2.746 1842.043
+   2.784 1692.399
+   2.811 1542.755
+   2.843 1339.667
+   2.999 883.61
+   3.083 520.19
+   3.177 277.91
+   3.271 128.266
+   3.365 53.444
+   3.443 24.941
+   3.5 0.0
+;
+; Pro75-4G 5472M2250-CS P
+M2250-CS 75 621 P 2.628 4.415 CTI
+   0.016 2542.114
+   0.051 2390.798
+   0.139 2582.466
+   0.259 2599.278
+   0.877 2663.168
+   1.388 2555.565
+   1.823 2458.05
+   1.86 2303.371
+   1.891 1926.761
+   1.997 1452.637
+   2.195 1452.637
+   2.244 1207.168
+   2.276 645.616
+   2.336 517.838
+   2.414 144.591
+   2.456 40.351
+   2.497 0.0
+;
+; Pro75-5G 6118M3100-WT P
+M3100-WT 75 757 P 2.95 5.018 CTI
+   0.02 3118.031
+   0.057 2976.886
+   0.148 3186.465
+   0.496 3391.768
+   0.817 3665.504
+   0.936 3532.913
+   1.173 3357.551
+   1.501 3199.297
+   1.717 3139.417
+   1.78 2412.304
+   1.812 2130.013
+   1.832 2031.639
+   1.937 346.448
+   1.985 81.266
+   2.0 0.0
+;
+; Pro98-4G 9994M3400-WT P
+M3400-WT 98 702 P 4.766 8.108 CTI
+   0.021 3639.453
+   0.049 3360.146
+   0.111 3300.899
+   0.374 3478.64
+   0.909 3774.874
+   1.059 3897.6
+   1.208 3884.904
+   1.571 3787.57
+   2.168 3402.465
+   2.467 3245.884
+   2.709 3292.435
+   2.734 3254.348
+   2.821 1032.589
+   2.876 550.15
+   2.93 165.045
+   2.99 0.0
+;
+; Pro75-6G 6800M3700-WT Plugged
+; 5.3G case or 6G + 0.7 spacer
+M3700-WT 75 803 P 3.1065 5.7785 CTI
+   0.017 3815.753
+   0.04 3969.863
+   0.099 3914.384
+   0.245 3957.534
+   0.563 3951.37
+   0.727 4105.479
+   0.959 4031.507
+   1.25 3982.192
+   1.511 3994.521
+   1.595 3994.521
+   1.739 1306.849
+   1.772 1109.589
+   1.83 221.918
+   1.835 0.0
+;
+; Pro98 6G 10347 N10000-VM P
+N10000-VM 98 1010 P 5.335 9.9185 CTI
+   0.0090 8953.955
+   0.027 10257.379
+   0.074 10753.247
+   0.125 11036.6
+   0.212 11107.438
+   0.358 11277.45
+   0.457 11475.797
+   0.548 11461.629
+   0.599 11277.45
+   0.663 10866.588
+   0.766 9988.194
+   0.837 9350.649
+   0.888 8996.458
+   0.908 8968.123
+   0.923 8585.596
+   0.942 7820.543
+   0.961 6276.269
+   0.976 4491.145
+   0.988 3357.733
+   1.004 1657.615
+   1.008 0.0
+;
+; Pro98 4G 10367 N1800-WH Plugged
+N1800-WH-P 98 702 P 4.8420000000000005 9.18 CTI
+   0.077 1769.444
+   0.123 2205.556
+   0.193 2041.667
+   0.339 1988.889
+   0.744 1994.444
+   2.398 2144.444
+   2.726 2119.444
+   2.977 2077.778
+   3.933 1786.111
+   4.643 1525.0
+   4.986 1444.444
+   5.152 1352.778
+   5.225 1261.111
+   5.348 994.444
+   5.437 738.889
+   5.541 622.222
+   5.73 355.556
+   5.915 75.0
+   5.931 0.0
+;
+; Pro98 6G 14272 N1975-GR P
+N1975-GR 98 1010 P 8.584 13.2475 CTI
+   0.04 1382.46
+   0.08 1699.147
+   0.201 1781.364
+   0.447 1793.544
+   0.678 1820.95
+   0.758 1927.527
+   0.853 1842.266
+   2.425 2088.916
+   2.52 2180.268
+   2.761 2198.538
+   3.434 2213.764
+   3.715 2268.575
+   4.077 2299.026
+   4.96 2238.124
+   5.492 2161.998
+   6.105 2024.97
+   6.446 1878.806
+   6.647 1668.697
+   7.074 602.923
+   7.239 140.073
+   7.254 0.0
+;
+; Pro98 6G 15227 N2501-WH Plugged
+N2501-WH-P 98 1010 P 8.704 13.308 CTI
+   0.039 1715.546
+   0.059 2835.722
+   0.141 3488.423
+   0.224 3188.534
+   0.373 3135.612
+   2.237 2998.897
+   2.905 2928.335
+   3.45 2769.57
+   3.462 2787.211
+   4.537 2407.938
+   4.804 1949.283
+   5.165 1684.675
+   5.511 1181.918
+   6.013 313.12
+   6.088 0.0
+;
+; Pro98-6G 11077N2600-SK P
+N2600-SK 98 1010 P 6.7700000000000005 11.482000000000001 CTI
+   0.063 2794.141
+   0.199 2497.593
+   0.485 2619.507
+   0.907 2777.666
+   1.367 2902.875
+   1.749 2949.005
+   2.051 2972.07
+   2.764 2817.206
+   3.549 2392.154
+   3.767 2309.779
+   3.958 2385.564
+   4.177 639.226
+   4.265 138.389
+   4.297 0.0
+;
+; Pro98-6G 13767N2850-BS P
+N2850-BS 98 1010 P 6.965 11.688 CTI
+   0.0030 286.922
+   0.085 3152.414
+   0.185 3103.973
+   0.322 3077.889
+   0.945 3212.034
+   1.725 3312.643
+   2.819 3118.878
+   4.163 2776.062
+   4.376 1982.369
+   4.538 845.86
+   4.763 435.972
+   4.849 149.05
+   4.9 0.0
+;
+; Pro98-6GXL 17613N2900-CL P
+N2900-CL 98 1239 P 8.788 14.166 CTI
+   0.026 1863.57
+   0.074 3605.399
+   0.122 4022.127
+   0.361 3619.446
+   1.18 3497.706
+   1.981 3586.67
+   3.493 3155.895
+   4.648 2874.955
+   4.939 2322.439
+   5.205 1648.183
+   5.629 945.832
+   5.972 430.775
+   6.219 206.023
+   6.278 149.835
+   6.296 0.0
+;
+; Pro98-6GXL 14263N3400-SK P
+N3400-SK 98 1239 P 8.471 13.972 CTI
+   0.055 3602.205
+   0.177 3060.167
+   0.608 3397.34
+   1.537 3811.337
+   2.252 3973.522
+   2.86 3760.121
+   3.152 3597.937
+   3.545 3346.124
+   3.71 3627.813
+   3.837 2868.106
+   3.884 1907.803
+   3.999 1510.877
+   4.188 273.153
+   4.28 81.092
+   4.3 0.0
+;
+; Pro98-6GXL 17631N3800-BS P
+N3800-BS 98 1239 P 8.71 14.261000000000001 CTI
+   0.016 2671.724
+   0.069 4632.012
+   0.159 4360.745
+   0.293 4355.626
+   1.11 4591.066
+   1.48 4703.667
+   1.847 4729.258
+   2.384 4683.194
+   2.628 4550.12
+   3.141 4135.542
+   3.343 4043.413
+   3.434 4022.94
+   3.497 3787.501
+   3.582 3204.021
+   3.681 2809.916
+   3.853 2385.102
+   4.042 1458.7
+   4.198 972.467
+   4.338 946.875
+   4.401 864.983
+   4.604 378.75
+   4.673 230.321
+   4.7 0.0
+;
+; Pro98-6GXL 17790N4100-RL P
+N4100-RL 98 1293 P 9.38 14.748000000000001 CTI
+   0.0030 203.877
+   0.05 2362.879
+   0.078 3946.845
+   0.121 4281.412
+   0.652 4370.281
+   1.123 4453.923
+   1.655 4772.807
+   2.353 4621.206
+   3.035 4511.427
+   3.7 4375.509
+   3.733 4182.087
+   3.887 2969.282
+   4.036 1589.193
+   4.197 533.216
+   4.262 240.47
+   4.3 0.0
+;
+; Pro98-6GXL 20146N5800-CS P
+N5800-CS 98 1239 P 9.425 14.826 CTI
+   0.019 6694.9
+   0.049 6720.292
+   0.103 6593.334
+   0.384 6677.973
+   1.109 6957.279
+   1.569 6940.352
+   1.991 6720.292
+   2.622 6009.329
+   3.011 3275.507
+   3.192 2606.864
+   3.334 1599.666
+   3.423 1041.053
+   3.513 389.337
+   3.581 220.06
+   3.594 0.0
+;
+; Pro-150-40K Skidmark Plugged
+O3700-SK-P 161 957 P 17.157 31.3505 CTI
+   0.052 1009.021
+   0.071 1646.907
+   0.084 2505.155
+   0.09 3183.634
+   0.116 3409.794
+   0.187 3114.046
+   0.245 3050.258
+   0.316 3108.247
+   0.445 3241.624
+   0.594 3461.985
+   0.819 3653.351
+   1.155 3676.546
+   1.503 3775.129
+   2.471 3931.701
+   3.277 4012.887
+   4.213 4030.284
+   4.787 3983.892
+   5.206 3925.902
+   5.671 3867.912
+   5.981 3850.515
+   6.413 3751.933
+   6.923 3618.557
+   7.387 3496.778
+   7.645 3363.402
+   7.819 3102.448
+   7.903 2905.284
+   7.942 2383.376
+   7.981 1948.454
+   8.026 1310.567
+   8.084 695.876
+   8.135 359.536
+   8.187 162.371
+   8.277 81.186
+   8.387 0.0
+;
+;
+O4900-BS 161 957 0 18.898 32.648 CTI 
+0.06 800
+0.1 4000
+0.15 5500
+0.25 5160
+0.45 5130
+0.8 5400
+1 5300
+2 5450
+3 5347
+4 5160
+5 4950
+6 4700
+6.8 4400
+7.05 4400
+7.3 3800
+7.6 300
+7.8 0
+;
+;
+H186RT 38 248 18 0.1765 0.469 GM 
+0.008 40.184
+0.042 133.634
+0.058 178
+0.1 196.9
+0.192 204
+0.483 215
+0.842 220.33
+1.075 219
+1.267 219
+1.35 207
+1.42 165
+1.48 118.949
+1.542 75
+1.69 0
+;
+;
+H225BL 38 248 1000 0.182001 0.474999 GM 
+0.0150659 113.792
+0.0326428 193.101
+0.0489642 172.412
+0.166981 256.893
+0.310107 296.548
+0.512241 303.445
+0.617702 305.169
+0.838669 298.272
+0.898933 291.376
+0.98 266.893
+1.02 244.652
+1.05 222.411
+1.26303 10.3447
+1.3 0
+;
+;
+I223GT 38 248 18 0.182 0.475 GM 
+0.02 170
+0.05 190
+0.141038 225
+0.462292 255
+0.681685 258
+0.887365 260
+1.14789 255
+1.32419 224.138
+1.40451 129.31
+1.48 0
+;
+;
+I324RT 38 369 1000 0.298 0.688 GM 
+0.015 238.506
+0.09 310
+0.25 360
+0.65 365
+1.06758 369.24
+1.25563 365
+1.35 340
+1.48678 195.402
+1.65 0
+;
+;
+I389GT 38 369 18 0.3026 0.6928 GM 
+0.016 181.961
+0.025 277.057
+0.045 379.719
+0.065 413.405
+0.366 450
+0.683 454.85
+1.066 443.265
+1.14398 421
+1.183 385
+1.241 280.84
+1.35 92.872
+1.42 0
+;
+;
+J485WC 54 326 1000 0.549 1.1648 GM
+0.05 263.913
+0.095 401.808
+0.15 444.822
+0.503226 544.253
+0.8 573.821
+1.075 569.372
+1.5 542.683
+2 444.822
+2.1 311.376
+2.19 0
+;
+;
+K1185GT 54 728 1000 1.314 2.541 GM 
+0.01 575
+0.06 810
+0.12 1050
+0.17 1175
+0.68 1345
+0.82 1366.15
+0.92 1379
+1.65 1290.5
+1.8 1268.25
+1.85 1223.75
+1.87 1068
+1.92 801
+2.05 222.5
+2.1 0
+;
+;
+K630WC 54 430 1000 0.731999 1.4533 GM 
+0.042 359.461
+0.05 440.908
+0.075 556.028
+0.15 622.751
+0.217 667.233
+0.9 800.68
+1.159 796.232
+1.33871 778.439
+1.517 720.612
+1.9 556.028
+2.1 133.447
+2.24 0
+;
+;
+K805WC 54 492 1000 0.887499 1.73965 GM 
+0.025 423.515
+0.0403226 667.233
+0.067 702.819
+0.095 747.301
+0.551613 1000.85
+0.8 1089.81
+1.25 1067.57
+1.75 667.233
+2.19 0
+;
+;
+L1065BL 75 787 1000 2.693 5.329 GM 
+0.02 1334.47
+0.1 1312.23
+0.65 1779.29
+1.75 1757.05
+2.2 1245.5
+2.75 667.233
+3.5 222.411
+3.95 0
+;
+;
+L1150WC 75 497 1000 1.75 3.502 GM 
+0.1 1000.85
+0.2 1067.57
+0.5 1178.78
+1.25 1668.08
+1.5 1757.05
+1.7 1734.81
+2 1334.47
+2.25047 982.747
+2.5 711.716
+2.75 556.028
+3 266.893
+3.11 0
+;
+;
+L789RT 75 497 1000 1.8 3.378 GM 
+0.05 600
+0.1 650
+0.2 712
+0.754163 850
+1.5 900
+2 906
+3.41332 867.816
+3.55 833.333
+3.92752 344.828
+4.17 0
+;
+;
+L985GT 75 497 1000 1.875 3.453 GM 
+0.2 725
+0.3 795.5
+0.75 950
+1.5 1120
+2 1120
+3.4 1112.5
+3.6 0
+;
+;
+M1355RT 75 787 1000 2.831 5.216 GM
+0.05 1334.47
+0.85 1779.29
+1.35 1868.25
+1.7 1890.49
+2.15 1859.36
+3.5 489.304
+3.81 0
+;
+;
+M1610BL 75 1039 1000 3.674 6.918 GM 
+0.0627746 1560.33
+1.3 2135.15
+1.64783 2206.87
+1.79535 2206.87
+1.89893 2189.63
+1.98996 2155.15
+2.50157 1715.5
+2.82486 1474.12
+2.99435 1241.36
+3.29253 594.82
+3.5 355.858
+3.71 0
+;
+;
+M1665WC 75 787 1000 2.95 5.579 GM 
+0.075 2068.42
+0.125 2001.7
+0.7 2224.11
+0.85 2268.59
+1.6 2268.59
+2.12 1801.53
+2.65 1178.78
+3.22 444.822
+3.42 0
+;
+;Input by Tim Van Milligan for RockSim users. Used John Coker's ThrustCruve
+;Tracer program. Thrust curve and engine data TRA certification dated Oct 14,
+;2008.
+G135R 29 206 6-10-14 0.0799995 0.226 KBA 
+0.011 156.916
+0.016 63.461
+0.027 98.191
+0.061 109.872
+0.094 111.135
+0.14 116.187
+0.197 127.553
+0.26 135.13
+0.316 139.235
+0.354 141.445
+0.408 147.128
+0.459 149.022
+0.502 153.443
+0.546 156.6
+0.6 158.178
+0.684 155.968
+0.743 152.811
+0.816 149.97
+0.875 148.075
+0.91 146.812
+0.963 151.232
+0.981 152.18
+0.993 149.022
+1.014 103.558
+1.02 61.251
+1.034 22.732
+1.039 7.893
+1.049 0
+;
+;Input by Tim Van Milligan for RockSim users. Used John Coker's ThrustCruve
+;Tracer program. Thrust curve and engine data TRA certification dated Oct 14,
+;2008.
+G82W 29 206 6-10-14 0.0839996 0.231 KBA 
+0.011 50.341
+0.028 53.498
+0.055 76.3
+0.068 80.159
+0.111 74.02
+0.134 74.02
+0.216 79.458
+0.295 83.667
+0.374 89.982
+0.406 91.911
+0.431 89.631
+0.453 92.437
+0.474 93.841
+0.489 91.385
+0.519 93.314
+0.551 90.333
+0.604 91.911
+0.642 92.262
+0.728 94.367
+0.79 96.647
+0.85 98.401
+0.905 99.453
+0.954 101.734
+0.995 102.962
+1.025 103.839
+1.076 102.435
+1.112 102.435
+1.142 102.26
+1.174 98.576
+1.221 95.244
+1.238 93.49
+1.274 98.226
+1.287 89.631
+1.317 87.877
+1.351 85.597
+1.434 81.913
+1.479 78.581
+1.503 73.845
+1.533 65.075
+1.565 50.516
+1.594 36.835
+1.62 28.591
+1.65 21.048
+1.701 14.208
+1.737 8.946
+1.829 5.613
+1.883 4.385
+1.959 0
+;
+;Input by Tim Van Milligan for RockSim users. Used John Coker's ThrustCruve
+;Tracer program. Thrust curve and engine data TRA certification dated Oct 14,
+;2008.
+H130W 29 291 6-10-14 0.140001 0.708999 KBA 
+0.016 154.848
+0.024 194.715
+0.055 224.09
+0.071 201.848
+0.078 227.027
+0.089 183.384
+0.123 172.054
+0.196 172.054
+0.254 176.67
+0.348 179.607
+0.426 180.866
+0.481 179.188
+0.554 178.348
+0.649 166.179
+0.672 165.339
+0.777 172.473
+0.86 172.893
+0.947 171.634
+1.038 167.018
+1.138 161.143
+1.185 157.366
+1.232 152.75
+1.266 143.098
+1.294 119.598
+1.326 101.134
+1.412 70.08
+1.53 46.58
+1.647 32.732
+1.674 29.375
+1.718 17.625
+1.838 12.17
+1.909 0
+;
+; KBA I301W
+I301W 38 369.6 18 0.295031 0.724 KBA
+   0.0080 266.093
+   0.014 327.114
+   0.03 354.124
+   0.058 350.122
+   0.107 335.117
+   0.133 326.114
+   0.189 326.114
+   0.217 333.116
+   0.237 383.134
+   0.253 402.14
+   0.287 395.138
+   0.33 381.133
+   0.72 381.133
+   1.035 341.119
+   1.437 317.111
+   1.57 262.092
+   1.698 130.045
+   1.789 83.029
+   1.833 74.026
+   1.867 53.019
+   1.893 23.008
+   1.916 13.005
+   1.952 0.0
+;
+;KBA I550R
+I550R 38 369.6 20 0.294999 0.712999 KBA 
+0.016 156.054
+0.028 278.097
+0.04 427.149
+0.054 550.192
+0.08 542.189
+0.245 588.205
+0.332 611.213
+0.424 631.22
+0.496 638.223
+0.613 644.225
+0.71 643.225
+0.758 631.22
+0.846 603.211
+0.894 613.214
+0.915 611.213
+0.939 586.205
+0.949 546.191
+0.959 505.176
+0.969 469.164
+0.983 381.133
+0.999 278.097
+1.011 200.07
+1.029 112.039
+1.053 42.015
+1.069 15.005
+1.089 0
+;
+;
+K1750R  54.0 728.00 0 1.25300 2.56000 KBA
+   0.02    1309.09 
+   0.03    1679.77 
+   0.05    1736.54 
+   0.11    1689.79 
+   0.26    1799.99 
+   0.40    1913.54 
+   0.46    1896.84 
+   0.68    2023.74 
+   0.90    2133.94 
+   0.95    2097.21 
+   1.00    2050.46 
+   1.05    1920.21 
+   1.10    1793.31 
+   1.16    1676.43 
+   1.21    1719.85 
+   1.25    1526.15 
+   1.27    1302.41 
+   1.32     874.95 
+   1.35     454.17 
+   1.36     317.25 
+   1.37     200.37 
+   1.40      90.17 
+   1.46       0.00 
+;
+; Kosdon by Aerotech K750 White Lightning.
+K750W 54 728 0 1.315 2.62 KBA
+   0.0080 266.075
+   0.012 457.102
+   0.02 750.467
+   0.032 999.485
+   0.044 1112.055
+   0.06 1180.279
+   0.095 1098.41
+   0.127 1057.476
+   0.163 1040.42
+   0.334 1050.653
+   0.62 1054.064
+   0.998 975.607
+   1.324 907.382
+   1.69 903.971
+   2.06 886.915
+   2.184 828.924
+   2.299 757.289
+   2.394 651.541
+   2.502 556.028
+   2.609 450.28
+   2.784 327.476
+   2.999 245.607
+   3.039 201.261
+   3.134 92.103
+   3.206 40.935
+   3.337 6.822
+   3.468 0.0
+;
+; KBA M1450W
+M1450W 75 1038.9 0 4.15 7.6000000000000005 KBA
+   0.035 1842.929
+   0.076 2287.088
+   0.146 1968.884
+   0.215 1882.704
+   0.291 1836.299
+   0.499 1862.816
+   1.005 1935.738
+   1.559 1889.333
+   2.155 1816.412
+   2.862 1750.119
+   3.493 1663.939
+   3.853 1358.994
+   4.221 1060.678
+   4.484 788.88
+   4.761 523.71
+   4.942 258.54
+   5.323 258.54
+   5.6 172.36
+   5.801 119.326
+   5.96 0.0
+;
+;@File: 070616w11.txt, @Pts-I: 1207, @Pts-O: 32, @Sm: 5, @CO: 5%
+;@TI: 5460.0, @TIa: 5447.69, @TIe: 0.0%, @ThMax: 3102.43, @ThAvg: 2675.68, @Tb: 2.036
+;Exported using ThrustCurveTool, www.ThrustGear.com
+M2900R 75 1039 1000 3.755 7.195 KBA 
+0 2.43719
+0.034 19.468
+0.05 69.6872
+0.052 166.128
+0.056 533.998
+0.06 1067.23
+0.064 1683.24
+0.066 1897.53
+0.072 2294.77
+0.082 2495.75
+0.102 2708.42
+0.108 2734.74
+0.204 2696.52
+0.438 2690.17
+0.726 2744.74
+0.824 2794
+1.1159 3041.86
+1.3179 3102.43
+1.5659 3015.86
+1.8159 2846.44
+1.8639 2744.09
+1.8979 2565.3
+1.9079 2455.92
+1.9599 1357.39
+1.9879 857.187
+2.0059 603.283
+2.0259 417.576
+2.0439 303.914
+2.0899 150.616
+2.1419 73.2216
+2.2259 25.6056
+2.4119 0
+;
+;
+G69-SF 38 127 0 0.0630011 0.240001 LR
+0.01 97.9215
+0.2 96.5358
+0.4 94.2263
+0.799544 76.6744
+1.2 58.1986
+1.6 0
+;
+;
+J350-SF 54 327 0 0.59 1.26 LR 
+0.02 325.858
+0.5 397.098
+1 457.784
+1.5 447.23
+2 415.567
+2.2 401.055
+2.5 48.8127
+2.7 0
+;
+;
+K690-SF 54 498 0 0.95 1.8 LR 
+0.01 643.799
+0.25 688.654
+0.5 730.871
+0.749636 770.449
+1 807.388
+1.25 796.834
+1.5 762.533
+1.75 733.509
+2 696.57
+2.25 659.631
+2.35 0
+;
+;
+K830-SF 54 726 0 1.4 2.4 LR 
+0.02 670.185
+0.5 775.726
+1 886.544
+1.5 986.807
+2 1092.35
+2.5 1187.34
+2.7 0
+;
+;
+L480-LR 75 498 1000 1.814 3.538 LR
+0.02 419.525
+1 509.235
+2 551.451
+3 567.282
+4 564.644
+5 522.427
+6 401.055
+6.4 0
+;
+;
+L780-SF 76 498 0 1.8 3.5 LR 
+0.02 506.596
+0.5 696.57
+1 844.327
+1.5 897.098
+2 934.037
+2.5 918.206
+3 865.435
+3.5 802.111
+3.8 0
+;
+;
+M1200-SF 76 785 0 2.968 5.368 LR 
+0.02 1018.47
+0.5 1203.17
+1 1303.43
+1.5 1398.42
+2 1514.51
+2.5 1498.68
+3 1408.97
+3.5 1203.17
+4 411.609
+4.25 89.7098
+4.5 0
+;
+;
+M3000-LW 76 1038 P 4.064 6.857 LR
+0.083333 3234.3980
+0.166666 3626.9781
+0.333333 4104.8876
+0.5 4045.3220
+0.666667 3824.0989
+0.833333 3649.3737
+1.0 3669.9088
+1.166667 3815.3653
+1.333333 3859.8580
+1.5 3781.1602
+1.666667 3626.9781
+1.833333 3434.5774
+2.0 3093.3818
+2.166667 2643.3598
+2.333333 2052.4438
+2.416667 950.4439
+2.5 846.5966
+2.666667 764.3097
+2.833333 718.9958
+2.916667 718.7712
+3.0 542.0856
+3.166667 410.3503
+3.333333 272.3106
+3.5 0
+;
+;
+M900-LR 75 785 1000 3.13 5.53 LR 
+0.02 807.388
+1 992.084
+2 1050.13
+3 1060.69
+4 992.084
+5 923.483
+5.5 591.029
+6 0
+;
+;
+N3800-LW 98 1016 1000 6.125 11.6 LR 
+0.01 4780.6
+0.5 4572.75
+1 4688.22
+1.5 4965.36
+2 3972.29
+2.5 3002.31
+3 1986.14
+3.25 0
+;
+; Loki Research EX P9381
+P9381 152 2362 0 34.641 57.368 LR-EX
+0.25 12185.3
+3.5 13368.3
+5.60 9582.61
+6.25 5323.67
+7.8 354.911
+8.0 0.0
+;
+; Loki Research EX P4935
+; From RLK test stand data.
+; Created by RL Kinsel.
+P4935 152 1829 0 30.0105 51.9196 LR-EX
+ 0.010 3885.74
+ 0.025 3998.33
+ 0.050 4117.14
+ 1.000 4343.65
+ 2.000 4627.11
+ 3.000 5123.29
+ 4.000 5425.44
+ 5.000 5660.40
+ 6.000 5825.16
+ 7.000 5913.61
+ 8.000 5924.29
+ 9.000 5864.21
+ 9.370 5825.05
+ 9.380 4427.75
+ 10.000 4366.79
+ 10.180 4344.98
+ 10.190 3079.40
+ 11.920 3079.40 
+ 11.930 0.00000
+;
+; Derek Deville DEAP EX Q Motor.
+; Flown in Deville Qu8k rocket to 121,478 ft
+; on September 30, 2011.
+; Exported from BurnSim 3.1 (www.burnsim.com)
+Q18000 203 2438 0 72.515 115.696 DEAP-EX
+   0.01 13861.433
+   0.28 14083.922
+   0.55 14316.859
+   0.82 14559.743
+   1.09 14812.149
+   1.36 15073.716
+   1.63 15344.132
+   1.9 15623.138
+   2.17 15910.506
+   2.44 16206.047
+   2.71 16509.592
+   2.98 16821
+   3.25 17140.156
+   3.52 17026.282
+   3.79 16901.881
+   4.06 16778.066
+   4.33 16654.833
+   4.6 16532.181
+   4.87 16410.112
+   5.14 16363.243
+   5.41 16443.846
+   5.68 16602.704
+   5.95 16814.786
+   6.22 17065.827
+   6.49 17346.975
+   6.76 17652.39
+   7.03 17978.053
+   7.3 18321.091
+   7.57 18679.403
+   7.84 19051.404
+   8.11 19435.888
+   8.38 19831.92
+   8.65 3928.48
+   8.92 2525.882
+   9.19 1559.617
+   9.46 838.016
+   9.73 279.483
+   10 0
+;
+; Prototype M685W, new Aerotech 75mm Moonburner.
+; Flown as upper stage on AeroPac Team two stage
+; rocket to 104,659 ft on September 11, 2012.
+; Won the Carmack Prize.
+; Thrust curve different than standard production
+; M685W Moonburner.
+M685W-Proto 75 879.3 0 4.436 6.954 AT
+0.255639 1066.85
+0.631579 876.987
+1.32331 1012.6
+3.5188 1128.33
+4.81203 1048.77
+6.19549 867.946
+7.21805 560.548
+7.54887 488.219
+7.89474 343.562
+8.27068 216.986
+8.99248 162.74
+9.60902 72.3288
+9.61 0.0
+;
+; Boosted Dart (Zero Thrust)
+Dart 1 1 0 0.01 0.02 NoThrust
+0.01 0.01
+0.02 0.01
+0.03 0.0
+;
+;@File: N1000.txt, @Pts-I: 8069, @Pts-O: 32, @Sm: 3, @CO: 5%
+;@TI: 14137.65, @TIa: 14071.08, @TIe: 0.0%, @ThMax: 2137.42, @ThAvg: 1048.203, @Tb: 13.424
+;Exported using ThrustCurveTool, www.ThrustGear.com
+N1000W 98 1046 1000 7.925 12.777 AT 
+0 0.457288
+0.152 0.314574
+0.162 40.2069
+0.164 148.395
+0.168 598.904
+0.172 890.058
+0.176 995.096
+0.178 1158.03
+0.182 1342.31
+0.19 1556.72
+0.222 1959.8
+0.234 2050.53
+0.254 2111.01
+0.308 2119.9
+0.356 2073.29
+0.47 2091.07
+0.528 1989.54
+0.582 1825.83
+0.648 1733.53
+0.782 1658.07
+0.892 1701.72
+0.914 1633.23
+0.966 1669.56
+1.7839 1594.08
+1.8239 1551.16
+3.1999 1533.43
+5.4538 1378.99
+6.9577 1170.93
+10.9216 424.692
+13.5895 106.05
+14.6754 12.6091
+16.1354 0
+;
+; L1040 Dark Matter
+L1040DM-P 75 681 1000 2.602 4.7170000000000005 AT
+   0.018 1126.167
+   0.042 1036.413
+   0.053 1002.543
+   0.116 988.995
+   0.504 1049.961
+   0.794 1095.685
+   1.002 1146.489
+   1.252 1192.213
+   1.499 1237.937
+   1.753 1261.646
+   1.912 1268.42
+   2.095 1254.872
+   2.511 1134.635
+   2.772 1056.734
+   3.012 966.98
+   3.153 933.11
+   3.217 863.677
+   3.291 817.953
+   3.34 758.681
+   3.488 438.613
+   3.552 284.505
+   3.598 220.153
+   3.657 167.655
+   3.746 118.544
+   3.88 42.337
+   3.996 6.774
+   4.127 0.0
+;
+; M1075 Dark Matter
+M1075DM 98 597 1000 3.846 6.971 AT
+   0.02 927.501
+   0.112 988.073
+   0.26 1033.501
+   0.53 1080.823
+   0.897 1124.359
+   1.509 1198.18
+   1.998 1239.823
+   2.355 1260.644
+   2.503 1264.43
+   2.773 1237.93
+   2.997 1222.787
+   3.502 1162.216
+   4.001 1063.787
+   4.501 906.68
+   4.741 834.751
+   4.878 742.001
+   4.96 664.394
+   5.062 448.608
+   5.164 223.357
+   5.26 79.5
+   5.352 30.286
+   5.5 0.0
+;
+; M1305 Metalstorm
+M1305M 98 597 1000 4.08 7.098 AT
+   0.016 1288.076
+   0.043 1462.78
+   0.08 1370.986
+   0.407 1622.679
+   0.535 1640.446
+   0.787 1705.59
+   0.985 1693.745
+   1.13 1717.434
+   1.328 1693.745
+   1.349 1927.672
+   1.397 1726.317
+   1.751 1711.512
+   2.018 1687.823
+   2.275 1690.784
+   2.297 1892.139
+   2.318 1678.94
+   2.929 1412.441
+   3.748 1113.371
+   4.24 906.095
+   4.503 802.456
+   4.717 663.285
+   4.813 538.919
+   4.92 387.903
+   5.027 245.771
+   5.166 145.094
+   5.263 79.95
+   5.386 32.572
+   5.498 23.689
+   5.707 0.0
+;
+; M685W-PS Moonburner
+M685W-PS 75 936 P 4.32 7.008 AT
+   0.083 1333.469
+   0.13 1368.376
+   0.249 1361.395
+   0.308 1380.012
+   0.403 1359.068
+   0.675 1184.53
+   1.018 1072.826
+   1.456 996.029
+   1.977 958.794
+   2.995 914.578
+   3.99 856.399
+   4.985 781.929
+   5.494 730.732
+   5.991 679.534
+   7.258 542.231
+   7.862 463.107
+   8.015 456.125
+   8.998 330.458
+   9.993 207.118
+   10.514 137.303
+   11.496 34.908
+   11.994 0.0
+;
+; M1780NT Redesign and recert
+M1780NT-PS 75 665 P 2.46 4.649 AT
+   0.014 1112.055
+   0.015 1497.932
+   0.022 1783.542
+   0.036 2105.612
+   0.047 2157.265
+   0.066 2169.419
+   0.104 2123.843
+   0.14 2108.651
+   0.164 2135.996
+   0.197 2129.92
+   0.238 2157.265
+   0.263 2205.88
+   0.274 2169.419
+   0.312 2145.112
+   0.411 2111.689
+   0.595 2081.305
+   0.899 2075.228
+   1.299 2047.883
+   1.601 1996.23
+   1.899 1938.5
+   2.058 1889.886
+   2.201 1813.926
+   2.3 1753.158
+   2.423 1701.505
+   2.467 1622.506
+   2.508 1555.662
+   2.566 1336.897
+   2.62 1112.055
+   2.67 893.29
+   2.724 668.448
+   2.755 568.181
+   2.812 486.144
+   2.9 267.379
+   2.999 75.96
+   3.029 0.0
+;
+;G80 New Blue Thunder
+G80NBT 29 123.825 4-7-10 0.069 0.129 AT 
+0.013 89.054
+0.018 101.584
+0.029 105.388
+0.047 102.927
+0.104 100.018
+0.19 102.255
+0.268 104.94
+0.306 104.269
+0.352 105.835
+0.41 104.94
+0.432 106.73
+0.512 105.612
+0.563 106.954
+0.591 104.493
+0.62 106.283
+0.715 103.15
+0.76 103.374
+0.806 101.36
+0.848 102.032
+1.2 88.383
+1.243 77.866
+1.269 57.952
+1.302 44.079
+1.329 34.011
+1.367 26.403
+1.398 22.823
+1.433 20.585
+1.48 21.704
+1.508 20.809
+1.584 13.201
+1.604 11.635
+1.652 11.188
+1.683 5.37
+1.701 0
+;
+;
+H195NBT 29 203.2 10 0.115 0.197 AT
+   0.003 178.052
+   0.005 224.131
+   0.013 252.516
+   0.019 256.571
+   0.022 248.461
+   0.058 239.614
+   0.1 240.351
+   0.199 235.559
+   0.255 228.555
+   0.285 227.449
+   0.301 230.767
+   0.399 223.025
+   0.5 223.025
+   0.603 220.445
+   0.774 217.127
+   0.802 211.598
+   0.899 201.644
+   0.961 180.632
+   0.999 169.942
+   1.023 161.094
+   1.054 155.196
+   1.101 69.304
+   1.169 0.0
+;
+; AT I140W DMS
+I140W 38 202.7 14-12-10-8-6 0.183 0.356 AT
+   0.011 96.257
+   0.024 80.214
+   0.049 160.428
+   0.062 144.02
+   0.114 160.428
+   0.159 164.074
+   0.238 174.647
+   0.314 173.918
+   0.419 179.023
+   0.627 178.293
+   0.835 176.835
+   0.943 177.2
+   1.146 164.803
+   1.349 148.76
+   1.459 141.103
+   1.562 131.259
+   1.773 113.393
+   2.192 83.86
+   2.295 67.088
+   2.395 37.555
+   2.435 31.356
+   2.47 20.418
+   2.478 0.0
+;
+; I280DM DMS
+I280DM 38 356.4 14-12-10-8-6 0.355 0.616 AT
+   0.016 342.389
+   0.048 297.021
+   0.111 316.16
+   0.173 328.211
+   0.202 327.502
+   0.261 322.54
+   0.334 311.907
+   0.498 310.489
+   0.602 308.363
+   0.705 307.654
+   0.802 310.489
+   0.902 310.489
+   1.0 306.236
+   1.025 316.869
+   1.057 309.072
+   1.1 308.363
+   1.139 317.578
+   1.205 307.654
+   1.298 304.109
+   1.336 316.16
+   1.4 299.856
+   1.5 296.312
+   1.55 298.438
+   1.595 306.945
+   1.634 295.603
+   1.652 280.716
+   1.716 253.07
+   1.743 224.006
+   1.8 153.827
+   1.9 62.381
+   1.97 20.558
+   1.971 0.0
+;
+; J270W DMS
+J270W 38 356.4 14-12-10-8-6 0.381 0.642 AT
+   0.007 367.585
+   0.02 325.124
+   0.074 353.027
+   0.136 329.977
+   0.176 343.928
+   0.273 324.518
+   0.33 342.715
+   0.357 326.338
+   0.399 330.584
+   0.473 310.567
+   0.553 325.731
+   0.734 340.895
+   0.744 357.273
+   0.761 315.419
+   0.788 337.256
+   0.897 340.895
+   1.009 333.617
+   1.053 354.24
+   1.105 320.878
+   1.18 345.748
+   1.214 321.485
+   1.249 345.748
+   1.274 314.206
+   1.5 316.026
+   1.601 309.96
+   1.916 303.894
+   1.956 265.073
+   2.0 214.121
+   2.052 179.546
+   2.102 158.923
+   2.201 117.676
+   2.268 106.151
+   2.303 87.953
+   2.369 55.805
+   2.407 49.739
+   2.486 39.427
+   2.558 21.837
+   2.563 0.0
+;
+;
+G25W-10A 29 152.4 10 0.097 0.17 AT
+   0.01 38.046
+   0.029 21.768
+   0.11 30.475
+   0.239 35.775
+   0.496 40.696
+   0.568 42.116
+   0.592 45.429
+   0.749 46.186
+   0.997 45.713
+   1.255 44.198
+   1.498 39.939
+   1.999 31.421
+   2.501 23.093
+   3.006 14.196
+   3.503 7.288
+   3.999 4.07
+   4.371 1.988
+   4.414 0.0
+;
+; At DMS G125
+G125T-14A 29 127 14 0.062 0.127 AT
+   0.008 89.654
+   0.017 117.24
+   0.027 119.654
+   0.047 111.033
+   0.115 124.826
+   0.2 134.136
+   0.399 149.308
+   0.601 155.17
+   0.8 138.274
+   0.824 133.791
+   0.878 88.964
+   0.914 44.482
+   0.933 22.414
+   0.974 2.069
+   1.001 0.0
+;
+; AT H115 Dark Matter DMS
+H115DM-14A 29 203 14 0.113 0.20500000000000002 AT
+   0.014 89.265
+   0.024 130.742
+   0.036 108.2
+   0.048 101.588
+   0.081 111.206
+   0.202 121.124
+   0.405 123.228
+   0.598 123.829
+   0.8 123.528
+   1.002 122.326
+   1.2 114.211
+   1.269 111.807
+   1.293 111.506
+   1.35 119.32
+   1.367 117.818
+   1.393 111.807
+   1.429 88.964
+   1.467 67.024
+   1.524 44.182
+   1.562 22.842
+   1.583 13.224
+   1.6 6.913
+   1.626 3.306
+   1.662 1.202
+   1.693 0.0
+;
+; At DMS I500T
+I500T-14A 38 355 14 0.248 0.58 AT
+   0.008 447.072
+   0.014 534.306
+   0.028 581.557
+   0.052 504.016
+   0.09 514.92
+   0.11 533.094
+   0.131 524.613
+   0.177 551.268
+   0.202 540.364
+   0.23 552.479
+   0.29 543.998
+   0.399 552.479
+   0.481 553.691
+   0.526 563.384
+   0.565 554.902
+   0.6 564.595
+   0.638 558.537
+   0.728 567.018
+   0.8 560.96
+   0.922 537.94
+   0.979 535.517
+   0.999 546.421
+   1.02 550.056
+   1.043 535.517
+   1.064 444.649
+   1.091 322.28
+   1.11 267.759
+   1.141 225.353
+   1.152 181.737
+   1.16 238.681
+   1.163 149.024
+   1.174 118.735
+   1.2 118.735
+   1.255 86.022
+   1.312 46.04
+   1.335 0.0
+;
+;
+L1250DM 75 801 P 2.565 5.647 AT
+   0.032 1511.087
+   0.049 1295.217
+   0.211 1334.466
+   0.247 1396.61
+   0.256 1553.606
+   0.284 1380.257
+   0.491 1354.09
+   1.493 1448.942
+   1.72 1468.567
+   1.862 1478.379
+   2.008 1458.755
+   2.499 1334.466
+   3.002 1174.199
+   3.108 889.644
+   3.156 667.233
+   3.245 444.822
+   3.42 225.682
+   3.505 94.852
+   3.529 62.144
+   3.574 39.249
+   3.663 16.354
+   3.785 6.541
+   3.842 0.0
+;
+;
+N2220DM 98 1046 P 7.183 11.997 AT
+   0.045 2638.366
+   0.067 2528.97
+   0.084 3063.078
+   0.124 2426.009
+   0.186 2548.275
+   0.231 2599.755
+   0.298 2554.71
+   0.371 2644.801
+   0.534 2638.366
+   0.979 2561.145
+   1.142 2606.19
+   2.002 2638.366
+   2.289 2638.366
+   2.761 2580.45
+   3.121 2496.795
+   3.436 2335.919
+   3.678 2213.653
+   3.79 2129.998
+   4.004 1653.805
+   4.415 888.035
+   4.538 630.634
+   4.656 450.453
+   4.82 289.577
+   5.005 135.136
+   5.219 25.74
+   5.371 0.0
+;
+; Aerotech L1365 Metalstorm for 75/5120, derived from instruction sheet thrust curve.
+L1365M 75 665.5 P 2.648 4.908 AT
+   0.009 166.808
+   0.013 618.303
+   0.022 940.799
+   0.03 1018.642
+   0.046 1160.985
+   0.059 1356.707
+   0.063 1496.826
+   0.076 1616.928
+   0.102 1434.551
+   0.15 1430.103
+   0.193 1472.361
+   0.245 1519.067
+   0.258 1541.308
+   0.282 1592.463
+   0.347 1623.6
+   0.393 1610.256
+   0.486 1574.67
+   0.556 1554.653
+   0.627 1539.084
+   0.673 1512.395
+   0.747 1479.033
+   0.779 1481.257
+   0.831 1496.826
+   0.885 1505.722
+   0.94 1523.515
+   0.987 1465.688
+   1.009 1532.412
+   1.026 1494.602
+   1.098 1534.636
+   1.142 1463.464
+   1.185 1505.722
+   1.224 1476.809
+   1.246 1523.515
+   1.296 1483.481
+   1.322 1516.843
+   1.346 1472.361
+   1.441 1501.274
+   1.504 1507.947
+   1.528 1601.359
+   1.589 1510.171
+   1.699 1512.395
+   1.732 1512.395
+   1.801 1463.464
+   1.864 1496.826
+   1.964 1521.291
+   2.007 1510.171
+   2.068 1450.12
+   2.129 1443.447
+   2.201 1510.171
+   2.237 1463.464
+   2.374 1474.585
+   2.457 1416.758
+   2.546 1427.879
+   2.632 1367.828
+   2.687 1403.413
+   2.776 1343.362
+   2.834 1425.655
+   2.897 1307.777
+   2.93 1347.811
+   2.947 1316.673
+   2.982 1361.155
+   3.051 1354.483
+   3.071 1330.018
+   3.14 1129.848
+   3.175 1029.763
+   3.227 842.938
+   3.277 582.717
+   3.307 449.27
+   3.353 329.168
+   3.414 184.601
+   3.479 88.964
+   3.527 48.93
+   3.587 20.017
+   3.663 17.793
+   3.711 8.896
+   3.752 0.0
+;
+; F44W Economax
+F44W 24 70 4-8 0.0197 0.048 AT
+   0.02 2.676
+   0.026 6.02
+   0.034 11.204
+   0.063 24.917
+   0.135 59.031
+   0.15 61.372
+   0.2 63.212
+   0.299 65.218
+   0.4 65.051
+   0.5 63.379
+   0.6 58.529
+   0.668 55.017
+   0.686 53.68
+   0.687 54.014
+   0.7 49.165
+   0.719 43.813
+   0.774 22.074
+   0.795 13.211
+   0.812 7.86
+   0.825 4.515
+   0.854 2.007
+   0.899 0.167
+   0.998 0.0
+;
+; G74W Economax
+G74W 29 83 4-6-9 0.039299999999999995 0.08700000000000001 AT
+   0.023 6.551
+   0.05 21.838
+   0.088 44.852
+   0.124 67.362
+   0.135 71.561
+   0.148 74.417
+   0.197 80.128
+   0.248 85.0
+   0.298 87.52
+   0.397 89.704
+   0.499 91.215
+   0.6 90.375
+   0.699 90.375
+   0.751 89.536
+   0.8 87.856
+   0.9 84.496
+   0.954 82.144
+   0.971 81.808
+   0.987 79.96
+   1.002 76.433
+   1.023 67.194
+   1.065 44.516
+   1.094 22.174
+   1.107 15.287
+   1.126 6.887
+   1.138 3.36
+   1.157 1.344
+   1.18 0.168
+   1.192 0.0
+;
+; From AT DMS announcement May 2014.
+H45 38 202.7 10 0.18 0.364 AT
+   0.04 84.004
+   0.854 86.004
+   1.377 84.804
+   2.046 79.204
+   2.69 66.003
+   3.286 51.603
+   4.414 28.401
+   5.042 16.001
+   5.429 9.2
+   6.113 6.4
+   6.186 0.0
+;
+; From AT DMS announcement May 2014.
+H182 29 203.2 14 0.115 0.20700000000000002 AT
+   0.007 82.404
+   0.031 159.208
+   0.091 158.408
+   0.186 182.409
+   0.5 192.009
+   0.904 188.809
+   1.054 175.209
+   1.106 180.809
+   1.144 200.81
+   1.163 162.408
+   1.201 36.802
+   1.212 16.801
+   1.235 0.0
+;
+; From AT DMS announcement May 2014.
+I65 54 218 10 0.377 0.752 AT
+   0.023 148.274
+   0.211 196.341
+   0.398 167.827
+   0.797 149.903
+   1.395 135.239
+   2.238 122.204
+   3.199 99.392
+   4.711 69.249
+   5.367 48.882
+   6.246 29.329
+   6.926 15.479
+   7.395 11.406
+   8.496 0.0
+;
+; From AT DMS announcement May 2014.
+I205 29 304.8 14 0.188 0.315 AT
+   0.008 377.299
+   0.028 241.932
+   0.36 256.333
+   0.711 246.252
+   0.861 233.292
+   1.121 230.411
+   1.146 214.571
+   1.242 211.69
+   1.349 141.127
+   1.404 125.286
+   1.489 72.004
+   1.602 41.762
+   1.712 11.521
+   1.787 12.961
+   1.892 0.0
+;
+; From AT DMS announcement May 2014.
+J425 38 356.4 14 0.364 0.631 AT
+   0.018 267.857
+   0.062 368.062
+   0.242 420.092
+   0.524 443.216
+   0.902 452.851
+   1.225 448.997
+   1.389 433.581
+   1.502 452.851
+   1.53 420.092
+   1.542 356.5
+   1.599 67.446
+   1.618 28.905
+   1.648 0.0
+;
+; revised per AT post on TRF 5/19/14
+K535 54 358.1 14 0.745 1.264 AT
+   0.015 467.288
+   0.063 642.221
+   0.104 613.465
+   0.23 627.843
+   0.419 620.654
+   0.883 623.05
+   1.335 599.087
+   1.646 555.953
+   1.843 500.837
+   2.017 450.513
+   2.258 404.983
+   2.488 366.641
+   2.6 230.049
+   2.611 172.537
+   2.648 124.61
+   2.696 81.476
+   2.789 40.738
+   2.837 9.585
+   2.952 0.0
+;
+; per AT announcement 5/8/14
+L1000 54 635 18 1.4000000000000001 2.194 AT
+   0.004 10.664
+   0.011 1268.961
+   0.04 1322.279
+   0.195 1226.307
+   0.249 1268.961
+   0.296 1242.303
+   0.372 1252.966
+   0.416 1215.644
+   0.6 1226.307
+   0.788 1215.644
+   1.066 1183.653
+   1.261 1167.658
+   1.507 1125.004
+   1.746 1087.681
+   1.865 1050.359
+   1.995 1045.027
+   2.093 911.733
+   2.158 746.448
+   2.263 554.504
+   2.389 405.215
+   2.577 191.944
+   2.693 85.308
+   2.761 42.654
+   3.0 0.0
+;
+; AT H550 ST DMS
+H550 38 206 14 0.176 0.316 AT
+   0.008 445.411
+   0.009 533.786
+   0.01 565.601
+   0.013 586.812
+   0.015 623.34
+   0.021 639.837
+   0.036 606.843
+   0.045 629.232
+   0.057 615.092
+   0.061 635.123
+   0.067 619.805
+   0.101 637.48
+   0.116 622.162
+   0.157 643.372
+   0.174 623.34
+   0.196 623.34
+   0.205 639.837
+   0.231 631.588
+   0.234 618.627
+   0.255 611.557
+   0.268 628.053
+   0.314 595.06
+   0.334 600.952
+   0.362 571.493
+   0.386 565.601
+   0.401 556.175
+   0.426 518.468
+   0.445 503.15
+   0.493 447.768
+   0.505 447.768
+   0.511 456.016
+   0.519 451.303
+   0.535 357.036
+   0.545 266.304
+   0.551 179.107
+   0.559 91.91
+   0.565 42.42
+   0.572 12.962
+   0.579 0.0
+;
+; AT M1350W DMS
+M1350W 75 622 p 1.97 4.808 AT
+   0.03 1428.886
+   0.044 1724.734
+   0.056 1548.484
+   0.078 1620.873
+   0.115 1589.399
+   0.178 1642.904
+   0.455 1749.913
+   0.496 1724.734
+   0.54 1737.324
+   1.132 1746.766
+   1.499 1731.029
+   1.639 1715.292
+   2.505 1334.466
+   3.086 1051.207
+   3.179 985.113
+   3.227 928.461
+   3.315 670.38
+   3.419 446.92
+   3.46 396.563
+   3.545 298.996
+   3.697 173.103
+   3.737 173.103
+   3.845 81.83
+   3.996 0.0
+;
+;
+H225R 29 291 10 0.133 0.316 KBA 
+0.025 104.61
+0.091 141.936
+0.104 177.297
+0.16 195.96
+0.26 219.534
+0.336 229.848
+0.345 225.919
+0.43 251.949
+0.562 267.174
+0.668 268.156
+0.742 268.156
+0.794 262.754
+0.818 262.263
+0.89322 256.917
+0.957 272.576
+0.971 275.523
+0.982 271.594
+0.991 230.339
+1.025 162.072
+1.055 72.687
+1.078 32.414
+1.121 0
+;
+;Animal Compatible.
+J740G 38 370 1000 0.308 0.724 KBA 
+0.003 84.03
+0.009 94.757
+0.015 459.483
+0.026 661.512
+0.039 740.178
+0.044 763.42
+0.054 775.935
+0.07 783.087
+0.078 792.026
+0.087 827.784
+0.167 884.996
+0.323 918.965
+0.495 911.814
+0.568 915.389
+0.589 920.753
+0.634 947.571
+0.649 956.51
+0.659 949.359
+0.7 870.693
+0.715 831.359
+0.727 781.299
+0.751 548.876
+0.765 362.938
+0.772 185.938
+0.78 286.059
+0.793 116.212
+0.807 59
+0.844 0
+;
+;
+K520F 38 368 6-10-14 0.327 0.722 KBA 
+0.018 696.864
+0.024 547.629
+0.031 737.092
+0.039 529.461
+0.051 524.27
+0.054 415.263
+0.063 547.629
+0.079 613.811
+0.094 543.735
+0.106 533.354
+0.127 546.331
+0.146 546.331
+0.191 548.926
+0.379 560.605
+0.558 591.75
+0.629 599.536
+0.787 596.941
+0.892 587.857
+0.971 572.285
+1.015 582.666
+1.026 582.666
+1.039 552.819
+1.1 330.913
+1.12 275.112
+1.145 254.349
+1.161 224.502
+1.209 77.862
+1.227 32.442
+1.255 0
+;
+;
+K700F 54 406 6-10-14 0.734 1.503 KBA 
+0.011 789.955
+0.045 831.342
+0.057 753.966
+0.118 741.37
+0.422 800.752
+0.454 818.746
+0.748 872.729
+0.798 870.93
+0.853 890.724
+0.923 903.32
+1.084 908.718
+1.209 897.921
+1.395 843.938
+1.517 786.356
+1.565 777.359
+1.587 775.559
+1.61 786.356
+1.635 753.966
+1.678 543.431
+1.71 446.262
+1.753 300.507
+1.796 131.359
+1.814 50.384
+1.85 0
+;
+;Animal Compatible
+L2300G 54 728 1000 1.31 2.63 KBA 
+0.013 2930.02
+0.019 2243.45
+0.029 2277.3
+0.033 2499.71
+0.054 2533.55
+0.11 2451.36
+0.207 2480.37
+0.443 2654.43
+0.636 2842.99
+0.664 2891.34
+0.757 2833.32
+0.794 2780.14
+0.804 2852.66
+0.812 2789.81
+0.874 2577.07
+0.912 2509.38
+0.943 2461.03
+0.977 2354.66
+0.991 2224.11
+0.997 2354.66
+1.042 1426.33
+1.074 498.007
+1.096 246.586
+1.117 149.886
+1.136 106.37
+1.172 48.35
+1.249 0
+;
+;
+M3500R 75 1039 1000 3.755 7.173 KBA 
+0 0.371006
+0.106 8.86696
+0.122 135.597
+0.14 1587.83
+0.156 2299.92
+0.178 2751.17
+0.2 2842.83
+0.21 2903.6
+0.248 3027.96
+0.932 3723.01
+1.5879 4059.41
+1.9859 3900.58
+2.0279 3759.75
+2.0399 3495.75
+2.0539 3522.63
+2.0739 3313.47
+2.0819 2962.24
+2.0899 2964.52
+2.1639 1015.77
+2.1979 218.762
+2.2059 440.947
+2.2119 274.648
+2.2199 474.133
+2.2219 353.742
+2.2399 180.084
+2.3499 0
+;
+;AWSRM
+P8000 215.9 721.401 1000 23.7228 36.015 CTI
+0.037 3408.31
+0.065 6493.21
+0.066 8284.44
+0.084 9229.81
+0.14 8632.73
+0.364 9254.69
+0.673 9677.61
+0.785 9578.1
+0.991 9602.98
+1.308 9727.37
+1.664 9876.64
+2 9951.27
+2.234 10001
+2.458 9851.76
+2.71 9702.49
+2.916 9428.83
+3.093 9030.78
+3.196 8682.49
+3.383 8458.58
+4 7612.73
+4.467 7090.28
+5 6567.84
+6.009 5622.47
+6.402 5249.3
+6.645 4950.76
+6.692 4776.61
+6.757 2313.67
+6.822 422.929
+6.86 149.269
+6.963 0
+;
+;Pro24-1G Vmax 25-E75
+E75-VM-17A 24 69 17-14-12-10-8 0.016 0.052 CTI 
+0.009 84.213
+0.012 95.099
+0.023 77.08
+0.027 68.697
+0.047 73.452
+0.092 81.835
+0.118 83.837
+0.141 86.465
+0.192 86.966
+0.222 85.339
+0.25 80.083
+0.26 78.332
+0.281 82.961
+0.287 78.206
+0.306 24.776
+0.314 14.14
+0.326 8.509
+0.329 0
+;
+;Pro24-3G White Thunder 74-F85
+F85-WT-15A 24 133 15-12-10-8-6 0.042 0.096 CTI 
+0.01 76.074
+0.023 100.185
+0.04 92.425
+0.118 100.878
+0.283 102.402
+0.51 96.443
+0.688 87.436
+0.787 25.912
+0.852 7.206
+0.873 0
+;
+;Pro24-6G Skidmark 114-G100
+G100-SK-14A 24 228 14-11-9-7-5 0.073 0.159 CTI 
+0.009 148.468
+0.024 178.207
+0.061 145.289
+0.475 117.367
+0.63 106.243
+0.833 85.131
+0.961 51.759
+1.024 29.966
+1.125 13.848
+1.186 0
+;
+;Pro24-6G RL 137-G127
+G127-RL-14A 24 228 14-11-9-7-5 0.081 0.166 CTI 
+0.018 164.454
+0.029 175.478
+0.042 172.103
+0.14 179.753
+0.378 158.83
+0.578 138.583
+0.763 121.485
+0.838 97.638
+0.9 62.317
+0.966 32.621
+1.056 13.048
+1.081 0
+;
+;Pro54-2G White 867-J244
+J244-WH-14A 54 236 14-11-9-7-5 0.511 0.911 CTI 
+0.029 154.144
+0.1 262.541
+0.161 235.691
+0.484 256.575
+0.853 261.215
+1.348 266.519
+1.904 262.541
+2.422 251.934
+2.855 235.691
+3.176 223.094
+3.252 221.768
+3.362 184.972
+3.5 0
+;
+;Pro54-3G White 1281-K360
+K360-WH-13A 54 236 13-10-8-6-4 0.747 1.232 CTI 
+0.034 289.25
+0.077 362.318
+0.463 387.514
+1.106 398.6
+1.564 405.151
+2.063 398.6
+2.57 383.483
+3.101 354.759
+3.18 343.673
+3.417 105.319
+3.5 0
+;
+;Pro54-4G C-Star 1874-K740
+K740-CS-18A 54 404 18-16-14-12-10-8 0.9 1.469 CTI 
+0.02 735.227
+0.052 853.409
+0.486 869.318
+0.893 848.864
+1.903 735.227
+2.131 722.727
+2.32 330.682
+2.462 101.136
+2.5 0
+;
+;Pro75-2G White 2406-K555
+K555-WH-P 75 350 1000 1.486 2.759 CTI 
+0.038 426.052
+0.07 585.324
+0.137 522.412
+0.751 543.914
+1.732 629.124
+2.057 639.477
+3.221 571.786
+3.84 516.041
+4.091 472.241
+4.163 398.976
+4.274 148.919
+4.314 0
+;
+;Pro75-3G White 3683-L851
+L851-WH-P 75 486 1000 2.195 3.789 CTI 
+0.059 971.271
+0.102 855.249
+0.485 838.674
+1.353 911.602
+1.824 980.11
+3.107 883.978
+3.68 816.575
+4.031 732.597
+4.128 579.006
+4.256 246.409
+4.339 0
+;
+;Pro75-6G White/LB 7521-M840
+M840-WH/LB-P 75 879.3 1000 4.436 6.954 CTI 
+0.072 1980.02
+0.246 1447.28
+0.835 1120.98
+2.132 1094.34
+3.922 1003.33
+5.441 810.211
+6.559 621.532
+7.357 472.808
+8.547 199.778
+8.973 97.669
+9.009 0
+;
+;Pro98-6GXL White 19318-N3301
+N3301-WH-P 98 1239 1000 10.919 16.525 CTI 
+0.027 5000
+0.074 4201.39
+0.114 4415.51
+0.325 4091.43
+1.438 3993.06
+2.391 3964.12
+3.139 3842.59
+4.033 3524.31
+4.425 2557.87
+4.774 2314.82
+5.318 1116.9
+5.793 329.861
+5.875 0
+;
+;Pro-54-1G C-Star 518-I165-17A
+;Ejection adjustable from 7 to 17
+I165-CS-17A 54 69 17-15-13-11-9-7 0.267 0.594 CTI 
+0.027 133.424
+0.056 174.831
+0.067 179.973
+0.497 188.633
+1.018 184.032
+1.704 169.959
+2.95 129.364
+3.05 130.717
+3.168 44.655
+3.213 17.862
+3.271 3.518
+3.5 0
+;
+;CTI 30,795-O25000-VM-P
+O25000-VM-P 132 1407 1000 14.705 23.558 CTI 
+0.008 21113.4
+0.022 24705.9
+0.042 26281.5
+0.067 24390.8
+0.201 24044.1
+0.56 25052.5
+0.927 24075.6
+1.202 22815.1
+1.25 23602.9
+1.297 4852.94
+1.32 0
+;
+;Smoky Sam 24mm 1G
+;24-E22-SS-13A
+E22-SS-13A 24 69 13-10-8-6-4 0.0203 0.0565 CTI 
+0.008 18.292
+0.026 30
+0.038 30.792
+0.067 18.708
+0.101 21.875
+0.33 26.083
+0.528 28.042
+0.716 27.875
+0.841 23.542
+0.912 17.833
+0.987 7
+1.016 3.333
+1.065 1.083
+1.087 0
+;
+;White 24mm 1G
+;26-E31-WH-15A
+E31-WH-15A 24 69 15-12-10-8-6 0.0169 0.052 CTI 
+0.02 43.824
+0.027 39.964
+0.049 26.781
+0.113 32.601
+0.193 34.739
+0.282 35.808
+0.5 34.442
+0.727 29.276
+0.771 22.743
+0.807 9.561
+0.84 3.563
+0.87 0
+;
+;Skidmark 24mm 3G
+;60-F50-SK-13A
+F50-SK-13A 24 133 13-10-8-6-4 0.0382 0.0939 CTI 
+0.015 64.982
+0.022 69.516
+0.064 55.537
+0.118 62.81
+0.342 62.149
+0.536 59.41
+0.743 53.837
+0.884 46.942
+0.976 40.047
+1.096 12.562
+1.246 2.078
+1.298 0
+;
+;Classic 24mm 3G
+;75-F51-CL-12A
+F51-CL-12A 24 133 12-9-7-5 0.04 0.095 CTI 
+0.02 75.924
+0.031 84.148
+0.062 70.441
+0.117 73.659
+1.211 38.737
+1.376 14.779
+1.456 7.271
+1.532 3.337
+1.577 0
+;
+;White 38mm 6GXL
+;1013-J453-WH-16A
+J453-WH-16A 38 500 16-13-11-9-7 0.6132 0.9643 CTI 
+0.018 663.789
+0.04 725.18
+0.105 630.216
+0.23 578.417
+0.451 543.885
+1.454 535.252
+1.797 291.607
+1.91 188.969
+2.088 128.537
+2.276 19.185
+2.364 0
+;
+;Skidmark 75mm 2G
+;1955-K735-SK-P
+K735-SK-P 75 350 1000 1.2221 2.5088 CTI 
+0.053 683.157
+0.142 593.64
+0.408 697.291
+0.893 848.057
+1.109 886.926
+1.24 882.214
+1.362 889.282
+2 783.274
+2.346 706.714
+2.439 648.999
+2.612 123.675
+2.676 36.514
+2.754 12.956
+2.831 0
+;
+;Pink 54mm 5G
+;1997-K650-PK-21
+K650-PK-21 54 488 21-19-17-15-13-11 1.0651 1.71 CTI 
+0.011 1353.5
+0.028 793.832
+0.186 815.421
+2.578 601.186
+2.689 479.953
+2.855 189.324
+3.086 43.179
+3.451 0
+;
+;VMax 75mm 2G
+;2330-K2000-VM-P
+K2000-VM-P 75 350 1000 1.1642 2.4645 CTI 
+0.01 1979.53
+0.029 1634.5
+0.161 1947.37
+0.321 2190.06
+0.457 2397.66
+0.548 2473.68
+0.678 2383.04
+0.768 2263.16
+0.977 1923.98
+1.027 1883.04
+1.104 859.649
+1.149 87.719
+1.191 0
+;
+;Blue Streak 75mm 2G
+;2430-K661-BS-P
+K661-BS-P 75 350 1000 1.2625 2.5278 CTI 
+0.041 588.591
+0.073 659.371
+0.122 635.157
+0.225 634.226
+0.679 713.388
+1.039 751.572
+1.241 758.091
+1.832 727.357
+2.298 687.311
+2.729 667.753
+3.195 645.402
+3.367 670.547
+3.584 182.538
+3.672 55.879
+3.72 18.626
+3.798 0
+;
+;White 54mm 6GXL
+;2833-L805-WH-P
+L805-WH-P 54 649 1000 1.6752 2.5025 CTI 
+0.012 1618.1
+0.037 1171.8
+0.173 1027.97
+0.388 994.125
+0.626 985.664
+2.318 886.251
+3.054 448.414
+3.464 126.91
+3.608 40.188
+3.827 0
+;
+;C-Star 75mm 2G
+;2856-L910-CS-P
+L910-CS-P 75 350 1000 1.3643 2.6158 CTI 
+0.034 858.741
+0.056 921.678
+0.305 952.448
+0.718 983.217
+1.221 1047.55
+1.642 1005.59
+1.842 973.427
+2.951 773.427
+3.035 584.615
+3.108 169.231
+3.152 72.727
+3.182 27.972
+3.262 0
+;
+;VMax 75mm 3G
+;3300-L3200-VM-P
+L3200-VM-P 75 486 1000 1.6584 3.2637 CTI 
+0.008 3315.23
+0.024 2672.96
+0.108 2975.21
+0.415 3669.42
+0.524 3711.92
+0.644 3669.42
+0.819 3225.5
+0.911 3022.43
+0.937 3050.77
+0.957 2899.65
+1.022 288.076
+1.039 51.948
+1.055 0
+;
+;Green 75mm 3G
+;3419-L645-GR-P
+L645-GR-P 75 486 1000 2.1441 3.7518 CTI 
+0.05 511.243
+0.12 647.574
+0.256 689.231
+0.425 684.497
+1.554 736.568
+2.043 764.97
+3.075 687.337
+4.557 601.183
+4.756 550.059
+4.985 412.781
+5.281 69.112
+5.39 0
+;
+;Blue Streak 75mm 3G
+;3727-L1050-BS-P
+L1050-BS-P 75 486 1000 1.8634 3.4477 CTI 
+0.035 721.412
+0.081 1110.12
+0.131 1057.41
+0.249 1100.23
+0.913 1194.12
+1.125 1207.29
+2.271 1100.23
+2.797 1055.77
+3.076 1042.59
+3.122 996.471
+3.23 807.059
+3.452 289.882
+3.544 123.529
+3.685 36.235
+3.731 0
+;
+;C-Star 75mm 3G
+;4263-L1350-CS-P
+L1350-CS-P 75 486 1000 2.0245 3.5707 CTI 
+0.016 1421.72
+0.034 1345.22
+0.049 1502.48
+0.081 1415.35
+0.21 1432.35
+0.453 1432.35
+0.809 1462.1
+1.07 1534.36
+1.28 1540.73
+2.661 1283.59
+2.843 1277.21
+2.932 1115.7
+3.037 488.784
+3.163 82.881
+3.284 0
+;
+;Green 98mm 6GXL
+;17907-N2540-GR-P
+N2540-GR-P 98 1239 1000 10.7042 16.2805 CTI 
+0.073 2586.93
+0.11 2789.97
+0.398 2761.96
+1.14 2761.96
+1.73 2828.47
+2.613 2894.98
+4.16 2747.96
+5.666 2565.93
+5.972 2415.4
+6.338 1953.33
+6.819 745.624
+7.061 101.517
+7.222 0
+;
+;Pink 38mm 5G
+;654-J316-PK-17A
+J316-PK-17A 38 367 17-14-12-10-8 0.3508 0.6071 CTI 
+0.017 393.07
+0.026 443.25
+0.064 381.123
+0.223 393.07
+0.503 379.331
+1.029 354.241
+1.52 320.789
+1.672 313.023
+1.695 296.296
+1.816 145.759
+1.901 88.411
+2.043 32.855
+2.184 0
+;
+; Imax Pro75 6GXL
+; 9977 M2245-IM-P
+M2245-IM-P 75 1025 P 5.309 8.182 CTI
+   0.043 3045.655
+   0.136 2629.813
+   1.393 3003.3
+   2.168 3007.151
+   2.708 2972.497
+   2.837 2883.938
+   3.152 1955.996
+   3.397 1409.241
+   3.878 562.156
+   4.371 0.0
+;
+; CTI Pro-38 5G
+; 567 I125 WH LB 10A
+I125-WH-LB-10 38 367 10-7-5-3 0.3556 0.647 CTI
+   0.046 174.74
+   0.089 267.82
+   0.135 235.986
+   0.258 193.772
+   0.35 182.007
+   0.553 174.74
+   1.124 176.125
+   1.502 173.01
+   1.806 162.284
+   2.439 135.986
+   3.372 84.775
+   4.005 36.678
+   4.395 14.879
+   4.585 0.0
+;
+; CTI Pro-98 4G
+; 8634 M6400-VM P
+M6400-VM-P 98 702 P 4.308 7.9190000000000005 CTI
+   0.011 6079.636
+   0.135 6598.407
+   0.354 7080.774
+   0.503 7244.596
+   0.713 7162.685
+   0.954 6707.622
+   1.183 5688.282
+   1.233 5460.751
+   1.26 4914.676
+   1.288 3394.767
+   1.331 800.91
+   1.383 0.0
+;
+; CTI Pro-98 6GXL
+; 21062 O3400-IM P
+O3400-IM-P 98 1239 P 11.272 16.842 CTI
+   0.04 3959.811
+   0.052 4432.624
+   0.101 4515.366
+   0.19 4420.804
+   0.38 4391.253
+   0.965 4444.444
+   2.176 4698.582
+   2.887 4592.199
+   3.658 4225.768
+   4.17 2854.61
+   4.493 2559.102
+   4.881 1619.385
+   5.483 868.794
+   6.137 248.227
+   6.322 0.0
+;
+;
+N5600WT 98 1010 P 6.363 11.28 CTI
+   0.019 6750.0
+   0.041 6250.0
+   0.044 6078.947
+   0.077 5960.526
+   0.198 6144.737
+   0.749 6328.947
+   0.931 6447.368
+   1.049 6368.421
+   1.25 6118.421
+   1.501 5828.947
+   1.751 5500.0
+   1.999 5263.158
+   2.131 5131.579
+   2.17 5144.737
+   2.2 4986.842
+   2.252 4013.158
+   2.291 3013.158
+   2.335 2000.0
+   2.373 1000.0
+   2.401 500.0
+   2.448 171.053
+   2.483 0.0
+;
+;CTI 56-F31-CL-12A
+F31-CL-12A 24 98.0008 13-9-7-5-3 0.032 0.102 CTI 
+0.001 3.483
+0.023 64.053
+0.05 31.347
+0.059 28.459
+0.095 32.027
+0.212 36.189
+0.344 37.549
+1.567 26.165
+1.631 26.93
+1.663 25.316
+1.785 3.653
+1.828 0
+;
+;CTI 50-F51-BS-13A
+F51-BS-13A 24 101.001 13-10-8-6-4 0.028 0.073 CTI 
+0.001 5.145
+0.027 67.976
+0.051 53.807
+0.06 52.88
+0.092 55.916
+0.119 57.94
+0.17 59.711
+0.3 61.145
+0.462 58.952
+0.569 55.578
+0.675 52.205
+0.778 46.386
+0.846 38.12
+0.917 20.325
+1.009 3.542
+1.032 1.602
+1.045 0
+;
+;CTI 53-F32-WH-12A
+F32-WH-12A 29 98.0008 12-9-7-5-3 0.037 0.107 CTI 
+0.002 2.999
+0.035 48.044
+0.065 24.055
+0.111 31.03
+0.162 32.79
+0.36 34.811
+0.521 35.593
+0.665 36.701
+0.787 35.984
+1.436 29.205
+1.513 27.249
+1.576 21.578
+1.641 7.171
+1.726 0
+;
+;CTI 53-F70-WT-14A
+F70-WT-14A 24 101.001 14-11-9-7-5 0.029 0.073 CTI 
+0.001 8.303
+0.013 85.68
+0.023 96.149
+0.052 78.821
+0.1 83.634
+0.379 77.858
+0.641 62.575
+0.665 55.716
+0.706 23.947
+0.744 9.146
+0.787 2.768
+0.816 0
+;
+;CTI 143-G33-MY-9A
+G33-MY-9A 29 187 9-6-4-2 0.089 0.197 CTI 
+0.009 5.657
+0.035 62.823
+0.07 27.443
+0.143 34.789
+0.228 38.589
+0.568 39.771
+1.358 37.66
+3.126 36.14
+3.405 31.58
+3.762 21.616
+4.224 6.671
+4.461 0
+;
+;CTI 186-H42-MY-10A
+H42-MY-10A 29 231 10-7-5-3-1 0.117 0.242 CTI 
+0.015 8.71
+0.035 82.796
+0.059 43.548
+0.118 48.387
+0.261 54.946
+0.391 55.484
+1.21 51.29
+2.797 49.462
+3.029 45.161
+3.757 20.538
+4.374 4.409
+4.448 0
+;
+;CTI 234-H53-MY-12A
+H53-MY-12A 29 275.999 12-9-7-5-3 0.145 0.286 CTI 
+0.006 8.958
+0.027 101.042
+0.042 63.234
+0.102 71.006
+0.2 77.988
+0.362 79.832
+0.98 71.138
+2.561 65.341
+2.663 60.862
+3.661 16.731
+4.011 9.353
+4.316 4.347
+4.447 0
+;
+;CTI 395-I55-MY-9A
+I55-MY-9A 38 245.001 9-6-4-2 0.243 0.437 CTI 
+0.009 10.024
+0.033 92.296
+0.066 57.669
+0.094 55.325
+0.222 64.308
+0.471 67.953
+2.088 63.266
+3.753 61.704
+5.195 62.225
+5.789 43.87
+6.105 40.095
+6.765 13.669
+7.085 6.639
+7.246 0
+;
+;CTI 644-J94-MY-P
+J94-MY-P 38 367 0 0.393 0.66 CTI 
+0.005 19.477
+0.014 168.646
+0.05 133.967
+0.113 133.967
+0.203 146.081
+0.752 133.967
+1.787 116.865
+3.075 110.451
+4.236 108.314
+4.803 77.672
+5.474 56.295
+6.375 17.577
+6.879 6.413
+6.928 0
+;
+;CTI 699-J145-SK-LB-19A
+J145-SK-LB-19A 54 235.999 19-17-15-13-11-9 0.416 0.837 CTI 
+0.011 39.12
+0.018 498.166
+0.059 224.939
+0.154 257.335
+0.488 235.33
+1.881 180.318
+3.612 78.851
+4.669 31.174
+4.896 22.616
+4.944 0
+;
+;CTI 949-J150-MY-P
+J150-MY-P 38 499.999 0 0.596 0.951 CTI 
+0.004 33.051
+0.03 324.576
+0.12 248.729
+0.617 225
+1.385 201.271
+2.306 183.475
+3.425 177.119
+4.149 123.729
+4.934 79.661
+5.59 42.373
+6.318 19.492
+6.434 0
+;
+;CTI 1711-K520-WH-17A
+K520-WH-17A 54 404 17-15-13-11-9-7 0.988 1.576 CTI 
+0.007 121.739
+0.023 591.787
+0.075 615.459
+0.151 580.797
+1.629 568.116
+2.177 535.145
+2.903 476.812
+2.993 414.251
+3.242 97.222
+3.34 0
+;
+;CTI 2130-K600-WH-17A
+K600-WH-17A 54 488 17-15-13-11-9-7 1.238 1.892 CTI 
+0.002 97.239
+0.007 785.114
+0.03 741.897
+0.101 745.498
+0.148 731.092
+0.455 699.88
+1.711 669.868
+2.313 619.448
+2.911 559.424
+3.093 420.168
+3.513 60.024
+3.535 0
+;
+;CTI 2377-K711-WH-18A
+K711-WH-18A 54 572 18-16-14-12-10-8 1.464 2.198 CTI 
+0.002 239.856
+0.003 1702.76
+0.03 976.711
+0.149 903.241
+0.474 855.702
+1.791 780.072
+2.397 721.729
+2.65 546.699
+2.976 395.438
+3.343 105.882
+3.359 0
+;
+;CTI 2645-L265-MY-P
+L265-MY-P 54 649 0 1.644 2.481 CTI 
+0.007 30.035
+0.021 461.131
+0.188 425.206
+0.607 399.882
+1.353 354.535
+1.939 336.278
+3.592 319.199
+6.053 312.132
+8.09 133.098
+8.508 95.995
+9.485 47.114
+9.882 0
+;
+;CTI 5198-M1101-WH-P
+M1101-WH-P 75 621 0 3.096 4.938 CTI 
+0.003 281.69
+0.05 1436.62
+0.121 1363.38
+0.366 1263.85
+0.59 1230.05
+1.745 1322.07
+2.835 1166.2
+4 974.648
+4.158 839.437
+4.668 82.629
+4.736 0
+;
+;CTI 4937-L395-MY-P
+L395-MY-P 75 757 0 3.488 5.706 CTI 
+0.04 91.159
+0.129 484.229
+0.209 578.734
+0.547 553.644
+2.043 511.828
+7.329 439.068
+8.632 424.014
+9.573 297.73
+11.399 100.358
+12.445 30.108
+12.501 0
+;
+;CTI 16803-N1560-WH-MB-P
+N1560-WH-MB-P 98 1239 0 10.387 15.858 CTI 
+0.007 260.331
+0.067 2888.43
+0.171 3198.35
+0.291 2826.45
+0.894 2421.49
+2.503 2231.41
+3.866 2041.32
+5.333 1723.14
+9.244 570.248
+10.711 165.289
+10.823 0
+;
+;
+M1590 75 893 P 3.59 6.0760000000000005 CTI
+   0.053 2045.469
+   0.119 2130.875
+   0.133 2220.551
+   0.226 2305.957
+   0.363 2241.903
+   0.438 2177.849
+   0.571 2130.875
+   0.748 2092.443
+   0.973 2088.172
+   1.225 2100.983
+   1.433 2079.632
+   1.597 2032.659
+   1.995 1883.198
+   2.411 1759.36
+   3.362 1567.197
+   3.491 1533.035
+   3.721 1076.113
+   3.769 1012.059
+   3.871 973.626
+   3.946 896.761
+   4.074 687.517
+   4.132 640.544
+   4.203 619.192
+   4.504 294.65
+   4.641 226.325
+   4.716 170.812
+   4.8 0.0
+;
+;
+K580-TT 54 491 P 0.895 1.823 CTI
+   0.019 832.772
+   0.022 892.014
+   0.042 968.182
+   0.078 858.161
+   0.111 876.78
+   0.407 832.772
+   0.49 812.46
+   0.59 803.997
+   0.958 754.911
+   1.278 695.669
+   1.601 626.271
+   1.919 567.03
+   2.242 499.325
+   2.434 463.779
+   2.512 436.697
+   2.568 407.923
+   2.601 384.226
+   2.629 345.296
+   2.66 316.521
+   2.701 279.283
+   2.791 223.427
+   2.88 169.263
+   2.93 138.795
+   3.066 88.017
+   3.178 47.394
+   3.194 0.0
+;
+;
+K935-WW 54 403 P 0.732 1.508 CTI
+   0.01 1058.833
+   0.016 1047.068
+   0.025 1005.051
+   0.038 974.799
+   0.06 1013.455
+   0.169 1050.43
+   0.256 1060.514
+   0.339 1070.598
+   0.508 1065.556
+   0.591 1062.195
+   0.681 1050.43
+   0.755 1045.388
+   0.849 1025.219
+   1.021 994.967
+   1.19 946.227
+   1.36 889.084
+   1.415 870.596
+   1.481 857.151
+   1.493 825.218
+   1.531 675.636
+   1.552 616.812
+   1.582 445.382
+   1.624 250.422
+   1.639 188.237
+   1.661 115.967
+   1.691 47.059
+   1.7 0.0
+;
+;
+M2050-SK 75 1039 P 3.87 7.1290000000000004 CTI
+   0.012 1461.807
+   0.027 2170.034
+   0.066 2128.168
+   0.196 2253.765
+   0.338 2344.474
+   0.459 2354.94
+   0.68 2442.16
+   0.81 2484.026
+   0.843 2518.914
+   1.094 2515.425
+   1.154 2543.335
+   1.487 2494.492
+   1.556 2508.447
+   1.702 2452.626
+   1.819 2396.806
+   1.907 2271.209
+   1.977 2215.388
+   2.01 2243.298
+   2.043 2173.522
+   2.209 2051.414
+   2.385 1960.706
+   2.542 1890.93
+   2.581 1894.418
+   2.599 1985.127
+   2.641 1894.418
+   2.726 1897.907
+   2.786 1856.042
+   2.892 1336.21
+   2.989 893.133
+   3.068 701.249
+   3.104 725.67
+   3.134 648.917
+   3.264 223.283
+   3.324 115.13
+   3.385 55.821
+   3.4 0.0
+;
+;
+J300LR 54 327 P 0.62 1.315 LR
+   0.015 78.248
+   0.025 89.305
+   0.06 358.069
+   0.076 395.492
+   0.111 403.147
+   0.176 381.033
+   0.287 365.724
+   0.504 363.172
+   0.998 361.471
+   1.497 363.172
+   2.001 344.461
+   2.227 331.703
+   2.504 310.44
+   2.993 270.465
+   3.255 242.398
+   3.502 222.836
+   3.578 222.836
+   3.643 190.516
+   3.699 134.382
+   3.724 118.222
+   3.8 106.315
+   3.926 44.227
+   3.996 29.768
+   4.278 0.0
+;
+;
+K527LR 54 492.1 P 1.0150000000000001 1.973 LR
+   0.023 87.866
+   0.051 624.477
+   0.06 701.36
+   0.079 759.414
+   0.125 707.636
+   0.176 682.531
+   0.269 654.288
+   0.501 649.581
+   1.01 644.874
+   1.265 640.167
+   1.52 646.443
+   1.701 643.305
+   2.035 618.201
+   2.526 567.991
+   2.827 539.749
+   2.943 530.335
+   2.999 513.075
+   3.04 442.468
+   3.115 356.171
+   3.309 219.665
+   3.481 91.004
+   3.546 59.623
+   3.652 43.933
+   3.791 37.657
+   3.967 10.983
+   4.129 0.0
+;
+;
+M1650LC 76 784.2 P 3.23 5.63 LR
+   0.015 1912.965
+   0.046 3779.835
+   0.097 3149.862
+   0.132 2865.606
+   0.183 2642.811
+   0.295 2458.429
+   0.407 2350.873
+   0.509 2297.095
+   0.91 2097.347
+   1.495 1920.648
+   1.612 1882.235
+   2.772 1336.771
+   3.266 1044.832
+   3.342 960.324
+   3.398 860.45
+   3.505 798.989
+   3.606 629.972
+   3.81 361.082
+   3.901 238.16
+   4.008 153.652
+   4.613 0.0
+;
+;
+M3400LB 76 1038.2 P 4.464 7.597 LR
+   0.007 4907.495
+   0.02 4008.216
+   0.047 3866.9
+   0.35 3866.9
+   0.502 3866.9
+   0.579 3892.594
+   1.239 4277.999
+   1.808 4303.693
+   1.886 4303.693
+   1.919 4188.071
+   2.0 3404.414
+   2.064 2916.234
+   2.152 2569.369
+   2.242 2569.369
+   2.283 2440.901
+   2.347 1965.567
+   2.384 1541.621
+   2.434 1104.829
+   2.485 835.045
+   2.545 719.423
+   2.596 475.333
+   2.717 205.55
+   2.862 51.387
+   2.976 0.0
+;
+;
+J1026 38 625.5 P 0.616 1.172 LR
+   0.019 62.798
+   0.034 795.446
+   0.045 1167.004
+   0.07 1182.703
+   0.149 1153.921
+   0.249 1146.071
+   0.4 1161.77
+   0.49 1185.32
+   0.6 1193.17
+   0.8 1180.087
+   0.851 1172.237
+   0.899 1169.62
+   0.922 1159.154
+   0.947 1167.004
+   0.979 1127.755
+   1.009 1067.573
+   1.089 669.85
+   1.13 486.688
+   1.142 468.371
+   1.151 408.19
+   1.161 316.609
+   1.176 222.411
+   1.201 128.213
+   1.227 65.415
+   1.264 26.166
+   1.297 0.0
+;
+;
+K1127LB 38 625.5 P 0.624 1.172 LR
+   0.009 77.978
+   0.021 1002.962
+   0.033 1368.654
+   0.045 1210.008
+   0.058 1365.965
+   0.067 1263.786
+   0.08 1360.587
+   0.092 1255.719
+   0.105 1331.009
+   0.117 1242.275
+   0.13 1312.186
+   0.142 1261.097
+   0.155 1304.12
+   0.167 1261.097
+   0.218 1290.675
+   0.395 1325.631
+   0.542 1368.654
+   0.689 1392.854
+   0.726 1382.098
+   0.755 1344.453
+   0.814 1110.518
+   0.867 949.184
+   0.874 1099.763
+   0.883 962.629
+   0.908 847.006
+   0.989 548.537
+   0.997 363.002
+   1.003 715.249
+   1.014 494.759
+   1.048 406.025
+   1.091 352.247
+   1.152 228.557
+   1.198 158.645
+   1.244 69.912
+   1.286 32.267
+   1.37 0.0
+;
+;
+L840CT 75 498 P 2.074 3.748 LR
+   0.021 889.644
+   0.046 1182.485
+   0.077 1082.4
+   0.139 978.608
+   0.303 971.195
+   0.662 1015.677
+   1.011 1108.348
+   1.33 1149.124
+   1.689 1189.899
+   1.971 1163.951
+   2.089 1145.417
+   2.3 1034.211
+   2.633 893.351
+   2.823 822.921
+   3.455 656.112
+   3.737 596.803
+   3.891 585.682
+   3.984 385.512
+   4.112 355.858
+   4.215 203.877
+   4.292 140.86
+   4.384 103.792
+   4.589 63.016
+   4.8 0.0
+;
+;
+M1969SF 75 1038 P 4.266 7.189 LR
+   0.036 263.323
+   0.044 1504.064
+   0.075 2204.77
+   0.087 2356.515
+   0.186 2204.77
+   0.23 2280.643
+   0.274 2240.475
+   0.503 2347.589
+   1.003 2432.388
+   1.058 2454.703
+   1.495 2307.421
+   2.002 2236.012
+   2.315 2186.918
+   2.501 2182.454
+   2.628 2169.065
+   2.815 2244.938
+   2.882 2191.381
+   3.045 1338.929
+   3.096 1142.553
+   3.164 1044.365
+   3.267 964.029
+   3.378 807.821
+   3.5 504.33
+   3.639 267.786
+   3.77 102.651
+   3.881 22.315
+   3.96 0.0
+;
+; 54-2800 Loki Red
+L1040LR 54 736 P 1.19 2.962 LR
+   0.015 1021.164
+   0.03 1237.857
+   0.074 1289.322
+   0.115 1324.534
+   0.218 1232.44
+   0.392 1189.101
+   0.514 1197.227
+   0.744 1232.44
+   1.032 1297.448
+   1.251 1340.786
+   1.517 1392.251
+   2.013 1394.959
+   2.161 1386.833
+   2.257 1343.495
+   2.416 1067.212
+   2.453 999.495
+   2.512 961.574
+   2.612 939.905
+   2.735 755.716
+   2.838 604.031
+   2.897 509.228
+   3.012 474.015
+   3.212 257.323
+   3.297 170.646
+   3.404 119.181
+   3.475 113.764
+   3.549 92.094
+   3.619 54.173
+   3.7 0.0
+;
+; 54-4000 Loki White
+L2050LW 54 1113.8 P 2.388 4.056 LR
+   0.027 366.324
+   0.028 137.372
+   0.043 2237.193
+   0.053 2701.64
+   0.074 2786.679
+   0.133 2682.015
+   0.218 2610.059
+   0.324 2708.181
+   0.495 2858.636
+   0.691 3061.422
+   0.87 3172.628
+   0.968 3329.624
+   1.066 3251.126
+   1.125 3139.92
+   1.157 2858.636
+   1.181 2701.64
+   1.213 2616.6
+   1.306 2479.229
+   1.338 2171.778
+   1.41 1962.45
+   1.503 1870.869
+   1.614 1426.047
+   1.753 1020.474
+   1.859 870.02
+   1.997 627.984
+   2.0 667.233
+   2.125 431.739
+   2.316 235.494
+   2.521 0.0
+;
+;
+L425WC 75 497 1000 1.75 3.502 GM
+0.02 756.198
+0.05 711.716
+0.125 756.198
+0.180791 689.647
+0.361582 662.061
+0.514124 644.82
+0.954802 631.027
+1.28249 620.682
+2.00565 586.2
+2.96296 524.132
+4.42561 427.581
+5.46139 341.375
+6.5725 224.135
+7.37602 110.343
+7.95 0
+;
+;
+L695BL 75 497 1000 1.65 3.402 GM
+0.01 333.617
+0.05 378.099
+0.49592 560.338
+0.994978 724.129
+1.49718 883.61
+1.98996 1043.09
+2.1312 1064.64
+2.2693 1064.64
+2.50471 1064.64
+2.63967 1043.09
+2.76208 965.506
+2.95355 797.404
+3.1764 512.925
+3.36472 288.79
+3.69115 38.7926
+3.84 0
+;
+;
+I235WC 38 348 1000 0.175 0.585 GM
+0.02 245
+0.2 270
+0.4 280
+0.6 290
+0.75 290
+1 278
+1.2 220
+1.4 0
+;
+;
+M1085WC 75 1039 1000 3.81 7.058 GM
+0.01 2001.7
+0.05 1934.98
+0.25 2112.91
+0.4 2224.11
+0.45 2268.59
+0.5 2290.83
+0.55 2290.83
+0.6 2224.11
+0.9 1846.01
+1.1 1690.32
+1.45 1534.64
+3.65 978.609
+4.65 667.233
+6.7 88.9644
+7.2 0
+;
+;
+I392BL 38 396 18 0.27 0.657 GM
+0.075 400.34
+0.2 498.201
+0.4 511.546
+0.6 498.201
+0.8 444.822
+0.9 400.34
+1.2 0
+;
+;
+I462WC 38 396 18 0.288 0.678 GM
+0.05 266.893
+0.075 400.34
+0.1 489.304
+0.2 533.787
+0.4 556.028
+0.6 542.683
+0.8 533.787
+1 511.546
+1.25 0
+;
+;
+J607WC 38 518 18 0.37 0.824 GM
+0.05 613.855
+0.2 747.301
+0.27 778.439
+0.35 800.68
+0.4 791.784
+0.8 667.233
+0.86 587.165
+1.05 142.343
+1.12 0
+;
+;
+M745WC 75 785 1000 2.95 5.62 GM
+0.1 1112.06
+0.15 1245.5
+0.3 1445.67
+0.6 1547.98
+0.7 1556.88
+0.75 1334.47
+7.25 0
+;
+;
+K670WC 75 368 1000 1.18 2.77 GM
+0.05 289.134
+0.1 444.822
+0.15 533.787
+1.2 845.162
+1.76711 845.162
+2.05 822.921
+2.25 778.439
+3.25 600.51
+3.6 66.7233
+3.75 0
+;
+;
+M2925WC 75 1039 1000 3.81 7.058 GM
+0.02 2579.97
+0.05 3024.79
+0.1 3291.68
+0.5 3869.95
+1 4448.22
+1.35 4537.19
+1.5 4225.81
+1.85 2446.52
+2.1 1334.47
+2.32 778.439
+2.75 0
+;
+;
+K235WC 75 368 1000 1.18 2.77 GM
+0.01 355.858
+0.02 378.099
+0.35 444.822
+0.45 409.236
+0.7 395.892
+4 275.79
+9.1 0
+;
+;
+K411BL 75 368 1000 1.08 2.67 GM
+0.01 88.9644
+0.015 44.4822
+0.1 88.9644
+0.15 177.929
+0.25 231.308
+1 311.376
+2.1 556.028
+2.4 578.269
+2.6 578.269
+3.7 511.546
+3.85 422.581
+4.3 44.4822
+4.4 0
+;
+;
+M1465BL 98 870 1000 4.49 9.80 GM
+0.33 1113
+1.65 1752
+3.0 2219
+3.5 2100
+4 1824
+4.3 1335
+4.45 334
+5.2 0
+;
+;
+M1025WC 98 870 1000 5.33 10.1 9.80 GM
+0.1 1780
+0.5 1558
+3.25 1500
+6.179 795
+9.36 0
+;
+;
+N2717WC 98 870 0 5.328 10.138 GM
+0.047 164.967
+0.063 377.068
+0.071 907.319
+0.075 1649.67
+0.0847458 2241.35
+0.241682 2465.49
+0.596359 2965.48
+0.8914 3379.27
+1.128 3688.19
+1.329 3947.43
+1.522 4100.61
+1.723 4194.88
+1.841 4194.88
+1.901 4194.88
+1.936 4135.96
+2.00879 4034.43
+2.19083 3706.85
+2.37916 3344.79
+2.60829 2931
+2.808 2568.77
+2.99121 2206.87
+3.20778 1810.32
+3.4275 1396.53
+3.5248 1206.88
+3.671 883.752
+3.841 459.551
+3.927 282.801
+4.014 200.317
+4.271 58.917
+4.393 0
+;
+;
+N1720WC 98 1212 0 7.468 15.423 GM
+0.033 3571.66
+0.06 3290.38
+0.067 3100.67
+0.113 3244.58
+0.207286 3275.82
+0.293 3303.46
+0.42 3473.54
+0.54 3591.28
+0.607 3591.28
+0.673 3584.74
+0.72 3506.24
+0.773 3427.75
+0.82 3336.16
+0.867 3251.13
+0.893 3205.34
+1.14 3100.67
+1.467 2897.89
+2.153 2610.06
+2.587 2446.52
+3 2276.44
+4.013 1812
+4.993 1341.01
+6.013 804.605
+6.647 510.237
+6.84673 431.029
+6.99121 379.306
+7.15452 310.341
+7.4309 258.618
+7.68216 189.653
+7.88945 120.688
+8.05276 51.7235
+8.253 0
+;
+;
+O2700BL 152.4 1206.5 P 15.149000000000001 33.339 GM
+   0.037 446.335
+   0.056 612.765
+   0.121 627.895
+   0.26 1210.4
+   0.261 1331.44
+   0.501 1739.95
+   0.734 2322.455
+   0.994 2594.795
+   2.006 3147.04
+   3.008 3646.33
+   3.519 3805.195
+   4.318 3888.41
+   4.494 3850.585
+   4.995 3691.72
+   5.478 3578.245
+   6.193 3162.17
+   6.249 3245.385
+   6.314 3101.65
+   7.001 2345.15
+   7.456 1777.775
+   7.864 1210.4
+   7.994 1051.535
+   8.208 839.715
+   8.431 605.2
+   8.598 506.855
+   8.821 355.555
+   9.044 234.515
+   9.331 143.735
+   9.443 121.04
+   9.499 0.0
+;
+;
+L1112BT 75 497.8 P 1.8 3.628 GM
+   0.017 983.011
+   0.05 1131.791
+   0.071 1174.3
+   0.113 1176.957
+   0.176 1211.495
+   0.263 1293.855
+   0.397 1145.075
+   0.493 1129.134
+   0.786 1182.27
+   1.062 1254.003
+   1.078 1232.749
+   1.229 1275.258
+   1.308 1254.003
+   1.492 1283.228
+   2.002 1293.855
+   2.236 1299.169
+   2.345 1283.228
+   2.545 1227.435
+   2.608 1198.211
+   2.688 1190.24
+   2.759 1206.181
+   2.809 1168.986
+   2.884 892.68
+   2.922 672.167
+   3.009 504.789
+   3.223 225.827
+   3.26 108.928
+   3.331 37.195
+   3.44 5.314
+   3.595 0.0
+;
+;
+M1952BT 75 784.9 P 2.97 5.4430000000000005 GM
+   0.025 1639.097
+   0.033 2397.644
+   0.046 2100.59
+   0.075 2519.648
+   0.096 2599.215
+   0.104 2689.392
+   0.187 2689.392
+   0.228 2620.434
+   0.274 2445.384
+   0.316 2328.685
+   0.403 2275.64
+   0.523 2291.553
+   1.001 2339.294
+   1.188 2344.598
+   1.499 2328.685
+   1.637 2302.162
+   1.794 2270.335
+   2.093 2238.508
+   2.193 2206.681
+   2.243 2143.027
+   2.368 1777.015
+   2.505 1310.217
+   2.525 1241.258
+   2.584 1220.04
+   2.609 1119.254
+   2.663 960.118
+   2.733 763.851
+   2.8 567.584
+   2.87 413.753
+   2.987 238.703
+   3.178 63.654
+   3.41 0.0
+;
+;
+E12 24 101 0-4-8 0.028 0.0532 EM
+0.01 31.17
+0.13 24.43
+0.17 23.34
+1.5 14.83
+2 10.28
+2.5 4.8
+2.91 2.3
+2.92 0
+;
+;
+F23 24 139 0-4-8 0.0476 0.0756 EM 
+0.01 24.19
+0.05 39
+0.07 39.14
+0.13 34.58
+1 26.94
+2 19.52
+2.4 14
+2.7 7.96
+3 4.46
+3.55 1.27
+3.58 0
+;
+; Ellis L330 54mm Single Use
+L330-54mm-SU 54 711 P 1.489 2.123 EM
+   0.03 447.474
+   0.1 883.346
+   0.189 598.289
+   0.987 522.053
+   2.004 464.047
+   3.081 434.215
+   3.579 424.271
+   3.998 399.412
+   4.596 372.895
+   5.234 331.462
+   5.992 265.17
+   6.989 180.647
+   7.996 112.697
+   9.282 59.663
+   9.671 23.202
+   9.721 0.0
+;
+;J160 
+J160 38 1219 1000 0.327926 0.544 RTW 
+0.015456 262.049
+0.185471 255.442
+0.278207 240.028
+0.278207 229.017
+0.386399 251.038
+0.510046 242.23
+0.64915 213.603
+0.788253 189.38
+1.00464 178.369
+1.45286 160.753
+2.00927 147.54
+2.44204 129.923
+2.90572 121.115
+2.96754 162.955
+3.15301 149.742
+3.32303 125.519
+3.67852 94.6899
+3.97218 74.8711
+4.32767 46.2439
+4.69861 19.8188
+5.1 0
+;
+;Rattworks L600 Hybrid
+L600 64 1066 1000 1.863 2.25 RTW 
+0 88.62
+0.02 153.82
+0.19 158.02
+0.35 169.94
+0.4 1127.04
+0.78 1001.2
+2.23 778.11
+2.84 736.24
+3.07 704
+3.62 673.43
+3.81 435.29
+3.89 350.43
+4.14 240.05
+4.31 197.19
+4.49 165.4
+4.66 139.26
+4.82 119.21
+5.01 99.01
+5.34 70.99
+5.93 49.74
+6.49 38.96
+6.98 36.42
+7.1 0
+;
+;Rattworks M900 Hybrid
+M900 64 1828 1000 3.167 5.956 RTW 
+0.04 151.9
+0.43 241.76
+0.5 1054.61
+7.04 718.06
+7.22 346.42
+7.26 297.14
+7.35 241.24
+7.48 200.65
+7.66 164.8
+12.28 49.36
+12.3 0
+;
+;
+L740-2800CC200MFX 75 1422.4 1000 2.667 6.416 HT 
+0.02 767.76
+0.05 1084.9
+0.07 1166.87
+0.09 1198.96
+0.12 1183.37
+0.38 1088.96
+0.63 1139.56
+0.89 1130.73
+1.15 1109
+1.4 1096.6
+1.66 1048.51
+1.92 1026.67
+2.18 980.7
+2.43 949.74
+2.69 909.63
+2.95 893.62
+3.21 866.64
+3.46 825.26
+3.72 820.05
+3.98 789.78
+4.24 874.08
+4.49 804.36
+4.75 738.04
+5.01 383.77
+5.38 255.83
+5.75 183.27
+6.13 130.48
+6.5 94.03
+6.8 0
+;
+;
+L970-2800CC300M 75 1422.4 1000 2.532 6.323 HT 
+0.02 1007.71
+0.03 1320.67
+0.04 1463.43
+0.05 1482.44
+0.25 1315.87
+0.64 1441.44
+0.84 1452.58
+1.04 1418.39
+1.23 1403.65
+1.43 1337.52
+1.63 1311.22
+1.83 1257.09
+2.02 1279.26
+2.22 1229.81
+2.42 1174.23
+2.81 1122.04
+3.02 1108.55
+3.21 1058.31
+3.41 981.23
+3.61 959.35
+3.8 778.83
+4.09 437.55
+4.38 294.3
+4.66 194.71
+4.94 129.33
+5.23 86.31
+5.23 0
+;
+;
+M740-2800CC200M 75 1422.4 1000 2.589 6.322 HT 
+0.04 979.34
+0.08 1135.85
+0.12 1065.56
+0.16 1026.83
+0.2 1022.88
+0.44 982.86
+0.68 1065.61
+0.91 1100.92
+1.15 1067.05
+1.39 1072.92
+1.63 1013.29
+1.87 1016.51
+2.11 1012.36
+2.35 1007.02
+2.58 968.14
+2.82 948.67
+3.06 944
+3.3 905.49
+3.54 899.55
+3.77 866.23
+4.02 847.5
+4.25 822.68
+4.49 813.98
+4.73 789.25
+4.97 752.47
+5.21 344.76
+5.45 271.93
+5.84 195.15
+6.46 108.81
+6.97 0
+;
+;
+M960-2800CC300MFX 75 1422.4 1000 2.629 6.414 HT 
+0.01 508.27
+0.02 1058.4
+0.03 1393.68
+0.04 1534.58
+0.05 1585.27
+0.25 1375.21
+0.44 1354.52
+0.64 1365.14
+0.84 1385.36
+1.04 1418.42
+1.23 1358.94
+1.43 1347.56
+1.63 1291.46
+1.83 1241.32
+2.02 1235.83
+2.22 1221.66
+2.42 1181.59
+2.62 1150.77
+2.81 1105.59
+3.02 1040.1
+3.21 982.54
+3.41 999.65
+3.61 943.72
+3.8 871.92
+4.11 526.67
+4.42 330.98
+4.72 212.71
+5.03 135.8
+5.33 0
+;
+;
+M956-3500CCRGM 98 1150.6 1000 3.162 7.061 HT 
+0.04 1325.32
+0.08 1335.19
+0.12 1273.52
+0.16 1245.8
+0.2 1261.01
+0.46 1283.75
+0.71 1339.94
+0.97 1333.16
+1.23 1322.79
+1.49 1330.11
+1.75 1294.72
+2.01 1271.81
+2.27 1246.37
+2.52 1233.02
+2.78 1214.19
+3.04 1199.4
+3.3 1152.16
+3.56 1128.04
+3.81 1119.3
+4.08 1098.79
+4.33 1054.12
+4.59 1031.85
+4.85 964.95
+5.11 548.37
+5.45 373.37
+5.79 248.05
+6.14 160.88
+6.48 109.1
+6.7 0
+;
+;
+I130-300CC098J 54 521 1000 0.298 1.049 HT 
+0.05 200
+0.1 223
+0.5 205
+1 187
+1.5 169
+2 151
+2.25 143
+2.4 89
+2.5 71
+3 40
+3.5 18
+4 0
+;
+;
+I136-300CC098J2 54 546 1000 0.283 1.001 HT 
+0.155 256.236
+0.5 232.756
+1 212.85
+1.5 196.005
+2 174.976
+2.21 163.338
+2.4 100.912
+2.5 83.813
+3 42.468
+3.5 19.754
+3.7 15.262
+3.8 0
+;
+;
+I145-300CC098JFX 54 546 1000 0.311 1.068 HT 
+0.057 256.195
+0.204 253.38
+0.497 236.488
+1.002 208.334
+1.205 199.888
+1.376 211.15
+1.482 197.073
+2.003 177.366
+2.125 168.92
+2.5 90.091
+2.997 45.045
+3.282 16.892
+3.7 0
+;
+;
+I205-300CC125J 54 521 1000 0.298 1.049 HT 
+0.05 312
+0.1 347
+0.5 312
+1 258
+1.35 223
+1.6 125
+1.75 80
+2 45
+2.25 22
+2.75 0
+;
+;
+I222-300CC125J2 54 546 1000 0.28 1.013 HT 
+0.037 394.146
+0.065 439.192
+0.12 450.547
+0.24 436.734
+0.5 411.158
+0.66 392.487
+1 338.349
+1.348 292.639
+1.432 259.337
+1.5 193.668
+1.67 117.056
+2 57.357
+2.3 22.358
+2.4 0
+;
+;
+I225-300CC125JFX 54 546 1000 0.298 1.067 HT 
+0.012 309.686
+0.037 343.47
+0.106 351.916
+0.244 354.732
+0.497 337.84
+0.749 320.948
+0.998 298.425
+1.254 273.087
+1.433 239.303
+1.502 194.258
+1.755 101.352
+1.999 53.491
+2.211 11.261
+2.37 0
+;
+;
+I260-440CC172J 54 614 1000 0.409 1.296 HT 
+0.03 339.01
+0.041 425.115
+0.12 413.854
+0.216 394.146
+0.354 391.331
+0.497 368.808
+0.749 346.286
+1.002 306.871
+1.36 264.641
+1.454 228.042
+1.502 180.181
+1.686 109.798
+2.003 50.676
+2.2 27.483
+2.3 0
+;
+;
+J295-440CC172JFX 54 614 1000 0.409 1.31 HT 
+0.004 467.345
+0.244 461.714
+0.501 416.669
+1.002 377.254
+1.254 343.47
+1.364 315.317
+1.502 219.596
+1.751 112.613
+2.003 50.676
+2.2 0
+;
+;
+M1000-4630CCRGMFX 98 1386.8 1000 4.236 8.854 HT 
+0.038 1606
+0.077 1460.27
+0.119 1395.9
+0.198 1397.74
+0.529 1379.58
+0.86 1519.39
+1.192 1468.05
+1.525 1439.88
+1.856 1374.3
+2.188 1383.54
+2.519 1423.72
+2.85 1390.37
+3.181 1330.72
+3.515 1265.27
+3.846 1304.62
+4.177 1253.26
+4.508 1215.74
+4.84 1194.95
+5.171 1171.51
+5.504 1163.44
+5.835 1096.22
+6.167 1060.26
+6.498 650.033
+6.856 506.96
+7.213 390.955
+7.571 306.492
+7.929 239.568
+8.288 181.189
+8.927 104.386
+9.004 0
+;
+;
+M1001-5478CCRGM 98 1493.5 1000 5.161 10.092 HT 
+0.04 1394.15
+0.08 1440.23
+0.12 1322.3
+0.2 1340.76
+0.57 1411.23
+0.95 1420.87
+1.32 1415.98
+1.69 1404.61
+2.07 1384.44
+2.44 1370.95
+2.82 1354.19
+3.19 1318.56
+3.57 1326.82
+3.94 1338.4
+4.32 1247.32
+4.69 1287.12
+5.07 1220.48
+5.44 1123.54
+5.82 1075.29
+6.19 1078.11
+6.56 996.41
+6.94 953.17
+7.31 676.72
+7.83 419.5
+8.35 285.78
+8.87 192.18
+9.39 128.7
+9.87 0
+;
+;
+M1010-4630CCRGMFX 98 1386.8 1000 4.301 8.949 HT 
+0.038 1731.91
+0.077 1574.5
+0.119 1608.04
+0.158 1483.42
+0.198 1519.62
+0.54 1434.84
+0.881 1517.44
+1.225 1426.6
+1.567 1342.42
+1.908 1406.79
+2.25 1395.05
+2.592 1340.28
+2.935 1299.1
+3.277 1353.56
+3.619 1338.72
+3.96 1285.01
+4.304 1246.83
+4.646 1221.78
+4.988 1198.34
+5.329 1156.06
+5.671 1125.67
+6.015 1111.42
+6.356 1077.83
+6.698 595.72
+7.04 481.329
+7.381 387.883
+7.723 305.182
+8.067 242.766
+8.408 192.795
+9.021 122.087
+9.094 0
+;
+;
+M1015-3500CCRGMFX 98 1150.6 1000 3.25 7.158 HT 
+0.04 1515.05
+0.08 1634.37
+0.12 1566.94
+0.16 1507.27
+0.2 1476.97
+0.41 1418.21
+0.63 1420.43
+0.85 1436.22
+1.06 1405.26
+1.28 1371.12
+1.49 1355
+1.71 1320.03
+1.93 1286.83
+2.14 1268.82
+2.36 1267.85
+2.58 1281.29
+2.79 1248.5
+3.01 1268.31
+3.23 1273.39
+3.44 1298.31
+3.66 1213.66
+3.87 1167.24
+4.09 1134.88
+4.31 1121.39
+4.69 544.64
+5.07 363.55
+5.46 234.8
+5.84 149.45
+6.22 94.73
+6.23 0
+;
+;
+M1040-4630CCRGMFX 98 1493.5 1000 5.293 10.181 HT 
+0.02 1288.12
+0.05 1545.28
+0.07 1583.82
+0.12 1497.57
+0.53 1421.58
+0.95 1430.43
+1.78 1398.74
+2.61 1382.63
+3.03 1406.27
+3.44 1478.77
+3.86 1420.86
+4.27 1377.59
+5.1 1289.09
+5.52 1274.62
+5.93 1176.1
+6.35 1152.46
+6.77 891.06
+7.18 582.18
+8.01 320.71
+8.84 175.92
+9.66 92.08
+9.7 0
+;
+;

--- a/core/src/test/java/info/openrocket/core/file/rasaero/export/RASAeroMotorExportTest.java
+++ b/core/src/test/java/info/openrocket/core/file/rasaero/export/RASAeroMotorExportTest.java
@@ -1,13 +1,159 @@
 package info.openrocket.core.file.rasaero.export;
 
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.util.Modules;
+import info.openrocket.core.ServicesForTesting;
+import info.openrocket.core.file.rasaero.RASAeroCommonConstants;
+import info.openrocket.core.file.rasaero.RASAeroMotorsLoader;
+import info.openrocket.core.file.rasaero.RASAeroMotorsLoader.RASAeroMotor;
+import info.openrocket.core.logging.Warning;
+import info.openrocket.core.logging.WarningSet;
+import info.openrocket.core.motor.Manufacturer;
+import info.openrocket.core.motor.Motor;
+import info.openrocket.core.motor.MotorConfiguration;
+import info.openrocket.core.motor.ThrustCurveMotor;
+import info.openrocket.core.rocketcomponent.AxialStage;
+import info.openrocket.core.rocketcomponent.BodyTube;
+import info.openrocket.core.rocketcomponent.FlightConfigurationId;
+import info.openrocket.core.rocketcomponent.InnerTube;
+import info.openrocket.core.plugin.PluginModule;
+import info.openrocket.core.startup.Application;
+import info.openrocket.core.util.Coordinate;
+import info.openrocket.core.util.CoordinateIF;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class RASAeroMotorExportTest {
-    // TODO: check correct name after export
-    // TODO: check 0-delay motors (should have -0 suffix)
+import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests the motor configuration fields written to RASAero simulations.
+ */
+public class RASAeroMotorExportTest {
+    private static final ThrustCurveMotor SUSTAINER_MOTOR = createMotor("H148R", 0.152, 0.210);
+    private static Injector originalInjector;
+
+    @BeforeAll
+    public static void setUpApplicationServices() {
+        originalInjector = Application.getInjector();
+        Injector injector = Guice.createInjector(
+                Modules.override(new ServicesForTesting()).with(new PluginModule()));
+        Application.setInjector(injector);
+    }
+
+    @AfterAll
+    public static void restoreApplicationServices() {
+        Application.setInjector(originalInjector);
+    }
+
+    /**
+     * Motor mounts may be nested inside structural inner tubes.  The exporter must
+     * still find the populated mount anywhere in the stage subtree.
+     */
     @Test
-    public void dummy() {
-        // We need at least one runnable test method
+    public void findsMotorFromNestedSustainerMount() {
+        AxialStage sustainer = new AxialStage();
+        BodyTube sustainerBody = new BodyTube(0.5, 0.05, 0.001);
+        sustainer.addChild(sustainerBody);
+
+        // This structural tube reproduces mounts nested more than one level below a body tube.
+        InnerTube structuralTube = new InnerTube();
+        structuralTube.setLength(0.2);
+        structuralTube.setOuterRadius(0.025);
+        structuralTube.setInnerRadius(0.021);
+        sustainerBody.addChild(structuralTube);
+        InnerTube sustainerMount = createMotorMount("Sustainer mount", 0.16);
+        structuralTube.addChild(sustainerMount);
+
+        FlightConfigurationId configurationId = new FlightConfigurationId();
+        setMotor(sustainerMount, configurationId, SUSTAINER_MOTOR);
+
+        assertSame(sustainerMount, SimulationListDTO.findMotorMount(sustainer));
+    }
+
+    /**
+     * RASAero includes this plugged motor as I59WN-P, while OpenRocket stores
+     * the motor designation separately from its selected delay.
+     */
+    @Test
+    public void mapsOpenRocketDesignationToPluggedRASAeroDesignation() {
+        WarningSet warnings = new WarningSet();
+        List<RASAeroMotor> motors = RASAeroMotorsLoader.loadAllRASAeroMotors(warnings);
+        ThrustCurveMotor openRocketMotor = createMotor("i59WN", 0.232, 0.487);
+
+        String result = RASAeroCommonConstants.OPENROCKET_TO_RASAERO_MOTOR(motors, openRocketMotor, warnings);
+
+        assertEquals("I59WN-P  (AT)", result);
+        assertEquals(0, warnings.size());
+    }
+
+    /**
+     * A motor absent from rasp.eng must not be written as if RASAero supports it.
+     */
+    @Test
+    public void warnsWhenMotorIsUnavailableInRASAeroCatalog() {
+        WarningSet warnings = new WarningSet();
+        List<RASAeroMotor> motors = RASAeroMotorsLoader.loadAllRASAeroMotors(warnings);
+        ThrustCurveMotor unavailableMotor = createMotor("I999ZZ", 0.232, 0.487);
+
+        String result = RASAeroCommonConstants.OPENROCKET_TO_RASAERO_MOTOR(motors, unavailableMotor, warnings);
+
+        assertNull(result);
+        assertEquals(1, warnings.size());
+        assertTrue(containsWarning(warnings, "not available in RASAero II's rasp.eng catalog"));
+    }
+
+    private static InnerTube createMotorMount(String name, double length) {
+        InnerTube mount = new InnerTube();
+        mount.setName(name);
+        mount.setLength(length);
+        mount.setOuterRadius(0.0205);
+        mount.setInnerRadius(0.019);
+        mount.setMotorMount(true);
+        return mount;
+    }
+
+    private static void setMotor(InnerTube mount, FlightConfigurationId configurationId, Motor motor) {
+        MotorConfiguration configuration = new MotorConfiguration(mount, configurationId);
+        configuration.setMotor(motor);
+        mount.setMotorConfig(configuration, configurationId);
+    }
+
+    private static ThrustCurveMotor createMotor(String designation, double length, double launchMass) {
+        CoordinateIF[] cgPoints = {
+                new Coordinate(length / 2, 0, 0, launchMass),
+                new Coordinate(length / 2, 0, 0, launchMass * 0.8),
+                new Coordinate(length / 2, 0, 0, launchMass * 0.6)
+        };
+        return new ThrustCurveMotor.Builder()
+                .setManufacturer(Manufacturer.getManufacturer("AeroTech"))
+                .setDesignation(designation)
+                .setCommonName(designation)
+                .setDescription("RASAero export test motor")
+                .setCaseInfo("Test case")
+                .setMotorType(Motor.Type.RELOAD)
+                .setStandardDelays(new double[] { Motor.PLUGGED_DELAY })
+                .setDiameter(0.038)
+                .setLength(length)
+                .setTimePoints(new double[] { 0, 1, 2 })
+                .setThrustPoints(new double[] { 0, 100, 0 })
+                .setCGPoints(cgPoints)
+                .setDigest("rasaero-export-" + designation)
+                .build();
+    }
+
+    private static boolean containsWarning(WarningSet warnings, String text) {
+        for (Warning warning : warnings) {
+            if (warning.toString().contains(text)) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
RASAero export only searched shallow component levels for motor mounts, so motors nested inside sustainer structures could be omitted. Exported motor names were also not validated against RASAero’s rasp.eng catalog.

The exporter now:

  - Searches the complete component tree of each stage for motor mounts.
  - Validates motors against the bundled RASAero catalog.
  - Matches designations case-insensitively and handles suffix differences such as `i59WN` → `I59WN-P`.
  - Warns and omits the motor field when no unique RASAero motor can be found.

  This ensures booster and sustainer motors are exported using names RASAero recognizes.