### PR TITLE
Add a subsonic pressure-drag floor for stubby stored-table nose cones

### DIFF
--- a/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/SymmetricComponentCalc.java
+++ b/core/src/main/java/info/openrocket/core/aerodynamics/barrowman/SymmetricComponentCalc.java
@@ -51,6 +51,23 @@ public class SymmetricComponentCalc extends RocketComponentCalc {
 	private final double wetArea;
 	private final double sinphi;
 
+	/**
+	 * Fineness ratio at/above which nose shape stops affecting subsonic pressure
+	 * drag. Centuri TIR-100 section 8 measures no significant variation across the
+	 * catalogue nose shapes from fineness ratio 4.0 down to 1.8.
+	 */
+	private static final double STUBBY_NOSE_FINENESS_LIMIT = 1.8;
+
+	/**
+	 * A stubby rounded nose's subsonic pressure drag as a fraction of this class's
+	 * own cone value at the same fineness ratio. Bracketed from measured deltas
+	 * (Mercer's TIR-100 series and a CFD estimate for a stubby nose), which put a
+	 * rounded stubby nose near 1/3 of this model's cone, ~0.12 on frontal area at
+	 * fineness ratio 0.5. Erring high charges more drag (conservative). This is a
+	 * bracket on the endpoint, not a calibrated curve.
+	 */
+	private static final double STUBBY_NOSE_ROUNDNESS = 1.0 / 3.0;
+
 	public SymmetricComponentCalc(RocketComponent c) {
 		super(c);
 		if (!(c instanceof SymmetricComponent)) {
@@ -389,6 +406,11 @@ public class SymmetricComponentCalc extends RocketComponentCalc {
 			int1 = int3;
 		}
 
+		// int1 != null is exactly the stored-table shapes (ELLIPSOID, POWER,
+		// PARABOLIC, HAACK); CONICAL and OGIVE build the interpolator analytically
+		// above. This is the scope of the stubby-nose subsonic floor applied below.
+		final boolean tableShape = int1 != null;
+
 		// Extrapolate for fineness ratio if necessary
 		if (int1 != null) {
 			double log4 = Math.log(fineness + 1) / Math.log(4);
@@ -405,26 +427,71 @@ public class SymmetricComponentCalc extends RocketComponentCalc {
 
 		double min = interpolator.getXPoints()[0];
 		double minValue = interpolator.getValue(min);
-		if (minValue < 0.001) {
-			// No interpolation necessary
-			return;
-		}
 
 		double cdMach0 = 0.8 * pow2(sinphi);
 		double minDeriv = (interpolator.getValue(min + 0.01) - minValue) / 0.01;
 
-		// These should not occur, but might cause havoc for the interpolation
-		if ((cdMach0 >= minValue - 0.01) || (minDeriv <= 0.01)) {
+		// Fit the subsonic region only when the leading point is non-zero and
+		// well-conditioned. Formerly three early returns; folded into one guard (the
+		// exact negation) so the stubby-nose floor below still runs when the fit is
+		// skipped. The first two terms are "no interpolation necessary"; the last two
+		// "should not occur, but might cause havoc for the interpolation".
+		if (minValue >= 0.001 && cdMach0 < minValue - 0.01 && minDeriv > 0.01) {
+			// Cd = a*M^b + cdMach0
+			final double b = min * minDeriv / (minValue - cdMach0);
+			final double a = (minValue - cdMach0) / Math.pow(min, b);
+
+			for (double m = 0; m < min; m += 0.05)
+				interpolator.addPoint(m, a * Math.pow(m, b) + cdMach0);
+		}
+
+		applyStubbyNoseFloor(interpolator, min, tableShape);
+	}
+
+	/**
+	 * Apply a subsonic pressure-drag floor for a stubby stored-table nose.
+	 * <p>
+	 * A short blunt body has real, measurable subsonic pressure drag, but the
+	 * stored-table shapes under-predict it at low fineness ratio: shapes whose
+	 * table is zero at drag divergence (POWER param &gt; 0.5, PARABOLIC param &gt;
+	 * 0.5, HAACK) skip the subsonic fit entirely and are left at ~0, and shapes
+	 * that do get the fit (ELLIPSOID, the analytically-blended POWER/PARABOLIC
+	 * cases) anchor it at a small {@code cdMach0}. This raises the whole subsonic
+	 * range, including the leading point, to at least the floor via
+	 * {@code max(existing, floor)}, so the curve does not sit low and then jump at
+	 * drag divergence.
+	 * <p>
+	 * Scope is the stored-table shapes only. CONICAL and OGIVE build their curve
+	 * analytically and a cone's own Cd(M=0) already exceeds this floor, so
+	 * {@code max()} would ignore it; a short tangent ogive wants its own evidence.
+	 *
+	 * @param interpolator the pressure-drag interpolator being built
+	 * @param min          the lowest Mach with a real (tabulated/analytic) point
+	 * @param tableShape   whether this nose uses a stored table (see caller)
+	 */
+	private void applyStubbyNoseFloor(LinearInterpolator interpolator, double min, boolean tableShape) {
+		// A nose is a symmetric component whose fore radius is (essentially) zero;
+		// mid-body transitions and boattails are out of scope.
+		final boolean isNose = foreRadius < 1e-9 && aftRadius > foreRadius;
+		if (!tableShape || !isNose)
 			return;
-		}
+		if (!(fineness > 0) || fineness >= STUBBY_NOSE_FINENESS_LIMIT)
+			return;
 
-		// Cd = a*M^b + cdMach0
-		final double b = min * minDeriv / (minValue - cdMach0);
-		final double a = (minValue - cdMach0) / Math.pow(min, b);
+		// 0.8/(1+4f^2) is this class's own conical Cd(M=0) (0.8*sin^2(phi) with
+		// sin(phi) = 1/sqrt(1+4f^2) for a cone of fineness ratio f).
+		double cone = 0.8 / (1 + 4 * fineness * fineness);
+		double taper = 1 - pow2(fineness / STUBBY_NOSE_FINENESS_LIMIT);
+		double floor = STUBBY_NOSE_ROUNDNESS * cone * taper;
+		if (!(floor > 0))
+			return;
 
-		for (double m = 0; m < min; m += 0.05) {
-			interpolator.addPoint(m, a * Math.pow(m, b) + cdMach0);
+		for (double m = 0; m <= min + 1e-9; m += 0.05) {
+			if (interpolator.getValue(m) < floor)
+				interpolator.addPoint(m, floor);
 		}
+		if (interpolator.getValue(min) < floor)
+			interpolator.addPoint(min, floor);
 	}
 
 	private static final PolyInterpolator conicalPolyInterpolator = new PolyInterpolator(new double[] { 1.0, 1.3 },

--- a/core/src/test/java/info/openrocket/core/aerodynamics/SymmetricComponentCalcTest.java
+++ b/core/src/test/java/info/openrocket/core/aerodynamics/SymmetricComponentCalcTest.java
@@ -145,4 +145,74 @@ public class SymmetricComponentCalcTest {
 		}
 	}
 
+	/**
+	 * A stubby stored-table nose (fineness ratio below the 1.8 cutoff) whose table
+	 * is zero at drag divergence skips the subsonic power-law fit, so without the
+	 * floor its subsonic pressure drag would be ~0. The floor lifts the whole
+	 * subsonic range to a fixed fraction of this model's cone value.
+	 */
+	@Test
+	public void testStubbyNoseSubsonicFloor() {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		NoseCone nose = (NoseCone) rocket.getChild(0).getChild(0);
+		// Von Karman (HAACK, parameter 0): its table is 0 at drag divergence, so the
+		// subsonic fit is skipped and the floor is the only subsonic source.
+		nose.setShapeType(Transition.Shape.HAACK);
+		nose.setShapeParameter(0.0);
+		// fineness ratio = length / (2 * aftRadius) = 0.5
+		nose.setLength(nose.getAftRadius());
+		SymmetricComponentCalc calcObj = new SymmetricComponentCalc(nose);
+
+		FlightConfiguration config = rocket.getSelectedConfiguration();
+		FlightConditions conditions = new FlightConditions(config);
+		conditions.setAOA(0.0);
+		WarningSet warnings = new WarningSet();
+
+		double frontalArea = Math.PI * nose.getAftRadius() * nose.getAftRadius();
+
+		// floor = STUBBY_NOSE_ROUNDNESS * cone * taper at fineness ratio 0.5:
+		// cone = 0.8/(1+4*0.5^2) = 0.4, taper = 1-(0.5/1.8)^2, roundness = 1/3.
+		double expectedFloor = 0.12304526748971193;
+
+		// Below the leading tabulated Mach (0.9) the whole subsonic range sits at the floor.
+		for (double m : new double[] { 0.0, 0.3, 0.6 }) {
+			conditions.setMach(m);
+			double testcd = calcObj.calculatePressureCD(conditions, 0.0, 0.0, warnings) *
+					conditions.getRefArea() / frontalArea;
+			assertEquals(expectedFloor, testcd, EPSILON,
+					"SymmetricComponentCalc produces bad stubby-nose floor Cd at m=" + m);
+		}
+	}
+
+	/**
+	 * At or above the fineness-ratio cutoff (1.8) the stubby-nose floor must not be
+	 * applied: a slender von Karman nose whose table is zero at drag divergence
+	 * keeps its ~0 subsonic pressure drag.
+	 */
+	@Test
+	public void testTallNoseNoSubsonicFloor() {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		NoseCone nose = (NoseCone) rocket.getChild(0).getChild(0);
+		nose.setShapeType(Transition.Shape.HAACK);
+		nose.setShapeParameter(0.0);
+		// fineness ratio = length / (2 * aftRadius) = 2.0, above the 1.8 cutoff
+		nose.setLength(nose.getAftRadius() * 4.0);
+		SymmetricComponentCalc calcObj = new SymmetricComponentCalc(nose);
+
+		FlightConfiguration config = rocket.getSelectedConfiguration();
+		FlightConditions conditions = new FlightConditions(config);
+		conditions.setAOA(0.0);
+		WarningSet warnings = new WarningSet();
+
+		double frontalArea = Math.PI * nose.getAftRadius() * nose.getAftRadius();
+
+		for (double m : new double[] { 0.0, 0.3, 0.6 }) {
+			conditions.setMach(m);
+			double testcd = calcObj.calculatePressureCD(conditions, 0.0, 0.0, warnings) *
+					conditions.getRefArea() / frontalArea;
+			assertEquals(0.0, testcd, EPSILON,
+					"SymmetricComponentCalc applied floor to a tall nose at m=" + m);
+		}
+	}
+
 }


### PR DESCRIPTION
# Summary

Short, blunt nose cones (fineness ratio below ~1.8) built from the stored experimental drag tables were being assigned essentially zero subsonic pressure drag, which is non-physical — a stubby ellipsoid or Von Kármán has real, measurable subsonic pressure drag. This PR adds a fineness-dependent floor to the subsonic region for those shapes coming from the mmrocket-sim project.

# Problem

SymmetricComponentCalc.calculateNoseInterpolator() builds the pressure-drag curve two ways:

CONICAL / OGIVE — computed analytically, with a proper Cd(M=0) anchor. These are fine.
ELLIPSOID / POWER / PARABOLIC / HAACK — taken from stored fineness-ratio-3 tables (NASA TR-R-100) and extrapolated to the actual fineness ratio.

For the stored-table shapes whose table is zero at drag divergence (POWER > 0.5, PARABOLIC > 0.5, HAACK), the subsonic power-law fit is skipped (the old minValue < 0.001 early return), and the fineness extrapolation is multiplicative, so 0 → 0 at every fineness ratio. The result is a stubby nose that carries ~0 subsonic pressure drag and then jumps at its drag-divergence Mach. The remaining table shapes (ELLIPSOID and the analytically-blended POWER/PARABOLIC cases) do get the fit, but it's anchored at a tiny cdMach0 for a blunt body, so their low-Mach end is unrealistically small too.

# Approach

Refactored the three subsonic-fit early returns into a single guard that is the exact De Morgan negation of the originals, so every nose that took the fit before takes it identically now — but control flow no longer skips past the new floor.
Added applyStubbyNoseFloor(...), applied only to stored-table nose shapes with fineness ratio > 0 and < 1.8. It raises the whole subsonic range (including the leading point) to at least the floor via max(existing, floor), so the curve doesn't sit low and then jump at drag divergence.
The floor is a fraction of this model's own cone value at the same fineness ratio:
cone = 0.8/(1+4f²) — the class's own conical Cd(M=0).
roundness = 1/3 — a rounded stubby nose as a fraction of that cone, bracketed from Mercer's Centuri TIR-100 measured deltas and an independent CFD estimate (~0.12 on frontal area at fineness ratio 0.5).
taper = 1 − (f/1.8)² — fades the floor to 0 at the 1.8 cutoff (TIR-100 §8 finds no significant nose-shape variation above ~1.8), so there is no discontinuity there.

Erring high charges more drag and predicts less altitude — the conservative direction. This is a bracket on the endpoint and shape of the law, not a calibrated curve; the region between fineness ratio 0.5 and the 1.8 cutoff is interpolation.

# Scope / non-goals

CONICAL and OGIVE are deliberately excluded — their analytic Cd(M=0) already exceeds this floor, so max() would ignore it anyway.
Only true noses (fore radius ≈ 0, expanding aft) are affected; mid-body transitions and boattails are out of scope.
Noses at fineness ratio ≥ 1.8 are untouched — behavior is identical to before.

# Testing

testStubbyNoseSubsonicFloor — Von Kármán (HAACK, param 0; the pure zero-at-divergence case) at fineness ratio 0.5 asserts subsonic Cd equals the floor (0.12304527) at M = 0.0, 0.3, 0.6. Locks the constants and the taper law.
testTallNoseNoSubsonicFloor — same nose at fineness ratio 2.0 asserts subsonic Cd stays ~0, locking the 1.8 cutoff.
Existing testEllipseNoseconeDrag / conical / ogive tests still pass, confirming the fit refactor is behavior-preserving.