### PR TITLE
Depth-test origin axes against each other

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/figure3d/rendering/OffscreenRenderTarget.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/figure3d/rendering/OffscreenRenderTarget.java
@@ -32,6 +32,7 @@ import static org.lwjgl.opengl.GL33.glBindFramebuffer;
 import static org.lwjgl.opengl.GL33.glBindRenderbuffer;
 import static org.lwjgl.opengl.GL33.glBlitFramebuffer;
 import static org.lwjgl.opengl.GL33.glCheckFramebufferStatus;
+import static org.lwjgl.opengl.GL33.glClear;
 import static org.lwjgl.opengl.GL33.glDeleteFramebuffers;
 import static org.lwjgl.opengl.GL33.glDeleteRenderbuffers;
 import static org.lwjgl.opengl.GL33.glDeleteTextures;
@@ -41,6 +42,7 @@ import static org.lwjgl.opengl.GL33.glGenFramebuffers;
 import static org.lwjgl.opengl.GL33.glGenRenderbuffers;
 import static org.lwjgl.opengl.GL33.glGenTextures;
 import static org.lwjgl.opengl.GL33.glGetInteger;
+import static org.lwjgl.opengl.GL33.glRenderbufferStorage;
 import static org.lwjgl.opengl.GL33.glRenderbufferStorageMultisample;
 
 /**
@@ -59,6 +61,7 @@ public class OffscreenRenderTarget implements GpuResource {
 	private int multisampleFramebufferId;
 	private int multisampleColorRenderbufferId;
 	private int multisampleDepthRenderbufferId;
+	private int isolatedDepthRenderbufferId;
 	private int width;
 	private int height;
 	private int requestedSamples;
@@ -88,6 +91,33 @@ public class OffscreenRenderTarget implements GpuResource {
 
 	public void unbindResolved() {
 		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	}
+
+	/**
+	 * Draws into the resolved color attachment with a fresh, temporary depth buffer.
+	 *
+	 * <p>This allows overlay geometry to depth-test against itself while remaining in
+	 * front of the main scene. The scene depth texture is detached without being
+	 * cleared and restored after drawing, so later effects still see the original
+	 * scene depth.</p>
+	 *
+	 * @param drawing rendering operation that should use the isolated depth buffer
+	 */
+	public void withIsolatedDepthBuffer(Runnable drawing) {
+		bindResolved();
+		ensureIsolatedDepthBuffer();
+		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER,
+				isolatedDepthRenderbufferId);
+		try {
+			if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+				throw new IllegalStateException("Failed to attach isolated overlay depth buffer");
+			}
+			glClear(GL_DEPTH_BUFFER_BIT);
+			drawing.run();
+		} finally {
+			bindResolved();
+			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, depthTextureId, 0);
+		}
 	}
 
 	public int getColorTextureId() {
@@ -204,6 +234,20 @@ public class OffscreenRenderTarget implements GpuResource {
 				"OffscreenRenderTarget msaa depth");
 	}
 
+	private void ensureIsolatedDepthBuffer() {
+		if (isolatedDepthRenderbufferId != 0) {
+			return;
+		}
+
+		isolatedDepthRenderbufferId = glGenRenderbuffers();
+		glBindRenderbuffer(GL_RENDERBUFFER, isolatedDepthRenderbufferId);
+		glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, width, height);
+		glBindRenderbuffer(GL_RENDERBUFFER, 0);
+		GpuResourceTracker.register(GpuResourceTracker.ResourceType.RENDERBUFFER,
+				isolatedDepthRenderbufferId, "OffscreenRenderTarget isolated overlay depth");
+		GLErrors.check("isolated overlay depth buffer creation");
+	}
+
 	private void resolveMultisampleAttachments() {
 		if (activeSamples <= 1 || multisampleFramebufferId == 0 || framebufferId == 0) {
 			return;
@@ -247,6 +291,12 @@ public class OffscreenRenderTarget implements GpuResource {
 			GpuResourceTracker.release(GpuResourceTracker.ResourceType.RENDERBUFFER, multisampleDepthRenderbufferId);
 			glDeleteRenderbuffers(multisampleDepthRenderbufferId);
 			multisampleDepthRenderbufferId = 0;
+		}
+		if (isolatedDepthRenderbufferId != 0) {
+			GpuResourceTracker.release(GpuResourceTracker.ResourceType.RENDERBUFFER,
+					isolatedDepthRenderbufferId);
+			glDeleteRenderbuffers(isolatedDepthRenderbufferId);
+			isolatedDepthRenderbufferId = 0;
 		}
 		if (framebufferId != 0) {
 			GpuResourceTracker.release(GpuResourceTracker.ResourceType.FRAMEBUFFER, framebufferId);

--- a/swing/src/main/java/info/openrocket/swing/gui/figure3d/rendering/passes/GeometryPass.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/figure3d/rendering/passes/GeometryPass.java
@@ -24,7 +24,7 @@ import static org.lwjgl.opengl.GL33.glUniform1i;
 
 /**
  * Renders opaque geometry first, then translucent geometry with weighted blended
- * order-independent transparency, and finally opaque objects marked "render on top".
+ * order-independent transparency, and finally objects marked "render on top".
  *
  * <p>The translucent pass accumulates fragments on the GPU. It therefore remains stable
  * when objects intersect or the camera moves through a point where a CPU depth sort would
@@ -146,20 +146,23 @@ public class GeometryPass implements RenderPass {
 		mainShader.use();
 		glDisable(GL_BLEND);
 		glDepthMask(true);
+		renderOriginAxes(scene);
 		glDisable(GL_DEPTH_TEST);
 		try {
 			// Opaque texture coverage was excluded from WBOIT. Draw it last for the
 			// (currently unused) combination of transparency and render-on-top.
 			setTransparencyOutputMode(TransparencyOutputMode.OPAQUE_TEXTURE_FRAGMENTS);
 			for (SceneObject object : scene.getObjects()) {
-				if (object.isRenderOnTop() && mayProduceOpaqueTextureFragments(object)) {
+				if (object.isRenderOnTop() && !object.isOriginAxis()
+						&& mayProduceOpaqueTextureFragments(object)) {
 					renderTransparentObject(object);
 				}
 			}
 
 			setTransparencyOutputMode(TransparencyOutputMode.SCENE_COLOR);
 			for (SceneObject object : scene.getObjects()) {
-				if (object.isRenderOnTop() && !TransparencyPolicy.isTransparent(object, config)) {
+				if (object.isRenderOnTop() && !object.isOriginAxis()
+						&& !TransparencyPolicy.isTransparent(object, config)) {
 					renderObject(object, false);
 				}
 			}
@@ -167,6 +170,33 @@ public class GeometryPass implements RenderPass {
 			setTransparencyOutputMode(TransparencyOutputMode.SCENE_COLOR);
 			glEnable(GL_DEPTH_TEST);
 		}
+	}
+
+	/**
+	 * Renders the origin axes over the scene while retaining normal depth testing
+	 * between the three intersecting arrow meshes.
+	 */
+	private void renderOriginAxes(SceneView scene) {
+		boolean hasOriginAxes = false;
+		for (SceneObject object : scene.getObjects()) {
+			if (object.isRenderOnTop() && object.isOriginAxis()) {
+				hasOriginAxes = true;
+				break;
+			}
+		}
+		if (!hasOriginAxes) {
+			return;
+		}
+
+		renderTarget.withIsolatedDepthBuffer(() -> {
+			glEnable(GL_DEPTH_TEST);
+			for (SceneObject object : scene.getObjects()) {
+				if (object.isRenderOnTop() && object.isOriginAxis()
+						&& !TransparencyPolicy.isTransparent(object, config)) {
+					renderObject(object, false);
+				}
+			}
+		});
 	}
 
 	private void renderTransparentObject(SceneObject object) {


### PR DESCRIPTION
Fixes #3272. The 'issue' in #3272 was caused by depth perspective in the axes, but, the rendering of the axes was actually not done well. They had a weird render order, causing certain axes to always be drawn on top.

The axes now correctly intersect and render:

https://github.com/user-attachments/assets/8dfe3975-6247-4591-9aec-b0cfcf70bf09

