### PR TITLE
Fix unit-dependent airframe continuity check by comparing diameters/positions numerically instead of as formatted display strings (#3285).

### DIFF
--- a/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanStabilityCalculator.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/BarrowmanStabilityCalculator.java
@@ -25,7 +25,6 @@ import info.openrocket.core.rocketcomponent.PodSet;
 import info.openrocket.core.rocketcomponent.Rocket;
 import info.openrocket.core.rocketcomponent.RocketComponent;
 import info.openrocket.core.rocketcomponent.SymmetricComponent;
-import info.openrocket.core.unit.UnitGroup;
 import info.openrocket.core.util.Coordinate;
 import info.openrocket.core.util.CoordinateIF;
 import info.openrocket.core.util.MathUtil;
@@ -39,6 +38,14 @@ public class BarrowmanStabilityCalculator implements StabilityCalculator {
 	private static final double STALL_ANGLE = 17.5 * Math.PI / 180;
 	private static final String BARROWMAN_PACKAGE = "info.openrocket.core.aerodynamics.barrowman";
 	private static final String BARROWMAN_SUFFIX = "Calc";
+
+	/**
+	 * Tolerance (in SI metres) below which two airframe diameters or axial positions are
+	 * considered continuous in {@link #checkGeometry}. Coarse enough to ignore sub-manufacturing
+	 * modelling noise, fine enough to flag a real step. Deliberately unit-independent: the
+	 * emitted continuity warnings must not depend on the user's display-unit preference.
+	 */
+	private static final double CONTINUITY_EPSILON = 0.0001; // 0.1 mm
 
 	private final WarningSet ignoreWarningSet = new WarningSet();
 
@@ -161,9 +168,8 @@ public class BarrowmanStabilityCalculator implements StabilityCalculator {
 							}
 						}
 					} else {
-						if (!UnitGroup.UNITS_LENGTH.getDefaultUnit().toStringUnit(2.0 * sym.getForeRadius())
-								.equals(UnitGroup.UNITS_LENGTH.getDefaultUnit()
-										.toStringUnit(2.0 * prevComp.getAftRadius()))) {
+						if (!MathUtil.equals(2.0 * sym.getForeRadius(), 2.0 * prevComp.getAftRadius(),
+								CONTINUITY_EPSILON)) {
 							actualWarnings.add(Warning.DIAMETER_DISCONTINUITY, prevComp, sym);
 						}
 
@@ -178,8 +184,7 @@ public class BarrowmanStabilityCalculator implements StabilityCalculator {
 						double symXaft = sym.toAbsolute(new Coordinate(comp.getLength(), 0, 0, 0))[0].getX();
 						double prevXaft = prevComp.toAbsolute(new Coordinate(prevComp.getLength(), 0, 0, 0))[0].getX();
 
-						if (!UnitGroup.UNITS_LENGTH.getDefaultUnit().toStringUnit(symXfore)
-								.equals(UnitGroup.UNITS_LENGTH.getDefaultUnit().toStringUnit(prevXaft))) {
+						if (!MathUtil.equals(symXfore, prevXaft, CONTINUITY_EPSILON)) {
 							if (symXfore > prevXaft) {
 								actualWarnings.add(Warning.AIRFRAME_GAP, prevComp, sym);
 							} else {

--- a/core/src/test/java/info/openrocket/core/aerodynamics/BarrowmanCalculatorTest.java
+++ b/core/src/test/java/info/openrocket/core/aerodynamics/BarrowmanCalculatorTest.java
@@ -32,6 +32,7 @@ import info.openrocket.core.rocketcomponent.Rocket;
 import info.openrocket.core.rocketcomponent.Transition;
 import info.openrocket.core.rocketcomponent.TrapezoidFinSet;
 import info.openrocket.core.startup.Application;
+import info.openrocket.core.unit.UnitGroup;
 import info.openrocket.core.util.MathUtil;
 import info.openrocket.core.util.TestRockets;
 
@@ -343,6 +344,44 @@ public class BarrowmanCalculatorTest {
 
 		calc.checkGeometry(configuration, rocket, warnings);
 		assertFalse(warnings.isEmpty(), " Estes Alpha III has an undetected discontinuity:");
+	}
+
+	/**
+	 * The airframe-continuity check must not depend on the user's display-unit
+	 * preference. A diameter step near display precision must be reported (or not)
+	 * identically whether lengths are shown in cm or inches. Regression test for
+	 * <a href="https://github.com/openrocket/openrocket/issues/3285">#3285</a>.
+	 */
+	@Test
+	public void testContinuityIndependentOfDisplayUnit() {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		AerodynamicCalculator calc = new BarrowmanCalculator();
+		FlightConfiguration configuration = rocket.getSelectedConfiguration();
+
+		// A 0.4 mm diameter step: below cm display precision (rounds away) but not below
+		// inch display precision, so the old string-based check disagreed across units.
+		NoseCone nose = (NoseCone) rocket.getChild(0).getChild(0);
+		BodyTube body = (BodyTube) rocket.getChild(0).getChild(1);
+		nose.setAftRadius(0.0502);
+		body.setOuterRadius(0.0500);
+
+		final int originalUnit = UnitGroup.UNITS_LENGTH.getDefaultUnitIndex();
+		try {
+			UnitGroup.UNITS_LENGTH.setDefaultUnit("cm");
+			WarningSet metric = new WarningSet();
+			calc.checkGeometry(configuration, rocket, metric);
+
+			UnitGroup.UNITS_LENGTH.setDefaultUnit("in");
+			WarningSet imperial = new WarningSet();
+			calc.checkGeometry(configuration, rocket, imperial);
+
+			assertEquals(metric.toString(), imperial.toString(),
+					"continuity warnings must not depend on the display unit");
+			assertFalse(metric.isEmpty(),
+					"a 0.4 mm diameter step should be reported as a discontinuity");
+		} finally {
+			UnitGroup.UNITS_LENGTH.setDefaultUnit(originalUnit);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
### Problem

BarrowmanStabilityCalculator.checkGeometry(...)` decided whether adjacent airframe
components were continuous — whether the body diameter "steps," and whether two
components leave an axial gap/overlap — by formatting both values to their display
string via `Unit.toStringUnit` and comparing the strings. Because that rounds the
value *in the user's configured display unit*, the geometry decision (and therefore
which warnings a simulation emits) depended on whether the user had cm or inches
selected. The same design could produce a `DIAMETER_DISCONTINUITY` warning for an
imperial user and none for a metric user.

### Fix

Replaced both string comparisons with direct numeric tolerance checks via
`MathUtil.equals(a, b, epsilon)` — the same approach the rest of the geometry code
already uses (e.g. `SymmetricComponentCalc`, `SymmetricComponent.getNextSymmetricComponent`).
The result is now independent of display units. Removed the now-unused `UnitGroup` import.

### ⚠️ Reviewer note — tolerance value

The tolerance is a hardcoded constant:

```java
private static final double CONTINUITY_EPSILON = 0.0001; // 0.1 mm
```

- **Left as a `static final` constant, not a preference**, on purpose — this is an
  internal validation threshold, not a user-tuning knob. 
- **`0.1 mm` was chosen** as coarse enough to ignore sub-manufacturing modelling noise
  but fine enough to flag a real step. Deliberately *not* `MathUtil.EPSILON` (1e-8 m),
  which would over-warn on floating-point-scale differences.
- **Behavior change to be aware of:** 0.1 mm absolute is *stricter* than the old metric
  rounding for large-diameter airframes (old cm display precision hid steps up to ~1 mm
  on a ~20 cm tube). A few very-near-continuous large designs may now surface a
  `DIAMETER_DISCONTINUITY` that they didn't before. This is arguably more correct, but
  flagging it in case a different threshold (or a relative tolerance for diameters vs.
  absolute for positions) is preferred. 

- **The old behavior wasn't an absolute tolerance, it was "equal to 3 significant figures in the display unit," which is effectively a relative tolerance. Concretely, what the old code actually did in the default metric unit (cm):

diameters under 10 cm → resolution ~0.1 mm (my constant already matches this)
diameters over 10 cm → resolution jumps to ~1 mm

```java
// diameter: relative, mirrors the "3 significant figures" behavior across all sizes
double d1 = 2.0 * sym.getForeRadius();
double d2 = 2.0 * prevComp.getAftRadius();
if (Math.abs(d1 - d2) > CONTINUITY_REL_TOL * Math.max(d1, d2))   // e.g. 0.005 (0.5%)
    actualWarnings.add(Warning.DIAMETER_DISCONTINUITY, prevComp, sym);
````

~0.5% (0.005) is a reasonable central match to the old 3-sig-fig behavior. At 100 mm that's a 0.5 mm threshold; at 20 cm, ~1 mm — close to what old metric did on large tubes, so it removes the "new warnings on large airframes" concern.

### Testing

Added `BarrowmanCalculatorTest.testContinuityIndependentOfDisplayUnit()`: builds an
airframe with a 0.4 mm diameter step (a case that produced no warning in cm but a
discontinuity in inches under the old code), runs `checkGeometry` under both `cm` and
`in` and asserts the emitted warning set is identical (and non-empty). All existing
`BarrowmanCalculatorTest` tests continue to pass.
