### PR TITLE
Fix simulation table sort race

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationRunDialog.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationRunDialog.java
@@ -262,6 +262,29 @@ public class SimulationRunDialog extends JDialog {
 	}
 
 	/**
+	 * Marks one worker as complete and reports whether this completed the batch.
+	 * A single batch-completion signal prevents the simulation table from sorting
+	 * while other workers are still publishing their result values.
+	 *
+	 * @param completed completion state for every worker in the batch
+	 * @param index index of the worker that completed
+	 * @return {@code true} only when this call completes the entire batch
+	 */
+	static boolean markSimulationComplete(boolean[] completed, int index) {
+		if (completed[index]) {
+			return false;
+		}
+
+		completed[index] = true;
+		for (boolean simulationComplete : completed) {
+			if (!simulationComplete) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
 	 * Returns true if all the simulations ran successfully. Returns false if the simulations encountered
 	 * an exception, or were cancelled.
 	 */
@@ -403,11 +426,17 @@ public class SimulationRunDialog extends JDialog {
 		 */
 		@Override
 		protected void simulationDone() {
-			simulationDone[index] = true;
+			boolean batchComplete = markSimulationComplete(simulationDone, index);
 			log.debug("Simulation done");
 			setSimulationProgress(1.0);
 			updateProgress();
-			document.fireDocumentChangeEvent(new SimulationChangeEvent(simulation));
+
+			// The simulation table is hidden behind this modal dialog. Refreshing it
+			// after each worker forces Swing to sort rows whose values are still being
+			// changed by other workers, which can violate TimSort's comparator contract.
+			if (batchComplete) {
+				document.fireDocumentChangeEvent(new SimulationChangeEvent(simulation));
+			}
 		}
 
 		/**

--- a/swing/src/test/java/info/openrocket/swing/gui/simulation/SimulationRunDialogTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/simulation/SimulationRunDialogTest.java
@@ -1,0 +1,29 @@
+package info.openrocket.swing.gui.simulation;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests completion tracking for concurrently executed simulation batches.
+ */
+class SimulationRunDialogTest {
+
+	@Test
+	void reportsCompletionOnlyAfterTheLastWorkerFinishes() {
+		boolean[] completed = new boolean[3];
+
+		assertFalse(SimulationRunDialog.markSimulationComplete(completed, 2));
+		assertFalse(SimulationRunDialog.markSimulationComplete(completed, 0));
+		assertTrue(SimulationRunDialog.markSimulationComplete(completed, 1));
+	}
+
+	@Test
+	void duplicateCompletionDoesNotPublishAnotherBatchCompletion() {
+		boolean[] completed = new boolean[1];
+
+		assertTrue(SimulationRunDialog.markSimulationComplete(completed, 0));
+		assertFalse(SimulationRunDialog.markSimulationComplete(completed, 0));
+	}
+}


### PR DESCRIPTION
When many simulations finished concurrently, each worker refreshed and re-sorted the simulation table while other rows were still changing. This could cause TimSort’s “Comparison method violates its general contract” exception or make OpenRocket unresponsive.

The simulation table is now refreshed only once, after the entire simulation batch has completed. This ensures all sortable result values are stable before sorting.

I was not able to reproduce the bug though. @kjhambrick could you verify with this PR's JAR whether it is fixed?

Fixes #3242.