### PR TITLE
Fix index bounds checks and expression race

### DIFF
--- a/core/src/main/java/info/openrocket/core/simulation/customexpression/CustomExpressionSimulationListener.java
+++ b/core/src/main/java/info/openrocket/core/simulation/customexpression/CustomExpressionSimulationListener.java
@@ -17,12 +17,12 @@ public class CustomExpressionSimulationListener extends AbstractSimulationListen
 
 	public CustomExpressionSimulationListener(List<CustomExpression> expressions) {
 		super();
-		this.expressions = expressions;
+		this.expressions = expressions == null ? List.of() : List.copyOf(expressions);
 	}
 
 	@Override
 	public void postStep(SimulationStatus status) throws SimulationException {
-		if (expressions == null || expressions.size() == 0) {
+		if (expressions.isEmpty()) {
 			return;
 		}
 		// Calculate values for custom expressions

--- a/core/src/test/java/info/openrocket/core/simulation/customexpression/CustomExpressionSimulationListenerTest.java
+++ b/core/src/test/java/info/openrocket/core/simulation/customexpression/CustomExpressionSimulationListenerTest.java
@@ -1,0 +1,44 @@
+package info.openrocket.core.simulation.customexpression;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import info.openrocket.core.simulation.FlightDataBranch;
+import info.openrocket.core.simulation.FlightDataType;
+import info.openrocket.core.simulation.SimulationStatus;
+import info.openrocket.core.simulation.exception.SimulationException;
+import info.openrocket.core.util.BaseTestCase;
+
+class CustomExpressionSimulationListenerTest extends BaseTestCase {
+
+	@Test
+	void snapshotsExpressionsAtConstruction() throws SimulationException {
+		CustomExpression originalExpression = mock(CustomExpression.class);
+		CustomExpression laterExpression = mock(CustomExpression.class);
+		List<CustomExpression> expressions = new ArrayList<>();
+		expressions.add(originalExpression);
+		CustomExpressionSimulationListener listener = new CustomExpressionSimulationListener(expressions);
+
+		expressions.clear();
+		expressions.add(laterExpression);
+
+		SimulationStatus status = mock(SimulationStatus.class);
+		FlightDataBranch dataBranch = mock(FlightDataBranch.class);
+		when(status.getFlightDataBranch()).thenReturn(dataBranch);
+		when(originalExpression.evaluateDouble(status)).thenReturn(12.5);
+		when(originalExpression.getType()).thenReturn(FlightDataType.TYPE_TIME);
+
+		listener.postStep(status);
+
+		verify(originalExpression).evaluateDouble(status);
+		verify(dataBranch).setValue(FlightDataType.TYPE_TIME, 12.5);
+		verifyNoInteractions(laterExpression);
+	}
+}

--- a/swing/src/main/java/info/openrocket/swing/gui/adaptors/CustomFocusTraversalPolicy.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/adaptors/CustomFocusTraversalPolicy.java
@@ -22,6 +22,10 @@ public class CustomFocusTraversalPolicy extends FocusTraversalPolicy {
     }
 
     public Component getComponentAfter(Container focusCycleRoot, Component aComponent) {
+        if (order.isEmpty()) {
+            return aComponent;
+        }
+
         // Get the next component
         int idx = (order.indexOf(aComponent) + 1) % order.size();
 
@@ -38,13 +42,17 @@ public class CustomFocusTraversalPolicy extends FocusTraversalPolicy {
     }
 
     public Component getComponentBefore(Container focusCycleRoot, Component aComponent) {
+        if (order.isEmpty()) {
+            return aComponent;
+        }
+
         int idx = order.indexOf(aComponent) - 1;
         if (idx < 0) {
             idx = order.size() - 1;
         }
         int count = 0;
         while (!order.get(idx).isEnabled() || !order.get(idx).isShowing() || !order.get(idx).isVisible()) {
-            idx = (idx - 1) % order.size();
+            idx = Math.floorMod(idx - 1, order.size());
             count++;
             if (count == order.size())
                 return aComponent;
@@ -57,6 +65,10 @@ public class CustomFocusTraversalPolicy extends FocusTraversalPolicy {
     }
 
     public Component getLastComponent(Container focusCycleRoot) {
+        if (order.isEmpty()) {
+            return null;
+        }
+
         int idx = order.size() - 1;
         if ((order.get(idx).isEnabled() && order.get(idx).isShowing() && order.get(idx).isVisible())) {
             return order.get(idx);
@@ -65,6 +77,10 @@ public class CustomFocusTraversalPolicy extends FocusTraversalPolicy {
     }
 
     public Component getFirstComponent(Container focusCycleRoot) {
+        if (order.isEmpty()) {
+            return null;
+        }
+
         int idx = 0;
         if ((order.get(idx).isEnabled() && order.get(idx).isShowing() && order.get(idx).isVisible())) {
             return order.get(idx);

--- a/swing/src/main/java/info/openrocket/swing/gui/adaptors/MaterialModel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/adaptors/MaterialModel.java
@@ -116,6 +116,9 @@ public class MaterialModel extends AbstractListModel<Material> implements
 
 	@Override
 	public Material getElementAt(int index) {
+		if (index < 0) {
+			return null;
+		}
 		if (index < applicationDatabase.size()) {
 			return applicationDatabase.get(index);
 		} else if (index < applicationDatabase.size() + documentDatabase.size()) {

--- a/swing/src/main/java/info/openrocket/swing/gui/customexpression/VariableTableModel.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/customexpression/VariableTableModel.java
@@ -64,7 +64,7 @@ public class VariableTableModel extends AbstractTableModel {
     }
 	
 	public String getSymbolAt(int row) {
-		if (row < 0 || row > types.size()){
+		if (row < 0 || row >= types.size()){
 			return "";
 		}
 		else { 

--- a/swing/src/test/java/info/openrocket/swing/gui/adaptors/CustomFocusTraversalPolicyTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/adaptors/CustomFocusTraversalPolicyTest.java
@@ -1,6 +1,8 @@
 package info.openrocket.swing.gui.adaptors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.awt.Component;
 import java.awt.Container;
@@ -112,6 +114,31 @@ class CustomFocusTraversalPolicyTest {
         Component previous = policy.getComponentBefore(null, first);
 
         assertEquals(second, previous);
+    }
+
+    @Test
+    void getComponentBeforeWrapsPastInactiveFirstEntry() {
+        StubComponent first = new StubComponent("first");
+        StubComponent second = new StubComponent("second");
+        StubComponent third = new StubComponent("third");
+        first.setEnabled(false);
+        CustomFocusTraversalPolicy policy = policyWith(first, second, third);
+
+        Component previous = policy.getComponentBefore(null, second);
+
+        assertEquals(third, previous);
+    }
+
+    @Test
+    void emptyOrderHasSafeFallbacks() {
+        StubComponent component = new StubComponent("component");
+        CustomFocusTraversalPolicy policy = policyWith();
+
+        assertSame(component, policy.getComponentAfter(null, component));
+        assertSame(component, policy.getComponentBefore(null, component));
+        assertNull(policy.getFirstComponent(null));
+        assertNull(policy.getLastComponent(null));
+        assertNull(policy.getDefaultComponent(null));
     }
 
     @Test

--- a/swing/src/test/java/info/openrocket/swing/gui/adaptors/MaterialModelTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/adaptors/MaterialModelTest.java
@@ -1,0 +1,24 @@
+package info.openrocket.swing.gui.adaptors;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+import info.openrocket.core.document.OpenRocketDocument;
+import info.openrocket.core.document.OpenRocketDocumentFactory;
+import info.openrocket.core.material.Material;
+import info.openrocket.core.rocketcomponent.BodyTube;
+import info.openrocket.swing.util.BaseTestCase;
+
+class MaterialModelTest extends BaseTestCase {
+
+	@Test
+	void negativeIndexReturnsNoMaterial() {
+		OpenRocketDocument document = OpenRocketDocumentFactory.createNewRocket();
+		BodyTube bodyTube = new BodyTube();
+		document.getRocket().getStage(0).addChild(bodyTube);
+		MaterialModel model = new MaterialModel(null, document, bodyTube, Material.Type.BULK);
+
+		assertNull(model.getElementAt(-1));
+	}
+}

--- a/swing/src/test/java/info/openrocket/swing/gui/customexpression/VariableTableModelTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/customexpression/VariableTableModelTest.java
@@ -1,0 +1,20 @@
+package info.openrocket.swing.gui.customexpression;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import info.openrocket.core.document.OpenRocketDocument;
+import info.openrocket.core.document.OpenRocketDocumentFactory;
+import info.openrocket.swing.util.BaseTestCase;
+
+class VariableTableModelTest extends BaseTestCase {
+
+	@Test
+	void rowEqualToSizeReturnsNoSymbol() {
+		OpenRocketDocument document = OpenRocketDocumentFactory.createNewRocket();
+		VariableTableModel model = new VariableTableModel(document);
+
+		assertEquals("", model.getSymbolAt(model.getRowCount()));
+	}
+}


### PR DESCRIPTION
Fixes several potential index-out-of-bounds exceptions and snapshots custom expressions before background simulation to prevent concurrent modification races.