### PR TITLE
Fix supersonic fin CP singularity for low-aspect-ratio fins

### DIFF
--- a/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/FinSetCalc.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/FinSetCalc.java
@@ -572,7 +572,13 @@ public class FinSetCalc extends RocketComponentCalc {
 		if (m >= 2) {
 			// At supersonic speeds use empirical formula
 			double beta = cond.getBeta();
-			return (ar * beta - 0.67) / (2 * ar * beta - 1);
+			double x = ar * beta;
+			// The formula (x - 0.67) / (2x - 1) has a pole at x = 0.5.
+			// Clamp the result to [0, 1] to prevent unphysical values.
+			if (Math.abs(2 * x - 1) < 1e-6) {
+				return 0.5;
+			}
+			return MathUtil.clamp((x - 0.67) / (2 * x - 1), 0, 1);
 		}
 		
 		// In between use interpolation polynomial
@@ -584,7 +590,18 @@ public class FinSetCalc extends RocketComponentCalc {
 			x *= m;
 		}
 
-		return val;
+		// When ar is near the polynomial singularity (poly all zeros), use linear
+		// interpolation between the subsonic and supersonic endpoints.
+		if (val == 0 && m > 0.5) {
+			double supersonicCP = (ar * cond.getBeta() - 0.67) / (2 * ar * cond.getBeta() - 1);
+			if (Double.isFinite(supersonicCP)) {
+				val = 0.25 + (MathUtil.clamp(supersonicCP, 0, 1) - 0.25) * (m - 0.5) / 1.5;
+			} else {
+				val = 0.25 + 0.25 * (m - 0.5) / 1.5;
+			}
+		}
+
+		return MathUtil.clamp(val, 0, 1);
 	}
 	
 	/**
@@ -605,6 +622,14 @@ public class FinSetCalc extends RocketComponentCalc {
 	 */
 	private void calculatePoly() {
 		double denom = pow2(1 - 3.4641 * ar); // common denominator
+		
+		// The polynomial coefficients have a singularity at ar = 1/3.4641 ≈ 0.2887.
+		// For aspect ratios near this value, use a linear fallback between the
+		// subsonic (0.25) and supersonic endpoints to avoid blowing up.
+		if (Math.abs(denom) < 1e-6) {
+			Arrays.fill(poly, 0);
+			return;
+		}
 		
 		poly[5] = (-1.58025 * (-0.728769 + ar) * (-0.192105 + ar)) / denom;
 		poly[4] = (12.8395 * (-0.725688 + ar) * (-0.19292 + ar)) / denom;

--- a/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/TubeFinSetCalc.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/TubeFinSetCalc.java
@@ -2,6 +2,8 @@ package info.openrocket.core.aerodynamics.barrowman;
 
 import static info.openrocket.core.util.MathUtil.pow2;
 
+import java.util.Arrays;
+
 import info.openrocket.core.aerodynamics.AerodynamicForces;
 import info.openrocket.core.aerodynamics.FlightConditions;
 import info.openrocket.core.logging.Warning;
@@ -225,7 +227,13 @@ public class TubeFinSetCalc extends TubeCalc {
 		if (m >= 2) {
 			// At supersonic speeds use empirical formula
 			double beta = cond.getBeta();
-			return (ar * beta - 0.67) / (2 * ar * beta - 1);
+			double x = ar * beta;
+			// The formula (x - 0.67) / (2x - 1) has a pole at x = 0.5.
+			// Clamp the result to [0, 1] to prevent unphysical values.
+			if (Math.abs(2 * x - 1) < 1e-6) {
+				return 0.5;
+			}
+			return MathUtil.clamp((x - 0.67) / (2 * x - 1), 0, 1);
 		}
 
 		// In between use interpolation polynomial
@@ -236,8 +244,20 @@ public class TubeFinSetCalc extends TubeCalc {
 			val += v * x;
 			x *= m;
 		}
+
+		// When ar is near the polynomial singularity (poly all zeros), use linear
+		// interpolation between the subsonic and supersonic endpoints.
+		if (val == 0 && m > 0.5) {
+			double supersonicCP = (ar * cond.getBeta() - 0.67) / (2 * ar * cond.getBeta() - 1);
+			if (Double.isFinite(supersonicCP)) {
+				val = 0.25 + (MathUtil.clamp(supersonicCP, 0, 1) - 0.25) * (m - 0.5) / 1.5;
+			} else {
+				val = 0.25 + 0.25 * (m - 0.5) / 1.5;
+			}
+		}
+
+		return MathUtil.clamp(val, 0, 1);
 		// log.debug("val = {}", val);
-		return val;
 	}
 
 	/**
@@ -258,6 +278,14 @@ public class TubeFinSetCalc extends TubeCalc {
 	 */
 	private void calculatePoly() {
 		double denom = pow2(1 - 3.4641 * ar); // common denominator
+
+		// The polynomial coefficients have a singularity at ar = 1/3.4641 ≈ 0.2887.
+		// For aspect ratios near this value, use a linear fallback between the
+		// subsonic (0.25) and supersonic endpoints to avoid blowing up.
+		if (Math.abs(denom) < 1e-6) {
+			Arrays.fill(poly, 0);
+			return;
+		}
 
 		poly[5] = (-1.58025 * (-0.728769 + ar) * (-0.192105 + ar)) / denom;
 		poly[4] = (12.8395 * (-0.725688 + ar) * (-0.19292 + ar)) / denom;

--- a/core/src/test/java/info/openrocket/core/aerodynamics/FinSetCalcTest.java
+++ b/core/src/test/java/info/openrocket/core/aerodynamics/FinSetCalcTest.java
@@ -434,4 +434,45 @@ public class FinSetCalcTest {
 		assertEquals(0.0, finForces.getBaseCD(), EPSILON, "Airfoil fin base CD should be zero in force analysis");
 		assertTrue(finForces.getPressureCD() > 0, "Airfoil fin pressure CD should be positive");
 	}
+
+	/**
+	 * Test that low-aspect-ratio fins do not produce singular CP values at
+	 * supersonic speeds. The empirical formula (ar*beta - 0.67) / (2*ar*beta - 1)
+	 * has a pole at ar*beta = 0.5, which can occur at normal supersonic Mach
+	 * numbers for fins with AR < 1.
+	 */
+	@Test
+	public void testLowAspectRatioFinCPSingularity() {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		TrapezoidFinSet fins = (TrapezoidFinSet) rocket.getChild(0).getChild(1).getChild(0);
+
+		// Set up low-aspect-ratio fins: root=6cm, tip=4cm, height=0.5cm
+		// This gives AR ≈ 0.2, so the pole occurs at beta = 2.5, i.e. Mach ≈ 2.69
+		fins.setRootChord(0.06);
+		fins.setTipChord(0.04);
+		fins.setHeight(0.005);
+
+		FlightConfiguration config = rocket.getSelectedConfiguration();
+		FlightConditions conditions = new FlightConditions(config);
+
+		// Test across the Mach range, especially near the pole at Mach ≈ 2.69
+		double[] testMachs = { 0.5, 1.0, 1.5, 2.0, 2.5, 2.69, 2.8, 3.0, 5.0 };
+		for (double mach : testMachs) {
+			conditions.setMach(mach);
+			AerodynamicForces forces = sumFins(fins, rocket);
+
+			// CP position must be finite and within the MAC
+			double cpX = forces.getCP().getX();
+			assertFalse(Double.isNaN(cpX),
+					"CP x-coordinate must not be NaN at Mach " + mach);
+			assertFalse(Double.isInfinite(cpX),
+					"CP x-coordinate must not be infinite at Mach " + mach);
+
+			// CNa must be positive (fins generate lift)
+			if (mach > 0.5) {
+				assertTrue(forces.getCP().getWeight() > 0,
+						"CNa must be positive at Mach " + mach);
+			}
+		}
+	}
 }


### PR DESCRIPTION
Fixes #3196

The empirical formula `(ar*beta - 0.67) / (2*ar*beta - 1)` used for the fin center-of-pressure position has a pole at `ar*beta = 0.5`. For low-aspect-ratio fins (AR < 1), this pole occurs at normal supersonic Mach numbers, causing CP to jump discontinuously to ±infinity.

Additionally, the transonic interpolation polynomial coefficients are divided by `(1 - 3.4641*ar)^2`, which vanishes at `ar ≈ 0.2887`, causing the polynomial to blow up for a different set of fin geometries.

Both `FinSetCalc` and `TubeFinSetCalc` contained equivalent versions of this code.

## Fix

- Clamp the supersonic CP formula result to [0, 1]
- Detect near-pole denominators (< 1e-6) and return a stable fallback (0.5)
- When the polynomial singularity zeroes all coefficients, use linear interpolation between the subsonic (0.25) and supersonic CP endpoints
- Clamp the transonic polynomial output to [0, 1] as well

## Test

Adds a test that verifies fin CP remains finite and physically reasonable across the full Mach range for a low-AR fin geometry (AR ≈ 0.2, pole near Mach 2.69).