### PR TITLE
Add SignPath Windows signing workflow

### DIFF
--- a/.github/workflows/sign-windows.yml
+++ b/.github/workflows/sign-windows.yml
@@ -1,0 +1,198 @@
+name: Sign Windows installers
+
+on:
+  workflow_dispatch:
+
+# SignPath reads the workflow artifact and build metadata through GitHub.
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: sign-windows-installers
+  cancel-in-progress: false
+
+jobs:
+  build-and-sign:
+    name: Build and sign Windows installers
+    runs-on: windows-latest
+    timeout-minutes: 60
+
+    env:
+      INSTALL4J_VERSION: '12.0.3'
+      INSTALL4J_DOWNLOAD_SHA256: '957fe72f9207fafae0b31f612cdd69a42f5b491108096eb16dfb79eea7c21e54'
+      SIGNPATH_ORGANIZATION_ID: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+      SIGNPATH_PROJECT_SLUG: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+      SIGNPATH_SIGNING_POLICY_SLUG: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+      SIGNPATH_ARTIFACT_CONFIGURATION_SLUG: ${{ vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+
+    steps:
+      - name: Validate repository signing configuration
+        shell: pwsh
+        env:
+          INSTALL4J_LICENSE_KEY: ${{ secrets.INSTALL4J_LICENSE_KEY }}
+          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+        run: |
+          $requiredValues = @{
+            'INSTALL4J_LICENSE_KEY secret' = $env:INSTALL4J_LICENSE_KEY
+            'SIGNPATH_API_TOKEN secret' = $env:SIGNPATH_API_TOKEN
+            'SIGNPATH_ORGANIZATION_ID variable' = $env:SIGNPATH_ORGANIZATION_ID
+            'SIGNPATH_PROJECT_SLUG variable' = $env:SIGNPATH_PROJECT_SLUG
+            'SIGNPATH_SIGNING_POLICY_SLUG variable' = $env:SIGNPATH_SIGNING_POLICY_SLUG
+            'SIGNPATH_ARTIFACT_CONFIGURATION_SLUG variable' = $env:SIGNPATH_ARTIFACT_CONFIGURATION_SLUG
+          }
+
+          foreach ($entry in $requiredValues.GetEnumerator()) {
+            if ([string]::IsNullOrWhiteSpace($entry.Value)) {
+              throw "Missing GitHub repository $($entry.Key)."
+            }
+          }
+
+      - name: Checkout repository and submodules
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          submodules: 'recursive'
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@4c125117fe7c5aed11272ec4213f602f012f89f2 # v5
+
+      - name: Read OpenRocket version
+        id: version
+        shell: pwsh
+        run: |
+          $match = Select-String -Path 'core/src/main/resources/build.properties' -Pattern '^build\.version=(.+)$'
+          if ($null -eq $match -or $match.Matches.Count -ne 1) {
+            throw 'Could not read a unique build.version from build.properties.'
+          }
+
+          $version = $match.Matches[0].Groups[1].Value.Trim()
+          if ([string]::IsNullOrWhiteSpace($version)) {
+            throw 'build.version must not be empty.'
+          }
+
+          "value=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Build OpenRocket distribution JAR
+        shell: pwsh
+        run: .\gradlew.bat shadowJar --no-daemon
+
+      - name: Install install4j
+        id: install4j
+        shell: pwsh
+        run: |
+          $versionForUrl = $env:INSTALL4J_VERSION.Replace('.', '_')
+          $archive = Join-Path $env:RUNNER_TEMP "install4j-$($env:INSTALL4J_VERSION).zip"
+          $installDirectory = Join-Path $env:RUNNER_TEMP "install4j-$($env:INSTALL4J_VERSION)"
+          $downloadUrl = "https://download.ej-technologies.com/install4j/install4j_windows-x64_$versionForUrl.zip"
+
+          Invoke-WebRequest -Uri $downloadUrl -OutFile $archive
+          $actualHash = (Get-FileHash -Path $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualHash -ne $env:INSTALL4J_DOWNLOAD_SHA256) {
+            throw "install4j archive checksum mismatch: expected $($env:INSTALL4J_DOWNLOAD_SHA256), got $actualHash."
+          }
+
+          Expand-Archive -Path $archive -DestinationPath $installDirectory
+          $compiler = Get-ChildItem -Path $installDirectory -Filter 'install4jc.exe' -File -Recurse |
+            Select-Object -First 1
+          if ($null -eq $compiler) {
+            throw 'install4jc.exe was not found in the downloaded install4j archive.'
+          }
+
+          "compiler=$($compiler.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Build unsigned Windows installers
+        shell: pwsh
+        env:
+          INSTALL4J_LICENSE_KEY: ${{ secrets.INSTALL4J_LICENSE_KEY }}
+          INSTALL4J_COMPILER: ${{ steps.install4j.outputs.compiler }}
+          OPENROCKET_VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          $mediaDirectory = (New-Item -Path 'install4j/26.xx/media' -ItemType Directory -Force).FullName
+          $arguments = @(
+            '--disable-signing'
+            '--build-ids=60,248'
+            "--release=$env:OPENROCKET_VERSION"
+            "--destination=$mediaDirectory"
+            '-D'
+            "JAR_NAME=OpenRocket-$env:OPENROCKET_VERSION.jar"
+            'install4j/26.xx/openrocket-26.xx.install4j'
+          )
+
+          & $env:INSTALL4J_COMPILER @arguments
+          if ($LASTEXITCODE -ne 0) {
+            throw "install4j exited with code $LASTEXITCODE."
+          }
+
+          $installers = @(Get-ChildItem -Path 'install4j/26.xx/media' -Filter '*.exe' -File)
+          if ($installers.Count -ne 2) {
+            throw "Expected two Windows installers, found $($installers.Count)."
+          }
+
+          foreach ($installer in $installers) {
+            $versionInfo = $installer.VersionInfo
+            if ($versionInfo.CompanyName -ne 'OpenRocket' -or
+                $versionInfo.ProductName -ne 'OpenRocket' -or
+                $versionInfo.FileVersion -ne $env:OPENROCKET_VERSION -or
+                $versionInfo.ProductVersion -ne $env:OPENROCKET_VERSION -or
+                $versionInfo.LegalCopyright -ne 'OpenRocket' -or
+                $versionInfo.OriginalFilename -ne $installer.Name) {
+              throw "Unexpected PE metadata in $($installer.Name); it will not match the SignPath artifact configuration."
+            }
+          }
+
+      - name: Upload unsigned installers for SignPath
+        id: upload-unsigned-artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: openrocket-windows-unsigned-${{ github.run_number }}
+          path: install4j/26.xx/media/*.exe
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Submit SignPath signing request
+        id: signpath
+        uses: signpath/github-action-submit-signing-request@c92b958760219087e01f8d67a1669ed57afe2627 # v2.3
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ env.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ env.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ env.SIGNPATH_SIGNING_POLICY_SLUG }}
+          artifact-configuration-slug: ${{ env.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ steps.upload-unsigned-artifact.outputs.artifact-id }}
+          wait-for-completion: true
+          wait-for-completion-timeout-in-seconds: 1800
+          output-artifact-directory: ${{ github.workspace }}/install4j/26.xx/signed-media
+          parameters: |
+            version: ${{ toJSON(steps.version.outputs.value) }}
+
+      - name: Verify Authenticode signatures
+        shell: pwsh
+        run: |
+          $installers = @(Get-ChildItem -Path 'install4j/26.xx/signed-media' -Filter '*.exe' -File -Recurse)
+          if ($installers.Count -ne 2) {
+            throw "Expected two signed Windows installers, found $($installers.Count)."
+          }
+
+          foreach ($installer in $installers) {
+            $signature = Get-AuthenticodeSignature -FilePath $installer.FullName
+            if ($signature.Status -ne 'Valid') {
+              throw "Invalid Authenticode signature for $($installer.Name): $($signature.StatusMessage)"
+            }
+            Write-Host "$($installer.Name): $($signature.SignerCertificate.Subject)"
+          }
+
+      - name: Upload signed Windows installers
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: openrocket-windows-signed-${{ github.run_number }}
+          path: install4j/26.xx/signed-media/**/*.exe
+          compression-level: 0
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ You can find the OpenRocket installers [here](https://openrocket.info/downloads.
 
 Release notes are available on each [release's page](https://github.com/openrocket/openrocket/releases) or on [our website](https://openrocket.info/release_notes.html).
 
+### Code signing policy
+
+Free code signing provided by [SignPath.io](https://about.signpath.io/), certificate by [SignPath Foundation](https://signpath.org/).
+
+- Committers and reviewers: [OpenRocket organization members](https://github.com/orgs/openrocket/people)
+- Approvers: [OpenRocket organization owners](https://github.com/orgs/openrocket/people?query=role%3Aowner)
+
+OpenRocket does not collect telemetry or upload rocket designs. It makes network requests for user-facing functions such as checking for application and motor-database updates, opening online resources, and submitting a bug report when requested by the user. Update checks can be disabled in the application preferences.
+
 ## 📖 Documentation
 
 You can find our documentation on [ReadTheDocs](https://openrocket.readthedocs.io/en/latest/).

--- a/docs/source/dev_guide/building_releasing.rst
+++ b/docs/source/dev_guide/building_releasing.rst
@@ -396,10 +396,127 @@ Once the OpenRocket installer has been code signed, users will receive no more (
 their operating system that the installer is from an unknown source and may contain malware.
 More information on how to do code signing in install4j can be found `here <https://www.ej-technologies.com/resources/install4j/help/doc/concepts/codeSigning.html>`__.
 
-Only the OpenRocket administrators have access to the code signing certificates.
+Only the OpenRocket administrators have access to the macOS code signing certificate. The Windows private key is held by
+SignPath and is not stored in the repository or in GitHub Actions.
 
-Code signing for Windows is done using a digital certificate from Sectigo. More information on the code signing procedure,
-including whitelisting OpenRocket by Microsoft, see the `README file on GitHub <https://github.com/openrocket/openrocket/blob/unstable/install4j/README.md>`__.
+Windows code signing with SignPath
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Windows installers are built and signed by the ``Sign Windows installers`` GitHub Actions workflow in
+:file:`.github/workflows/sign-windows.yml`. The workflow:
+
+1. builds the OpenRocket distribution JAR from the selected commit;
+2. downloads the pinned install4j 12.0.3 archive and verifies its SHA-256 checksum;
+3. builds the x86-64 and Arm64 installers with install4j code signing disabled;
+4. uploads both unsigned installers as one GitHub workflow artifact;
+5. submits that artifact to SignPath and waits for approval and signing;
+6. verifies both returned Authenticode signatures and uploads the signed installers as a separate workflow artifact.
+
+This arrangement lets SignPath verify the GitHub repository, commit, workflow, and GitHub-hosted runner that produced the
+artifact. Never publish the ``openrocket-windows-unsigned-*`` workflow artifact. It is retained only long enough for SignPath
+to retrieve it. The install4j project also pins the bundled Liberica JRE; update that version deliberately and validate both
+Windows installers whenever the runtime is upgraded.
+
+One-time SignPath website configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Configure the following at ``https://app.signpath.io``. The exact organization ID and slugs are shown on the SignPath
+signing-policy details page. SignPath's `GitHub integration documentation <https://docs.signpath.io/trusted-build-systems/github>`__
+describes the corresponding connector and GitHub App settings.
+
+The ``release-signing`` and ``test-signing`` pages are signing policies; they control the certificate, submitters,
+approvals, and origin restrictions. Artifact configurations and trusted build systems are separate sections on the
+OpenRocket project's overview page. Return to the project overview before performing steps 2 and 3 below.
+
+1. Add the predefined ``GitHub.com`` trusted build system to the SignPath organization. Install the SignPath GitHub App and
+   grant it access to ``openrocket/openrocket``.
+2. Create or open the OpenRocket project, set its repository URL to ``https://github.com/openrocket/openrocket``, and link the
+   ``GitHub.com`` trusted build system to the project.
+3. In the project's :guilabel:`Artifact Configurations` section, select :guilabel:`Add`, then :guilabel:`Custom`. Create a
+   configuration with a stable slug such as ``windows-installers`` and paste the XML below. The GitHub upload is a ZIP
+   containing exactly two PE files. The configuration matches the install4j filenames and enforces the metadata required
+   by the SignPath Foundation:
+
+   .. code-block:: xml
+
+      <artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
+        <parameters>
+          <parameter name="version" required="true" />
+        </parameters>
+        <zip-file>
+          <pe-file-set company-name="OpenRocket"
+                       copyright="OpenRocket"
+                       file-version="${version}"
+                       original-filename="${file.name}"
+                       product-name="OpenRocket"
+                       product-version="${version}">
+            <include path="OpenRocket-${version}-installer-Windows-*.exe"
+                     min-matches="2" max-matches="2" />
+            <for-each>
+              <authenticode-sign />
+            </for-each>
+          </pe-file-set>
+        </zip-file>
+      </artifact-configuration>
+
+   SignPath recommends generating a configuration by uploading an unsigned sample first. If you do that, compare the
+   generated configuration with the restrictions above and make sure it signs only the two OpenRocket installer files.
+4. Open the ``release-signing`` signing policy. Select the OpenRocket release certificate, require a manual approval, allow
+   only the dedicated CI user to submit, assign the OpenRocket approvers, enable trusted-build-system and origin
+   verification, and restrict the origin to the protected release branch. The repository URL comes from the project
+   settings. The artifact configuration is not selected on this page; the GitHub workflow supplies its slug with each
+   signing request.
+5. Create an API token for the dedicated CI user. The user needs submitter permission for the project and release signing
+   policy; it does not need approval permission.
+
+One-time GitHub configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In :menuselection:`GitHub repository --> Settings --> Secrets and variables --> Actions`, add:
+
+.. list-table:: GitHub Actions configuration
+   :widths: 35 65
+   :header-rows: 1
+
+   *  - Name
+      - Value
+   *  - Secret ``SIGNPATH_API_TOKEN``
+      - API token for the dedicated SignPath CI user.
+   *  - Secret ``INSTALL4J_LICENSE_KEY``
+      - The install4j license key supplied to OpenRocket by ej-technologies.
+   *  - Variable ``SIGNPATH_ORGANIZATION_ID``
+      - SignPath organization ID.
+   *  - Variable ``SIGNPATH_PROJECT_SLUG``
+      - OpenRocket project slug.
+   *  - Variable ``SIGNPATH_SIGNING_POLICY_SLUG``
+      - Release signing policy slug.
+   *  - Variable ``SIGNPATH_ARTIFACT_CONFIGURATION_SLUG``
+      - Windows installer artifact configuration slug.
+
+The SignPath API token and install4j license are secrets. IDs and slugs are identifiers and should be repository variables,
+which makes configuration errors easier to diagnose without exposing credentials.
+
+Running and validating a Windows signing build
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. Set ``build.version`` in :file:`core/src/main/resources/build.properties` to the release version and merge the release
+   commit into the branch allowed by the SignPath signing policy.
+2. Open :menuselection:`GitHub --> Actions --> Sign Windows installers`, select :guilabel:`Run workflow`, and select that
+   branch. Do not approve a request built from an unexpected repository, branch, commit, or workflow run.
+3. An approver reviews the verified origin and artifact details in SignPath, then approves the signing request.
+4. After the workflow succeeds, download ``openrocket-windows-signed-<run number>`` from the workflow run. Those are the
+   Windows release installers. The workflow rejects missing or invalid Authenticode signatures before uploading them.
+5. Test both architectures as appropriate and regenerate any release checksums from the signed files. Checksums produced by
+   install4j before signing are no longer valid after SignPath adds the signatures.
+
+.. note::
+   SignPath signs the two outer install4j installer executables. SignPath treats PE files as non-composite artifacts, so this
+   workflow does not deep-sign the install4j launcher embedded inside each installer. Signing the installed launcher as well
+   would require an install4j-compatible SignPath crypto provider or a package format that SignPath supports for deep signing.
+   The outer signature is the one Windows evaluates when a downloaded installer is launched.
+
+For Microsoft Defender SmartScreen submission instructions, see the
+`install4j README <https://github.com/openrocket/openrocket/blob/unstable/install4j/README.md>`__.
 
 For macOS, the code signing is done using an Apple Developer ID. Besides code signing, the OpenRocket app also needs to
 be notarized. Luckily, install4j takes care of this. More information on the code signing procedure for macOS can be found in the
@@ -423,8 +540,9 @@ the *openrocket/install4j/<build-version>/media/* directory.
 
    Building the installers in install4j.
 
-If you do not have access to the code signing certificates, you can create the installers without code signing by
-enabling the checkboxes ``Disable code signing`` and ``Disable notarization`` in the ``Build`` tab.
+The current install4j project deliberately has Windows code signing disabled because SignPath signs Windows installers after
+the GitHub build. For local development builds, enable ``Disable code signing`` and ``Disable notarization`` in the
+install4j :menuselection:`Build` tab when the macOS credentials are unavailable.
 
 macOS QuickLook Extension
 -------------------------
@@ -499,10 +617,13 @@ with the new results) to ensure that they are up-to-date with the latest changes
    - run ``./gradlew :core:publish``
    - call the Sonatype manual upload endpoint to make the staged deployment appear in the Central Portal
 
-8. **Create the packaged installers** using install4j (see above).
+8. **Create the packaged installers** (see above).
 
    .. warning::
-      Make sure to **enable code signing** for the installers.
+      Build and sign the Windows installers with the ``Sign Windows installers`` GitHub Actions workflow. Download only its
+      ``openrocket-windows-signed-*`` artifact; never release the unsigned SignPath input artifact.
+
+      When building the macOS installers in install4j, make sure macOS code signing and notarization are enabled.
 
       Make sure that `DS_Store <https://github.com/openrocket/openrocket/blob/unstable/install4j/23.09/macOS_resources/DS_Store>`__ for the macOS
       installer is updated. Instructions can be found `here <https://github.com/openrocket/openrocket/blob/unstable/install4j/README.md>`__.
@@ -520,6 +641,9 @@ with the new results) to ensure that they are up-to-date with the latest changes
     Follow these steps:
 
     - Add the release to `downloads_config.json <https://github.com/openrocket/openrocket.github.io/blob/development/assets/downloads_config.json>`__.
+
+    - Keep a visible **Code signing policy** link on the downloads page. It may link to the policy in the main OpenRocket
+      repository README. This is required while using a SignPath Foundation certificate.
     - Update the ``current_version`` in `_config <https://github.com/openrocket/openrocket.github.io/blob/development/_config.yml>`__.
     - Add a new entry to `_whats_new <https://github.com/openrocket/openrocket.github.io/tree/development/_whats-new>`__ for the new release.
       Create a ``wn-<version number>.md`` file with the changes that are part of the new release. Please take a close look to the previous entries to see how it should be formatted.
@@ -541,8 +665,9 @@ with the new results) to ensure that they are up-to-date with the latest changes
     If you want to credit the developers who contributed to the release, you can tag them anywhere in the release text using the `@username` syntax.
     They will then be automatically displayed in the contributors list on the release page.
 
-    Finally, upload all the packaged installers and the JAR file to the release. The source code (zip and tar.gz) is
-    automatically appended to each release, you do not need to upload it manually.
+    Finally, upload all the packaged installers and the JAR file to the release. For Windows, use only the installers from the
+    successful ``openrocket-windows-signed-*`` workflow artifact. The source code (zip and tar.gz) is automatically appended
+    to each release, you do not need to upload it manually.
 
     If this is an alpha, beta, or release candidate release, tick the *Set as a pre-release* checkbox.
 

--- a/install4j/26.xx/openrocket-26.xx.install4j
+++ b/install4j/26.xx/openrocket-26.xx.install4j
@@ -9,7 +9,7 @@
       <variable name="JAR_FILE_LOCATION" value="../../build/libs/${compiler:JAR_NAME}" />
       <variable name="JAR_NAME" value="OpenRocket-${compiler:sys.version}.jar" />
     </variables>
-    <codeSigning macEnabled="true" macPkcs12File="./code_signing/OpenRocket_macOS.p12" windowsEnabled="true" windowsPkcs12File="./code_signing/OpenRocket_Windows.pfx" macNotarize="true" macApiIssuer="${compiler:ISSUER_ID}" macApiKey="${compiler:KEY_ID}" macApiPrivateKey="${compiler:PRIVATE_API_KEY}">
+    <codeSigning macEnabled="true" macPkcs12File="./code_signing/OpenRocket_macOS.p12" windowsEnabled="false" macNotarize="true" macApiIssuer="${compiler:ISSUER_ID}" macApiKey="${compiler:KEY_ID}" macApiPrivateKey="${compiler:PRIVATE_API_KEY}">
       <macSearchedJars>
         <entry>jna-*</entry>
         <entry>swt-*</entry>
@@ -17,7 +17,7 @@
         <entry>OpenRocket-26.xx.jar</entry>
       </macSearchedJars>
     </codeSigning>
-    <jreBundles jdkProviderId="Liberica" release="17/latest">
+    <jreBundles jdkProviderId="Liberica" release="17/17.0.20.1+1">
       <modules>
         <defaultModules set="jre" />
         <module name="java.scripting" />
@@ -69,7 +69,7 @@
 </infoPlist>
       <iconImageFiles>
         <file path="../../swing/build/resources/main/pix/icon/icon-016.png" />
-        <file path="../../swing/build/resources/main/pix/icon/icon-032.png" />
+        <file path="../../swing/resources-src/pix/icon/icon-032.png" />
         <file path="../../swing/build/resources/main/pix/icon/icon-048.png" />
         <file path="../../swing/build/resources/main/pix/icon/icon-064.png" />
         <file path="../../swing/build/resources/main/pix/icon/icon-128.png" />
@@ -93,7 +93,7 @@
             </add>
             <add>
               <object class="com.install4j.api.beans.ExternalFile">
-                <string>../../swing/build/resources/main/pix/icon/icon-032.png</string>
+                <string>../../swing/resources-src/pix/icon/icon-032.png</string>
               </object>
             </add>
             <add>

--- a/install4j/README.md
+++ b/install4j/README.md
@@ -16,6 +16,26 @@ to publish installers for the following platforms.
 * Joe Pfeiffer
 * Sibo Van Gool
 
+# Windows code signing with SignPath
+
+The current install4j project builds unsigned Windows installers. Release
+installers are built and signed by the GitHub Actions workflow
+`.github/workflows/sign-windows.yml`; the Windows certificate and private key
+are not stored in this repository or in GitHub.
+
+Before the first signing build, configure the SignPath project, trusted
+GitHub build system, artifact configuration, signing policy, CI user, and API
+token. Also configure the required GitHub Actions secrets and variables. The
+complete setup and release procedure is documented in the
+[Building and Releasing guide](https://openrocket.readthedocs.io/en/latest/dev_guide/building_releasing.html#windows-code-signing-with-signpath).
+
+For a release, run the **Sign Windows installers** workflow from the approved
+release branch. A SignPath approver must verify the repository, commit, and
+workflow-run origin before approving the request. Publish only the
+`openrocket-windows-signed-<run number>` artifact. The similarly named
+`openrocket-windows-unsigned-<run number>` artifact is only SignPath input and
+must never be released.
+
 # Instructions on updating the macOS drag-and-drop installer
 
 Either run "update_ds_store.sh" or follow the instructions below.


### PR DESCRIPTION
## Summary

We decided that we would not buy a code signing certificate anymore, partially due to the high cost, and to instead let SignPath code sign the Windows installers for us. This is a free service for open source projects. They keep the private key and only sign approved builds from our GitHub workflow, so it avoids the “one developer owns the key” problem.

They do control the signing service, so if they disappeared we’d need another provider for future releases. But already signed and timestamped releases would remain signed; they don’t need SignPath to keep operating. They also don’t control the repo, source code or distribution.

This PR adds a GitHub Actions workflow that builds the x86-64 and Arm64 Windows installers and submits them to SignPath for approval and Authenticode signing.

After signing, the workflow verifies both signatures and publishes the installers as a GitHub Actions artifact. Release maintainers download this artifact, test the installers, and upload them to the GitHub release manually.

The `Sign Windows installers` needs to be **manually** triggered, so no need to worry about code signing something on every new commit.

## Other platforms

- **macOS:** Continues to be built locally with install4j, including Apple Developer ID signing, notarization, and QuickLook extension integration.
- **Linux:** Continues to be built locally with install4j and does not require code signing.
- GitHub releases and their assets are still published manually.

## Additional changes

- Disables the previous Windows PFX signing configuration.
- Pins the bundled Windows JRE.
- Adds the SignPath code-signing policy and setup documentation.

## Testing

Once this PR is merged, we should run a test run of the workflow. We have configured two different SignPath policies: `release-signing` and `test-signing`. The former is for releases to be published, the latter is for testing the workflow. Currently, we have a repo secret (`Settings > Secrets and variables > Actions > Repository secrets`) `SIGNPATH_SIGNING_POLICY_SLUG ` set to `test-signing`. For official releases, we must modify this to `release-signing`.