### PR TITLE
Harden motor database update installation

### DIFF
--- a/core/src/main/java/info/openrocket/core/database/MotorDatabaseRemoteUpdater.java
+++ b/core/src/main/java/info/openrocket/core/database/MotorDatabaseRemoteUpdater.java
@@ -276,9 +276,11 @@ public class MotorDatabaseRemoteUpdater {
 							", sha256_db=" + actualDbSha256 + ")");
 				}
 
+				// Validate the full database before replacing the local one.
 				validateDownloadedDatabase(tmpDbFile);
 			}
 
+			// Cancellation and the total deadline also apply to validation time, not just network reads.
 			deadline.throwIfExpired();
 			MotorDatabaseMetadataIO.writeRawJson(tmpMetadataFile, remoteMetadata.getRawJson());
 			rejectStaleInstall(targetMetadataFile, remoteMetadata.getDatabaseVersion());
@@ -463,7 +465,8 @@ public class MotorDatabaseRemoteUpdater {
 
 	private static void validateDownloadedDatabase(File dbFile) throws IOException {
 		try {
-			ThrustCurveMotorSQLiteDatabase.validateDatabase(dbFile);
+			// Reading every motor exercises the full schema and data conversion path used after installation.
+			ThrustCurveMotorSQLiteDatabase.readDatabase(dbFile);
 		} catch (SQLException e) {
 			throw new IOException("Downloaded motor database failed validation: " + e.getMessage(), e);
 		}

--- a/core/src/main/java/info/openrocket/core/database/MotorDatabaseRemoteUpdater.java
+++ b/core/src/main/java/info/openrocket/core/database/MotorDatabaseRemoteUpdater.java
@@ -221,60 +221,77 @@ public class MotorDatabaseRemoteUpdater {
 		validateDatabaseDownloadUrl(databaseGzUrl);
 		OperationDeadline deadline = new OperationDeadline(databaseOperationTimeoutMs);
 
+		Path lockPath = new File(motorLibraryDir, INSTALL_LOCK_FILENAME).toPath();
+		try (FileChannel lockChannel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+			FileLock installationLock = tryAcquireInstallationLock(lockChannel);
+			try (installationLock) {
+				installRemoteDatabaseLocked(motorLibraryDir, remoteMetadata, databaseGzUrl, deadline);
+			}
+		}
+	}
+
+	private void installRemoteDatabaseLocked(File motorLibraryDir, MotorDatabaseMetadata remoteMetadata,
+			String databaseGzUrl, OperationDeadline deadline) throws IOException {
+
 		File targetDbFile = new File(motorLibraryDir, MOTORS_DB_FILENAME);
 		File targetMetadataFile = new File(motorLibraryDir, METADATA_FILENAME);
 
-		File tmpDbFile = new File(motorLibraryDir, MOTORS_DB_FILENAME + ".download");
-		File tmpMetadataFile = new File(motorLibraryDir, METADATA_FILENAME + ".download");
+		File tmpDbFile = Files.createTempFile(motorLibraryDir.toPath(), MOTORS_DB_FILENAME + ".", ".download").toFile();
+		File tmpMetadataFile = null;
 
-		log.info("Downloading motor database from {}", databaseGzUrl);
-		String rawSha256Gz = remoteMetadata.getSha256Gz();
-		String expectedGzipSha256 = normalizeSha256(rawSha256Gz);
-		if (expectedGzipSha256 == null) {
-			throw new IOException("Remote metadata missing or invalid sha256_gz");
-		}
-
-		try (InputStream rawIn0 = openStream(databaseGzUrl, deadline);
-			 InputStream rawIn = new ThrowingLimitedInputStream(rawIn0, MAX_DB_GZ_BYTES);
-			 FileOutputStream out = new FileOutputStream(tmpDbFile)) {
-
-			MessageDigest gzipDigest = sha256Digest();
-			MessageDigest dbDigest = sha256Digest();
-			String actualGzipSha256;
-			String actualDbSha256;
-
-			try (DigestInputStream gzipDigestStream = new DigestInputStream(rawIn, gzipDigest);
-				 GZIPInputStream gzIn = new GZIPInputStream(nonClosing(gzipDigestStream));
-				 DigestInputStream dbDigestStream = new DigestInputStream(gzIn, dbDigest);
-				 InputStream dbLimited = new ThrowingLimitedInputStream(dbDigestStream, MAX_DB_BYTES)) {
-				FileUtils.copy(dbLimited, out);
-				// Ensure we hash the full response body for the gzip digest (not only what the decompressor consumed).
-				drain(gzipDigestStream);
+		try {
+			tmpMetadataFile = Files.createTempFile(
+					motorLibraryDir.toPath(), METADATA_FILENAME + ".", ".download").toFile();
+			log.info("Downloading motor database from {}", databaseGzUrl);
+			String rawSha256Gz = remoteMetadata.getSha256Gz();
+			String expectedGzipSha256 = normalizeSha256(rawSha256Gz);
+			if (expectedGzipSha256 == null) {
+				throw new IOException("Remote metadata missing or invalid sha256_gz");
 			}
 
-			actualGzipSha256 = TextUtil.bytesToHex(gzipDigest.digest());
-			actualDbSha256 = TextUtil.bytesToHex(dbDigest.digest());
+			try (InputStream rawIn0 = openStream(databaseGzUrl, deadline);
+				 InputStream rawIn = new ThrowingLimitedInputStream(rawIn0, MAX_DB_GZ_BYTES);
+				 FileOutputStream out = new FileOutputStream(tmpDbFile)) {
 
-			if (!expectedGzipSha256.equals(actualGzipSha256)) {
-				throw new IOException("Downloaded motor database SHA-256 mismatch (expected sha256_gz=" +
-						expectedGzipSha256 + ", got sha256_gz=" + actualGzipSha256 +
-						", sha256_db=" + actualDbSha256 + ")");
+				MessageDigest gzipDigest = sha256Digest();
+				MessageDigest dbDigest = sha256Digest();
+				String actualGzipSha256;
+				String actualDbSha256;
+
+				try (DigestInputStream gzipDigestStream = new DigestInputStream(rawIn, gzipDigest);
+					 GZIPInputStream gzIn = new GZIPInputStream(nonClosing(gzipDigestStream));
+					 DigestInputStream dbDigestStream = new DigestInputStream(gzIn, dbDigest);
+					 InputStream dbLimited = new ThrowingLimitedInputStream(dbDigestStream, MAX_DB_BYTES)) {
+					FileUtils.copy(dbLimited, out);
+					// Ensure we hash the full response body for the gzip digest (not only what the decompressor consumed).
+					drain(gzipDigestStream);
+				}
+
+				actualGzipSha256 = TextUtil.bytesToHex(gzipDigest.digest());
+				actualDbSha256 = TextUtil.bytesToHex(dbDigest.digest());
+
+				if (!expectedGzipSha256.equals(actualGzipSha256)) {
+					throw new IOException("Downloaded motor database SHA-256 mismatch (expected sha256_gz=" +
+							expectedGzipSha256 + ", got sha256_gz=" + actualGzipSha256 +
+							", sha256_db=" + actualDbSha256 + ")");
+				}
+
+				validateDownloadedDatabase(tmpDbFile);
 			}
 
-			validateDownloadedDatabase(tmpDbFile);
 			deadline.throwIfExpired();
-		} catch (IOException e) {
-			if (tmpDbFile.isFile() && !tmpDbFile.delete()) {
-				log.debug("Unable to delete partial download {}", tmpDbFile.getAbsolutePath());
+			MotorDatabaseMetadataIO.writeRawJson(tmpMetadataFile, remoteMetadata.getRawJson());
+			rejectStaleInstall(targetMetadataFile, remoteMetadata.getDatabaseVersion());
+
+			FileUtils.replaceFile(tmpDbFile, targetDbFile);
+			FileUtils.replaceFile(tmpMetadataFile, targetMetadataFile);
+			log.info("Installed updated motor database (database_version={})", remoteMetadata.getDatabaseVersion());
+		} finally {
+			deleteTemporaryFile(tmpDbFile);
+			if (tmpMetadataFile != null) {
+				deleteTemporaryFile(tmpMetadataFile);
 			}
-			throw e;
 		}
-
-		MotorDatabaseMetadataIO.writeRawJson(tmpMetadataFile, remoteMetadata.getRawJson());
-
-		FileUtils.replaceFile(tmpDbFile, targetDbFile);
-		FileUtils.replaceFile(tmpMetadataFile, targetMetadataFile);
-		log.info("Installed updated motor database (database_version={})", remoteMetadata.getDatabaseVersion());
 	}
 
 	/**
@@ -283,10 +300,6 @@ public class MotorDatabaseRemoteUpdater {
 	 * @return the InputStream
 	 * @throws IOException if an I/O error occurs
 	 */
-	private InputStream openStream(String url) throws IOException {
-		return openStream(url, new OperationDeadline(databaseOperationTimeoutMs));
-	}
-
 	private InputStream openStream(String url, OperationDeadline deadline) throws IOException {
 		validateHttpsUrl(url);
 		final int maxRedirects = 3;
@@ -454,6 +467,41 @@ public class MotorDatabaseRemoteUpdater {
 			ThrustCurveMotorSQLiteDatabase.validateDatabase(dbFile);
 		} catch (SQLException e) {
 			throw new IOException("Downloaded motor database failed validation: " + e.getMessage(), e);
+		}
+	}
+
+	private static FileLock tryAcquireInstallationLock(FileChannel lockChannel) throws IOException {
+		try {
+			FileLock lock = lockChannel.tryLock();
+			if (lock == null) {
+				throw new IOException("Another OpenRocket process is installing a motor database update");
+			}
+			return lock;
+		} catch (OverlappingFileLockException e) {
+			throw new IOException("Another motor database update is already running", e);
+		}
+	}
+
+	private static void rejectStaleInstall(File localMetadataFile, long remoteVersion) throws IOException {
+		if (!localMetadataFile.isFile()) {
+			return;
+		}
+		long installedVersion;
+		try {
+			installedVersion = MotorDatabaseMetadataIO.readDatabaseVersion(localMetadataFile);
+		} catch (IOException e) {
+			log.debug("Unable to read installed motor database version before commit: {}", e.getMessage());
+			return;
+		}
+		if (installedVersion >= remoteVersion) {
+			throw new IOException("Refusing stale motor database update " + remoteVersion +
+					" because version " + installedVersion + " is already installed");
+		}
+	}
+
+	private static void deleteTemporaryFile(File temporaryFile) {
+		if (temporaryFile.isFile() && !temporaryFile.delete()) {
+			log.debug("Unable to delete temporary update file {}", temporaryFile.getAbsolutePath());
 		}
 	}
 

--- a/core/src/main/java/info/openrocket/core/database/MotorDatabaseRemoteUpdater.java
+++ b/core/src/main/java/info/openrocket/core/database/MotorDatabaseRemoteUpdater.java
@@ -10,25 +10,37 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.net.HttpURLConnection;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URL;
-import java.sql.SQLException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.nio.charset.StandardCharsets;
-import java.security.GeneralSecurityException;
-import java.util.Objects;
 import java.security.DigestInputStream;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
-import java.security.KeyFactory;
 import java.security.Signature;
 import java.security.spec.X509EncodedKeySpec;
+import java.sql.SQLException;
 import java.util.Base64;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.GZIPInputStream;
 
 /**
@@ -68,6 +80,8 @@ public class MotorDatabaseRemoteUpdater {
 
 	private static final int CONNECT_TIMEOUT_MS = 10_000;
 	private static final int READ_TIMEOUT_MS = 30_000;
+	private static final long METADATA_OPERATION_TIMEOUT_MS = 60_000;
+	private static final long DATABASE_OPERATION_TIMEOUT_MS = 5 * 60_000;
 
 	// Safety limits against unexpectedly large downloads/decompression bombs.
 	private static final long MAX_METADATA_BYTES = 128 * 1024;
@@ -76,9 +90,13 @@ public class MotorDatabaseRemoteUpdater {
 
 	private static final String MOTORS_DB_FILENAME = "motors.db";
 	private static final String METADATA_FILENAME = "metadata.json";
+	private static final String INSTALL_LOCK_FILENAME = ".motor-database-update.lock";
 
 	private final ConnectionSource connectionSource;
 	private final PublicKey trustedSigningKey;
+	private final long metadataOperationTimeoutMs;
+	private final long databaseOperationTimeoutMs;
+	private final AtomicReference<HttpURLConnection> activeConnection = new AtomicReference<>();
 
 	public MotorDatabaseRemoteUpdater() {
 		this(new DefaultConnectionSource(), defaultSigningKey());
@@ -89,8 +107,31 @@ public class MotorDatabaseRemoteUpdater {
 	}
 
 	public MotorDatabaseRemoteUpdater(ConnectionSource connectionSource, PublicKey trustedSigningKey) {
+		this(connectionSource, trustedSigningKey, METADATA_OPERATION_TIMEOUT_MS, DATABASE_OPERATION_TIMEOUT_MS);
+	}
+
+	MotorDatabaseRemoteUpdater(ConnectionSource connectionSource, PublicKey trustedSigningKey,
+			long metadataOperationTimeoutMs, long databaseOperationTimeoutMs) {
 		this.connectionSource = Objects.requireNonNull(connectionSource, "connectionSource");
 		this.trustedSigningKey = Objects.requireNonNull(trustedSigningKey, "trustedSigningKey");
+		if (metadataOperationTimeoutMs <= 0 || databaseOperationTimeoutMs <= 0) {
+			throw new IllegalArgumentException("Motor database operation timeouts must be positive");
+		}
+		this.metadataOperationTimeoutMs = metadataOperationTimeoutMs;
+		this.databaseOperationTimeoutMs = databaseOperationTimeoutMs;
+	}
+
+	/**
+	 * Cancel the current network operation, if any.
+	 * <p>
+	 * Disconnecting the active HTTP connection unblocks a pending read so callers do not need to wait for the socket
+	 * timeout before cancellation takes effect.
+	 */
+	public void cancelCurrentOperation() {
+		HttpURLConnection connection = activeConnection.getAndSet(null);
+		if (connection != null) {
+			connection.disconnect();
+		}
 	}
 
 	/**
@@ -109,7 +150,8 @@ public class MotorDatabaseRemoteUpdater {
 	 * @throws IOException if an I/O error occurs
 	 */
 	public MotorDatabaseMetadata fetchRemoteMetadata(String metadataUrl) throws IOException {
-		try (InputStream in = openStream(metadataUrl);
+		OperationDeadline deadline = new OperationDeadline(metadataOperationTimeoutMs);
+		try (InputStream in = openStream(metadataUrl, deadline);
 			 InputStream limited = new ThrowingLimitedInputStream(in, MAX_METADATA_BYTES)) {
 			MotorDatabaseMetadata metadata = MotorDatabaseMetadata.parse(limited);
 			verifySignedMetadata(metadata);
@@ -177,6 +219,7 @@ public class MotorDatabaseRemoteUpdater {
 		}
 		verifySignedMetadata(remoteMetadata);
 		validateDatabaseDownloadUrl(databaseGzUrl);
+		OperationDeadline deadline = new OperationDeadline(databaseOperationTimeoutMs);
 
 		File targetDbFile = new File(motorLibraryDir, MOTORS_DB_FILENAME);
 		File targetMetadataFile = new File(motorLibraryDir, METADATA_FILENAME);
@@ -191,7 +234,7 @@ public class MotorDatabaseRemoteUpdater {
 			throw new IOException("Remote metadata missing or invalid sha256_gz");
 		}
 
-		try (InputStream rawIn0 = openStream(databaseGzUrl);
+		try (InputStream rawIn0 = openStream(databaseGzUrl, deadline);
 			 InputStream rawIn = new ThrowingLimitedInputStream(rawIn0, MAX_DB_GZ_BYTES);
 			 FileOutputStream out = new FileOutputStream(tmpDbFile)) {
 
@@ -218,8 +261,8 @@ public class MotorDatabaseRemoteUpdater {
 						", sha256_db=" + actualDbSha256 + ")");
 			}
 
-			// Always validate the downloaded DB before replacing the local one (even if SHA is missing).
 			validateDownloadedDatabase(tmpDbFile);
+			deadline.throwIfExpired();
 		} catch (IOException e) {
 			if (tmpDbFile.isFile() && !tmpDbFile.delete()) {
 				log.debug("Unable to delete partial download {}", tmpDbFile.getAbsolutePath());
@@ -241,35 +284,50 @@ public class MotorDatabaseRemoteUpdater {
 	 * @throws IOException if an I/O error occurs
 	 */
 	private InputStream openStream(String url) throws IOException {
+		return openStream(url, new OperationDeadline(databaseOperationTimeoutMs));
+	}
+
+	private InputStream openStream(String url, OperationDeadline deadline) throws IOException {
 		validateHttpsUrl(url);
 		final int maxRedirects = 3;
 		String current = url;
 
 		for (int redirects = 0; redirects <= maxRedirects; redirects++) {
+			deadline.throwIfExpired();
 			HttpURLConnection connection = connectionSource.getConnection(current);
+			boolean streamReturned = false;
+			activeConnection.set(connection);
 			connection.setInstanceFollowRedirects(false);
-			connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
-			connection.setReadTimeout(READ_TIMEOUT_MS);
+			connection.setConnectTimeout(deadline.boundedTimeout(CONNECT_TIMEOUT_MS));
+			connection.setReadTimeout(deadline.boundedTimeout(READ_TIMEOUT_MS));
 			connection.setRequestProperty("User-Agent", "OpenRocket");
 			connection.setRequestProperty("Accept", "application/json, */*");
 			connection.setRequestProperty("Accept-Encoding", "identity");
-			connection.connect();
-
-			int code = connection.getResponseCode();
-			if (code >= 200 && code < 300) {
-				return connection.getInputStream();
-			}
-			if (code == 301 || code == 302 || code == 303 || code == 307 || code == 308) {
-				String location = connection.getHeaderField("Location");
-				if (location == null || location.trim().isEmpty()) {
-					throw new IOException("HTTP " + code + " without Location header when fetching " + current);
+			try {
+				connection.connect();
+				int code = connection.getResponseCode();
+				deadline.throwIfExpired();
+				if (code >= 200 && code < 300) {
+					InputStream input = connection.getInputStream();
+					streamReturned = true;
+					return new DeadlineInputStream(input, connection, deadline, activeConnection);
 				}
-				String next = resolveRedirect(current, location);
-				validateRedirect(url, next);
-				current = next;
-				continue;
+				if (code == 301 || code == 302 || code == 303 || code == 307 || code == 308) {
+					String location = connection.getHeaderField("Location");
+					if (location == null || location.trim().isEmpty()) {
+						throw new IOException("HTTP " + code + " without Location header when fetching " + current);
+					}
+					String next = resolveRedirect(current, location);
+					validateRedirect(url, next);
+					current = next;
+					continue;
+				}
+				throw new IOException("HTTP " + code + " when fetching " + current);
+			} finally {
+				if (!streamReturned && activeConnection.compareAndSet(connection, null)) {
+					connection.disconnect();
+				}
 			}
-			throw new IOException("HTTP " + code + " when fetching " + current);
 		}
 
 		throw new IOException("Too many redirects when fetching " + url);
@@ -407,7 +465,7 @@ public class MotorDatabaseRemoteUpdater {
 	}
 
 	private static InputStream nonClosing(InputStream in) {
-		return new java.io.FilterInputStream(in) {
+		return new FilterInputStream(in) {
 			@Override
 			public void close() {
 				// Do not close the underlying stream; the caller owns it.
@@ -444,6 +502,78 @@ public class MotorDatabaseRemoteUpdater {
 			throw e;
 		} catch (Exception e) {
 			throw new IOException("Invalid redirect URL: " + redirectedUrl, e);
+		}
+	}
+
+	/**
+	 * Monotonic deadline shared by redirects and response-body reads for one network operation.
+	 */
+	private static final class OperationDeadline {
+		private final long deadlineNanos;
+
+		private OperationDeadline(long timeoutMs) {
+			long timeoutNanos = TimeUnit.MILLISECONDS.toNanos(timeoutMs);
+			this.deadlineNanos = System.nanoTime() + timeoutNanos;
+		}
+
+		private void throwIfExpired() throws IOException {
+			if (Thread.currentThread().isInterrupted()) {
+				throw new InterruptedIOException("Motor database update was cancelled");
+			}
+			if (System.nanoTime() >= deadlineNanos) {
+				throw new SocketTimeoutException("Motor database update exceeded its total time limit");
+			}
+		}
+
+		private int boundedTimeout(int maximumTimeoutMs) throws IOException {
+			throwIfExpired();
+			long remainingNanos = deadlineNanos - System.nanoTime();
+			long remainingMs = Math.max(1, TimeUnit.NANOSECONDS.toMillis(remainingNanos));
+			return (int) Math.min(maximumTimeoutMs, remainingMs);
+		}
+	}
+
+	/**
+	 * Response stream that enforces the operation deadline and owns the HTTP connection lifecycle.
+	 */
+	private static final class DeadlineInputStream extends InputStream {
+		private final InputStream delegate;
+		private final HttpURLConnection connection;
+		private final OperationDeadline deadline;
+		private final AtomicReference<HttpURLConnection> activeConnection;
+
+		private DeadlineInputStream(InputStream delegate, HttpURLConnection connection, OperationDeadline deadline,
+				AtomicReference<HttpURLConnection> activeConnection) {
+			this.delegate = delegate;
+			this.connection = connection;
+			this.deadline = deadline;
+			this.activeConnection = activeConnection;
+		}
+
+		@Override
+		public int read() throws IOException {
+			deadline.throwIfExpired();
+			int value = delegate.read();
+			deadline.throwIfExpired();
+			return value;
+		}
+
+		@Override
+		public int read(byte[] buffer, int offset, int length) throws IOException {
+			deadline.throwIfExpired();
+			int count = delegate.read(buffer, offset, length);
+			deadline.throwIfExpired();
+			return count;
+		}
+
+		@Override
+		public void close() throws IOException {
+			try {
+				delegate.close();
+			} finally {
+				activeConnection.compareAndSet(connection, null);
+				connection.disconnect();
+			}
 		}
 	}
 

--- a/core/src/main/java/info/openrocket/core/database/MotorDatabaseRemoteUpdater.java
+++ b/core/src/main/java/info/openrocket/core/database/MotorDatabaseRemoteUpdater.java
@@ -283,8 +283,7 @@ public class MotorDatabaseRemoteUpdater {
 			MotorDatabaseMetadataIO.writeRawJson(tmpMetadataFile, remoteMetadata.getRawJson());
 			rejectStaleInstall(targetMetadataFile, remoteMetadata.getDatabaseVersion());
 
-			FileUtils.replaceFile(tmpDbFile, targetDbFile);
-			FileUtils.replaceFile(tmpMetadataFile, targetMetadataFile);
+			commitDatabasePair(tmpDbFile, targetDbFile, tmpMetadataFile, targetMetadataFile);
 			log.info("Installed updated motor database (database_version={})", remoteMetadata.getDatabaseVersion());
 		} finally {
 			deleteTemporaryFile(tmpDbFile);
@@ -502,6 +501,47 @@ public class MotorDatabaseRemoteUpdater {
 	private static void deleteTemporaryFile(File temporaryFile) {
 		if (temporaryFile.isFile() && !temporaryFile.delete()) {
 			log.debug("Unable to delete temporary update file {}", temporaryFile.getAbsolutePath());
+		}
+	}
+
+	/**
+	 * Commit the database first and roll it back if committing the matching metadata fails.
+	 * <p>
+	 * Each individual replacement is atomic where supported by the filesystem. The backup closes the remaining
+	 * failure window between the two replacements for ordinary I/O errors.
+	 */
+	private static void commitDatabasePair(File temporaryDbFile, File targetDbFile, File temporaryMetadataFile,
+			File targetMetadataFile) throws IOException {
+		boolean targetDbExisted = targetDbFile.exists();
+		File backupDbFile = null;
+		if (targetDbFile.isFile()) {
+			backupDbFile = Files.createTempFile(targetDbFile.getParentFile().toPath(),
+					MOTORS_DB_FILENAME + ".", ".backup").toFile();
+			Files.copy(targetDbFile.toPath(), backupDbFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+		}
+
+		boolean databaseCommitted = false;
+		try {
+			FileUtils.replaceFile(temporaryDbFile, targetDbFile);
+			databaseCommitted = true;
+			FileUtils.replaceFile(temporaryMetadataFile, targetMetadataFile);
+		} catch (IOException commitError) {
+			if (databaseCommitted) {
+				try {
+					if (backupDbFile != null) {
+						FileUtils.replaceFile(backupDbFile, targetDbFile);
+					} else if (!targetDbExisted) {
+						Files.deleteIfExists(targetDbFile.toPath());
+					}
+				} catch (IOException rollbackError) {
+					commitError.addSuppressed(rollbackError);
+				}
+			}
+			throw commitError;
+		} finally {
+			if (backupDbFile != null) {
+				deleteTemporaryFile(backupDbFile);
+			}
 		}
 	}
 

--- a/core/src/main/java/info/openrocket/core/database/motor/ThrustCurveMotorSQLiteDatabase.java
+++ b/core/src/main/java/info/openrocket/core/database/motor/ThrustCurveMotorSQLiteDatabase.java
@@ -76,6 +76,7 @@ public final class ThrustCurveMotorSQLiteDatabase {
 
 		try (Connection connection = openConnection(dbFile)) {
 			int schemaVersion = validateSchema(connection);
+			validateIntegrity(connection);
 			// Only include optional columns in queries if they actually exist.
 			boolean hasMotorDescriptionSource =
 					columnExists(connection, "motors", "description") && columnExists(connection, "motors", "source");
@@ -89,6 +90,30 @@ public final class ThrustCurveMotorSQLiteDatabase {
 		}
 		try (Connection connection = openConnection(dbFile)) {
 			validateSchema(connection);
+			validateIntegrity(connection);
+		}
+	}
+
+	/**
+	 * Validate the SQLite page structure and all declared foreign-key relationships.
+	 *
+	 * @param connection open read connection
+	 * @throws SQLException if SQLite reports corruption or broken relationships
+	 */
+	private static void validateIntegrity(Connection connection) throws SQLException {
+		try (Statement statement = connection.createStatement();
+			 ResultSet result = statement.executeQuery("PRAGMA integrity_check")) {
+			if (!result.next() || !"ok".equalsIgnoreCase(result.getString(1)) || result.next()) {
+				throw new SQLException("SQLite motor database failed integrity_check");
+			}
+		}
+
+		try (Statement statement = connection.createStatement();
+			 ResultSet result = statement.executeQuery("PRAGMA foreign_key_check")) {
+			if (result.next()) {
+				throw new SQLException("SQLite motor database failed foreign_key_check for table " +
+						result.getString(1));
+			}
 		}
 	}
 

--- a/core/src/test/java/info/openrocket/core/database/MotorDatabaseRemoteUpdaterTest.java
+++ b/core/src/test/java/info/openrocket/core/database/MotorDatabaseRemoteUpdaterTest.java
@@ -1,7 +1,9 @@
 package info.openrocket.core.database;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import info.openrocket.core.communication.ConnectionSourceStub;
 import info.openrocket.core.communication.HttpURLConnectionMock;
@@ -24,9 +26,14 @@ import java.security.PrivateKey;
 import java.security.Signature;
 import java.util.Base64;
 import java.net.HttpURLConnection;
+import java.net.SocketTimeoutException;
 import java.net.URL;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 import java.io.InputStream;
 import java.io.IOException;
 import java.util.zip.GZIPOutputStream;
@@ -142,6 +149,103 @@ public class MotorDatabaseRemoteUpdaterTest {
 
 		byte[] installed = Files.readAllBytes(new File(tempDir.toFile(), "motors.db").toPath());
 		assertArrayEquals(dbBytes, installed);
+	}
+
+	@Test
+	public void testMetadataFetchEnforcesTotalDeadline() throws Exception {
+		KeyPair keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+		MotorDatabaseMetadata metadata = signedMetadata(
+				123,
+				"0000000000000000000000000000000000000000000000000000000000000000",
+				keyPair.getPrivate());
+
+		HttpURLConnectionMock connection = new HttpURLConnectionMock();
+		connection.setDoInput(true);
+		connection.setResponseCode(200);
+		connection.setContent(metadata.getRawJson());
+		connection.setConnectionDelay(25);
+
+		MotorDatabaseRemoteUpdater updater = new MotorDatabaseRemoteUpdater(
+				new ConnectionSourceStub(connection), keyPair.getPublic(), 1, 1_000);
+
+		assertThrows(SocketTimeoutException.class, updater::fetchRemoteMetadata);
+	}
+
+	@Test
+	public void testInstallRejectsConcurrentInstaller() throws Exception {
+		KeyPair keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+		byte[] dbBytes = createValidMotorDbBytes();
+		byte[] gzBytes = gzip(dbBytes);
+		MotorDatabaseMetadata metadata = signedMetadata(123, sha256Hex(gzBytes), keyPair.getPrivate());
+
+		HttpURLConnectionMock connection = new HttpURLConnectionMock();
+		connection.setDoInput(true);
+		connection.setResponseCode(200);
+		connection.setContent(gzBytes);
+		MotorDatabaseRemoteUpdater updater = new MotorDatabaseRemoteUpdater(
+				new ConnectionSourceStub(connection), keyPair.getPublic());
+
+		Path lockPath = tempDir.resolve(".motor-database-update.lock");
+		try (FileChannel channel = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+			 FileLock ignored = channel.lock()) {
+			IOException error = assertThrows(IOException.class,
+					() -> updater.installRemoteDatabase(tempDir.toFile(), metadata,
+							"https://openrocket.info/motor-database/motors.db.gz"));
+			assertTrue(error.getMessage().contains("already running"));
+		}
+	}
+
+	@Test
+	public void testInstallRejectsStaleVersionAtCommit() throws Exception {
+		KeyPair keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+		byte[] dbBytes = createValidMotorDbBytes();
+		byte[] gzBytes = gzip(dbBytes);
+		MotorDatabaseMetadata metadata = signedMetadata(123, sha256Hex(gzBytes), keyPair.getPrivate());
+		Files.writeString(tempDir.resolve("metadata.json"), "{\"database_version\":124}");
+
+		HttpURLConnectionMock connection = new HttpURLConnectionMock();
+		connection.setDoInput(true);
+		connection.setResponseCode(200);
+		connection.setContent(gzBytes);
+		MotorDatabaseRemoteUpdater updater = new MotorDatabaseRemoteUpdater(
+				new ConnectionSourceStub(connection), keyPair.getPublic());
+
+		IOException error = assertThrows(IOException.class,
+				() -> updater.installRemoteDatabase(tempDir.toFile(), metadata,
+						"https://openrocket.info/motor-database/motors.db.gz"));
+		assertTrue(error.getMessage().contains("Refusing stale motor database update"));
+		assertNoDownloadFiles();
+	}
+
+	@Test
+	public void testDatabaseIsRolledBackWhenMetadataCommitFails() throws Exception {
+		KeyPair keyPair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+		byte[] dbBytes = createValidMotorDbBytes();
+		byte[] gzBytes = gzip(dbBytes);
+		MotorDatabaseMetadata metadata = signedMetadata(123, sha256Hex(gzBytes), keyPair.getPrivate());
+		byte[] originalDatabase = "existing database".getBytes(StandardCharsets.UTF_8);
+		Files.write(tempDir.resolve("motors.db"), originalDatabase);
+		Files.createDirectory(tempDir.resolve("metadata.json"));
+		Files.writeString(tempDir.resolve("metadata.json").resolve("block-replacement"), "keep");
+
+		HttpURLConnectionMock connection = new HttpURLConnectionMock();
+		connection.setDoInput(true);
+		connection.setResponseCode(200);
+		connection.setContent(gzBytes);
+		MotorDatabaseRemoteUpdater updater = new MotorDatabaseRemoteUpdater(
+				new ConnectionSourceStub(connection), keyPair.getPublic());
+
+		assertThrows(IOException.class,
+				() -> updater.installRemoteDatabase(tempDir.toFile(), metadata,
+						"https://openrocket.info/motor-database/motors.db.gz"));
+		assertArrayEquals(originalDatabase, Files.readAllBytes(tempDir.resolve("motors.db")));
+		assertNoDownloadFiles();
+	}
+
+	private void assertNoDownloadFiles() throws IOException {
+		try (Stream<Path> files = Files.list(tempDir)) {
+			assertFalse(files.anyMatch(path -> path.getFileName().toString().endsWith(".download")));
+		}
 	}
 
 	private static byte[] gzip(byte[] content) throws Exception {

--- a/docs/source/dev_guide/motor_database_updates.rst
+++ b/docs/source/dev_guide/motor_database_updates.rst
@@ -84,6 +84,19 @@ The updater takes several precautions when downloading and installing data:
 
   - This reduces risk from oversized downloads and decompression bombs.
 
+- Bounded and cancellable operations
+
+  - Metadata checks have a one-minute total deadline and database downloads have a five-minute total deadline, in
+    addition to socket inactivity timeouts.
+  - The progress dialog can cancel the worker and disconnect its active HTTP connection.
+
+- Concurrent-install protection
+
+  - An inter-process file lock prevents multiple OpenRocket instances from updating the shared motor library at once.
+  - Downloads use unique temporary files, and the installed version is checked again immediately before commit.
+  - If metadata replacement fails after database replacement, the previous database is restored from a temporary
+    backup.
+
 Signature format
 ----------------
 
@@ -117,6 +130,7 @@ Testing
 -------
 
 - `core/src/test/java/info/openrocket/core/database/MotorDatabaseRemoteUpdaterTest.java` verifies SHA handling (compressed
-  vs decompressed) and that mismatches are rejected.
+  vs decompressed), signature rejection, operation deadlines, concurrent-install locking, stale-version rejection,
+  and rollback when committing metadata fails.
 - `core/src/test/java/info/openrocket/core/database/motor/InitialMotorsDatabaseFormatTest.java` ensures the bundled
   `initial_motors.db` can be validated and loaded.

--- a/swing/src/main/java/info/openrocket/swing/startup/MotorDatabaseUpdateChecker.java
+++ b/swing/src/main/java/info/openrocket/swing/startup/MotorDatabaseUpdateChecker.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.swing.JDialog;
+import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -22,8 +23,11 @@ import javax.swing.SwingWorker;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.awt.Component;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 
 /**
  * Startup-time motor database update checker that can optionally install the latest remote motor database.
@@ -77,10 +81,14 @@ public abstract class MotorDatabaseUpdateChecker {
 		TaskResult<MotorDatabaseMetadata> remoteResult = runWithProgressDialog(
 				trans.get("MotorDbUpdate.Checking.title"),
 				trans.get("MotorDbUpdate.Checking.message"),
-				updater::fetchRemoteMetadata);
+				updater::fetchRemoteMetadata,
+				updater::cancelCurrentOperation);
 
 		MotorDatabaseMetadata remote = remoteResult.value;
 		if (remote == null) {
+			if (remoteResult.cancelled) {
+				return;
+			}
 			// If metadata cannot be downloaded/validated/parsed, we cannot safely offer an update.
 			// For user-initiated checks, show the failure message (and the underlying exception if present).
 			if (userInitiated) {
@@ -215,13 +223,17 @@ public abstract class MotorDatabaseUpdateChecker {
 				() -> {
 					updater.installRemoteDatabase(motorLibraryDir, remote);
 					return Boolean.TRUE;
-				});
+				},
+				updater::cancelCurrentOperation);
 
 		// An unattended auto-install at startup should not interrupt the user with result dialogs;
 		// the outcome is logged instead. Manual checks and explicit "Install" clicks always report back.
 		boolean reportResult = userInitiated || !autoInstall;
 
 		if (installedResult.value == null || !installedResult.value) {
+			if (installedResult.cancelled) {
+				return;
+			}
 			// Unable to download and install the motor database update.
 			if (!reportResult) {
 				log.warn("Automatic motor database update to version {} failed", remoteVersion);
@@ -255,10 +267,12 @@ public abstract class MotorDatabaseUpdateChecker {
 	private static final class TaskResult<T> {
 		private final T value;
 		private final Throwable error;
+		private final boolean cancelled;
 
-		private TaskResult(T value, Throwable error) {
+		private TaskResult(T value, Throwable error, boolean cancelled) {
 			this.value = value;
 			this.error = error;
+			this.cancelled = cancelled;
 		}
 	}
 
@@ -268,9 +282,11 @@ public abstract class MotorDatabaseUpdateChecker {
 	 * @param title   the dialog title
 	 * @param message the dialog message
 	 * @param task    the task to run
-	 * @return the result of the task, or null if an error occurred
+	 * @param cancelAction action that disconnects any blocking external work
+	 * @return the task value together with its failure or cancellation state
 	 */
-	private static <T> TaskResult<T> runWithProgressDialog(String title, String message, WorkerTask<T> task) {
+	private static <T> TaskResult<T> runWithProgressDialog(String title, String message, WorkerTask<T> task,
+			Runnable cancelAction) {
 		final ProgressDialog dialog = new ProgressDialog(title, message);
 		final SwingWorker<T, Void> worker = new SwingWorker<>() {
 			@Override
@@ -283,17 +299,24 @@ public abstract class MotorDatabaseUpdateChecker {
 				dialog.setVisible(false);
 			}
 		};
+		dialog.setCancelAction(() -> {
+			worker.cancel(true);
+			cancelAction.run();
+		});
 
 		worker.execute();
 		dialog.setVisible(true);
 
 		try {
-			return new TaskResult<>(worker.get(), null);
+			return new TaskResult<>(worker.get(), null, false);
+		} catch (CancellationException e) {
+			log.info("Motor database update check/download cancelled by user");
+			return new TaskResult<>(null, null, true);
 		} catch (Exception e) {
 			Throwable t = unwrapWorkerException(e);
 			log.info("Motor database update check/download failed: {}", t.getMessage());
 			log.debug("Motor database update check/download failed", t);
-			return new TaskResult<>(null, t);
+			return new TaskResult<>(null, t, false);
 		} finally {
 			dialog.dispose();
 		}
@@ -318,6 +341,9 @@ public abstract class MotorDatabaseUpdateChecker {
 	}
 
 	private static class ProgressDialog extends JDialog {
+		private Runnable cancelAction = () -> {
+		};
+
 		ProgressDialog(String title, String message) {
 			super(null, title, ModalityType.DOCUMENT_MODAL);
 
@@ -326,13 +352,27 @@ public abstract class MotorDatabaseUpdateChecker {
 
 			JProgressBar progress = new JProgressBar();
 			progress.setIndeterminate(true);
-			panel.add(progress, "growx");
+			panel.add(progress, "growx, wrap para");
+
+			JButton cancelButton = new JButton(trans.get("dlg.but.cancel"));
+			cancelButton.addActionListener(event -> cancelAction.run());
+			panel.add(cancelButton, "right");
 
 			this.add(panel);
 			this.pack();
 			this.setDefaultCloseOperation(DO_NOTHING_ON_CLOSE);
+			this.addWindowListener(new WindowAdapter() {
+				@Override
+				public void windowClosing(WindowEvent event) {
+					cancelAction.run();
+				}
+			});
 			this.setLocationByPlatform(true);
 			GUIUtil.setWindowIcons(this);
+		}
+
+		private void setCancelAction(Runnable cancelAction) {
+			this.cancelAction = cancelAction;
 		}
 	}
 }


### PR DESCRIPTION
Improves the safety of motor database updates:

- Adds download timeouts and cancellation
- Prevents concurrent and stale installs
- Validates SQLite integrity before installation
- Uses unique temporary files
- Rolls back if the database and metadata cannot both be installed