### PR TITLE
Keep calipers behind rocket information

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketFigure.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketFigure.java
@@ -106,7 +106,7 @@ public class RocketFigure extends AbstractScaleFigure {
 	
 	private final ArrayList<FigureElement> relativeExtra = new ArrayList<>();
 	private final ArrayList<FigureElement> absoluteExtra = new ArrayList<>();
-	/** Elements painted last, on top of everything (including absoluteExtra), using the rocket transform. */
+	/** Elements painted over the rocket but below screen-space HUD elements, using the rocket transform. */
 	private final ArrayList<FigureElement> relativeTopExtra = new ArrayList<>();
 
 	private static Color motorFillColor;
@@ -358,20 +358,22 @@ public class RocketFigure extends AbstractScaleFigure {
 		}
 
 		
-		// Draw absolute extras
-		g2.setTransform(baseTransform);
-		Rectangle rect = this.getVisibleRect();
-
-		for (FigureElement e : absoluteExtra) {
-			e.paint(g2, 1.0, rect);
-		}
-
-		// Draw relative top extras (on top of everything, using the rocket transform)
+		// Draw relative overlays above the rocket, but below the screen-space HUD.
+		// Calipers use this layer so their handles stay interactive without obscuring
+		// rocket information in the top corners.
 		if (drawCarets && !relativeTopExtra.isEmpty()) {
 			g2.setTransform(rocketTransform);
 			for (FigureElement e : relativeTopExtra) {
 				e.paint(g2, scale, visibleRect);
 			}
+		}
+
+		// Draw absolute screen-space extras last so informational text remains legible.
+		g2.setTransform(baseTransform);
+		Rectangle rect = this.getVisibleRect();
+
+		for (FigureElement e : absoluteExtra) {
+			e.paint(g2, 1.0, rect);
 		}
 
 	}

--- a/swing/src/test/java/info/openrocket/swing/gui/scalefigure/RocketFigureLayeringTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/scalefigure/RocketFigureLayeringTest.java
@@ -1,0 +1,48 @@
+package info.openrocket.swing.gui.scalefigure;
+
+import info.openrocket.core.util.TestRockets;
+import info.openrocket.swing.gui.figureelements.FigureElement;
+import info.openrocket.swing.util.BaseTestCase;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class RocketFigureLayeringTest extends BaseTestCase {
+
+	@Test
+	void screenSpaceInformationPaintsAfterRocketRelativeOverlays() {
+		List<String> paintOrder = new ArrayList<>();
+		RocketFigure figure = new RocketFigure(TestRockets.makeEstesAlphaIII());
+		figure.setSize(800, 300);
+		figure.addRelativeTopExtra(new RecordingElement("relative-overlay", paintOrder));
+		figure.addAbsoluteExtra(new RecordingElement("screen-space-information", paintOrder));
+		BufferedImage image = new BufferedImage(800, 300, BufferedImage.TYPE_INT_ARGB);
+		Graphics2D graphics = image.createGraphics();
+		try {
+			figure.paint(graphics);
+		} finally {
+			graphics.dispose();
+		}
+
+		assertEquals(List.of("relative-overlay", "screen-space-information"), paintOrder);
+	}
+
+	/** Records when an overlay is painted so the layer contract can be tested without pixel matching. */
+	private record RecordingElement(String name, List<String> paintOrder) implements FigureElement {
+		@Override
+		public void paint(Graphics2D graphics, double scale) {
+			paintOrder.add(name);
+		}
+
+		@Override
+		public void paint(Graphics2D graphics, double scale, Rectangle visible) {
+			paintOrder.add(name);
+		}
+	}
+}


### PR DESCRIPTION
Fixes #3271. The calipers are now drawn behind the flight info. To be fair, it's still a bit difficult to read, but I don't see another easy way out other than dimming the caliper right behind the flight info boundary boxes, or to add a semi-transparent background box behind the flight info when the caliper is behind it. In my opinion, this solution is ok for now.

<img width="1522" height="885" alt="image" src="https://github.com/user-attachments/assets/2326e3d1-1edd-4058-885a-371edc980e5f" />
