### PR TITLE
Exit directly when quitting on macOS

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/main/BasicFrame.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/BasicFrame.java
@@ -2340,8 +2340,8 @@ private static final Translator trans = Application.getTranslator();
 
 		frames.remove(BasicFrame.this);
 		if (frames.isEmpty()) {
-			// Don't quit the application on macOS, but keep the application open
-			if (SystemInfo.getPlatform() == SystemInfo.Platform.MAC_OS) {
+			// Closing the last window keeps the macOS application available, but an explicit quit must exit directly.
+			if (SystemInfo.getPlatform() == SystemInfo.Platform.MAC_OS && !quitCalled) {
 				DummyFrameMenuOSX.createDummyDialog();
 			} else {
 				log.info("Last frame closed, exiting");


### PR DESCRIPTION
On macOS, Cmd+Q could unnecessarily create the dummy menu frame before exiting, potentially triggering a class-loading error:

<details><summary>View the error</summary>

i had openrocket open and hit cmd+q and got this error:
 ---------- Bug report ----------

Please include a description about what actions you were performing when the exception occurred:
(You can edit text directly in this window)

1.
2.
3.

If possible, please send us the .ork file that caused the bug.

Include your email address (optional; it helps if we can contact you in case we need additional information):




(Do not modify anything below this line.)
---------- Exception stack trace ----------
java.lang.NoClassDefFoundError: info/openrocket/swing/gui/util/DummyFrameMenuOSX
at info.openrocket.swing.gui.main.BasicFrame.closeAction(BasicFrame.java:2345)
at info.openrocket.swing.gui.main.BasicFrame.quitAction(BasicFrame.java:2427)
at info.openrocket.swing.startup.OSXSetup.lambda$static$1(OSXSetup.java:53)
at java.desktop/com.apple.eawt._AppEventHandler$_QuitDispatcher.performUsing(_AppEventHandler.java:431)
at java.desktop/com.apple.eawt._AppEventHandler$_QuitDispatcher.performUsing(_AppEventHandler.java:420)
at java.desktop/com.apple.eawt._AppEventHandler$_AppEventDispatcher$1.run(_AppEventHandler.java:552)
at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:773)
at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:720)
at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:714)
at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:742)
at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:117)
at java.desktop/java.awt.WaitDispatchSupport$2.run(WaitDispatchSupport.java:191)
at java.desktop/java.awt.WaitDispatchSupport$4.run(WaitDispatchSupport.java:236)
at java.desktop/java.awt.WaitDispatchSupport$4.run(WaitDispatchSupport.java:234)
at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
at java.desktop/java.awt.WaitDispatchSupport.enter(WaitDispatchSupport.java:234)
at java.desktop/java.awt.Dialog.show(Dialog.java:1080)
at java.desktop/java.awt.Component.show(Component.java:1728)
at java.desktop/java.awt.Component.setVisible(Component.java:1675)
at java.desktop/java.awt.Window.setVisible(Window.java:1036)
at java.desktop/java.awt.Dialog.setVisible(Dialog.java:1016)
at info.openrocket.swing.gui.main.SimulationPanel.openDialog(SimulationPanel.java:1013)
at info.openrocket.swing.gui.main.SimulationPanel.openDialog(SimulationPanel.java:1019)
at info.openrocket.swing.gui.main.SimulationPanel.plotSimulation(SimulationPanel.java:531)
at info.openrocket.swing.gui.main.SimulationPanel$PlotSimulationAction.actionPerformed(SimulationPanel.java:1245)
at java.desktop/javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:1972)
at java.desktop/javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2313)
at java.desktop/javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:405)
at java.desktop/javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:262)
at java.desktop/javax.swing.plaf.basic.BasicButtonListener.mouseReleased(BasicButtonListener.java:279)
at java.desktop/java.awt.AWTEventMulticaster.mouseReleased(AWTEventMulticaster.java:297)
at java.desktop/java.awt.Component.processMouseEvent(Component.java:6626)
at java.desktop/javax.swing.JComponent.processMouseEvent(JComponent.java:3389)
at java.desktop/java.awt.Component.processEvent(Component.java:6391)
at java.desktop/java.awt.Container.processEvent(Container.java:2266)
at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5001)
at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2324)
at java.desktop/java.awt.Component.dispatchEvent(Component.java:4833)
at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4948)
at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4575)
at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4516)
at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2310)
at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2780)
at java.desktop/java.awt.Component.dispatchEvent(Component.java:4833)
at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:775)
at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:720)
at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:714)
at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:97)
at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:747)
at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:745)
at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:744)
at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
Caused by: java.lang.ClassNotFoundException: info.openrocket.swing.gui.util.DummyFrameMenuOSX
at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:429)
at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:421)
at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:420)
at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:592)
at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
... 66 more
Caused by: java.util.zip.ZipException: ZipFile invalid LOC header (bad signature)
at java.base/java.util.zip.ZipFile$ZipFileInputStream.initDataOffset(ZipFile.java:928)
at java.base/java.util.zip.ZipFile$ZipFileInputStream.read(ZipFile.java:939)
at java.base/java.util.zip.ZipFile$ZipFileInflaterInputStream.fill(ZipFile.java:456)
at java.base/java.util.zip.InflaterInputStream.read(InflaterInputStream.java:158)
at java.base/jdk.internal.loader.Resource.getBytes(Resource.java:126)
at java.base/jdk.internal.loader.URLClassPath$JarLoader$2.getBytes(URLClassPath.java:895)
at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:519)
at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:427)
... 71 more
</details


This change exits directly during an explicit quit while preserving the dummy frame when only the last window is closed.