### PR TITLE
Allow selecting macOS app bundles as graphics editors

### DIFF
--- a/swing/src/main/java/info/openrocket/swing/gui/util/GraphicsEditorChooser.java
+++ b/swing/src/main/java/info/openrocket/swing/gui/util/GraphicsEditorChooser.java
@@ -2,11 +2,14 @@ package info.openrocket.swing.gui.util;
 
 import java.awt.Component;
 import java.io.File;
+import java.util.Locale;
 import java.util.Optional;
 
 import javax.swing.JFileChooser;
+import javax.swing.filechooser.FileView;
 
 import info.openrocket.core.arch.SystemInfo;
+import info.openrocket.core.arch.SystemInfo.Platform;
 import info.openrocket.core.startup.Application;
 
 /**
@@ -19,6 +22,9 @@ public final class GraphicsEditorChooser {
 
 	public static Optional<String> chooseEditor(Component parentComponent) {
 		JFileChooser chooser = new JFileChooser();
+		if (SystemInfo.getPlatform() == Platform.MAC_OS) {
+			chooser.setFileView(createMacApplicationFileView());
+		}
 		File initialDirectory = determineInitialDirectory();
 		if (initialDirectory != null) {
 			chooser.setCurrentDirectory(initialDirectory);
@@ -33,6 +39,24 @@ public final class GraphicsEditorChooser {
 		}
 
 		return Optional.empty();
+	}
+
+	/**
+	 * Create a file view that exposes macOS application bundles as selectable files.
+	 * Swing otherwise treats these directories as folders and opens them in the chooser.
+	 */
+	static FileView createMacApplicationFileView() {
+		return new FileView() {
+			@Override
+			public Boolean isTraversable(File file) {
+				return isMacApplicationBundle(file) ? Boolean.FALSE : null;
+			}
+		};
+	}
+
+	private static boolean isMacApplicationBundle(File file) {
+		return file != null && file.isDirectory()
+				&& file.getName().toLowerCase(Locale.ROOT).endsWith(".app");
 	}
 
 	/**

--- a/swing/src/test/java/info/openrocket/swing/gui/util/GraphicsEditorChooserTest.java
+++ b/swing/src/test/java/info/openrocket/swing/gui/util/GraphicsEditorChooserTest.java
@@ -1,0 +1,38 @@
+package info.openrocket.swing.gui.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.swing.JFileChooser;
+import javax.swing.filechooser.FileView;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class GraphicsEditorChooserTest {
+
+	@Test
+	void macApplicationBundlesAreSelectableInsteadOfTraversable(@TempDir Path temporaryDirectory) throws IOException {
+		File applicationBundle = Files.createDirectory(temporaryDirectory.resolve("Editor.app")).toFile();
+		File uppercaseApplicationBundle = Files.createDirectory(temporaryDirectory.resolve("Alternate.APP")).toFile();
+		File ordinaryDirectory = Files.createDirectory(temporaryDirectory.resolve("editors")).toFile();
+		File ordinaryFile = Files.createFile(temporaryDirectory.resolve("editor")).toFile();
+
+		FileView fileView = GraphicsEditorChooser.createMacApplicationFileView();
+		assertFalse(fileView.isTraversable(applicationBundle));
+		assertFalse(fileView.isTraversable(uppercaseApplicationBundle));
+		assertNull(fileView.isTraversable(ordinaryDirectory));
+		assertNull(fileView.isTraversable(ordinaryFile));
+
+		JFileChooser chooser = new JFileChooser();
+		chooser.setFileView(fileView);
+		assertFalse(chooser.isTraversable(applicationBundle));
+		assertTrue(chooser.isTraversable(ordinaryDirectory));
+	}
+}


### PR DESCRIPTION
Fixes #3303. You can now select `.app` folders on macOS as the graphics editor.
<img width="844" height="879" alt="image" src="https://github.com/user-attachments/assets/19e73bd5-c406-4259-a334-bd7a347e74f1" />
