### PR TITLE
Respect concave fin outlines in 3D

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/figure3d/geometry/components/FinSetGenerator.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/figure3d/geometry/components/FinSetGenerator.java
@@ -14,10 +14,10 @@ import info.openrocket.swing.gui.figure3d.scene.properties.GraphicsQualitySettin
 import info.openrocket.swing.gui.figure3d.scene.properties.RenderingConfiguration;
 import org.joml.Vector2f;
 import org.joml.Vector3f;
-import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygon;
-import org.locationtech.jts.triangulate.DelaunayTriangulationBuilder;
+import org.locationtech.jts.triangulate.polygon.ConstrainedDelaunayTriangulator;
+import org.locationtech.jts.triangulate.tri.Tri;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1031,34 +1031,30 @@ public class FinSetGenerator {
 		jtsCoords[polygonPoints.length] = new org.locationtech.jts.geom.Coordinate(polygonPoints[0].getX(), polygonPoints[0].getY());
 
 		Polygon polygon = geometryFactory.createPolygon(jtsCoords);
-		DelaunayTriangulationBuilder builder = new DelaunayTriangulationBuilder();
-		builder.setSites(polygon);
-
-		Geometry triangles = builder.getTriangles(geometryFactory);
+		// The fin perimeter must be a triangulation constraint. An unconstrained Delaunay
+		// mesh fills the convex hull and can bridge across indentations in freeform fins.
+		List<Tri> triangles = new ConstrainedDelaunayTriangulator(polygon).getTriangles();
 		IntList indices = new IntList();
 		int droppedTriangles = 0;
 
-		for (int i = 0; i < triangles.getNumGeometries(); i++) {
-			Polygon tri = (Polygon) triangles.getGeometryN(i);
-			if (polygon.contains(tri.getInteriorPoint())) {
-				org.locationtech.jts.geom.Coordinate[] triCoords = tri.getCoordinates();
-				int[] mappedIndices = new int[3];
-				boolean mapped = true;
-				for (int j = 0; j < 3; j++) {
-					Integer mappedIndex = coordIndexMap.get(quantizedCoordinateKey(triCoords[j].x, triCoords[j].y));
-					if (mappedIndex == null) {
-						mapped = false;
-						break;
-					}
-					mappedIndices[j] = mappedIndex;
+		for (Tri triangle : triangles) {
+			int[] mappedIndices = new int[3];
+			boolean mapped = true;
+			for (int i = 0; i < 3; i++) {
+				org.locationtech.jts.geom.Coordinate coordinate = triangle.getCoordinate(i);
+				Integer mappedIndex = coordIndexMap.get(quantizedCoordinateKey(coordinate.x, coordinate.y));
+				if (mappedIndex == null) {
+					mapped = false;
+					break;
 				}
-				if (mapped) {
-					indices.add(mappedIndices[0]);
-					indices.add(mappedIndices[1]);
-					indices.add(mappedIndices[2]);
-				} else {
-					droppedTriangles++;
-				}
+				mappedIndices[i] = mappedIndex;
+			}
+			if (mapped) {
+				indices.add(mappedIndices[0]);
+				indices.add(mappedIndices[2]);
+				indices.add(mappedIndices[1]);
+			} else {
+				droppedTriangles++;
 			}
 		}
 		if (droppedTriangles > 0) {

--- a/swing/src/test/java/info/openrocket/swing/gui/figure3d/geometry/components/FinSetGeneratorTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/figure3d/geometry/components/FinSetGeneratorTest.java
@@ -13,6 +13,9 @@ import info.openrocket.swing.gui.figure3d.scene.properties.RenderingConfiguratio
 import info.openrocket.swing.util.BaseTestCase;
 import org.joml.Vector3f;
 import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Polygon;
 
 import java.util.List;
 
@@ -294,6 +297,56 @@ class FinSetGeneratorTest extends BaseTestCase {
 		}
 	}
 
+	/** Concave freeform fins must retain their indentation instead of filling the convex hull. */
+	@Test
+	void concaveFinFaceMatchesPlanformArea() {
+		BodyTube parent = new BodyTube();
+		parent.setOuterRadius(0.025);
+		parent.setLength(0.2);
+
+		FreeformFinSet finSet = new FreeformFinSet();
+		parent.addChild(finSet);
+		finSet.setThickness(0.001);
+		finSet.setPoints(new CoordinateIF[] {
+				new Coordinate(0.0, 0.0),
+				new Coordinate(0.0, 0.0067818),
+				new Coordinate(0.092075, 0.0067818),
+				new Coordinate(0.098425, 0.02032),
+				new Coordinate(0.111125, 0.02032),
+				new Coordinate(0.111125, 0.0)
+		}, false);
+
+		CoordinateIF[] planform = finSet.generateContinuousFinAndTabShape();
+		Mesh mesh = FinSetGenerator.create(finSet, parent, new RenderingConfiguration());
+		GeometryFactory geometryFactory = new GeometryFactory();
+		Polygon planformPolygon = createPolygon(geometryFactory, planform);
+		Geometry planformWithFloatTolerance = planformPolygon.buffer(1.0e-7);
+
+		double faceArea = 0.0;
+		for (int i = 0; i < mesh.getIndices().size(); i += 3) {
+			int first = mesh.getIndices().get(i);
+			int second = mesh.getIndices().get(i + 1);
+			int third = mesh.getIndices().get(i + 2);
+			if (first < planform.length && second < planform.length && third < planform.length) {
+				Vertex firstVertex = mesh.getVertices().get(first);
+				Vertex secondVertex = mesh.getVertices().get(second);
+				Vertex thirdVertex = mesh.getVertices().get(third);
+				faceArea += triangleArea(firstVertex, secondVertex, thirdVertex);
+				assertTrue(signedTwiceTriangleArea(firstVertex, secondVertex, thirdVertex) > 0.0,
+						"Front-face triangles must use counter-clockwise winding");
+				assertTrue(planformWithFloatTolerance.covers(createPolygon(geometryFactory,
+						new CoordinateIF[] {
+								new Coordinate(firstVertex.position.x, firstVertex.position.y),
+								new Coordinate(secondVertex.position.x, secondVertex.position.y),
+								new Coordinate(thirdVertex.position.x, thirdVertex.position.y)
+						})), "Every front-face triangle must remain inside the concave planform");
+			}
+		}
+
+		assertEquals(polygonArea(planform), faceArea, 1.0e-8,
+				"Front-face triangles must cover only the concave fin planform");
+	}
+
 	private static float expectedTrailingEdgeU(CoordinateIF[] shapePoints, CoordinateIF trailingRootPoint, float spanX) {
 		int trailingIndex = findMatchingPointIndex(shapePoints, trailingRootPoint);
 		float accumulatedLength = 0f;
@@ -339,5 +392,34 @@ class FinSetGeneratorTest extends BaseTestCase {
 		float dx = (float) (b.getX() - a.getX());
 		float dy = (float) (b.getY() - a.getY());
 		return (float) Math.sqrt(dx * dx + dy * dy);
+	}
+
+	private static double polygonArea(CoordinateIF[] points) {
+		double twiceArea = 0.0;
+		for (int i = 0; i < points.length; i++) {
+			CoordinateIF current = points[i];
+			CoordinateIF next = points[(i + 1) % points.length];
+			twiceArea += current.getX() * next.getY() - next.getX() * current.getY();
+		}
+		return Math.abs(twiceArea) * 0.5;
+	}
+
+	private static Polygon createPolygon(GeometryFactory geometryFactory, CoordinateIF[] points) {
+		org.locationtech.jts.geom.Coordinate[] coordinates =
+				new org.locationtech.jts.geom.Coordinate[points.length + 1];
+		for (int i = 0; i < points.length; i++) {
+			coordinates[i] = new org.locationtech.jts.geom.Coordinate(points[i].getX(), points[i].getY());
+		}
+		coordinates[points.length] = coordinates[0].copy();
+		return geometryFactory.createPolygon(coordinates);
+	}
+
+	private static double triangleArea(Vertex first, Vertex second, Vertex third) {
+		return Math.abs(signedTwiceTriangleArea(first, second, third)) * 0.5;
+	}
+
+	private static double signedTwiceTriangleArea(Vertex first, Vertex second, Vertex third) {
+		return (second.position.x - first.position.x) * (third.position.y - first.position.y)
+				- (third.position.x - first.position.x) * (second.position.y - first.position.y);
 	}
 }


### PR DESCRIPTION
Fixes #3281. The 3D mesh generator used unconstrained triangulation, which could fill across indentations in freeform fin outlines. This uses constrained triangulation and preserves correct face winding.

<img width="1080" height="558" alt="image" src="https://github.com/user-attachments/assets/d1533ba6-8d0e-482f-ab12-3e55362c2610" />

