### PR TITLE
[#3251] Keep horizontal caliper label on-screen

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/figureelements/HorizontalCaliperLine.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/figureelements/HorizontalCaliperLine.java
@@ -293,7 +293,8 @@ public class HorizontalCaliperLine implements FigureElement {
 			
 			// Draw drag position tooltip below the handle
 			if (dragPositionLabel != null) {
-				drawDragTooltip(g2Screen, handleX_screen + DIAMOND_HALF_WIDTH, handleY_screen + DIAMOND_HALF_HEIGHT);
+				drawDragTooltip(g2Screen, handleX_screen + DIAMOND_HALF_WIDTH,
+						handleY_screen + DIAMOND_HALF_HEIGHT, screenVisible);
 			}
 
 			// Draw out-of-view indicator if the caliper line is outside the visible area
@@ -411,19 +412,18 @@ public class HorizontalCaliperLine implements FigureElement {
 	 * @param g2    graphics context in screen coordinates
 	 * @param cx    horizontal center of the handle diamond
 	 * @param topY  Y coordinate of the handle's bottom tip
+	 * @param visible visible viewport bounds used to keep the tooltip on-screen
 	 */
-	private void drawDragTooltip(Graphics2D g2, double cx, double topY) {
-		Font font = HANDLE_LABEL_FONT.deriveFont(Font.PLAIN, HANDLE_LABEL_FONT.getSize2D() * 1.5f);
+	private void drawDragTooltip(Graphics2D g2, double cx, double topY, Rectangle visible) {
+		Font font = HANDLE_LABEL_FONT.deriveFont(Font.PLAIN, HANDLE_LABEL_FONT.getSize2D() * 1.2f);
 		g2.setFont(font);
-		FontRenderContext frc = g2.getFontRenderContext();
-		Rectangle2D textBounds = font.getStringBounds(dragPositionLabel, frc);
-		double tw = textBounds.getWidth();
-		double th = textBounds.getHeight();
+		Rectangle2D.Double tooltipBounds = getDragTooltipBounds(g2, cx, topY, visible);
+		double boxX = tooltipBounds.getX();
+		double boxY = tooltipBounds.getY();
+		double boxW = tooltipBounds.getWidth();
+		double boxH = tooltipBounds.getHeight();
+		double textHeight = font.getStringBounds(dragPositionLabel, g2.getFontRenderContext()).getHeight();
 		double pad = 4.0;
-		double boxW = tw + pad * 2;
-		double boxH = th + pad;
-		double boxX = cx - boxW / 2.0;
-		double boxY = topY + 5.0;
 
 		g2.setColor(handleColor);
 		g2.fill(new RoundRectangle2D.Double(boxX, boxY, boxW, boxH, 6, 6));
@@ -432,7 +432,36 @@ public class HorizontalCaliperLine implements FigureElement {
 				handleBorderColor.getBlue(), 120));
 		g2.draw(new RoundRectangle2D.Double(boxX, boxY, boxW, boxH, 6, 6));
 		g2.setColor(handleTextColor);
-		g2.drawString(dragPositionLabel, (float) (boxX + pad), (float) (boxY + th * 0.8));
+		g2.drawString(dragPositionLabel, (float) (boxX + pad), (float) (boxY + textHeight * 0.8));
+	}
+
+	/**
+	 * Calculate the drag tooltip bounds and constrain them to the visible viewport horizontally.
+	 *
+	 * @param g2 graphics context used to measure the label
+	 * @param cx horizontal center of the handle diamond
+	 * @param topY Y coordinate of the handle's bottom tip
+	 * @param visible visible viewport bounds, or {@code null} when no viewport is available
+	 * @return the tooltip bounds in screen coordinates
+	 */
+	Rectangle2D.Double getDragTooltipBounds(Graphics2D g2, double cx, double topY, Rectangle visible) {
+		Font font = HANDLE_LABEL_FONT.deriveFont(Font.PLAIN, HANDLE_LABEL_FONT.getSize2D() * 1.2f);
+		FontRenderContext frc = g2.getFontRenderContext();
+		Rectangle2D textBounds = font.getStringBounds(dragPositionLabel, frc);
+		double padding = 4.0;
+		double boxWidth = textBounds.getWidth() + padding * 2;
+		double boxHeight = textBounds.getHeight() + padding;
+		double boxX = cx - boxWidth / 2.0;
+		double boxY = topY + 5.0;
+
+		if (visible != null) {
+			double viewportPadding = 2.0;
+			double minimumX = visible.getMinX() + viewportPadding;
+			double maximumX = visible.getMaxX() - viewportPadding - boxWidth;
+			boxX = Math.max(minimumX, Math.min(boxX, maximumX));
+		}
+
+		return new Rectangle2D.Double(boxX, boxY, boxWidth, boxHeight);
 	}
 
 	/**

--- a/swing/src/test/java/info/openrocket/swing/gui/figureelements/HorizontalCaliperLineTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/figureelements/HorizontalCaliperLineTest.java
@@ -1,0 +1,55 @@
+package info.openrocket.swing.gui.figureelements;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+
+import org.junit.jupiter.api.Test;
+
+import info.openrocket.swing.util.BaseTestCase;
+
+/**
+ * Tests screen-space positioning of horizontal caliper handles and labels.
+ */
+class HorizontalCaliperLineTest extends BaseTestCase {
+
+	@Test
+	void handleTracksLeftEdgeOfShiftedViewport() {
+		HorizontalCaliperLine line = new HorizontalCaliperLine(200.0);
+		AffineTransform transform = new AffineTransform();
+		Rectangle initialViewport = new Rectangle(0, 0, 800, 600);
+		Rectangle shiftedViewport = new Rectangle(125, 0, 800, 600);
+
+		Rectangle2D.Double initialBounds = line.getHandleBounds(transform, initialViewport);
+		Rectangle2D.Double shiftedBounds = line.getHandleBounds(transform, shiftedViewport);
+
+		assertEquals(shiftedViewport.x - initialViewport.x, shiftedBounds.x - initialBounds.x, 0.0,
+				"The handle must remain anchored to the viewport's left edge");
+		assertEquals(initialBounds.y, shiftedBounds.y, 0.0,
+				"Horizontal scrolling must not change the handle's Y position");
+	}
+
+	@Test
+	void dragTooltipStaysInsideLeftEdgeOfViewport() {
+		HorizontalCaliperLine line = new HorizontalCaliperLine(100.0);
+		line.setDragPositionLabel("454 in");
+		Rectangle viewport = new Rectangle(75, 0, 250, 400);
+		BufferedImage image = new BufferedImage(400, 400, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D graphics = image.createGraphics();
+		try {
+			Rectangle2D.Double bounds = line.getDragTooltipBounds(graphics, viewport.x + 10, 100, viewport);
+
+			assertTrue(bounds.getMinX() >= viewport.getMinX(),
+					"The tooltip must not extend beyond the viewport's left edge");
+			assertTrue(bounds.getMaxX() <= viewport.getMaxX(),
+					"The tooltip must not extend beyond the viewport's right edge");
+		} finally {
+			graphics.dispose();
+		}
+	}
+}


### PR DESCRIPTION
Fixes #3251 by keeping the horizontal caliper’s live position label within the visible viewport. The label font is also reduced to match the vertical caliper display, with regression tests covering shifted viewport positioning.