### PR TITLE
mass inertia correction

### DIFF
--- a/core/src/main/java/info/openrocket/core/masscalc/MassCalculation.java
+++ b/core/src/main/java/info/openrocket/core/masscalc/MassCalculation.java
@@ -70,7 +70,20 @@ public class MassCalculation {
 	public void addInertia( final RigidBody data ) {
 		this.bodies.add( data );
 	}
-	
+
+	/**
+	 * Scale the mass and moment of inertia of every accumulated body by the given
+	 * non-negative factor.  Used when a mass override covers all subcomponents: the
+	 * geometric mass distribution is preserved but rescaled to the overridden total,
+	 * keeping the moment of inertia consistent with the mass.
+	 *
+	 * @param factor  non-negative scale factor
+	 */
+	void scaleInertia( final double factor ) {
+		for (int i = 0; i < this.bodies.size(); i++)
+			this.bodies.set(i, this.bodies.get(i).scaleMass(factor));
+	}
+
 	public void addMass( final CoordinateIF pointMass ) {
 		if( MIN_MASS > this.centerOfMass.getWeight() ){
 		    this.centerOfMass = pointMass;
@@ -353,6 +366,13 @@ public class MassCalculation {
 			// setting zero as the CG position means the top of the component, which is component.getPosition()
 			final CoordinateIF compZero = parentTransform.transform( component.getPosition() );
 
+			// Geometric (non-overridden) mass of this component, captured before a
+			// mass override rewrites compCM's weight.  A subcomponent mass override
+			// then rescales the inertia to the overridden mass instead of leaving it
+			// at the geometric value (see below).
+			final double componentGeometricMass = compCM.getWeight();
+			double inertiaMass = componentGeometricMass;
+
 			if (component.isMassOverridden()) {
 				if (!component.isMassive()) {
 					compCM = children.getCM();
@@ -360,7 +380,26 @@ public class MassCalculation {
 				compCM = compCM.setWeight(component.getOverrideMass());
 
 				if (component.isSubcomponentsOverriddenMass()) {
+					// The override replaces the mass of this component AND all of its
+					// subcomponents.  Keep the geometric mass *distribution* but
+					// rescale it to the overridden total so the moment of inertia
+					// stays consistent with the mass.  Previously only the mass was
+					// zeroed while the inertia of the subcomponents (and of this
+					// component) was left at its geometric value, so overriding the
+					// mass silently left the rotational/longitudinal inertia
+					// unchanged.
+					final double geometricMass = componentGeometricMass + children.getMass();
+					final double scale = geometricMass > MIN_MASS
+							? component.getOverrideMass() / geometricMass
+							: 0.0;
+					children.scaleInertia(scale);
 					children.setCM(children.getCM().setWeight(0));
+					inertiaMass = componentGeometricMass * scale;
+				} 
+				else {
+					// Override applies to this component only; its own inertia
+					// follows the overridden mass.
+					inertiaMass = component.getOverrideMass();
 				}
 			}
 
@@ -380,9 +419,9 @@ public class MassCalculation {
 				entry.updateAverageCM(compCM);
 			}
 			
-			final double compIx = component.getRotationalUnitInertia() * compCM.getWeight();
-			final double compIt = component.getLongitudinalUnitInertia() * compCM.getWeight();
-			final RigidBody componentInertia = new RigidBody( compCM, compIx, compIt, compIt );
+			final double compIx = component.getRotationalUnitInertia() * inertiaMass;
+			final double compIt = component.getLongitudinalUnitInertia() * inertiaMass;
+			final RigidBody componentInertia = new RigidBody( compCM.setWeight(inertiaMass), compIx, compIt, compIt );
 			this.addInertia( componentInertia );
 			// // vvv DEBUG
 			// if( 0 < compCM.getWeight() ) {

--- a/core/src/main/java/info/openrocket/core/masscalc/RigidBody.java
+++ b/core/src/main/java/info/openrocket/core/masscalc/RigidBody.java
@@ -43,6 +43,21 @@ public class RigidBody {
 		return new RigidBody(newCM, newIxx, newIyy, newIzz);
 	}
 
+	/**
+	 * Return a copy of this body with its mass and moment of inertia scaled by the
+	 * given non-negative factor.  For a fixed geometry the moment of inertia scales
+	 * linearly with mass, so scaling the stored MOI together with the mass keeps the
+	 * body self-consistent under {@link #rebase(CoordinateIF)}, whose parallel-axis
+	 * term uses the mass.
+	 *
+	 * @param factor  non-negative scale factor
+	 * @return a mass- and inertia-scaled copy of this body
+	 */
+	public RigidBody scaleMass(final double factor) {
+		return new RigidBody(cm.setWeight(cm.getWeight() * factor),
+				Ixx * factor, Iyy * factor, Izz * factor);
+	}
+
 	public CoordinateIF getCenterOfMass() {
 		return cm;
 	}

--- a/core/src/test/java/info/openrocket/core/masscalc/MassCalculatorTest.java
+++ b/core/src/test/java/info/openrocket/core/masscalc/MassCalculatorTest.java
@@ -182,6 +182,47 @@ public class MassCalculatorTest extends BaseTestCase {
 		assertEquals(actualMOIlong, overrideMOIlong, EPSILON, "Alpha III Longitudinal MOI calculated incorrectly: ");
 	}
 
+	/**
+	 * A mass override that covers all subcomponents must scale the moment of
+	 * inertia to the overridden mass.  Regression test for the bug where only the
+	 * mass was replaced while the inertia stayed at the geometric value, so the
+	 * roll/pitch inertia was identical no matter what mass you pinned the stage to.
+	 */
+	@Test
+	public void testSubcomponentMassOverrideScalesInertia() {
+		Rocket rocket = TestRockets.makeEstesAlphaIII();
+		rocket.setName("AlphaIII." + Thread.currentThread().getStackTrace()[1].getMethodName());
+		FlightConfiguration config = rocket.getEmptyConfiguration();
+		config.setAllStages();
+
+		// Baseline: geometric mass and inertia of the un-overridden rocket.
+		final RigidBody baseline = MassCalculator.calculateStructure(config);
+		final double geometricMass = baseline.getMass();
+		final double baselineRot = baseline.getRotationalInertia();
+		final double baselineLong = baseline.getLongitudinalInertia();
+
+		// Pin the whole (single) stage's mass, covering its subcomponents.
+		final AxialStage sustainer = rocket.getStage(0);
+		sustainer.setSubcomponentsOverriddenMass(true);
+		sustainer.setMassOverridden(true);
+
+		// Keeping the geometric distribution, mass X carries X/m times the inertia.
+		// (Before the fix the two inertia asserts failed for every factor != 1.)
+		for (double factor : new double[] { 1.0, 1.8, 3.6, 9.1 }) {
+			sustainer.setOverrideMass(geometricMass * factor);
+			final RigidBody pinned = MassCalculator.calculateStructure(config);
+			final double expMass = geometricMass * factor;
+			final double expRot  = baselineRot * factor;
+			final double expLong = baselineLong * factor;
+			assertEquals(expMass, pinned.getMass(), Math.abs(expMass) * 1e-6,
+					"overridden total mass wrong at factor " + factor);
+			assertEquals(expRot, pinned.getRotationalInertia(), Math.abs(expRot) * 1e-6,
+					"rotational (roll) inertia must scale with the overridden mass, factor " + factor);
+			assertEquals(expLong, pinned.getLongitudinalInertia(), Math.abs(expLong) * 1e-6,
+					"longitudinal inertia must scale with the overridden mass, factor " + factor);
+		}
+	}
+
 	@Test
 	public void testAlphaIIILaunchMass() {
 		Rocket rocket = TestRockets.makeEstesAlphaIII();
@@ -1196,12 +1237,15 @@ public class MassCalculatorTest extends BaseTestCase {
 		assertEquals(expCM.getZ(), boosterSetCM.getZ(), EPSILON, " Booster Launch CM.getZ() is incorrect: ");
 		assertEquals(expCM, boosterSetCM, " Booster Launch CM is incorrect: ");
 
-		// Validate MOI
-		double expMOI_axial = 0.005873702474290652;
+		// Validate MOI.  Because the 0.5 kg mass override covers the booster's
+		// subcomponents, the geometric inertia is rescaled to the overridden mass
+		// (scale = overrideMass / geometricMass); the values below reflect the
+		// mass-consistent inertia rather than the geometric-mass inertia.
+		double expMOI_axial = 0.004843421529808234;
 		double boosterMOI_xx = burnout.getRotationalInertia();
 		assertEquals(expMOI_axial, boosterMOI_xx, EPSILON, " Booster x-axis MOI is incorrect: ");
 
-		double expMOI_tr = 17.78089035006232;
+		double expMOI_tr = 14.662020679052493;
 		double boosterMOI_tr = burnout.getLongitudinalInertia();
 		assertEquals(expMOI_tr, boosterMOI_tr, EPSILON, " Booster transverse MOI is incorrect: ");
 	}


### PR DESCRIPTION
# Problem

When a component's mass is overridden with "override mass of all subcomponents" enabled, MassCalculation.calculateStructure() only zeroed the children's center-of-mass weight. Their RigidBody entries stayed in the bodies list at their geometric masses, so the moment-of-inertia sum reflected the geometric mass while the reported total mass was the overridden mass.

So the rocket flew with mass X but the rotational/longitudinal inertia of a different mass — roll and pitch inertia off by exactly the override factor. This threw off weathercocking and drift; apogee was largely unaffected.

Found via a cross-check against mmrocket-sim, which surfaced the mass/inertia discrepancy on overridden subcomponents.

$ Fix

When the override covers subcomponents, keep the geometric mass distribution but rescale it to the overridden total:

scale = overrideMass / geometricSubtreeMass

Only the inertia bodies are rescaled — mass and CG bookkeeping are untouched. The no-override and self-only-override paths reduce to the previous values exactly, so they're bit-identical.

Rescaling proportionally to the existing geometry is the physically-consistent default (for fixed geometry, MOI scales linearly with mass), but it's a deliberate behavior choice worth a reviewer's eye.

# Testing

Full core test suite passes.
Added testSubcomponentMassOverrideScalesInertia: pins a stage over its subcomponents at factors 1.0 / 1.8 / 3.6 / 9.1 and asserts mass and both inertia axes scale linearly. Before the fix, the inertia asserts failed for every factor ≠ 1.
Updated testFalcon9HeavyBoosterStageMassOverride: its recorded MOI values were the bug — a 0.5 kg override carrying the full geometric boosters' inertia — so they're updated to the mass-consistent values.
