### PR TITLE
Fix simulation plot color synchronization

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/plot/PlotPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/plot/PlotPanel.java
@@ -335,7 +335,7 @@ public class PlotPanel<T extends DataType & Groupable<G>,
 	protected void addSelectionListeners(S selector, final int idx) {
 		// Type
 		selector.addTypeSelectionListener(e -> {
-			if (modifying > 0) return;
+			if (modifying > 0 || e.getStateChange() != ItemEvent.SELECTED) return;
 			T selectedType = selector.getSelectedType();
 			configuration.setPlotDataType(idx, selectedType);
 			selector.setUnitGroup(selectedType.getUnitGroup());
@@ -345,13 +345,13 @@ public class PlotPanel<T extends DataType & Groupable<G>,
 
 		// Unit
 		selector.addUnitSelectionListener(e -> {
-			if (modifying > 0) return;
+			if (modifying > 0 || e.getStateChange() != ItemEvent.SELECTED) return;
 			configuration.setPlotDataUnit(idx, selector.getSelectedUnit());
 		});
 
 		// Axis
 		selector.addAxisSelectionListener(e -> {
-			if (modifying > 0) return;
+			if (modifying > 0 || e.getStateChange() != ItemEvent.SELECTED) return;
 			configuration.setPlotDataAxis(idx, selector.getSelectedAxis());
 		});
 

--- a/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationPlotPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/simulation/SimulationPlotPanel.java
@@ -81,6 +81,7 @@ public class SimulationPlotPanel extends PlotPanel<FlightDataType, FlightDataBra
 	private final Simulation simulation;
 	private FlightEventTableModel eventTableModel;
 	private Map<Integer, java.awt.Color> defaultPlotColors = Collections.emptyMap();
+	private final Map<Integer, SimulationPlotTypeSelector> plotTypeSelectors = new HashMap<>();
 	private static java.awt.Color darkErrorColor;
 
 	static {
@@ -292,6 +293,7 @@ public class SimulationPlotPanel extends PlotPanel<FlightDataType, FlightDataBra
 	@Override
 	protected void updatePlots() {
 		defaultPlotColors = computeDefaultPlotColors();
+		plotTypeSelectors.clear();
 		super.updatePlots();
 		eventTableModel.fireTableDataChanged();
 	}
@@ -308,7 +310,10 @@ public class SimulationPlotPanel extends PlotPanel<FlightDataType, FlightDataBra
 			color = defaultPlotColors.getOrDefault(i, Util.getPlotColor(i));
 		}
 		LineStyle lineStyle = configuration.getPlotDataLineStyle(i);
-		return new SimulationPlotTypeSelector(i, type, unit, axis, Arrays.asList(typesY), color, lineStyle);
+		SimulationPlotTypeSelector selector = new SimulationPlotTypeSelector(
+				i, type, unit, axis, Arrays.asList(typesY), color, lineStyle);
+		plotTypeSelectors.put(i, selector);
+		return selector;
 	}
 
 	@Override
@@ -336,26 +341,22 @@ public class SimulationPlotPanel extends PlotPanel<FlightDataType, FlightDataBra
 		});
 
 		selector.addAxisSelectionListener(e -> {
-			if (modifying > 0) {
+			if (modifying > 0 || e.getStateChange() != ItemEvent.SELECTED) {
 				return;
 			}
 			defaultPlotColors = computeDefaultPlotColors();
-			if (configuration.getPlotDataColor(idx) == null) {
-				java.awt.Color color = defaultPlotColors.getOrDefault(idx, Util.getPlotColor(idx));
-				modifying++;
-				selector.setSelectedColor(color);
-				modifying--;
-			}
+			refreshDefaultPlotColors();
 		});
 
 		selector.addTypeSelectionListener(e -> {
-			if (modifying > 0) {
+			if (modifying > 0 || e.getStateChange() != ItemEvent.SELECTED) {
 				return;
 			}
 			FlightDataType selectedType = selector.getSelectedType();
 			modifying++;
 			defaultPlotColors = computeDefaultPlotColors();
 			applyTypeAppearance(idx, selectedType, selector);
+			refreshDefaultPlotColors();
 			modifying--;
 			syncButtonStates(selector, idx);
 		});
@@ -441,6 +442,25 @@ public class SimulationPlotPanel extends PlotPanel<FlightDataType, FlightDataBra
 				: defaultPlotColors.getOrDefault(index, Util.getPlotColor(index));
 		selector.setSelectedColor(selectorColor);
 		selector.setSelectedLineStyle(lineStyle);
+	}
+
+	/**
+	 * Refresh every selector whose color comes from the automatic palette.  Auto-axis assignment is global: changing
+	 * one row can move other rows to a different axis and therefore change their rendered palette position.
+	 */
+	private void refreshDefaultPlotColors() {
+		modifying++;
+		try {
+			for (Map.Entry<Integer, SimulationPlotTypeSelector> entry : plotTypeSelectors.entrySet()) {
+				int index = entry.getKey();
+				if (configuration.getPlotDataColor(index) == null) {
+					java.awt.Color color = defaultPlotColors.getOrDefault(index, Util.getPlotColor(index));
+					entry.getValue().setSelectedColor(color);
+				}
+			}
+		} finally {
+			modifying--;
+		}
 	}
 
 	/**

--- a/swing/src/test/java/info/openrocket/swing/gui/plot/SimulationChartTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/plot/SimulationChartTest.java
@@ -4,7 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
@@ -12,17 +17,25 @@ import org.jfree.chart.LegendItemCollection;
 import org.jfree.chart.plot.XYPlot;
 import org.jfree.chart.renderer.xy.XYItemRenderer;
 import org.jfree.chart.title.LegendTitle;
+import org.jfree.data.xy.XYDataset;
 import org.jfree.data.xy.XYSeriesCollection;
 import org.junit.jupiter.api.Test;
 
 import info.openrocket.core.componentanalysis.CADataBranch;
 import info.openrocket.core.componentanalysis.CADataType;
 import info.openrocket.core.componentanalysis.CADomainDataType;
+import info.openrocket.core.document.OpenRocketDocument;
+import info.openrocket.core.document.OpenRocketDocumentFactory;
+import info.openrocket.core.document.Simulation;
 import info.openrocket.core.rocketcomponent.BodyTube;
 import info.openrocket.core.simulation.FlightDataBranch;
+import info.openrocket.core.simulation.FlightData;
 import info.openrocket.core.simulation.FlightDataType;
+import info.openrocket.core.simulation.SimulationOptions;
 import info.openrocket.swing.gui.dialogs.componentanalysis.CAPlot;
 import info.openrocket.swing.gui.dialogs.componentanalysis.CAPlotConfiguration;
+import info.openrocket.swing.gui.simulation.SimulationPlotPanel;
+import info.openrocket.swing.gui.simulation.SimulationPlotTypeSelector;
 import info.openrocket.swing.util.BaseTestCase;
 
 /**
@@ -100,6 +113,40 @@ public class SimulationChartTest extends BaseTestCase {
 				((BasicStroke) renderer.getSeriesStroke(1)).getLineWidth());
 	}
 
+	/**
+	 * Changing one auto-axis variable can alter the palette position of another variable.  Every automatic color shown
+	 * in the configuration panel must be refreshed to match the final rendered plot.
+	 */
+	@Test
+	public void automaticColorsRefreshWhenLaterVariableChangesAxisAssignment() {
+		FlightDataBranch branch = createPositionFlightDataBranch();
+		OpenRocketDocument document = OpenRocketDocumentFactory.createNewRocket();
+		Simulation simulation = new Simulation(document, document.getRocket(), Simulation.Status.UPTODATE, "Test",
+				new SimulationOptions(), Collections.emptyList(), new FlightData(branch));
+		SimulationPlotPanel panel = SimulationPlotPanel.create(simulation);
+
+		SimulationPlotConfiguration configuration = new SimulationPlotConfiguration("Test", FlightDataType.TYPE_TIME);
+		configuration.addPlotDataType(FlightDataType.TYPE_ALTITUDE, 1);
+		configuration.addPlotDataType(FlightDataType.TYPE_VELOCITY_Z);
+		configuration.addPlotDataType(FlightDataType.TYPE_ACCELERATION_Z);
+		panel.setConfiguration(configuration);
+		((PlotPanel<?, ?, ?, ?, ?>) panel).updatePlots();
+
+		List<SimulationPlotTypeSelector> selectors = findComponents(panel, SimulationPlotTypeSelector.class);
+		selectors.sort(Comparator.comparingInt(SimulationPlotTypeSelector::getIndex));
+		selectors.get(1).typeSelector.setSelectedItem(FlightDataType.TYPE_POSITION_X);
+		Color colorBeforeThirdChange = selectors.get(1).getSelectedColor();
+		selectors.get(2).typeSelector.setSelectedItem(FlightDataType.TYPE_POSITION_Y);
+
+		Color displayedColor = selectors.get(1).getSelectedColor();
+		SimulationPlot plot = SimulationPlot.create(simulation, panel.getConfiguration(), false);
+		Color renderedColor = findRenderedColor(plot.getJFreeChart().getXYPlot(), 1);
+
+		assertNotEquals(colorBeforeThirdChange, displayedColor,
+				"The later variable must cause this auto-assigned palette position to change");
+		assertEquals(renderedColor, displayedColor);
+	}
+
 	private static void addAnalysisPoint(CADataBranch branch, BodyTube firstComponent,
 			BodyTube secondComponent, double mach, double firstValue, double secondValue) {
 		branch.addPoint();
@@ -118,6 +165,52 @@ public class SimulationChartTest extends BaseTestCase {
 		branch.setValue(FlightDataType.TYPE_TIME, 1);
 		branch.setValue(FlightDataType.TYPE_ALTITUDE, altitude + 10);
 		return branch;
+	}
+
+	private static FlightDataBranch createPositionFlightDataBranch() {
+		FlightDataBranch branch = new FlightDataBranch("Sustainer", FlightDataType.TYPE_TIME,
+				FlightDataType.TYPE_ALTITUDE, FlightDataType.TYPE_VELOCITY_Z, FlightDataType.TYPE_ACCELERATION_Z,
+				FlightDataType.TYPE_POSITION_X, FlightDataType.TYPE_POSITION_Y);
+		for (int i = 0; i < 3; i++) {
+			branch.addPoint();
+			branch.setValue(FlightDataType.TYPE_TIME, i);
+			branch.setValue(FlightDataType.TYPE_ALTITUDE, i * 100.0);
+			branch.setValue(FlightDataType.TYPE_VELOCITY_Z, i * 20.0);
+			branch.setValue(FlightDataType.TYPE_ACCELERATION_Z, i * 1000.0);
+			branch.setValue(FlightDataType.TYPE_POSITION_X, i * 10.0);
+			branch.setValue(FlightDataType.TYPE_POSITION_Y, i * 10.0);
+		}
+		return branch;
+	}
+
+	private static Color findRenderedColor(XYPlot plot, int dataIndex) {
+		for (int axis = 0; axis < plot.getDatasetCount(); axis++) {
+			XYDataset dataset = plot.getDataset(axis);
+			if (dataset == null) {
+				continue;
+			}
+			XYSeriesCollection seriesCollection = (XYSeriesCollection) dataset;
+			for (int series = 0; series < dataset.getSeriesCount(); series++) {
+				Plot.MetadataXYSeries metadata = (Plot.MetadataXYSeries) seriesCollection.getSeries(series);
+				if (metadata.getDataIdx() == dataIndex) {
+					return (Color) plot.getRenderer(axis).getSeriesPaint(series);
+				}
+			}
+		}
+		throw new AssertionError("No rendered series for data index " + dataIndex);
+	}
+
+	private static <T extends Component> List<T> findComponents(Container container, Class<T> type) {
+		List<T> matches = new ArrayList<>();
+		for (Component component : container.getComponents()) {
+			if (type.isInstance(component)) {
+				matches.add(type.cast(component));
+			}
+			if (component instanceof Container child) {
+				matches.addAll(findComponents(child, type));
+			}
+		}
+		return matches;
 	}
 
 	/**


### PR DESCRIPTION
There was an issue with custom plot appearances:

1. open an example design
2. open a sim plot config
3. change second var to "position east of launch" -> color of that var changes to orange for some reason
4. change 3rd var to "position north of launch"
5. plot
6. var 2 is plotted in blue instead of the displayed orange. var 3 is in green (normal)

This PR refreshes all automatically assigned plot colors whenever a variable or axis change alters palette ordering. Also filters duplicate combo-box events and adds regression coverage verifying displayed colors match rendered plots.