### PR TITLE
Fix locale-dependent test failures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,6 +149,13 @@ subprojects {
         useJUnitPlatform()
         finalizedBy jacocoTestReport
 
+        // Keep verification output independent of the host operating-system locale.
+        // These properties are applied when the test JVM starts, before locale-sensitive
+        // classes can cache formatting state.
+        systemProperty 'user.language', 'en'
+        systemProperty 'user.country', 'US'
+        systemProperty 'user.variant', ''
+
         testLogging {
             events 'PASSED', 'FAILED', 'SKIPPED', 'STANDARD_OUT'
             exceptionFormat = 'full'

--- a/core/src/main/java/info/openrocket/core/unit/Unit.java
+++ b/core/src/main/java/info/openrocket/core/unit/Unit.java
@@ -1,6 +1,8 @@
 package info.openrocket.core.unit;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 
 import info.openrocket.core.util.Chars;
 
@@ -84,9 +86,8 @@ public abstract class Unit {
 
 	// TODO: Should this use grouping separator ("#,##0.##")?
 
-	private static final DecimalFormat intFormat = new DecimalFormat("#");
-	private static final DecimalFormat decFormat = new DecimalFormat("0.0##");
-	private static final DecimalFormat expFormat = new DecimalFormat("0.00E0");
+	private static final ThreadLocal<LocaleDecimalFormats> LOCAL_FORMATS =
+			ThreadLocal.withInitial(Unit::createLocaleDecimalFormats);
 
 	/**
 	 * Format the given value (in SI units) to a string representation of the value
@@ -101,12 +102,13 @@ public abstract class Unit {
 			return "N/A";
 
 		double val = toUnit(value);
+		LocaleDecimalFormats formats = getLocaleDecimalFormats();
 
 		if (Math.abs(val) > 1.0E6) {
-			return expFormat.format(val);
+			return formats.exponentialFormat.format(val);
 		}
 		if (Math.abs(val) >= 100) {
-			return intFormat.format(val);
+			return formats.integerFormat.format(val);
 		}
 		if (Math.abs(val) <= 0.0005) {
 			return "0";
@@ -115,9 +117,54 @@ public abstract class Unit {
 		val = roundForDecimalFormat(val);
 		// Check for approximate integer
 		if (Math.abs(val - Math.floor(val)) < 0.0001) {
-			return intFormat.format(val);
+			return formats.integerFormat.format(val);
 		}
-		return decFormat.format(val);
+		return formats.decimalFormat.format(val);
+	}
+
+	/**
+	 * Return thread-confined formatters for the current default formatting locale.
+	 *
+	 * <p>{@link DecimalFormat} captures the locale at construction time and is not
+	 * thread-safe. Recreate the current thread's formatters when its locale changes.</p>
+	 *
+	 * @return formatters matching the current locale
+	 */
+	private static LocaleDecimalFormats getLocaleDecimalFormats() {
+		Locale currentLocale = Locale.getDefault(Locale.Category.FORMAT);
+		LocaleDecimalFormats formats = LOCAL_FORMATS.get();
+		if (!formats.locale.equals(currentLocale)) {
+			formats = createLocaleDecimalFormats();
+			LOCAL_FORMATS.set(formats);
+		}
+		return formats;
+	}
+
+	private static LocaleDecimalFormats createLocaleDecimalFormats() {
+		Locale locale = Locale.getDefault(Locale.Category.FORMAT);
+		DecimalFormatSymbols symbols = DecimalFormatSymbols.getInstance(locale);
+		return new LocaleDecimalFormats(locale,
+				new DecimalFormat("#", symbols),
+				new DecimalFormat("0.0##", symbols),
+				new DecimalFormat("0.00E0", symbols));
+	}
+
+	/**
+	 * Locale and its associated thread-confined number formatters.
+	 */
+	private static final class LocaleDecimalFormats {
+		private final Locale locale;
+		private final DecimalFormat integerFormat;
+		private final DecimalFormat decimalFormat;
+		private final DecimalFormat exponentialFormat;
+
+		private LocaleDecimalFormats(Locale locale, DecimalFormat integerFormat, DecimalFormat decimalFormat,
+				DecimalFormat exponentialFormat) {
+			this.locale = locale;
+			this.integerFormat = integerFormat;
+			this.decimalFormat = decimalFormat;
+			this.exponentialFormat = exponentialFormat;
+		}
 	}
 
 	protected double roundForDecimalFormat(double val) {

--- a/core/src/test/java/info/openrocket/core/rocketcomponent/FlightConfigurationTest.java
+++ b/core/src/test/java/info/openrocket/core/rocketcomponent/FlightConfigurationTest.java
@@ -16,8 +16,12 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import com.google.inject.Injector;
+import info.openrocket.core.database.Databases;
+import info.openrocket.core.startup.Application;
 import info.openrocket.core.util.BoundingBox;
 import info.openrocket.core.util.CoordinateIF;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -28,11 +32,32 @@ import info.openrocket.core.util.ModID;
 
 public class FlightConfigurationTest {
 	private final static double EPSILON = MathUtil.EPSILON * 1.0E3;
+	private static Locale previousLocale;
+	private static Injector previousInjector;
 
 	@BeforeAll
 	public static void setup() throws Exception {
+		previousLocale = Locale.getDefault();
+		previousInjector = Application.getInjector();
+
+		// Initialize shared localized databases with the normal testing translator.
+		// The debug translator below is intentionally scoped to this test class and
+		// must not permanently populate those static databases with bracketed names.
+		Locale.setDefault(Locale.US);
+		BaseTestCase.setUp();
+		Databases.fakeMethod();
+
 		Locale.setDefault(new Locale("xx"));
 		BaseTestCase.setUp();
+	}
+
+	/**
+	 * Restore the process-wide test state changed by {@link #setup()}.
+	 */
+	@AfterAll
+	public static void tearDown() {
+		Locale.setDefault(previousLocale);
+		Application.setInjector(previousInjector);
 	}
 
 	/**

--- a/core/src/test/java/info/openrocket/core/unit/UnitToStringTest.java
+++ b/core/src/test/java/info/openrocket/core/unit/UnitToStringTest.java
@@ -19,6 +19,24 @@ public class UnitToStringTest {
 		Locale.setDefault(Locale.US);
 	}
 
+	/**
+	 * Verify that Unit does not retain decimal symbols from the locale active when
+	 * its formatter was first used.
+	 */
+	@Test
+	public void testLocaleChangeAfterUnitInitialization() {
+		Locale originalLocale = Locale.getDefault();
+		try {
+			Locale.setDefault(Locale.US);
+			assertEquals("-0.001", Unit.NOUNIT.toString(-0.00051));
+
+			Locale.setDefault(Locale.GERMANY);
+			assertEquals("-0,001", Unit.NOUNIT.toString(-0.00051));
+		} finally {
+			Locale.setDefault(originalLocale);
+		}
+	}
+
 	@Test
 	public void testPositiveToString() {
 		if (isPointDecimalSeparator()) {


### PR DESCRIPTION
Because I run my tests on a non-US locale, sometimes, my unit tests fail, like:

```
Expected :-0.001                                                                                                                                                                                               
  Actual   :-0,001  
```

This PR sets a deterministic locale for Gradle tests, makes unit formatting respond safely to locale changes, and prevents debug translator state from leaking between tests.