### PR TITLE
3288 bug save as brings up save design info panel with empty design name kills rocket name

### DIFF
--- a/core/src/main/java/info/openrocket/core/rocketcomponent/Rocket.java
+++ b/core/src/main/java/info/openrocket/core/rocketcomponent/Rocket.java
@@ -541,6 +541,10 @@ public class Rocket extends ComponentAssembly {
 		this.functionalModID = source.functionalModID;
 		this.refType = source.refType;
 		this.customReferenceLength = source.customReferenceLength;
+		this.designer = source.designer;
+		this.revision = source.revision;
+		this.designType = source.designType;
+		this.kitName = source.kitName;
 		this.stageMap = new ConcurrentHashMap<>(source.stageMap);
 
 		// these flight configurations need to reference the _this_ Rocket:

--- a/core/src/test/java/info/openrocket/core/document/OpenRocketDocumentUndoRedoTest.java
+++ b/core/src/test/java/info/openrocket/core/document/OpenRocketDocumentUndoRedoTest.java
@@ -1,0 +1,52 @@
+package info.openrocket.core.document;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import info.openrocket.core.rocketcomponent.DesignType;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.util.BaseTestCase;
+import info.openrocket.core.util.TestRockets;
+import org.junit.jupiter.api.Test;
+
+public class OpenRocketDocumentUndoRedoTest extends BaseTestCase {
+
+	/**
+	 * The design info stored on the Rocket itself (designer, revision, design type, kit name) has to survive an
+	 * undo/redo round trip just like the component fields do.
+	 */
+	@Test
+	public void undoRedoDesignInfo_restoresTheRocketsOwnFields() {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		OpenRocketDocument document = OpenRocketDocumentFactory.createDocumentFromRocket(rocket);
+
+		rocket.setName("My Rocket");
+		rocket.setDesigner("Original designer");
+		rocket.setRevision("Revision 1");
+		rocket.setDesignType(DesignType.CLONE_KIT);
+		rocket.setKitName("Original kit");
+		document.clearUndo();
+
+		document.addUndoPosition("Modify Rocket");
+		rocket.setName("Renamed");
+		rocket.setDesigner("Someone else");
+		rocket.setRevision("Revision 2");
+		rocket.setDesignType(DesignType.COMMERCIAL_KIT);
+		rocket.setKitName("Other kit");
+
+		document.undo();
+
+		assertEquals("My Rocket", rocket.getName());
+		assertEquals("Original designer", rocket.getDesigner());
+		assertEquals("Revision 1", rocket.getRevision());
+		assertEquals(DesignType.CLONE_KIT, rocket.getDesignType());
+		assertEquals("Original kit", rocket.getKitName());
+
+		document.redo();
+
+		assertEquals("Renamed", rocket.getName());
+		assertEquals("Someone else", rocket.getDesigner());
+		assertEquals("Revision 2", rocket.getRevision());
+		assertEquals(DesignType.COMMERCIAL_KIT, rocket.getDesignType());
+		assertEquals("Other kit", rocket.getKitName());
+	}
+}

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/RocketComponentConfig.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/RocketComponentConfig.java
@@ -442,37 +442,42 @@ public class RocketComponentConfig extends JPanel implements Invalidatable, Inva
 		// Component name
 		componentNameField.setText(component.getName());
 
-		// Info label
-		StringBuilder sb = new StringBuilder();
-
-		if (allSameType && component.getPresetComponent() != null) {
-			ComponentPreset preset = component.getPresetComponent();
-			sb.append(preset.getManufacturer() + " " + preset.getPartNo() + "      ");
-		}
-
 		List<RocketComponent> listeners = component.getConfigListeners();
-		if (allMassive && (listeners == null || listeners.size() == 0)) {	// TODO: support aggregate mass display for current component and listeners?
-			sb.append(trans.get("RocketCompCfg.lbl.Componentmass") + " ");
-			sb.append(UnitGroup.UNITS_MASS.getDefaultUnit().toStringUnit(
-					component.getComponentMass()));
-			
-			String overridetext = null;
-			if (component.isMassOverridden()) {
-				overridetext = trans.get("RocketCompCfg.lbl.overriddento") + " " + UnitGroup.UNITS_MASS.getDefaultUnit().
-						toStringUnit(component.getOverrideMass()) + ")";
+
+		// Info label
+		// (infoLabel and multiCompEditLabel are created by addButtons(); subclasses may override
+		//  that method without creating them, so both must be null-checked here)
+		if (infoLabel != null) {
+			StringBuilder sb = new StringBuilder();
+
+			if (allSameType && component.getPresetComponent() != null) {
+				ComponentPreset preset = component.getPresetComponent();
+				sb.append(preset.getManufacturer() + " " + preset.getPartNo() + "      ");
 			}
 
-			if (component.getMassOverriddenBy() != null) {
-				overridetext = trans.get("RocketCompCfg.lbl.overriddenby") + " " + component.getMassOverriddenBy().getName() + ")";
+			if (allMassive && (listeners == null || listeners.size() == 0)) {	// TODO: support aggregate mass display for current component and listeners?
+				sb.append(trans.get("RocketCompCfg.lbl.Componentmass") + " ");
+				sb.append(UnitGroup.UNITS_MASS.getDefaultUnit().toStringUnit(
+						component.getComponentMass()));
+
+				String overridetext = null;
+				if (component.isMassOverridden()) {
+					overridetext = trans.get("RocketCompCfg.lbl.overriddento") + " " + UnitGroup.UNITS_MASS.getDefaultUnit().
+							toStringUnit(component.getOverrideMass()) + ")";
+				}
+
+				if (component.getMassOverriddenBy() != null) {
+					overridetext = trans.get("RocketCompCfg.lbl.overriddenby") + " " + component.getMassOverriddenBy().getName() + ")";
+				}
+
+				if (overridetext != null) {
+					sb.append(" " + overridetext);
+				}
+
+				infoLabel.setText(sb.toString());
+			} else {
+				infoLabel.setText("");
 			}
-			
-			if (overridetext != null) {
-				sb.append(" " + overridetext);
-			}
-			
-			infoLabel.setText(sb.toString());
-		} else {
-			infoLabel.setText("");
 		}
 
 		// Multi-comp edit label
@@ -482,25 +487,29 @@ public class RocketComponentConfig extends JPanel implements Invalidatable, Inva
 				infoBtn.setVisible(false);
 			}
 
-			multiCompEditLabel.setText(trans.get("ComponentCfgDlg.MultiComponentEdit"));
+			if (multiCompEditLabel != null) {
+				multiCompEditLabel.setText(trans.get("ComponentCfgDlg.MultiComponentEdit"));
 
-			StringBuilder components = new StringBuilder(trans.get("ComponentCfgDlg.MultiComponentEdit.ttip"));
-			components.append(component.getName()).append(", ");
-			for (int i = 0; i < listeners.size(); i++) {
-				if (i < listeners.size() - 1) {
-					components.append(listeners.get(i).getName()).append(", ");
-				} else {
-					components.append(listeners.get(i).getName());
+				StringBuilder components = new StringBuilder(trans.get("ComponentCfgDlg.MultiComponentEdit.ttip"));
+				components.append(component.getName()).append(", ");
+				for (int i = 0; i < listeners.size(); i++) {
+					if (i < listeners.size() - 1) {
+						components.append(listeners.get(i).getName()).append(", ");
+					} else {
+						components.append(listeners.get(i).getName());
+					}
 				}
+				multiCompEditLabel.setToolTipText(components.toString());
 			}
-			multiCompEditLabel.setToolTipText(components.toString());
 		} else {
 			if (infoBtn != null) {
 				componentInfo.setVisible(false);
 				infoBtn.setSelected(true);
 				infoBtn.setVisible(true);
 			}
-			multiCompEditLabel.setText("");
+			if (multiCompEditLabel != null) {
+				multiCompEditLabel.setText("");
+			}
 		}
 	}
 

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/SaveDesignInfoPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/SaveDesignInfoPanel.java
@@ -7,6 +7,7 @@ import info.openrocket.core.document.OpenRocketDocument;
 import info.openrocket.core.l10n.Translator;
 import info.openrocket.core.rocketcomponent.RocketComponent;
 import info.openrocket.core.startup.Application;
+import info.openrocket.core.util.ModID;
 
 import info.openrocket.swing.gui.components.StyledLabel;
 
@@ -26,8 +27,13 @@ public class SaveDesignInfoPanel extends RocketConfig {
     private static final Translator trans = Application.getTranslator();
     private static final ApplicationPreferences preferences = Application.getPreferences();
 
+    /** State of the rocket when this panel was created, used to detect whether Cancel has anything to undo. */
+    private final ModID modIDAtOpen;
+
     public SaveDesignInfoPanel(OpenRocketDocument d, RocketComponent c, JDialog parent) {
         super(d, c, parent);
+
+        this.modIDAtOpen = d.getRocket().getModID();
 
         // (Optional) Fill in the design information for this file
         StyledLabel label = new StyledLabel(trans.get("SaveDesignInfoPanel.lbl.FillInInfo"), StyledLabel.Style.BOLD);
@@ -63,8 +69,8 @@ public class SaveDesignInfoPanel extends RocketConfig {
                 int resultYesNo = JOptionPane.showConfirmDialog(SaveDesignInfoPanel.this, msg,
                         trans.get("RocketCompCfg.CancelOperation.title"), JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
                 if (resultYesNo == JOptionPane.YES_OPTION) {
-                    ComponentConfigDialog.clearConfigListeners = false;		// Undo action => config listeners of new component will be cleared
                     disposeDialog();
+                    undoChangesSince(document, modIDAtOpen);
                 }
             }
         });
@@ -82,5 +88,23 @@ public class SaveDesignInfoPanel extends RocketConfig {
         buttonPanel.add(okButton);
 
         this.add(buttonPanel, "newline, spanx, growx");
+    }
+
+    /**
+     * Discard the design info edits made in this dialog, restoring the state the rocket was in when the dialog
+     * was opened. The caller is expected to have added an undo position just before opening the dialog (see
+     * {@code BasicFrame.showSaveRocketInfoDialog()}), which is what that undo restores.
+     * <p>
+     * Nothing is undone when the rocket was not modified while the dialog was open: the document would then be in
+     * a clean state, and {@link OpenRocketDocument#undo()} would step back past the undo position and roll back
+     * whatever the user did <em>before</em> opening the dialog (see issue #2680).
+     *
+     * @param document      the document being edited
+     * @param modIDAtOpen   the rocket's modification ID at the time the dialog was opened
+     */
+    static void undoChangesSince(OpenRocketDocument document, ModID modIDAtOpen) {
+        if (document.getRocket().getModID() != modIDAtOpen) {
+            document.undo();
+        }
     }
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/configdialog/SaveDesignInfoPanel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/configdialog/SaveDesignInfoPanel.java
@@ -83,9 +83,4 @@ public class SaveDesignInfoPanel extends RocketConfig {
 
         this.add(buttonPanel, "newline, spanx, growx");
     }
-
-    @Override
-    public void updateFields() {
-        // Do nothing
-    }
 }

--- a/swing/src/main/java/info/openrocket/swing/gui/main/BasicFrame.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/main/BasicFrame.java
@@ -2194,6 +2194,10 @@ private static final Translator trans = Application.getTranslator();
 		// Select the rocket in the component tree to indicate to users that they can edit the rocket info by editing the rocket
 		setSelectedComponent(rocket);
 
+		// Mark the current state so that the dialog's Cancel button has something to restore. This has to happen
+		// before the dialog is shown, because the dialog is modal and setVisible() blocks until it is closed.
+		document.addUndoPosition(trans.get("ComponentCfgDlg.Modify") + " " + rocket.getComponentName());
+
 		// Open the save rocket info
 		JDialog dialog = new JDialog();
 		SaveDesignInfoPanel panel = new SaveDesignInfoPanel(document, rocket, dialog);

--- a/swing/src/test/java/info/openrocket/swing/gui/configdialog/SaveDesignInfoPanelTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/configdialog/SaveDesignInfoPanelTest.java
@@ -1,0 +1,86 @@
+package info.openrocket.swing.gui.configdialog;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import info.openrocket.core.document.OpenRocketDocument;
+import info.openrocket.core.document.OpenRocketDocumentFactory;
+import info.openrocket.core.rocketcomponent.Rocket;
+import info.openrocket.core.util.ModID;
+import info.openrocket.core.util.TestRockets;
+import info.openrocket.swing.util.BaseTestCase;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the undo behaviour of the "Save Design Info" dialog's Cancel button.
+ * <p>
+ * The dialog is opened from {@code BasicFrame.showSaveRocketInfoDialog()}, which pushes an undo
+ * position just before the dialog becomes visible; these tests simulate that sequence.
+ */
+class SaveDesignInfoPanelTest extends BaseTestCase {
+
+	/** Set up a document whose undo history is at a clean, known state. */
+	private static OpenRocketDocument documentAt(Rocket rocket, String name) {
+		rocket.setName(name);
+		OpenRocketDocument document = OpenRocketDocumentFactory.createDocumentFromRocket(rocket);
+		document.clearUndo();
+		return document;
+	}
+
+	@Test
+	void cancelRevertsTheEditsMadeInTheDialog() {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		OpenRocketDocument document = documentAt(rocket, "My Rocket");
+		rocket.setDesigner("Original designer");
+
+		// Open the dialog
+		document.addUndoPosition("Modify Rocket");
+		ModID modIDAtOpen = rocket.getModID();
+
+		// Edit the design info, then cancel
+		rocket.setName("Renamed in the dialog");
+		rocket.setDesigner("Someone else");
+		rocket.setRevision("Revision 2");
+		SaveDesignInfoPanel.undoChangesSince(document, modIDAtOpen);
+
+		assertEquals("My Rocket", document.getRocket().getName());
+		assertEquals("Original designer", document.getRocket().getDesigner());
+		assertEquals("", document.getRocket().getRevision());
+	}
+
+	@Test
+	void cancelWithoutEditsKeepsTheWorkDoneBeforeTheDialogWasOpened() {
+		// Regression test for #2680: cancelling an untouched dialog used to undo the user's
+		// previous action instead of doing nothing.
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		OpenRocketDocument document = documentAt(rocket, "My Rocket");
+
+		// Work done before the dialog was opened, and not yet saved
+		document.addUndoPosition("Rename rocket");
+		rocket.setName("Work in progress");
+
+		// Open the dialog, change nothing, cancel
+		document.addUndoPosition("Modify Rocket");
+		ModID modIDAtOpen = rocket.getModID();
+		SaveDesignInfoPanel.undoChangesSince(document, modIDAtOpen);
+
+		assertEquals("Work in progress", document.getRocket().getName());
+	}
+
+	@Test
+	void cancelRevertsOnlyTheDialogsEditsWhenEarlierChangesArePending() {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		OpenRocketDocument document = documentAt(rocket, "My Rocket");
+
+		// Work done before the dialog was opened, and not yet saved
+		document.addUndoPosition("Rename rocket");
+		rocket.setName("Work in progress");
+
+		// Open the dialog, edit the design info, cancel
+		document.addUndoPosition("Modify Rocket");
+		ModID modIDAtOpen = rocket.getModID();
+		rocket.setName("Renamed in the dialog");
+		SaveDesignInfoPanel.undoChangesSince(document, modIDAtOpen);
+
+		assertEquals("Work in progress", document.getRocket().getName());
+	}
+}


### PR DESCRIPTION
Closes #3288

# Overview

Two commits, two independent bugs in the "Save As..." → *Save Design Info* dialog.

## Commit 1 — empty design name wipes the rocket name

**Cause.** `SaveDesignInfoPanel` overrode `updateFields()` as a no-op. That override
existed only to dodge an NPE: the base `RocketComponentConfig.updateFields()`
dereferences `infoLabel` and `multiCompEditLabel`, which are created in `addButtons()` —
a method `SaveDesignInfoPanel` overrides without creating them.

The side effect was the real bug. `componentNameField` is populated *only* by
`updateFields()`, so "Design name" came up empty. On focus loss the text listener saw
`""` ≠ the rocket's name and called `setName("")`, which `RocketComponent` maps to the
default component name — hence the rocket being renamed to "Rocket".

**Fix.**
- `RocketComponentConfig.updateFields()` — null-guard `infoLabel` and
  `multiCompEditLabel`; subclasses may override `addButtons()` without creating them.
  (Most of the diff is re-indenting the existing info-label logic inside the new `if`.)
- `SaveDesignInfoPanel` — delete the no-op override so the inherited one runs.

## Commit 2 — Cancel does not discard its edits

**Cause 1 — no undo position.** `BasicFrame.showSaveRocketInfoDialog()` builds the panel
in a plain modal `JDialog`, bypassing `ComponentConfigDialog.showDialog()` — the thing
that pushes `document.addUndoPosition(...)`. With no snapshot of the dialog's opening
state, commit `56cdced69` had to strip the inherited `document.undo()` from the cancel
handler, because cancelling was rolling back whatever the user did *before* opening the
dialog (#2680). That removed the symptom and left the cause.

**Cause 2 — undo could not restore the design info anyway.** `Rocket.loadFrom()` never
copied `designer`, `revision`, `designType` or `kitName` back from the snapshot. These
live on `Rocket` rather than `RocketComponent`, so `copyFrom()` does not cover them
either, and undo restored only the design name. This affected Edit ▸ Undo everywhere,
not just this dialog.

**Fix.**
- `Rocket.loadFrom()` — copy the four design-info fields alongside `refType` /
  `customReferenceLength`.
- `BasicFrame.showSaveRocketInfoDialog()` — `document.addUndoPosition(...)` before
  `setVisible(true)`. It must be before: the dialog is modal, so `setVisible` blocks.
- `SaveDesignInfoPanel` — snapshot `rocket.getModID()` at construction; on cancel call
  `undoChangesSince(document, modIDAtOpen)`, which undoes **only if the rocket actually
  changed while the dialog was open**. That guard is what keeps #2680 from returning:
  with no edits the document is in a clean state, and `undo()` would step back past the
  undo position into the user's earlier work.
- `SaveDesignInfoPanel` — also drop `ComponentConfigDialog.clearConfigListeners = false`
  from the same cancel handler. Survivor of the same copy-paste `56cdced69` trimmed. The
  flag is a one-shot "skip `component.clearConfigListeners()` on the next
  `ComponentConfigDialog.windowClosed`", and this panel's parent is a plain `JDialog`, so
  `disposeDialog()` takes the `parent.dispose()` branch and that handler never runs —
  nothing on this path reads or resets the flag. A dead write, not a behaviour change;
  removing it keeps the handler honest about what it touches. Detail in
  `issue-draft-clearconfiglisteners-leak.md`.

**Tests.**
- `OpenRocketDocumentUndoRedoTest` (core) — undo/redo round-trip over name, designer,
  revision, design type, kit name.
- `SaveDesignInfoPanelTest` (swing) — cancel reverts the dialog's edits; cancel without
  edits preserves unsaved prior work (#2680 regression); cancel reverts *only* the
  dialog's edits when earlier changes are pending.

All four failed against the old code and pass now; full `:core:test`, `:swing:test` and
checkstyle are green.