### PR TITLE
Use horizontal scroll bar for design view bottom row

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/RocketPanel.java
@@ -80,7 +80,6 @@ import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
 import javax.swing.JRadioButton;
 import javax.swing.JSeparator;
 import javax.swing.JPopupMenu;
@@ -128,8 +127,6 @@ import java.awt.datatransfer.UnsupportedFlavorException;
 import java.awt.image.BufferedImage;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.ComponentAdapter;
-import java.awt.event.ComponentEvent;
 import java.awt.event.InputEvent;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
@@ -982,41 +979,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 		final ConfigurationComboBox configComboBox = new ConfigurationComboBox(rkt);
 		ribbon.add(configComboBox, "cell 8 1, width 16%, wmin 100");
 
-		JScrollPane ribbonScroll = new JScrollPane(ribbon,
-				JScrollPane.VERTICAL_SCROLLBAR_NEVER,
-				JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED) {
-			private void applyBorderlessStyling() {
-				setBorder(null);
-				setViewportBorder(null);
-			}
-
-			@Override
-			public void updateUI() {
-				super.updateUI();
-				applyBorderlessStyling();
-			}
-
-			@Override
-			public Dimension getPreferredSize() {
-				Dimension d = super.getPreferredSize();
-				if (getHorizontalScrollBar().isVisible()) {
-					d.height += getHorizontalScrollBar().getPreferredSize().height;
-				}
-				return d;
-			}
-		};
-		ribbonScroll.setBorder(null);
-		ribbonScroll.setViewportBorder(null);
-		ribbonScroll.getHorizontalScrollBar().addComponentListener(new ComponentAdapter() {
-			@Override
-			public void componentShown(ComponentEvent e) {
-				RocketPanel.this.revalidate();
-			}
-			@Override
-			public void componentHidden(ComponentEvent e) {
-				RocketPanel.this.revalidate();
-			}
-		});
+		SingleRowScrollPane ribbonScroll = new SingleRowScrollPane(ribbon, this::revalidate);
 		add(ribbonScroll, "growx, span, wrap");
 
 		// Create rotation control
@@ -1038,7 +1001,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 
 			//// <html>Click to select &nbsp;&nbsp; Shift+click to select other &nbsp;&nbsp; Double-click to edit &nbsp;&nbsp; Click+drag to move
 			infoMessage = new StyledLabel(trans.get("RocketPanel.lbl.infoMessage"), -3);
-			bottomRow.add(infoMessage);
+			bottomRow.add(infoMessage, "wmin 0, growx, pushx");
 			refreshInfoMessage();
 
 		//// Configure display button
@@ -1046,7 +1009,7 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 				trans.get("RocketPanel.btn.configureDisplay"), Icons.CONFIGURE_DISPLAY);
 		configureDisplayButton.setToolTipText(trans.get("RocketPanel.btn.configureDisplay.ttip"));
 		configureDisplayButton.addActionListener(e -> showDisplaySettingsDialog());
-		bottomRow.add(configureDisplayButton, "pushx, right, gapright rel");
+		bottomRow.add(configureDisplayButton, "right, gapright rel");
 
 		//// Screenshot button
 		JButton screenshotButton = new JButton(
@@ -1070,8 +1033,8 @@ public class RocketPanel extends JPanel implements TreeSelectionListener, Change
 				updateFigures();
 			}
 		});
-
-		add(bottomRow, "skip, growx, gapleft 25");
+		SingleRowScrollPane bottomRowScroll = new SingleRowScrollPane(bottomRow, this::revalidate);
+		add(bottomRowScroll, "skip, growx, gapleft 25");
 
 		addExtras();
 	}

--- a/swing/src/main/java/info/openrocket/swing/gui/scalefigure/SingleRowScrollPane.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/scalefigure/SingleRowScrollPane.java
@@ -1,0 +1,61 @@
+package info.openrocket.swing.gui.scalefigure;
+
+import javax.swing.JScrollPane;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+
+/**
+ * Borderless horizontal scroll pane for a fixed-height toolbar or footer row.
+ *
+ * <p>The preferred height grows when the horizontal scrollbar becomes visible,
+ * leaving the full viewport height available to the row's controls.</p>
+ */
+class SingleRowScrollPane extends JScrollPane {
+	private final Runnable scrollbarVisibilityChanged;
+
+	SingleRowScrollPane(Component view, Runnable scrollbarVisibilityChanged) {
+		super(view, VERTICAL_SCROLLBAR_NEVER, HORIZONTAL_SCROLLBAR_AS_NEEDED);
+		this.scrollbarVisibilityChanged = scrollbarVisibilityChanged;
+		applyBorderlessStyling();
+		getHorizontalScrollBar().addComponentListener(new ComponentAdapter() {
+			@Override
+			public void componentShown(ComponentEvent event) {
+				onScrollbarVisibilityChanged();
+			}
+
+			@Override
+			public void componentHidden(ComponentEvent event) {
+				onScrollbarVisibilityChanged();
+			}
+		});
+	}
+
+	@Override
+	public void updateUI() {
+		super.updateUI();
+		applyBorderlessStyling();
+	}
+
+	@Override
+	public Dimension getPreferredSize() {
+		Dimension size = super.getPreferredSize();
+		if (getHorizontalScrollBar().isVisible()) {
+			size.height += getHorizontalScrollBar().getPreferredSize().height;
+		}
+		return size;
+	}
+
+	private void applyBorderlessStyling() {
+		setBorder(null);
+		setViewportBorder(null);
+	}
+
+	private void onScrollbarVisibilityChanged() {
+		revalidate();
+		if (scrollbarVisibilityChanged != null) {
+			scrollbarVisibilityChanged.run();
+		}
+	}
+}

--- a/swing/src/test/java/info/openrocket/swing/gui/scalefigure/SingleRowScrollPaneTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/scalefigure/SingleRowScrollPaneTest.java
@@ -1,0 +1,55 @@
+package info.openrocket.swing.gui.scalefigure;
+
+import info.openrocket.swing.util.BaseTestCase;
+import net.miginfocom.swing.MigLayout;
+import org.junit.jupiter.api.Test;
+
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import java.awt.Dimension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SingleRowScrollPaneTest extends BaseTestCase {
+
+	@Test
+	void narrowViewportShowsHorizontalScrollbarWithoutClippingControls() {
+		JPanel footer = createFooter();
+		SingleRowScrollPane scrollPane = new SingleRowScrollPane(footer, null);
+		Dimension footerSize = footer.getPreferredSize();
+		int scrollbarHeight = scrollPane.getHorizontalScrollBar().getPreferredSize().height;
+
+		scrollPane.setSize(250, footerSize.height + scrollbarHeight);
+		scrollPane.doLayout();
+
+		assertTrue(scrollPane.getHorizontalScrollBar().isVisible());
+		assertFalse(scrollPane.getVerticalScrollBar().isVisible());
+		assertTrue(scrollPane.getViewport().getExtentSize().height >= footerSize.height,
+				"The scrollbar must receive its own height instead of clipping the footer controls");
+	}
+
+	@Test
+	void wideViewportDoesNotShowHorizontalScrollbar() {
+		JPanel footer = createFooter();
+		SingleRowScrollPane scrollPane = new SingleRowScrollPane(footer, null);
+		Dimension footerSize = footer.getPreferredSize();
+
+		scrollPane.setSize(footerSize.width + 20, footerSize.height);
+		scrollPane.doLayout();
+
+		assertFalse(scrollPane.getHorizontalScrollBar().isVisible());
+	}
+
+	private static JPanel createFooter() {
+		JPanel footer = new JPanel(new MigLayout("fillx, gapy 0, ins 0"));
+		footer.add(new JLabel("Click to select; shift-click to add; double-click to edit"),
+				"growx, pushx");
+		footer.add(new JButton("View settings"));
+		footer.add(new JButton("Capture"));
+		footer.add(new JCheckBox("Show warnings"));
+		return footer;
+	}
+}


### PR DESCRIPTION
Fixes #3268. The bottom row of the design view now has a horizontal scroll bar that activates when the view becomes too narrow - similar to what's already implemented for the top ribbon of the design view. In fact, they now use a common widget, `SingleRowScrollPane` for the scroll behavior. It improves upon the normal `JScrollPane` widget by not including the scroll bar height to the pane when the scroll bar is hidden. When the scroll bar does appear, the pane's height changes.

https://github.com/user-attachments/assets/aa5c8d49-c382-4900-b4b0-b33f5e6c6307

