### PR TITLE
[#3250] Fix caliper distance repaint artifacts

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
@@ -91,6 +91,7 @@ import javax.swing.JViewport;
 import javax.swing.ListCellRenderer;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.LineBorder;
@@ -2283,20 +2284,20 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		unitsDistPanel.add(new JLabel(trans.get("RocketPanel.lbl.CaliperUnits")));
 		unitsDistPanel.add(caliperManager.getUnitSelector());
 
-		// Distance display
+		JPanel distancePanel = new JPanel(new MigLayout("ins 0", "[]2[]2[]2[]2[]", ""));
+		distancePanel.setOpaque(false);
+
+		// An opaque Swing component must have an opaque background or old glyph pixels can survive repaints.
 		JTextField distanceField = new JTextField("–", 6);
 		distanceField.setEditable(false);
 		distanceField.setOpaque(true);
-		distanceField.setBackground(valueBg);
+		distanceField.setBackground(ColorConversion.compositeColor(valueBg, UIManager.getColor("Panel.background")));
 		distanceField.setForeground(valueFg);
 		distanceField.setBorder(new CompoundBorder(
 				new LineBorder(caliperColor, 1, true),
 				new EmptyBorder(1, 4, 1, 4)));
 		distanceField.setFont(distanceField.getFont().deriveFont(Font.BOLD));
 		distanceField.setHorizontalAlignment(JTextField.CENTER);
-
-		JPanel distancePanel = new JPanel(new MigLayout("ins 0", "[]2[]2[]2[]2[]", ""));
-		distancePanel.setOpaque(false);
 
 		JButton diamond1Btn = new JButton(createCaliperDiamondIcon("1", caliperColor, diamondLabelColor));
 		diamond1Btn.setRolloverIcon(createCaliperDiamondIcon("1", caliperHoverColor, diamondLabelColor));
@@ -2383,7 +2384,8 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 			leftArrow.setIcon(createCaliperSingleArrowIcon(true, newCaliperColor));
 			rightArrow.setIcon(createCaliperSingleArrowIcon(false, newCaliperColor));
 
-			distanceField.setBackground(newValueBg);
+			distanceField.setBackground(ColorConversion.compositeColor(
+					newValueBg, UIManager.getColor("Panel.background")));
 			distanceField.setForeground(newValueFg);
 			distanceField.setBorder(new CompoundBorder(
 					new LineBorder(newCaliperColor, 1, true),

--- a/swing/src/main/java/info/openrocket/swing/gui/util/ColorConversion.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/util/ColorConversion.java
@@ -52,6 +52,30 @@ public class ColorConversion {
 				Math.min(255, color.getBlue() + amount));
 	}
 
+	/**
+	 * Composite a possibly translucent foreground color over an opaque background color.
+	 * The returned color is opaque, making it safe to use as the background of an opaque Swing component.
+	 *
+	 * @param foreground the color drawn over the background
+	 * @param background the opaque color below the foreground
+	 * @return the opaque composite color
+	 */
+	public static Color compositeColor(Color foreground, Color background) {
+		int foregroundAlpha = foreground.getAlpha();
+		int backgroundAlpha = 255 - foregroundAlpha;
+		return new Color(
+				compositeChannel(foreground.getRed(), background.getRed(), foregroundAlpha, backgroundAlpha),
+				compositeChannel(foreground.getGreen(), background.getGreen(), foregroundAlpha, backgroundAlpha),
+				compositeChannel(foreground.getBlue(), background.getBlue(), foregroundAlpha, backgroundAlpha));
+	}
+
+	/**
+	 * Composite one foreground color channel over its background channel with integer rounding.
+	 */
+	private static int compositeChannel(int foreground, int background, int foregroundAlpha, int backgroundAlpha) {
+		return (foreground * foregroundAlpha + background * backgroundAlpha + 127) / 255;
+	}
+
 	public static ORColor fromHexColor(String hexColor) {
 		if (hexColor == null || hexColor.isBlank()) {
 			return null;

--- a/swing/src/test/java/info/openrocket/swing/gui/util/ColorConversionTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/util/ColorConversionTest.java
@@ -1,0 +1,32 @@
+package info.openrocket.swing.gui.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.awt.Color;
+
+import org.junit.jupiter.api.Test;
+
+class ColorConversionTest {
+
+	@Test
+	void compositeColorReturnsOpaqueForegroundUnchanged() {
+		Color foreground = new Color(12, 34, 56);
+
+		assertEquals(foreground, ColorConversion.compositeColor(foreground, Color.WHITE));
+	}
+
+	@Test
+	void compositeColorReturnsBackgroundForTransparentForeground() {
+		Color background = new Color(12, 34, 56);
+
+		assertEquals(background, ColorConversion.compositeColor(new Color(200, 150, 100, 0), background));
+	}
+
+	@Test
+	void compositeColorBlendsTranslucentForegroundIntoOpaqueBackground() {
+		Color foreground = new Color(80, 45, 10, 60);
+		Color background = new Color(73, 76, 79);
+
+		assertEquals(new Color(75, 69, 63), ColorConversion.compositeColor(foreground, background));
+	}
+}


### PR DESCRIPTION
Fixes #3250 by ensuring the caliper distance field uses a fully opaque background. This prevents old text pixels from accumulating during repaints while preserving the intended translucent theme appearance through color compositing.