### PR TITLE
Add startup consent for update checks

### DIFF
--- a/core/src/main/java/info/openrocket/core/preferences/ApplicationPreferences.java
+++ b/core/src/main/java/info/openrocket/core/preferences/ApplicationPreferences.java
@@ -83,6 +83,7 @@ public abstract class ApplicationPreferences implements ChangeSource, ORPreferen
 	private static final String IGNORE_WELCOME = "IgnoreWelcome";
 
 	private static final String CHECK_UPDATES = "CheckUpdates";
+	private static final String UPDATE_CHECK_PERMISSION = "UpdateCheckPermission";
 
 	private static final String IGNORE_UPDATE_VERSIONS = "IgnoreUpdateVersions";
 	private static final String CHECK_BETA_UPDATES = "CheckBetaUpdates";
@@ -304,6 +305,28 @@ public abstract class ApplicationPreferences implements ChangeSource, ORPreferen
 	
 	public final void setCheckUpdates(boolean check) {
 		this.putBoolean(CHECK_UPDATES, check);
+	}
+
+	/**
+	 * Returns whether the user has answered the one-time question about update checks that access the internet.
+	 *
+	 * @return {@code true} if the user has allowed or declined automatic update checks
+	 */
+	public final boolean isUpdateCheckPermissionSet() {
+		return this.getPreferences().get(UPDATE_CHECK_PERMISSION, null) != null;
+	}
+
+	/**
+	 * Stores the user's update-check permission and applies it to both automatic update checkers.
+	 * The permission is stored after the individual settings so an interrupted write causes the question to be
+	 * shown again instead of allowing either checker to access the internet without a recorded answer.
+	 *
+	 * @param allowed {@code true} to enable automatic software and motor-database update checks
+	 */
+	public final void setUpdateCheckPermission(boolean allowed) {
+		this.setCheckUpdates(allowed);
+		this.setCheckMotorDatabaseUpdates(allowed);
+		this.putBoolean(UPDATE_CHECK_PERMISSION, allowed);
 	}
 
 	public final List<String> getIgnoreUpdateVersions() {

--- a/core/src/main/resources/l10n/messages.properties
+++ b/core/src/main/resources/l10n/messages.properties
@@ -1447,6 +1447,12 @@ MotorDbUpdate.Installed.message = Motor database updated successfully.
 MotorDbUpdate.Failed.title = Motor database update
 MotorDbUpdate.Failed.message = Unable to download and install the motor database update.
 
+! Startup update-check consent
+UpdateCheckConsent.title = Allow update checks?
+UpdateCheckConsent.message = <html><b>May OpenRocket check the internet for updates?</b><br><br>OpenRocket can automatically check for new program versions and motor database updates.<br>These checks use secure HTTPS connections and do not upload your rocket designs,<br>simulations, preferences, or other personal files.<br><br>You can change this choice later in Preferences.</html>
+UpdateCheckConsent.btn.allow = Allow update checks
+UpdateCheckConsent.btn.decline = Don't allow
+
 ! AppearanceConfig
 AppearanceCfg.lbl.Usedefault = Use default appearance
 AppearanceCfg.but.edit = Edit

--- a/core/src/test/java/info/openrocket/core/preferences/ApplicationPreferencesTest.java
+++ b/core/src/test/java/info/openrocket/core/preferences/ApplicationPreferencesTest.java
@@ -114,6 +114,23 @@ public class ApplicationPreferencesTest {
         assertTrue(prefs.isRandomSeedFixed());
     }
 
+    @Test
+    @DisplayName("update check permission is unset until answered and controls both automatic checks")
+    public void testUpdateCheckPermission() {
+        assertFalse(prefs.isUpdateCheckPermissionSet());
+
+        prefs.setUpdateCheckPermission(false);
+
+        assertTrue(prefs.isUpdateCheckPermissionSet());
+        assertFalse(prefs.getCheckUpdates());
+        assertFalse(prefs.getCheckMotorDatabaseUpdates());
+
+        prefs.setUpdateCheckPermission(true);
+
+        assertTrue(prefs.getCheckUpdates());
+        assertTrue(prefs.getCheckMotorDatabaseUpdates());
+    }
+
     private static class PreferencesModule extends AbstractModule {
         @Override
         protected void configure() {

--- a/swing/src/main/java/info/openrocket/swing/startup/SwingStartup.java
+++ b/swing/src/main/java/info/openrocket/swing/startup/SwingStartup.java
@@ -214,6 +214,9 @@ public class SwingStartup {
 			prefs.setUITheme(UITheme.Themes.valueOf(cmdLAF));
 		}
 		GUIUtil.applyLAF();
+
+		// Ask before either startup update checker is allowed to access the internet.
+		requestUpdateCheckPermission();
 		
 		guiModule.startLoader();
 		
@@ -268,6 +271,36 @@ public class SwingStartup {
 		String message = String.format(trans.get("SwingStartup.pluginMigrated"),
 				f.getName().replace(JarMigrationHelper.MIGRATION_SUFFIX, ""), f);
 		JOptionPane.showMessageDialog(null, message, "Plugin migrated", JOptionPane.INFORMATION_MESSAGE);
+	}
+
+	/**
+	 * Displays the one-time permission prompt for automatic software and motor-database update checks.
+	 * Closing the dialog is treated as declining permission, and the answer can later be changed in Preferences.
+	 */
+	private static void requestUpdateCheckPermission() {
+		ApplicationPreferences preferences = Application.getPreferences();
+		if (preferences.isUpdateCheckPermissionSet()) {
+			return;
+		}
+
+		Translator translator = Application.getTranslator();
+		Object[] options = {
+				translator.get("UpdateCheckConsent.btn.allow"),
+				translator.get("UpdateCheckConsent.btn.decline")
+		};
+		int choice = JOptionPane.showOptionDialog(
+				null,
+				translator.get("UpdateCheckConsent.message"),
+				translator.get("UpdateCheckConsent.title"),
+				JOptionPane.YES_NO_OPTION,
+				JOptionPane.QUESTION_MESSAGE,
+				null,
+				options,
+				options[0]);
+
+		boolean allowed = choice == JOptionPane.YES_OPTION;
+		preferences.setUpdateCheckPermission(allowed);
+		log.info("Automatic internet update checks {} by user", allowed ? "allowed" : "declined");
 	}
 
 	/**


### PR DESCRIPTION
OpenRocket can access the internet to check for software and motor database updates. This PR adds a one-time startup prompt asking for permission. Allowing enables both update preferences; declining disables them. After answering, a preference flag prevents the prompt from appearing again.

<img width="761" height="325" alt="Screenshot 2026-08-20 at 21 43 23" src="https://github.com/user-attachments/assets/aa8a4508-248d-442a-aea0-1164a5b80118" />
